### PR TITLE
fix: update pr_lint workflow to use project ruff config

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -40,25 +40,25 @@ jobs:
             The subject "{subject}" found in the pull request title "{title}"
             didn't match the configured pattern. Please ensure that the subject
             doesn't start with an uppercase character.
-      
+
       - name: Check branch naming
         run: |
           BRANCH_NAME="${{ github.head_ref }}"
-          
+
           # Skip branch naming check for long-lived branches
           if [[ "$BRANCH_NAME" == "develop" ]]; then
             echo "✅ Branch 'develop' is a long-lived branch - skipping naming convention check"
             exit 0
           fi
-          
+
           VALID_PREFIXES="^(feature|fix|hotfix|chore|docs|test|refactor)/"
-          
+
           if [[ ! "$BRANCH_NAME" =~ $VALID_PREFIXES ]]; then
             echo "❌ Branch name '$BRANCH_NAME' does not follow naming convention."
             echo "Branch names should start with: feature/, fix/, hotfix/, chore/, docs/, test/, or refactor/"
             exit 1
           fi
-          
+
           echo "✅ Branch name follows naming convention"
 
   frontend-checks:
@@ -78,7 +78,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          cache-dependency-path: frontend/pnpm-lock.yaml 
+          cache-dependency-path: frontend/pnpm-lock.yaml
           node-version: 20
           cache: pnpm
       - name: Install dependencies
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Needed for changed files detection
-      
+
       - name: Get changed Python files
         id: changed-files
         run: |
@@ -111,33 +111,35 @@ jobs:
           else
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
-      
+
       - name: 🚨 Critical Issues Check (BLOCKING)
         if: steps.changed-files.outputs.skip == 'false'
         uses: astral-sh/ruff-action@v3
         with:
           src: ${{ steps.changed-files.outputs.files }}
-          args: check --select F401,F811,F821,F841,B007,B008 --output-format github
+          args: --config backend/pyproject.toml check --output-format github
         # This step will FAIL the workflow for critical issues
-      
+
       - name: 💅 Style & Format Check (NON-BLOCKING)
         if: steps.changed-files.outputs.skip == 'false'
         run: |
           echo "Installing ruff for style checks..."
           pip install ruff
           echo "Checking style issues in: ${{ steps.changed-files.outputs.files }}"
-          ruff check --select E,W,I,UP,B --ignore F401,F811,F821,F841,B007,B008 --output-format github ${{ steps.changed-files.outputs.files }} || echo "⚠️ Style issues found (non-blocking)"
+          ruff check --config backend/pyproject.toml --output-format github ${{ steps.changed-files.outputs.files }} || echo "⚠️ Style issues found (non-blocking)"
         continue-on-error: true
-      
-      - name: 🎨 Auto-format Check (NON-BLOCKING)
-        if: steps.changed-files.outputs.skip == 'false'
-        run: |
-          echo "Installing ruff for formatting check..."
-          pip install ruff
-          echo "Checking format of: ${{ steps.changed-files.outputs.files }}"
-          ruff format --check ${{ steps.changed-files.outputs.files }} || echo "⚠️ Files need formatting (run 'ruff format' locally)"
-        continue-on-error: true
-      
+
+      # Disabled for now as the project has not used ruff formatting previously
+      # TODO: Re-enable this when the project is ready to use ruff formatting
+      # - name: 🎨 Auto-format Check (NON-BLOCKING)
+      #   if: steps.changed-files.outputs.skip == 'false'
+      #   run: |
+      #     echo "Installing ruff for formatting check..."
+      #     pip install ruff
+      #     echo "Checking format of: ${{ steps.changed-files.outputs.files }}"
+      #     ruff format --config backend/pyproject.toml --check ${{ steps.changed-files.outputs.files }} || echo "⚠️ Files need formatting (run 'ruff format' locally)"
+      #   continue-on-error: true
+
       - name: Skip message
         if: steps.changed-files.outputs.skip == 'true'
         run: echo "✅ No Python files changed in backend/ - skipping ruff checks"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,20 +2,9 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.3
     hooks:
-      # Critical checks (will block commits)
+      # Lint using project configuration (pyproject.toml)
       - id: ruff-check
-        name: ruff-critical
-        args: [--select, "F401,F811,F821,F841,B007,B008", --fix]
+        name: ruff
+        args: [--fix]
         stages: [commit]
