### PR TITLE
feat: add Klang.ai and OpenRouter providers, expose API port 8123

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     command: sleep infinity
     networks:
       - eneo
+    ports:
+      - "8123:8123"
     environment:
       - POSTGRES_HOST=db
       - REDIS_HOST=redis

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -206,6 +206,17 @@ BERGET_API_BASE=
 GDM_API_KEY=
 # GDM_API_BASE=https://ai.gdm.se/api/v1  # Optional: Override default base URL
 
+# Klang.ai (Swedish AI provider)
+# Get from: https://klang.ai/
+KLANG_API_KEY=
+KLANG_API_SECRET=
+# KLANG_API_BASE=https://api.klang.ai/api/v1  # Optional: Override default base URL
+
+# OpenRouter (Multi-provider aggregator)
+# Get from: https://openrouter.ai/
+OPENROUTER_API_KEY=
+# OPENROUTER_API_BASE=https://openrouter.ai/api/v1  # Optional: Override default base URL
+
 # Flux (Image generation)
 FLUX_API_KEY=
 

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -22,4 +22,4 @@ fi
 
 echo "Starting Eneo backend with $workers workers"
 
-exec gunicorn src.intric.server.main:app --workers $workers --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000
+exec gunicorn src.intric.server.main:app --workers $workers --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000 --bind 0.0.0.0:8123

--- a/backend/src/intric/ai_models/litellm_providers/klang_provider.py
+++ b/backend/src/intric/ai_models/litellm_providers/klang_provider.py
@@ -1,0 +1,54 @@
+import os
+from typing import Dict, Any
+
+from .base_provider import BaseLiteLLMProvider
+
+
+class KlangProvider(BaseLiteLLMProvider):
+    """
+    Configuration for Klang.ai OpenAI-compatible API.
+    Klang.ai uses custom headers for authentication:
+    - X-KLANG-API-KEY
+    - X-KLANG-API-SECRET
+    """
+
+    def get_model_prefix(self) -> str:
+        return "klang/"
+
+    def get_litellm_model(self, model_name: str) -> str:
+        """Convert klang/model to openai/model for LiteLLM routing"""
+        if model_name.startswith(self.get_model_prefix()):
+            # Strip 'klang/' and add 'openai/' for LiteLLM routing
+            actual_model = model_name.replace(self.get_model_prefix(), "")
+            return f"openai/{actual_model}"
+        return f"openai/{model_name}"
+
+    def get_api_config(self) -> Dict[str, Any]:
+        """Return Klang API configuration with custom headers"""
+        api_key = os.getenv("KLANG_API_KEY")
+        api_secret = os.getenv("KLANG_API_SECRET")
+        api_base = os.getenv("KLANG_API_BASE", "https://api.klang.ai/api/v1")
+
+        config = {}
+
+        # Klang requires custom headers instead of Authorization: Bearer
+        if api_key and api_secret:
+            config["extra_headers"] = {
+                "X-KLANG-API-KEY": api_key,
+                "X-KLANG-API-SECRET": api_secret,
+            }
+            # Use a dummy api_key since LiteLLM requires one
+            config["api_key"] = "klang-auth-via-headers"
+
+        if api_base:
+            config["api_base"] = api_base
+
+        return config
+
+    def get_env_vars(self) -> Dict[str, str]:
+        """Return required environment variable names"""
+        return {
+            "api_key": "KLANG_API_KEY",
+            "api_secret": "KLANG_API_SECRET",
+            "api_base": "KLANG_API_BASE",
+        }

