### PR TITLE
fix: remove incorrect OIDC prefix from shared authentication logs

### DIFF
--- a/backend/src/intric/users/user_service.py
+++ b/backend/src/intric/users/user_service.py
@@ -432,7 +432,7 @@ class UserService:
         correlation_id = correlation_id or "no-correlation-id"
 
         logger.info(
-            "OIDC: Checking user and tenant state",
+            "Checking user and tenant state",
             extra={
                 "correlation_id": correlation_id,
                 "user_id": str(user_in_db.id),
@@ -471,7 +471,7 @@ class UserService:
             raise TenantSuspendedException()
 
         logger.info(
-            "OIDC: User and tenant state check passed",
+            "User and tenant state check passed",
             extra={
                 "correlation_id": correlation_id,
                 "user_id": str(user_in_db.id),


### PR DESCRIPTION
# Pull Request

## Description
Fix incorrect logging prefix in shared authentication method. The `_check_user_and_tenant_state` method was
incorrectly prefixed with "OIDC:" in log messages, but this method is used by all authentication types (password
login, API key auth, OIDC), not just OIDC.

## Type of Change
- [x] 🐛 **fix**: A bug fix

## Branch Naming Convention
Your branch name should start with one of these prefixes:
- `feature/` - for new features
- `fix/` - for bug fixes
- `hotfix/` - for urgent fixes
- `chore/` - for maintenance tasks
- `docs/` - for documentation changes
- `test/` - for test-related changes
- `refactor/` - for code refactoring
- `ci/` - for CI/CD changes

**Branch**: `fix/remove-incorrect-oidc-prefix`

## Checklist
- [x] My branch name follows the naming convention
- [x] I have tested my changes locally
- [x] I have updated documentation if necessary
- [x] My changes do not break existing functionality
- [ ] I have added tests for new functionality (if applicable)

## Changes Made
- Remove "OIDC:" prefix from `_check_user_and_tenant_state` logs
- This method is used by all login types, not just OIDC

## Testing
- Verified that regular password login no longer shows "OIDC:" prefixed logs
- Confirmed OIDC login still has appropriate OIDC-specific logs in `login_with_mobilityguard` method
- Checked that API key authentication logs are now correctly labeled

## Additional Notes
This is a follow-up fix to PR #42 which added comprehensive OIDC logging. The shared authentication state checking
method was mistakenly given OIDC-specific log prefixes.