### PR TITLE
fix: improve job manager display with overflow scroll and better job …

### DIFF
--- a/backend/src/intric/websites/domain/crawl_service.py
+++ b/backend/src/intric/websites/domain/crawl_service.py
@@ -320,7 +320,7 @@ class CrawlService:
             # Optimistic Acquire Pattern
             # Step 1: Create job record WITHOUT enqueueing to ARQ
             crawl_job = await self.task_service.queue_crawl(
-                name=website.name,
+                name=website.name or website.url,
                 run_id=crawl_run.id,
                 website_id=website.id,
                 url=website.url,
@@ -398,7 +398,7 @@ class CrawlService:
         else:
             # Feeder disabled: Original direct enqueue behavior
             crawl_job = await self.task_service.queue_crawl(
-                name=website.name,
+                name=website.name or website.url,
                 run_id=crawl_run.id,
                 website_id=website.id,
                 url=website.url,

--- a/backend/src/intric/worker/crawl_tasks.py
+++ b/backend/src/intric/worker/crawl_tasks.py
@@ -203,7 +203,7 @@ async def queue_website_crawls(container: Container):
                         )
                         job = Job(
                             task=Task.CRAWL,
-                            name=f"Crawl: {website.name}",
+                            name=f"Crawl: {website.name or website.url}",
                             status=Status.QUEUED,
                             user_id=website.user_id,
                         )

--- a/frontend/apps/web/src/lib/features/jobs/components/JobListView.svelte
+++ b/frontend/apps/web/src/lib/features/jobs/components/JobListView.svelte
@@ -18,7 +18,7 @@
         <div
           class="border-dimmer flex items-center justify-between gap-x-3 border-b px-2 py-1.5 whitespace-nowrap last-of-type:border-b-0"
         >
-          <div class="flex-shrink truncate pr-4">
+          <div class="flex-shrink truncate pr-4" title={job.name ?? job.id}>
             {prefix ? prefix + " " : ""}{job.name ?? job.id}
           </div>
           {#if job.status === "in progress" || job.status === "queued"}

--- a/frontend/apps/web/src/lib/features/jobs/components/JobManagerDropdownButton.svelte
+++ b/frontend/apps/web/src/lib/features/jobs/components/JobManagerDropdownButton.svelte
@@ -54,7 +54,7 @@
     use:menu
     in:fly={{ y: -15, duration: 100 }}
     out:fly={{ y: -5, duration: 200 }}
-    class="items border-strongest bg-primary absolute z-[50] flex min-w-[22rem] -translate-y-[0.75rem] flex-col rounded-sm border-b p-3 shadow-md"
+    class="items border-strongest bg-primary absolute z-[50] flex max-h-[70vh] min-w-[22rem] -translate-y-[0.75rem] flex-col overflow-y-auto rounded-sm border-b p-3 shadow-md"
   >
     <p
       class="border-default text-secondary mb-2 border-b px-6 pt-1 pb-2.5 font-mono text-[0.85rem] font-medium tracking-[0.015rem]"


### PR DESCRIPTION
  - Use website URL as fallback when name is None for crawl jobs
  - Limit failed jobs display to last 24h instead of 1 week
  - Add max-height and scroll to job dropdown panel
  - Add title attribute for tooltip on truncated job names

## Changes
<!-- What did you change? -->

## Why
<!-- Why was this needed? -->

## Testing
<!-- How did you test this? -->

## Screenshots
<!-- If UI changes, add before/after -->