--- a/backend/src/intric/ai_models/litellm_providers/openrouter_provider.py
+++ b/backend/src/intric/ai_models/litellm_providers/openrouter_provider.py
@@ -1,0 +1,43 @@
+import os
+from typing import Dict, Any
+
+from .base_provider import BaseLiteLLMProvider
+
+
+class OpenRouterProvider(BaseLiteLLMProvider):
+    """
+    Configuration for OpenRouter API.
+    OpenRouter provides access to multiple LLM providers through a single API.
+    Uses standard OpenAI-compatible endpoints.
+    """
+
+    def get_model_prefix(self) -> str:
+        return "openrouter/"
+
+    def get_litellm_model(self, model_name: str) -> str:
+        """Convert openrouter/model to openai/model for LiteLLM routing"""
+        if model_name.startswith(self.get_model_prefix()):
+            # Strip 'openrouter/' and add 'openai/' for LiteLLM routing
+            actual_model = model_name.replace(self.get_model_prefix(), "")
+            return f"openai/{actual_model}"
+        return f"openai/{model_name}"
+
+    def get_api_config(self) -> Dict[str, Any]:
+        """Return OpenRouter API configuration"""
+        api_key = os.getenv("OPENROUTER_API_KEY")
+        api_base = os.getenv("OPENROUTER_API_BASE", "https://openrouter.ai/api/v1")
+
+        config = {}
+        if api_key:
+            config["api_key"] = api_key
+        if api_base:
+            config["api_base"] = api_base
+
+        return config
+
+    def get_env_vars(self) -> Dict[str, str]:
+        """Return required environment variable names"""
+        return {
+            "api_key": "OPENROUTER_API_KEY",
+            "api_base": "OPENROUTER_API_BASE",
+        }

--- a/backend/src/intric/ai_models/litellm_providers/provider_registry.py
+++ b/backend/src/intric/ai_models/litellm_providers/provider_registry.py
@@ -3,6 +3,8 @@ from typing import Optional
 from .base_provider import BaseLiteLLMProvider
 from .berget_provider import BergetProvider
 from .gdm_provider import GDMProvider
+from .klang_provider import KlangProvider
+from .openrouter_provider import OpenRouterProvider
 
 
 class LiteLLMProviderRegistry:
@@ -58,6 +60,14 @@ class LiteLLMProviderRegistry:
         # Check for GDM models by litellm_model_name prefix
         if litellm_model_name and litellm_model_name.startswith("gdm/"):
             return GDMProvider()
+
+        # Check for Klang models by litellm_model_name prefix
+        if litellm_model_name and litellm_model_name.startswith("klang/"):
+            return KlangProvider()
+
+        # Check for OpenRouter models by litellm_model_name prefix
+        if litellm_model_name and litellm_model_name.startswith("openrouter/"):
+            return OpenRouterProvider()
 
         # Default provider for standard LiteLLM-supported providers
         return cls._default_provider

--- a/backend/src/intric/main/config.py
+++ b/backend/src/intric/main/config.py
@@ -127,6 +127,9 @@ class Settings(BaseSettings):
     vllm_api_key: Optional[str] = None
     berget_api_key: Optional[str] = None
     gdm_api_key: Optional[str] = None
+    klang_api_key: Optional[str] = None
+    klang_api_secret: Optional[str] = None
+    openrouter_api_key: Optional[str] = None
     intric_marketplace_api_key: Optional[str] = None
     intric_marketplace_url: Optional[str] = None
     intric_super_api_key: Optional[str] = None

--- a/backend/src/intric/server/dependencies/ai_models.yml
+++ b/backend/src/intric/server/dependencies/ai_models.yml
@@ -393,6 +393,60 @@ completion_models:
     org: Google
     vision: false
 
+  # Klang.ai - Swedish AI provider
+  - name: 'mistral-small-3.2-24b-instruct-2506'
+    nickname: 'Mistral Small (Klang)'
+    family: 'openai'
+    token_limit: 32000
+    stability: 'stable'
+    is_deprecated: false
+    hosting: 'swe'
+    litellm_model_name: 'klang/mistral-small-3.2-24b-instruct-2506'
+    description: Mistral Small 24B instruction-tuned model, hosted by Klang.ai in Sweden.
+    org: Klang
+    vision: false
+    reasoning: false
+
+  # OpenRouter - Multi-provider aggregator
+  - name: 'anthropic/claude-3.5-sonnet'
+    nickname: 'Claude 3.5 Sonnet (OpenRouter)'
+    family: 'openai'
+    token_limit: 200000
+    stability: 'stable'
+    is_deprecated: false
+    hosting: 'usa'
+    litellm_model_name: 'openrouter/anthropic/claude-3.5-sonnet'
+    description: Anthropic's Claude 3.5 Sonnet via OpenRouter.
+    org: OpenRouter
+    vision: true
+    reasoning: false
+
+  - name: 'google/gemini-2.0-flash-001'
+    nickname: 'Gemini 2.0 Flash (OpenRouter)'
+    family: 'openai'
+    token_limit: 1000000
+    stability: 'stable'
+    is_deprecated: false
+    hosting: 'usa'
+    litellm_model_name: 'openrouter/google/gemini-2.0-flash-001'
+    description: Google's Gemini 2.0 Flash via OpenRouter.
+    org: OpenRouter
+    vision: true
+    reasoning: false
+
+  - name: 'deepseek/deepseek-r1'
+    nickname: 'DeepSeek R1 (OpenRouter)'
+    family: 'openai'
+    token_limit: 64000
+    stability: 'stable'
+    is_deprecated: false
+    hosting: 'usa'
+    litellm_model_name: 'openrouter/deepseek/deepseek-r1'
+    description: DeepSeek R1 reasoning model via OpenRouter.
+    org: OpenRouter
+    vision: false
+    reasoning: true
+
 
 embedding_models:
   # ⚠️ CRITICAL: Embedding models have NO 'nickname' field!

