### PR TITLE
fix: restore websites tab visibility in personal space

### DIFF
--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/+page.svelte
@@ -116,7 +116,7 @@
       {#if userCanSeeCollections}
         <Page.TabTrigger tab="collections">{m.collections()}</Page.TabTrigger>
       {/if}
-      {#if userCanSeeWebsites && !isPersonalSpace}
+      {#if userCanSeeWebsites}
         <Page.TabTrigger tab="websites">{m.websites()}</Page.TabTrigger>
       {/if}
       {#if userCanSeeIntegrations}


### PR DESCRIPTION
**Summary:**
- File: frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/+page.svelte
- Line 119: Changed {#if userCanSeeWebsites && !isPersonalSpace} → {#if userCanSeeWebsites}
- Impact: Users with the "website" read permission can now see the Websites tab in personal spaces
- No other functionality broken: The isPersonalSpace variable is still used for integrations logic (line 95),
so that behavior remains unchanged