-      
-      # Auto-format (will fix automatically)  
-      - id: ruff-format
-        name: ruff-format
-        stages: [commit]
-        
-      # Style checks (warnings only)
-      - id: ruff-check
-        name: ruff-style
-        args: [--select, "E,W,I,UP,B", --ignore, "F401,F811,F821,F841,B007,B008", --fix]
-        stages: [commit]
-        verbose: true
+        files: ^backend/

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -86,7 +86,7 @@ line-length = 88
 exclude = [
     ".venv",
     "__pycache__",
-    ".git", 
+    ".git",
     ".pytest_cache",
     "build",
     "dist",
@@ -94,21 +94,17 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-# All rules
+# Minimal ruleset to start with
 select = [
-    "E",   # pycodestyle errors
-    "F",   # Pyflakes
-    "W",   # pycodestyle warnings
-    "UP",  # pyupgrade (for modern Python)
-    "B",   # flake8-bugbear (common bugs)
-    "I",   # isort
+    "F",   # Pyflakes (correctness: undefined names, etc.)
+    "E9",  # pycodestyle “runtime”/syntax errors,
 ]
 
-# Basic ignores for formatter compatibility
-ignore = [
-    "E501",  # Line too long (formatter handles this)
-    "E203",  # Whitespace before ':'
-]
+# Basic ignores for formatter compatibility (kept for when E/W are enabled later)
+ignore = []
+
+[tool.ruff.lint.per-file-ignores]
+"**/__init__.py" = ["F401"]  # Allow re-exports without being flagged as unused
 
 [tool.ruff.format]
 quote-style = "double"

--- a/backend/src/intric/actors/actors/space_actor.py
+++ b/backend/src/intric/actors/actors/space_actor.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from typing import TYPE_CHECKING, Union
 
-from intric.main.config import SETTINGS
 from intric.main.models import ResourcePermission
 from intric.modules.module import Modules
 from intric.roles.permissions import Permission

--- a/backend/src/intric/completion_models/application/completion_model_crud_service.py
+++ b/backend/src/intric/completion_models/application/completion_model_crud_service.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Optional, Union
 
-from intric.completion_models.domain import ModelFamily, ModelHostingLocation
+from intric.completion_models.domain import ModelFamily
 from intric.main.config import SETTINGS
 from intric.main.exceptions import UnauthorizedException
 from intric.main.models import NOT_PROVIDED, ModelId, NotProvided

--- a/backend/src/intric/main/container/container.py
+++ b/backend/src/intric/main/container/container.py
@@ -153,7 +153,6 @@ from intric.jobs.job_service import JobService
 from intric.jobs.task_service import TaskService
 from intric.limits.limit_service import LimitService
 from intric.main.aiohttp_client import aiohttp_client
-from intric.main.config import SETTINGS
 from intric.modules.module_repo import ModuleRepository
 from intric.predefined_roles.predefined_role_service import PredefinedRolesService
 from intric.predefined_roles.predefined_roles_repo import PredefinedRolesRepository

--- a/backend/src/intric/templates/app_template/api/app_template_router.py
+++ b/backend/src/intric/templates/app_template/api/app_template_router.py
@@ -1,16 +1,11 @@
-from uuid import UUID
 
 from fastapi import APIRouter, Depends
 
-from intric.main.config import SETTINGS
 from intric.main.container.container import Container
 from intric.server.dependencies.container import get_container
 from intric.server.protocol import responses
 from intric.templates.app_template.api.app_template_models import (
-    AppTemplateCreate,
     AppTemplateListPublic,
-    AppTemplatePublic,
-    AppTemplateUpdate,
 )
 
 router = APIRouter()

--- a/backend/src/intric/templates/assistant_template/api/assistant_template_router.py
+++ b/backend/src/intric/templates/assistant_template/api/assistant_template_router.py
@@ -1,16 +1,11 @@
-from uuid import UUID
 
 from fastapi import APIRouter, Depends
 
-from intric.main.config import SETTINGS
 from intric.main.container.container import Container
 from intric.server.dependencies.container import get_container
 from intric.server.protocol import responses
 from intric.templates.assistant_template.api.assistant_template_models import (
-    AssistantTemplateCreate,
     AssistantTemplateListPublic,
-    AssistantTemplatePublic,
-    AssistantTemplateUpdate,
 )
 
 router = APIRouter()


### PR DESCRIPTION
Update ruff config to use minimal ruleset since no linting has previously been used.
In the future we can incrementally add new rules as we go and make necessary changes to the codebase.