### PR TITLE
fix: add IntricEventType enum to openapi schema

### DIFF
--- a/backend/src/intric/server/main.py
+++ b/backend/src/intric/server/main.py
@@ -14,7 +14,7 @@ from intric.server.middleware.cors import CORSMiddleware
 from intric.server.models.api import VersionResponse
 from intric.server.routers import router as api_router
 from intric.server.websockets.websocket_models import WS_MODELS
-from intric.sessions.session import SSE_MODELS
+from intric.sessions.session import SSE_MODELS, SSE_ENUMS
 
 logger = get_logger(__name__)
 
@@ -55,6 +55,12 @@ def get_application():
             openapi_schema["components"]["schemas"][model.__name__] = model.model_json_schema(
                 ref_template=f"#/components/schemas/{model.__name__}/$defs/{{model}}"
             )
+
+        # Adding SSE enums to the schema
+        for enum_type in SSE_ENUMS:
+            from pydantic import TypeAdapter
+            adapter = TypeAdapter(enum_type)
+            openapi_schema["components"]["schemas"][enum_type.__name__] = adapter.json_schema()
 
         app.openapi_schema = openapi_schema
         return app.openapi_schema

--- a/backend/src/intric/sessions/session.py
+++ b/backend/src/intric/sessions/session.py
@@ -117,3 +117,6 @@ class SSEFirstChunk(AskChatResponse):
 
 # Add the SSE models here in order to include them in the openapi schema
 SSE_MODELS = [SSEText, SSEIntricEvent, SSEFiles, SSEFirstChunk]
+
+# Add standalone enums that need to be included in the openapi schema
+SSE_ENUMS = [IntricEventType]


### PR DESCRIPTION
### Background
Tinkering around with openapi-generator to generate markdown files from the openapi.json.

### Problem
Generation failed due to missing enum `IntricEventType` not being a part of the generated schema.

### Solution
Add the sse enum to the schema.