### PR TITLE
feat: show crawl failure warnings in knowledge source picker

### DIFF
--- a/backend/alembic/versions/2fb2e2b2609a_merge_migration_heads.py
+++ b/backend/alembic/versions/2fb2e2b2609a_merge_migration_heads.py
@@ -1,0 +1,19 @@
+"""merge migration heads
+Revision ID: 2fb2e2b2609a
+Revises: 0f433b5c24c3, e7354c72805b
+Create Date: 2026-01-29 19:44:52.547790
+"""
+
+
+
+# revision identifiers, used by Alembic
+revision = '2fb2e2b2609a'
+down_revision = ('0f433b5c24c3', 'e7354c72805b')
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    pass
+
+def downgrade() -> None:
+    pass

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -119,6 +119,8 @@
   "capabilities": "Capabilities",
   "cards": "Cards",
   "knowledge": "Knowledge",
+  "noPagesFound": "No pages found",
+  "pageCount": "{count} pages",
   "collections": "Collections",
   "websites": "Websites",
   "integrations": "Integrations",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -119,6 +119,8 @@
   "capabilities": "Kapaciteter",
   "cards": "Kort",
   "knowledge": "Kunskap",
+  "noPagesFound": "Inga sidor hittades",
+  "pageCount": "{count} sidor",
   "collections": "Samlingar",
   "websites": "Webbplatser",
   "integrations": "Integrationer",

--- a/frontend/apps/web/src/lib/features/knowledge/components/SelectKnowledgeV2.svelte
+++ b/frontend/apps/web/src/lib/features/knowledge/components/SelectKnowledgeV2.svelte
@@ -438,8 +438,10 @@
       {@const totalPages = getTotalPages(allBlobs)}
       {@const currentPage = currentPages.get(website.id) || 1}
       {@const pagesCrawled = website.latest_crawl?.pages_crawled}
+      {@const pagesFailed = website.latest_crawl?.pages_failed ?? 0}
+      {@const hasFailures = pagesFailed > 0}
       <div class="knowledge-item-container">
