### PR TITLE
fixed faulty orphan cleanup timestamp

### DIFF
--- a/backend/src/intric/worker/crawl_feeder.py
+++ b/backend/src/intric/worker/crawl_feeder.py
@@ -516,7 +516,7 @@ class CrawlFeeder:
                         and_(
                             Jobs.task == "CRAWL",  # Only crawl jobs
                             Jobs.status.in_([Status.QUEUED, Status.IN_PROGRESS]),
-                            Jobs.created_at < cutoff_time,
+                            Jobs.updated_at < cutoff_time,
                         )
                     )
                     .values(status=Status.FAILED)


### PR DESCRIPTION
## Changes
Fixed orphan cleanup query to use `updated_at` instead of `created_at` in `crawl_feeder.py:519`

## Why
The orphan cleanup logic was incorrectly using `Jobs.created_at < cutoff_time` to identify stuck jobs. This ignores heartbeats that update `updated_at` via `touch_job()`, causing active long-running crawls to be incorrectly marked as FAILED after 6 hours even if they're still healthy and sending heartbeats.