### PR TITLE
feat(sharepoint): discover sites from followed sites and group memberships

### DIFF
--- a/backend/src/intric/integration/infrastructure/auth_service/sharepoint_auth_service.py
+++ b/backend/src/intric/integration/infrastructure/auth_service/sharepoint_auth_service.py
@@ -21,9 +21,7 @@ logger = getLogger(__name__)
 
 
 class SharepointAuthService(BaseOauthService):
-    # Personal OAuth: no User.Read needed (service account flow adds it
-    # separately to retrieve the account email)
-    DEFAULT_SCOPES = ["Files.Read.All", "Sites.Read.All"]
+    DEFAULT_SCOPES = ["Files.Read.All", "Sites.Read.All", "User.Read"]
 
     def __init__(self, tenant_sharepoint_app_service: Optional["TenantSharePointAppService"] = None):
         self.tenant_sharepoint_app_service = tenant_sharepoint_app_service

--- a/backend/src/intric/integration/infrastructure/preview_service/sharepoint_preview_service.py
+++ b/backend/src/intric/integration/infrastructure/preview_service/sharepoint_preview_service.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import TYPE_CHECKING, List, Optional
 
 from intric.integration.domain.entities.integration_preview import IntegrationPreview
@@ -48,13 +49,9 @@ class SharePointPreviewService(BasePreviewService):
             token_id=token.id,
             token_refresh_callback=self.token_refresh_callback,
         ) as content_client:
-            # Get SharePoint sites
-            try:
-                sites_data = await content_client.get_sites()
-                results.extend(self._to_sharepoint_preview_data(data=sites_data))
-            except Exception as e:
-                logger.error(f"Error fetching SharePoint sites: {e}")
-                raise
+            # Get SharePoint sites from all accessible sources
+            sites = await self._fetch_all_accessible_sites(content_client)
+            results.extend(sites)
 
             # Get user's OneDrive (only available with user OAuth, not tenant app)
             try:
@@ -109,20 +106,91 @@ class SharePointPreviewService(BasePreviewService):
             )
 
         # Use the token to fetch sites
-        data = {}
         async with SharePointContentClient(
             base_url="https://graph.microsoft.com",
             api_token=access_token,
             token_id=None,  # No token_id for app auth
             token_refresh_callback=None,  # No refresh callback needed for app auth
         ) as content_client:
+            if tenant_app.is_service_account():
+                # Service account (delegated auth) — combine multiple sources
+                return await self._fetch_all_accessible_sites(content_client)
+            else:
+                # Tenant app (application permissions) — search sees everything
+                try:
+                    data = await content_client.get_sites()
+                except Exception as e:
+                    logger.error(f"Error fetching SharePoint preview data with app auth: {e}")
+                    raise
+                return self._to_sharepoint_preview_data(data=data)
+
+    async def _fetch_all_accessible_sites(
+        self,
+        content_client: SharePointContentClient,
+    ) -> List[IntegrationPreview]:
+        """Fetch sites from multiple Graph API sources and deduplicate.
+
+        Combines:
+        1. sites?search=* (search-indexed sites)
+        2. me/followedSites (sites the user follows)
+        3. Group-connected sites (via me/memberOf)
+
+        Each source is best-effort — if one fails the others still return.
+        """
+
+        async def _search_sites() -> List[dict]:
             try:
                 data = await content_client.get_sites()
+                return data.get("value", [])
             except Exception as e:
-                logger.error(f"Error fetching SharePoint preview data with app auth: {e}")
-                raise
+                logger.warning("Failed to fetch search-indexed sites: %s", e)
+                return []
 
