### PR TITLE
fix: remove link headers if too large

### DIFF
--- a/frontend/apps/web/src/hooks.server.ts
+++ b/frontend/apps/web/src/hooks.server.ts
@@ -64,19 +64,9 @@ const paraglideHandle: Handle = ({ event, resolve }) =>
   });
 
 const headerFilterHandle: Handle = async ({ event, resolve }) => {
-  const response = await resolve(event);
-
-  // Filter oversized Link header to prevent HAProxy 502 Bad Gateway
-  // HAProxy buffer limit: 16KB-64KB (effective header space = bufsize - maxrewrite)
-  const linkHeader = response.headers.get('link');
-  if (linkHeader && linkHeader.length > 12000) {
-    console.warn(
-      `[Headers] Link header too large (${linkHeader.length} bytes) - removing to prevent HAProxy 502. ` +
-      `Consider disabling modulePreload in vite.config.ts.`
-    );
-    response.headers.delete('link');
-  }
-
+  const response = await resolve(event, {
+    preload: () => false,
+  });
   return response;
 };
 


### PR DESCRIPTION
## Changes
Drop link header if too large

## Why
Proxy fails with 502 if headers too large
