### PR TITLE
Fix exception during Azure openai stream iteration

### DIFF
--- a/backend/src/intric/completion_models/infrastructure/get_response_open_ai.py
+++ b/backend/src/intric/completion_models/infrastructure/get_response_open_ai.py
@@ -147,6 +147,9 @@ async def iterate_stream(stream):
             if len(chunk.choices) > 0:
                 delta = chunk.choices[0].delta
 
+                if delta is None:
+                    continue
+                
                 if delta.tool_calls:
                     _tool_call = delta.tool_calls[0]
                     tool_call = FunctionCall(


### PR DESCRIPTION
## Changes
Check if choice.delta is None and skip iteration if it is.

## Why
While streaming long responses using Azure OpenAI model we sometimes get the following exception:
Error during stream iteration: 'NoneType' object has no attribute 'tool_calls'

Example chunk that is causing the issue:
ChatCompletionChunk(id='', choices=[Choice(delta=None, finish_reason=None, index=0, logprobs=None, content_filter_offsets={'check_offset': 167461, 'start_offset': 167461, 'end_offset': 168455}, content_filter_results={'hate': {'filtered': False, 'severity': 'safe'}, 'self_harm': {'filtered': False, 'severity': 'safe'}, 'sexual': {'filtered': False, 'severity': 'safe'}, 'violence': {'filtered': False, 'severity': 'safe'}})], created=0, model='', object='', service_tier=None, system_fingerprint=None, usage=None)