-        <div class="knowledge-item">
+        <div class="knowledge-item" class:knowledge-item-warning={hasFailures}>
           {#if pagesCrawled && pagesCrawled > 0}
             <button
               class="expand-button"
@@ -464,9 +466,14 @@
           </button>
           {#if !isItemModelEnabled}<span>(model disabled)</span>{/if}
           <div class="flex-grow"></div>
+          {#if hasFailures}
+            <span class="rounded-full border px-3 py-1 text-sm border-orange-300 bg-orange-50 text-orange-700 dark:border-orange-600 dark:bg-orange-950 dark:text-orange-300">
+              {m.pages_failed({ count: pagesFailed })}
+            </span>
+          {/if}
           {#if pagesCrawled && pagesCrawled > 0}
             <span class="label-blue border-label-default bg-label-dimmer text-label-stronger rounded-full border px-3 py-1 text-sm">
-              {pagesCrawled} {pagesCrawled === 1 ? 'page' : 'pages'}
+              {m.pageCount({ count: pagesCrawled })}
             </span>
           {/if}
           <Button variant="destructive" padding="icon" on:click={() => {
@@ -512,7 +519,7 @@
                 </div>
               {/if}
             {:else}
-              <div class="blob-item text-muted">No pages found</div>
+              <div class="blob-item text-muted">{m.noPagesFound()}</div>
             {/if}
           </div>
         {/if}
@@ -645,8 +652,10 @@
       {@const totalPages = getTotalPages(allBlobs)}
       {@const currentPage = currentPages.get(website.id) || 1}
       {@const pagesCrawled = website.latest_crawl?.pages_crawled}
+      {@const pagesFailed = website.latest_crawl?.pages_failed ?? 0}
+      {@const hasFailures = pagesFailed > 0}
       <div class="knowledge-item-container">
-        <div class="knowledge-item">
+        <div class="knowledge-item" class:knowledge-item-warning={hasFailures}>
           {#if pagesCrawled && pagesCrawled > 0}
             <button
               class="expand-button"
@@ -671,9 +680,14 @@
           </button>
           {#if !isItemModelEnabled}<span>(model disabled)</span>{/if}
           <div class="flex-grow"></div>
+          {#if hasFailures}
+            <span class="rounded-full border px-3 py-1 text-sm border-orange-300 bg-orange-50 text-orange-700 dark:border-orange-600 dark:bg-orange-950 dark:text-orange-300">
+              {m.pages_failed({ count: pagesFailed })}
+            </span>
+          {/if}
           {#if pagesCrawled && pagesCrawled > 0}
             <span class="label-blue border-label-default bg-label-dimmer text-label-stronger rounded-full border px-3 py-1 text-sm">
-              {pagesCrawled} {pagesCrawled === 1 ? 'page' : 'pages'}
+              {m.pageCount({ count: pagesCrawled })}
             </span>
           {/if}
           <Button variant="destructive" padding="icon" on:click={() => {
@@ -719,7 +733,7 @@
                 </div>
               {/if}
             {:else}
-              <div class="blob-item text-muted">No pages found</div>
+              <div class="blob-item text-muted">{m.noPagesFound()}</div>
             {/if}
           </div>
         {/if}
@@ -825,11 +839,17 @@
               {/each}
 
               {#each section.websites as website (`website:${website.id}`)}
-                <div class="knowledge-item cursor-pointer" {...$optionPersonal({ value: { website } })} use:optionPersonal>
+                {@const wPagesFailed = website.latest_crawl?.pages_failed ?? 0}
+                <div class="knowledge-item cursor-pointer" class:knowledge-item-warning={wPagesFailed > 0} {...$optionPersonal({ value: { website } })} use:optionPersonal>
                   <div class="flex max-w-full flex-grow items-center gap-3">
                     <IconWeb />
                     <span class="truncate">{formatWebsiteName(website)}</span>
                   </div>
+                  {#if wPagesFailed > 0}
+                    <span class="rounded-full border px-3 py-1 text-sm border-orange-300 bg-orange-50 text-orange-700 dark:border-orange-600 dark:bg-orange-950 dark:text-orange-300">
+                      {m.pages_failed({ count: wPagesFailed })}
+                    </span>
+                  {/if}
                 </div>
               {/each}
 
@@ -928,11 +948,17 @@
               {/each}
 
               {#each section.websites as website (`website:${website.id}`)}
-                <div class="knowledge-item cursor-pointer" {...$optionOrg({ value: { website } })} use:optionOrg>
+                {@const wPagesFailed = website.latest_crawl?.pages_failed ?? 0}
+                <div class="knowledge-item cursor-pointer" class:knowledge-item-warning={wPagesFailed > 0} {...$optionOrg({ value: { website } })} use:optionOrg>
                   <div class="flex max-w-full flex-grow items-center gap-3">
                     <IconWeb />
                     <span class="truncate">{formatWebsiteName(website)}</span>
                   </div>
+                  {#if wPagesFailed > 0}
+                    <span class="rounded-full border px-3 py-1 text-sm border-orange-300 bg-orange-50 text-orange-700 dark:border-orange-600 dark:bg-orange-950 dark:text-orange-300">
+                      {m.pages_failed({ count: wPagesFailed })}
+                    </span>
+                  {/if}
                 </div>
               {/each}
 
@@ -966,6 +992,10 @@
 
   .knowledge-item {
     @apply border-default bg-primary hover:bg-hover-dimmer flex h-16 w-full items-center gap-2 border-b px-4;
+  }
+
+  .knowledge-item-warning {
+    @apply bg-orange-50 dark:bg-orange-950/30;
   }
 
   div[data-highlighted] {


### PR DESCRIPTION
  - Add orange warning badge and row highlight when website pages fail
  - Translate hardcoded "page/pages" text using i18n (en/sv)
  - Add "No pages found" i18n translation
  - Merge alembic migration heads
