### PR TITLE
fix: remove expired Yarn repository in devcontainer setup

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -18,6 +18,8 @@ if [ -e /var/run/docker.sock ]; then
 fi
 
 # Install system dependencies
+# Remove expired Yarn repository (not needed - we use Bun)
+sudo rm -f /etc/apt/sources.list.d/yarn.list
 sudo apt-get update
 sudo apt-get install -y libmagic1 ffmpeg
 


### PR DESCRIPTION
## Changes
Remove the expired Yarn repository before running apt-get update in the devcontainer post-create script.

## Why
The Yarn classic repository's GPG signing key has expired, causing apt-get update to fail and blocking devcontainer setup. We don't use Yarn (we use Bun), so removing the repo is safe.
