### PR TITLE
fix(worker): use same session for job status updates to prevent deadlock

### DIFF
--- a/backend/src/intric/main/container/container.py
+++ b/backend/src/intric/main/container/container.py
@@ -1058,9 +1058,6 @@ class Container(containers.DeclarativeContainer):
     )
 
     # Worker
-    # NOTE: TaskManager no longer requires session - it creates its own
-    # sessions via sessionmanager.session() for complete_job/fail_job.
-    # This allows TaskManager to work with sessionless containers.
     task_manager = providers.Factory(
         TaskManager,
         user=user,


### PR DESCRIPTION
## Changes
Removed dead code branches that created fresh sessions for status updates

## Why
File uploads were completing successfully (embeddings stored in pgvector) but job status was never updated in PostgreSQL. Root cause was a nested session deadlock: @worker.function() holds an outer
  transaction while complete_job() created a new session trying to update the same job row. The new session blocked waiting for locks held by the outer transaction. The exception was caught and logged but not
  propagated, causing silent failures.