-        return self._to_sharepoint_preview_data(data=data)
+        async def _followed_sites() -> List[dict]:
+            try:
+                return await content_client.get_followed_sites()
+            except Exception as e:
+                logger.warning("Failed to fetch followed sites: %s", e)
+                return []
+
+        async def _group_sites() -> List[dict]:
+            try:
+                return await content_client.get_group_connected_sites()
+            except Exception as e:
+                logger.warning("Failed to fetch group-connected sites: %s", e)
+                return []
+
+        search_results, followed_results, group_results = await asyncio.gather(
+            _search_sites(), _followed_sites(), _group_sites()
+        )
+
+        # Deduplicate on site ID
+        seen_ids: set[str] = set()
+        unique_sites: List[IntegrationPreview] = []
+        for site in (*search_results, *followed_results, *group_results):
+            site_id = site.get("id")
+            if site_id and site_id not in seen_ids:
+                seen_ids.add(site_id)
+                unique_sites.append(
+                    IntegrationPreview(
+                        name=site.get("displayName"),
+                        key=site_id,
+                        url=site.get("webUrl"),
+                        type="site",
+                    )
+                )
+
+        logger.info(
+            "SharePoint preview site discovery completed",
+            extra={
+                "search_count": len(search_results),
+                "followed_count": len(followed_results),
+                "group_count": len(group_results),
+                "unique_count": len(unique_sites),
+            },
+        )
+
+        return unique_sites
 
     def _to_sharepoint_preview_data(
         self,

--- a/backend/tests/unittests/integration/test_sharepoint_content_client.py
+++ b/backend/tests/unittests/integration/test_sharepoint_content_client.py
@@ -1,5 +1,6 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 
 from intric.integration.infrastructure.clients.sharepoint_content_client import (
@@ -44,5 +45,123 @@ async def test_explicit_max_download_bytes_overrides_settings():
 
     try:
         assert client.max_download_bytes == 2_048
+    finally:
+        await client.client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_my_unified_groups_falls_back_to_unfiltered_lookup_on_unsupported_filter():
+    settings = MagicMock()
+    settings.sharepoint_max_download_bytes = 12_345_678
+
+    with patch(
+        "intric.integration.infrastructure.clients.sharepoint_content_client.get_settings",
+        return_value=settings,
+    ):
+        client = SharePointContentClient(
+            base_url="https://graph.microsoft.com",
+            api_token="mock-token",
+        )
+
+    try:
+        unsupported_filter_error = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=400,
+            message="Request_UnsupportedQuery",
+        )
+        client.client = AsyncMock()
+        client.client.get = AsyncMock(
+            side_effect=[
+                unsupported_filter_error,
+                {
+                    "value": [
+                        {"id": "group-1", "displayName": "Unified Group", "groupTypes": ["Unified"]},
+                        {"id": "group-2", "displayName": "Security Group", "groupTypes": []},
+                    ]
+                },
+            ]
+        )
+
+        groups = await client.get_my_unified_groups()
+
+        assert len(groups) == 1
+        assert groups[0]["id"] == "group-1"
+        assert groups[0]["displayName"] == "Unified Group"
+    finally:
+        await client.client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_group_connected_sites_is_best_effort():
+    settings = MagicMock()
+    settings.sharepoint_max_download_bytes = 12_345_678
+
+    with patch(
+        "intric.integration.infrastructure.clients.sharepoint_content_client.get_settings",
+        return_value=settings,
+    ):
+        client = SharePointContentClient(
+            base_url="https://graph.microsoft.com",
+            api_token="mock-token",
+        )
+
+    try:
+        client.get_my_unified_groups = AsyncMock(
+            return_value=[{"id": "g1"}, {"id": "g2"}, {"id": "g3"}]
+        )
+
+        async def _group_site_side_effect(group_id: str):
+            if group_id == "g2":
+                raise RuntimeError("transient error")
+            return {"id": f"site-{group_id}"}
+
+        client.get_group_site = AsyncMock(side_effect=_group_site_side_effect)
+
+        sites = await client.get_group_connected_sites(max_concurrency=2)
+
+        assert [s["id"] for s in sites] == ["site-g1", "site-g3"]
+    finally:
+        await client.client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_my_unified_groups_fallback_keeps_groups_when_group_types_missing():
+    settings = MagicMock()
+    settings.sharepoint_max_download_bytes = 12_345_678
+
+    with patch(
+        "intric.integration.infrastructure.clients.sharepoint_content_client.get_settings",
+        return_value=settings,
+    ):
+        client = SharePointContentClient(
+            base_url="https://graph.microsoft.com",
+            api_token="mock-token",
+        )
+
+    try:
+        unsupported_filter_error = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=400,
+            message="Request_UnsupportedQuery",
+        )
+        client.client = AsyncMock()
+        client.client.get = AsyncMock(
+            side_effect=[
+                unsupported_filter_error,
+                {
+                    "value": [
+                        {"id": "group-1", "displayName": "No Types"},
+                        {"id": "group-2", "displayName": "Security", "groupTypes": []},
+                    ]
+                },
+            ]
+        )
+
+        groups = await client.get_my_unified_groups()
+
+        assert len(groups) == 1
+        assert groups[0]["id"] == "group-1"
     finally:
         await client.client.close()

