### PR TITLE
fix: resolve Poetry packaging dependency conflict in Docker build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get install -y ffmpeg
 # Install libmagic, for mimetypes
 RUN apt-get install libmagic1
 
+# Install poetry
 RUN pip install poetry
 
 WORKDIR /code
@@ -16,14 +17,17 @@ COPY ./pyproject.toml ./poetry.lock ./
 
 COPY . /code/
 
-# Install ALL dependencies (including dev dependencies for init_db.py)
+# Install ALL dependencies and fix packaging
 RUN poetry config virtualenvs.create false \
-  && poetry install --no-interaction --no-ansi
+  && poetry install --no-interaction --no-ansi \
+  && pip install --force-reinstall packaging==25.0
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1
+# Disable virtualenv creation via environment variable
+ENV POETRY_VIRTUALENVS_CREATE=false
 
-# Handle tiktoken to be able to run in disconnected mode
+# Handle tiktoken
 ENV TIKTOKEN_CACHE_DIR=/tiktoken
 RUN mkdir /tiktoken
 ADD --chmod=644 https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken /tiktoken/9b5ad71b2ce5302211f9c61530b329a4922fc6a4
@@ -31,7 +35,7 @@ ADD --chmod=644 https://openaipublic.blob.core.windows.net/encodings/cl100k_base
 # CRITICAL: Give ownership to UID 1000 BEFORE switching user
 RUN chown -R 1000:1000 /code /tiktoken
 
-# Run as unpriviledged user
+# Run as unprivileged user
 USER 1000
 
 CMD ["sh", "-c", "./run.sh"]


### PR DESCRIPTION
# Pull Request

## Description
<!-- Provide a brief description of the changes in this PR -->
Fixes Docker build failures caused by a dependency conflict between Poetry's internal requirements and the application's locked dependencies. The Poetry 2.x runtime requires `packaging>=25.0` internally, but our `poetry.lock` has `packaging==24.1` locked. This PR resolves the conflict without modifying the application's dependency specifications.

## Type of Change
<!-- Mark the appropriate option(s) with [x] -->

- [ ] 🚀 **feat**: A new feature
- [x] 🐛 **fix**: A bug fix
- [ ] 📚 **docs**: Documentation only changes
- [ ] 💄 **style**: Changes that do not affect the meaning of the code (white-space, formatting, etc)
- [ ] ♻️ **refactor**: A code change that neither fixes a bug nor adds a feature
- [ ] ✅ **test**: Adding missing tests or correcting existing tests
- [ ] 🔧 **chore**: Changes to the build process or auxiliary tools
- [ ] ⚡ **perf**: A code change that improves performance
- [ ] 🔄 **ci**: Changes to CI configuration files and scripts

## Branch Naming Convention
<!-- Ensure your branch follows the naming convention -->

Your branch name should start with one of these prefixes:
- `feature/` - for new features
- `fix/` - for bug fixes
- `hotfix/` - for urgent fixes
- `chore/` - for maintenance tasks
- `docs/` - for documentation changes
- `test/` - for test-related changes
- `refactor/` - for code refactoring
- `ci/` - for CI/CD changes

**Example**: `feature/user-authentication` or `fix/login-validation`

## Checklist
<!-- Mark the appropriate option(s) with [x] -->

- [x] My branch name follows the naming convention (`hotfix/worker-dockerfile-fix`)
- [x] I have tested my changes locally
- [ ] I have updated documentation if necessary
- [x] My changes do not break existing functionality
- [ ] I have added tests for new functionality (if applicable)

## Testing
<!-- Describe how you tested your changes -->
- Built the Docker image locally with the updated Dockerfile
- Verified that Poetry installs dependencies correctly without errors
- Confirmed the container runs successfully with the unprivileged user (UID 1000)
- Validated that the packaging conflict is resolved

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->
N/A - Dockerfile changes only

## Additional Notes
<!-- Any additional information that reviewers should know -->

### Changes Made:
- Force reinstall `packaging==25.0` after Poetry install to satisfy Poetry 2.x requirements
- Add `POETRY_VIRTUALENVS_CREATE=false` environment variable for unprivileged user execution
- Fixes build failures caused by version mismatch between Poetry internal needs (packaging>=25.0) and locked app dependency (packaging==24.1)

This solution bridges the gap between Poetry's internal requirements and the app's locked dependencies without modifying poetry.lock, ensuring both the build tools and application dependencies are satisfied.