### PR TITLE
fix: make feature flag disable_tenant idempotent to prevent 500 error

### DIFF
--- a/backend/src/intric/feature_flag/feature_flag.py
+++ b/backend/src/intric/feature_flag/feature_flag.py
@@ -23,7 +23,9 @@ class FeatureFlag:
         return enabled
 
     def disable_tenant(self, tenant_id: UUID) -> None:
-        self.tenant_ids.remove(tenant_id)
+        # Use discard() instead of remove() to make this operation idempotent
+        # remove() raises KeyError if tenant not in set, discard() is safe
+        self.tenant_ids.discard(tenant_id)
 
     def enable_tenant(self, tenant_id: UUID) -> None:
         self.tenant_ids.add(tenant_id)

--- a/backend/tests/unittests/feature_flag/test_feature_flag.py
+++ b/backend/tests/unittests/feature_flag/test_feature_flag.py
@@ -17,3 +17,33 @@ async def test_feature_update_tenant(feature_flag: FeatureFlag):
 
     feature_flag.disable_tenant(tenant_id=tenant_id)
     assert tenant_id not in feature_flag.tenant_ids
+
+
+async def test_disable_tenant_is_idempotent(feature_flag: FeatureFlag):
+    """Test that disabling a tenant that was never enabled doesn't raise an error.
+
+    This is a regression test for the 500 error when toggling templates off
+    for a tenant that never had them enabled.
+    """
+    tenant_id = "never-enabled-tenant"
+
+    # Tenant was never enabled - this should NOT raise KeyError
+    feature_flag.disable_tenant(tenant_id=tenant_id)
+    assert tenant_id not in feature_flag.tenant_ids
+
+    # Calling disable again should also be safe (idempotent)
+    feature_flag.disable_tenant(tenant_id=tenant_id)
+    assert tenant_id not in feature_flag.tenant_ids
+
+
+async def test_enable_tenant_is_idempotent(feature_flag: FeatureFlag):
+    """Test that enabling a tenant multiple times is safe."""
+    tenant_id = "test-tenant"
+
+    feature_flag.enable_tenant(tenant_id=tenant_id)
+    assert tenant_id in feature_flag.tenant_ids
+
+    # Enabling again should be safe (idempotent)
+    feature_flag.enable_tenant(tenant_id=tenant_id)
+    assert tenant_id in feature_flag.tenant_ids
+    assert len(feature_flag.tenant_ids) == 1  # Still only one entry


### PR DESCRIPTION
## Changes

- Changed `set.remove()` to `set.discard()` in `FeatureFlag.disable_tenant()` method
- Added regression tests for idempotent enable/disable operations

## Why

When toggling templates OFF in the admin panel for a tenant that never had templates enabled, the system
returned a 500 Internal Server Error.

Root cause: `set.remove(tenant_id)` raises `KeyError` if the tenant_id doesn't exist in the set. Using
`set.discard()` is the idempotent alternative that safely handles this case.

This affects all users on the latest version who try to toggle templates when they were never enabled, or
toggle off twice in a row.

## Testing

- Added `test_disable_tenant_is_idempotent` - verifies disabling a never-enabled tenant doesn't crash
- Added `test_enable_tenant_is_idempotent` - verifies enabling twice is safe

```bash
python -m pytest tests/unittests/feature_flag/test_feature_flag.py -v

Screenshots

N/A - Backend fix only
```