### PR TITLE
Fix user filtering bug in admin page

### DIFF
--- a/frontend/packages/ui/src/lib/Table/create.ts
+++ b/frontend/packages/ui/src/lib/Table/create.ts
@@ -191,7 +191,9 @@ export function createWithStore<Resource extends Record<string, unknown>>(
     },
     createViewModel(columns: Column<Resource, Plugins<Resource>>[]) {
       const dataCols = table.createColumns(columns);
-      return table.createViewModel(dataCols);
+      return table.createViewModel(dataCols, {
+        rowDataId: (item) => String((item as any).id)
+      });
     }
   };
 }


### PR DESCRIPTION
Use unique user IDs instead of array indices for table row IDs to prevent incorrect user data display when filtering.

## Changes
- Configure table row IDs to use unique user IDs instead of array indices
- Update UserEditor component to use Svelte 5 `$props()` and reactive state

## Why
When filtering the user list, clicking "edit" on a filtered result would open the modal with data from the wrong user
(e.g., 5th filtered result showed 5th user from the original unfiltered list). This happened because table rows were
identified by position rather than user ID.

## Testing
1. Navigate to `/admin/users?tab=active`
2. Search for "jack" to filter users
3. Click "..." on 5th result → "redigera användare"
4. Verify modal shows correct user data (5th jack result, not 5th original user)