### PR TITLE
docs: add healthchecks and troubleshooting to deployment config

### DIFF
--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -47,8 +47,42 @@ cp env_db.template env_db.env
 docker network create proxy_tier
 docker compose up -d
 
-# 7. Login with DEFAULT_USER_EMAIL / DEFAULT_USER_PASSWORD (change password immediately!)
+# 7. Verify db-init completed successfully (wait ~30 seconds for startup)
+docker logs eneo_db_init
+# Should see: "Great! Your Tenant and User are all set up."
+
+# 8. Login with DEFAULT_USER_EMAIL / DEFAULT_USER_PASSWORD (change password immediately!)
 ```
+
+## Troubleshooting
+
+### Can't login with default credentials (401 error)
+
+1. **Check if db-init succeeded:**
+   ```bash
+   docker logs eneo_db_init
+   ```
+   You should see `"Great! Your Tenant and User are all set up."`
+
+2. **Check if user exists in database:**
+   ```bash
+   docker exec -it eneo_db psql -U postgres -d eneo -c "SELECT email, state FROM users;"
+   ```
+
+3. **If user doesn't exist**, the db-init likely failed. Reset and try again:
+   ```bash
+   docker compose down -v
+   docker compose up -d
+   sleep 30
+   docker logs eneo_db_init
+   ```
+
+### db-init fails with migration errors
+
+This usually means db-init started before PostgreSQL was ready. The docker-compose.yml includes healthchecks to prevent this, but if you're using a custom configuration, ensure:
+
+- `db` service has a healthcheck
+- `db-init` depends on `db` with `condition: service_healthy`
 
 ## Full Documentation
 

--- a/docs/deployment/docker-compose.yml
+++ b/docs/deployment/docker-compose.yml
@@ -13,6 +13,12 @@
 #   This is a reference configuration. Customize for your organization's
 #   security requirements, network topology, and infrastructure needs.
 #
+# STARTUP ORDER (handled automatically via healthchecks):
+#   1. db + redis start and become healthy
+#   2. db-init runs migrations and creates default user
+#   3. backend + worker start (only after db-init succeeds)
+#   4. frontend starts
+#
 # VOLUME MANAGEMENT:
 #   The "name: eneo" ensures consistent volume names (eneo_postgres_data, etc.)
 #   regardless of which directory you run commands from.
@@ -42,7 +48,7 @@ services:
       - "443:443"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
-      - "letsencrypt:/letsencrypt"
+      - "traefik_letsencrypt:/letsencrypt"
     networks:
       - proxy_tier
     labels:
@@ -99,9 +105,12 @@ services:
       - "traefik.http.services.eneo-backend-svc.loadbalancer.server.port=8000"
       - "traefik.http.routers.eneo-backend-secure.priority=10"
     depends_on:
-      - db
-      - redis
-      - db-init
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      db-init:
+        condition: service_completed_successfully
 
   worker:
     # Background task processor (crawls, uploads, integrations)
@@ -129,20 +138,32 @@ services:
     env_file:
       - env_db.env
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - eneo_postgres_data:/var/lib/postgresql/data
     networks:
       - proxy_tier
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:7-alpine
     container_name: eneo_redis
     restart: unless-stopped
     volumes:
-      - redis_data:/data
+      - eneo_redis_data:/data
     networks:
       - proxy_tier
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   db-init:
+    # Runs database migrations and creates default tenant/user on first startup
+    # Only runs once - exits after completion (restart: "no")
     image: ghcr.io/eneo-ai/eneo-backend:latest
     container_name: eneo_db_init
     command: ["python", "init_db.py"]
@@ -151,7 +172,11 @@ services:
     networks:
       - proxy_tier
     depends_on:
-      - db
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: "no"
 
 networks:
   proxy_tier:


### PR DESCRIPTION
- Add healthchecks to db and redis services to ensure readiness
- Update db-init to wait for service_healthy condition
- Update backend to wait for db-init service_completed_successfully
- Fix volume name mismatches (postgres_data -> eneo_postgres_data, etc.)
- Add startup order documentation in docker-compose header
- Add troubleshooting section to README for common issues (401 errors)
- Add step to verify db-init logs after deployment

This prevents race conditions where db-init runs before PostgreSQL is ready to accept connections, which caused migration failures and missing default users.