### PR TITLE
fix: resolve OpenAPI schema issues for Java code generation

### DIFF
--- a/backend/src/intric/services/service.py
+++ b/backend/src/intric/services/service.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Any, Literal, Optional
 from uuid import UUID
 
 from pydantic import (
@@ -106,7 +106,7 @@ class RunService(BaseModel):
 
 
 class ServiceOutput(BaseModel):
-    output: dict | list | str | bool
+    output: Any
     files: list[FilePublic] = []
 
 

--- a/backend/src/intric/tenants/tenant.py
+++ b/backend/src/intric/tenants/tenant.py
@@ -23,7 +23,9 @@ class TenantBase(BaseModel):
     name: str
     display_name: Optional[str] = None
     quota_limit: int = Field(
-        default=10 * 1024**3, description="Size in bytes. Default is 10 GB"
+        default=10 * 1024**3,
+        description="Size in bytes. Default is 10 GB",
+        json_schema_extra={"format": "int64"},
     )
     domain: Optional[str] = None
     zitadel_org_id: Optional[str] = None


### PR DESCRIPTION
## Summary

- Add `int64` format to `quota_limit` field to prevent integer overflow in Java (10GB default value `10737418240` exceeds Java `int` max of `2147483647`)
- Change `ServiceOutput.output` from union type (`dict | list | str | bool`) to `Any` to avoid empty class generation (Java doesn't support `anyOf` unions natively)

## Root Cause

1. **Integer overflow**: The `quota_limit` field defaults to 10GB in bytes (`10 * 1024³`), which is larger than Java's 32-bit `int` max. Without `format: int64` in OpenAPI, Java generators use `int` instead of `long`.

2. **Empty class**: Python union types generate `anyOf` in OpenAPI. Java code generators create empty/unusable classes for `anyOf` since Java lacks native union types.

## Test plan

- [ ] Regenerate OpenAPI spec
- [ ] Verify `quota_limit` has `format: int64` in generated spec
- [ ] Verify `ServiceOutput.output` no longer has `anyOf`
- [ ] Java team regenerates code and compiles successfully