--- a/docs/deployment/nas/docker-compose.yml
+++ b/docs/deployment/nas/docker-compose.yml
@@ -1,0 +1,105 @@
+# ============================================================================
+# ENEO SYNOLOGY NAS DEPLOYMENT - Docker Compose Configuration
+# ============================================================================
+# Simplified stack for Synology NAS with external SSL handling
+# SSL is managed by Synology's built-in reverse proxy
+#
+# Configure Synology Reverse Proxy:
+#   - eneo.neomeda.se → localhost:3000 (frontend)
+#   - eneo.neomeda.se/api/* → localhost:8000 (backend)
+#   - eneo.neomeda.se/docs → localhost:8000 (backend)
+#   - eneo.neomeda.se/openapi.json → localhost:8000 (backend)
+#   - eneo.neomeda.se/version → localhost:8000 (backend)
+# ============================================================================
+
+name: eneo
+
+services:
+  frontend:
+    image: ghcr.io/eneo-ai/eneo-frontend:latest
+    container_name: eneo_frontend
+    restart: unless-stopped
+    ports:
+      - "3002:3000"
+    env_file:
+      - env_frontend.env
+    networks:
+      - eneo_network
+    depends_on:
+      - backend
+
+  backend:
+    image: ghcr.io/eneo-ai/eneo-backend:latest
+    container_name: eneo_backend
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+      - "8123:8123"
+    env_file:
+      - env_backend.env
+    volumes:
+      - backend_data:/app/data
+      - temp_files:/tmp
+    networks:
+      - eneo_network
+    depends_on:
+      - db
+      - redis
+      - db-init
+
+  worker:
+    image: ghcr.io/eneo-ai/eneo-backend:latest
+    container_name: eneo_worker
+    restart: unless-stopped
+    environment:
+      - RUN_AS_WORKER=true
+    env_file:
+      - env_backend.env
+    volumes:
+      - backend_data:/app/data
+      - temp_files:/tmp
+    networks:
+      - eneo_network
+    depends_on:
+      - backend
+
+  db:
+    image: pgvector/pgvector:pg16
+    container_name: eneo_db
+    restart: unless-stopped
+    env_file:
+      - env_db.env
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - eneo_network
+
+  redis:
+    image: redis:7-alpine
+    container_name: eneo_redis
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+    networks:
+      - eneo_network
+
+  db-init:
+    image: ghcr.io/eneo-ai/eneo-backend:latest
+    container_name: eneo_db_init
+    command: ["python", "init_db.py"]
+    env_file:
+      - env_backend.env
+    networks:
+      - eneo_network
+    depends_on:
+      - db
+
+networks:
+  eneo_network:
+    driver: bridge
+
+volumes:
+  postgres_data:
+  redis_data:
+  backend_data:
+  temp_files:


### PR DESCRIPTION
- Add Klang.ai provider with custom header authentication (X-KLANG-API-KEY/SECRET)
- Add OpenRouter provider for multi-model aggregation
- Expose port 8123 for API access in devcontainer and NAS deployment
- Update run.sh to bind gunicorn on both 8000 and 8123
- Add new models: Mistral Small (Klang), Claude 3.5 Sonnet, Gemini 2.0 Flash, DeepSeek R1 via OpenRouter

## Changes
<!-- What did you change? -->

## Why
<!-- Why was this needed? -->

## Testing
<!-- How did you test this? -->

## Screenshots
<!-- If UI changes, add before/after -->