--- a/backend/tests/unittests/integration/test_sharepoint_preview_multi_source.py
+++ b/backend/tests/unittests/integration/test_sharepoint_preview_multi_source.py
@@ -1,0 +1,231 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from intric.integration.infrastructure.preview_service.sharepoint_preview_service import (
+    SharePointPreviewService,
+)
+
+
+def _make_site(site_id: str, name: str = "Site") -> dict:
+    return {"id": site_id, "displayName": name, "webUrl": f"https://example.com/{site_id}"}
+
+
+def _make_service(*, is_service_account: bool = False):
+    """Create a SharePointPreviewService with mocked dependencies."""
+    oauth_token_service = MagicMock()
+    tenant_app_auth_service = AsyncMock()
+    service_account_auth_service = AsyncMock()
+    tenant_sharepoint_app_repo = AsyncMock()
+
+    service = SharePointPreviewService(
+        oauth_token_service=oauth_token_service,
+        tenant_app_auth_service=tenant_app_auth_service,
+        service_account_auth_service=service_account_auth_service,
+        tenant_sharepoint_app_repo=tenant_sharepoint_app_repo,
+    )
+
+    return service
+
+
+def _make_tenant_app(*, is_service_account: bool = False):
+    app = MagicMock()
+    app.is_service_account.return_value = is_service_account
+    app.auth_method = "service_account" if is_service_account else "tenant_app"
+    app.service_account_refresh_token = "old-refresh"
+    app.id = "app-id"
+    return app
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_accessible_sites_combines_three_sources():
+    service = _make_service()
+    content_client = AsyncMock()
+
+    content_client.get_sites.return_value = {"value": [_make_site("site-1", "Search Site")]}
+    content_client.get_followed_sites.return_value = [_make_site("site-2", "Followed Site")]
+    content_client.get_group_connected_sites.return_value = [_make_site("site-3", "Group Site")]
+
+    result = await service._fetch_all_accessible_sites(content_client)
+
+    assert len(result) == 3
+    names = {s.name for s in result}
+    assert names == {"Search Site", "Followed Site", "Group Site"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_accessible_sites_deduplicates_on_id():
+    service = _make_service()
+    content_client = AsyncMock()
+
+    # Same site ID from all three sources
+    content_client.get_sites.return_value = {"value": [_make_site("site-1", "From Search")]}
+    content_client.get_followed_sites.return_value = [_make_site("site-1", "From Followed")]
+    content_client.get_group_connected_sites.return_value = [_make_site("site-1", "From Group")]
+
+    result = await service._fetch_all_accessible_sites(content_client)
+
+    assert len(result) == 1
+    # First occurrence (from search) wins
+    assert result[0].name == "From Search"
+    assert result[0].key == "site-1"
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_accessible_sites_handles_single_source_failure():
+    service = _make_service()
+    content_client = AsyncMock()
+
+    content_client.get_sites.return_value = {"value": [_make_site("site-1")]}
+    content_client.get_followed_sites.side_effect = Exception("403 Forbidden")
+    content_client.get_group_connected_sites.return_value = [_make_site("site-2")]
+
+    result = await service._fetch_all_accessible_sites(content_client)
+
+    assert len(result) == 2
+    ids = {s.key for s in result}
+    assert ids == {"site-1", "site-2"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_accessible_sites_handles_all_sources_failing():
+    service = _make_service()
+    content_client = AsyncMock()
+
+    content_client.get_sites.side_effect = Exception("Network error")
+    content_client.get_followed_sites.side_effect = Exception("Network error")
+    content_client.get_group_connected_sites.side_effect = Exception("Network error")
+
+    result = await service._fetch_all_accessible_sites(content_client)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_service_account_uses_multi_source():
+    """Service account preview should use _fetch_all_accessible_sites."""
+    service = _make_service(is_service_account=True)
+    tenant_app = _make_tenant_app(is_service_account=True)
+
+    service.service_account_auth_service.refresh_access_token.return_value = {
+        "access_token": "mock-token",
+        "refresh_token": "old-refresh",
+    }
+
+    mock_client = AsyncMock()
+    mock_client.get_sites.return_value = {"value": [_make_site("site-1")]}
+    mock_client.get_followed_sites.return_value = [_make_site("site-2")]
+    mock_client.get_group_connected_sites.return_value = []
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "intric.integration.infrastructure.preview_service.sharepoint_preview_service.SharePointContentClient",
+        return_value=mock_client,
+    ):
+        result = await service.get_preview_info_with_app(tenant_app)
+
+    assert len(result) == 2
+    # Verify multi-source methods were called
+    mock_client.get_sites.assert_called_once()
+    mock_client.get_followed_sites.assert_called_once()
+    mock_client.get_group_connected_sites.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_tenant_app_uses_only_search():
+    """Tenant app (application permissions) should only use get_sites search."""
+    service = _make_service()
+    tenant_app = _make_tenant_app(is_service_account=False)
+
+    service.tenant_app_auth_service.get_access_token.return_value = "mock-token"
+
+    mock_client = AsyncMock()
+    mock_client.get_sites.return_value = {"value": [_make_site("site-1")]}
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "intric.integration.infrastructure.preview_service.sharepoint_preview_service.SharePointContentClient",
+        return_value=mock_client,
+    ):
+        result = await service.get_preview_info_with_app(tenant_app)
+
+    assert len(result) == 1
+    # Should NOT call multi-source methods
+    mock_client.get_followed_sites.assert_not_called()
+    mock_client.get_group_connected_sites.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_group_site_returns_none_on_404():
+    """get_group_site should return None when the group has no site (404)."""
+    import aiohttp
+
+    from intric.integration.infrastructure.clients.sharepoint_content_client import (
+        SharePointContentClient,
+    )
+
+    settings = MagicMock()
+    settings.sharepoint_max_download_bytes = 50 * 1024 * 1024
+
+    with patch(
+        "intric.integration.infrastructure.clients.sharepoint_content_client.get_settings",
+        return_value=settings,
+    ):
+        client = SharePointContentClient(
+            base_url="https://graph.microsoft.com",
+            api_token="mock-token",
+        )
+
+    try:
+        error = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=404,
+            message="Not Found",
+        )
+        client.client = AsyncMock()
+        client.client.get = AsyncMock(side_effect=error)
+
+        result = await client.get_group_site("group-123")
+        assert result is None
+    finally:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_get_group_site_returns_none_on_403():
+    """get_group_site should return None when access is forbidden (403)."""
+    import aiohttp
+
+    from intric.integration.infrastructure.clients.sharepoint_content_client import (
+        SharePointContentClient,
+    )
+
+    settings = MagicMock()
+    settings.sharepoint_max_download_bytes = 50 * 1024 * 1024
+
+    with patch(
+        "intric.integration.infrastructure.clients.sharepoint_content_client.get_settings",
+        return_value=settings,
+    ):
+        client = SharePointContentClient(
+            base_url="https://graph.microsoft.com",
+            api_token="mock-token",
+        )
+
+    try:
+        error = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=403,
+            message="Forbidden",
+        )
+        client.client = AsyncMock()
+        client.client.get = AsyncMock(side_effect=error)
+
+        result = await client.get_group_site("group-456")
+        assert result is None
+    finally:
+        pass

--- a/frontend/apps/docs-site/src/content/guides/sharepoint-integration.mdx
+++ b/frontend/apps/docs-site/src/content/guides/sharepoint-integration.mdx
@@ -85,6 +85,7 @@ These permissions are used for personal spaces and the Service Account method. T
 
 - `Files.Read.All` – read files the user has access to
 - `Sites.Read.All` – read SharePoint sites
+- `User.Read` – read the user's profile and group memberships (required for discovering sites via followed sites and group connections)
 - `offline_access` – keep the session active without the user needing to log in again
 
 **Application permissions (only for Tenant App method):**


### PR DESCRIPTION
Service accounts and personal OAuth only saw search-indexed sites via sites?search=*. Combine three Graph API sources in parallel (search, me/followedSites, me/memberOf → group sites) with deduplication. Add User.Read scope for personal OAuth and update docs.
