### PR TITLE
fix: pass include_applications to service and load group_chats in spa…

### DIFF
--- a/backend/src/intric/spaces/api/space_router.py
+++ b/backend/src/intric/spaces/api/space_router.py
@@ -307,7 +307,7 @@ async def get_spaces(
     service = container.space_service()
     assembler = container.space_assembler()
 
-    spaces = await service.get_spaces(include_personal=include_personal)
+    spaces = await service.get_spaces(include_personal=include_personal, include_applications=include_applications)
     spaces = [assembler.from_space_to_sparse_model(space, include_applications=include_applications) for space in spaces]
 
     return protocol.to_paginated_response(spaces)

--- a/backend/src/intric/spaces/space_repo.py
+++ b/backend/src/intric/spaces/space_repo.py
@@ -939,13 +939,15 @@ class SpaceRepository:
             if include_applications:
                 assistants = await self._get_assistants(space_id=record.id)
                 apps = await self._get_apps(space_id=record.id)
+                group_chats = await self._get_group_chats(space_id=record.id)
             else:
                 assistants = []
                 apps = []
+                group_chats = []
 
             spaces.append(
                 self.factory.create_space_from_db(
-                    record, user=self.user, assistants_in_db=assistants, apps_in_db=apps
+                    record, user=self.user, assistants_in_db=assistants, apps_in_db=apps, group_chats_in_db=group_chats
                 )
             )
 

--- a/backend/tests/unittests/spaces/test_space_service.py
+++ b/backend/tests/unittests/spaces/test_space_service.py
@@ -139,3 +139,27 @@ async def test_get_spaces_and_personal_space_returns_personal_space_first(
     spaces = await service.get_spaces(include_personal=True)
 
     assert spaces == [personal_space] + other_spaces
+
+
+async def test_get_spaces_passes_include_applications_to_repo(
+    service: SpaceService,
+):
+    service.repo.get_spaces_for_member.return_value = []
+
+    await service.get_spaces(include_applications=True)
+
+    service.repo.get_spaces_for_member.assert_called_once_with(
+        include_applications=True
+    )
+
+
+async def test_get_spaces_defaults_include_applications_to_false(
+    service: SpaceService,
+):
+    service.repo.get_spaces_for_member.return_value = []
+
+    await service.get_spaces()
+
+    service.repo.get_spaces_for_member.assert_called_once_with(
+        include_applications=False
+    )


### PR DESCRIPTION
GET /api/v1/spaces/?include_applications=true always returned empty application lists because the router never forwarded include_applications to the service layer, causing it to default to False. Additionally, group_chats were never fetched in the repository even when include_applications was True.

- Forward include_applications from router to service.get_spaces()
- Fetch group_chats in space_repo.get_spaces_for_member() when include_applications=True
- Add unit tests for include_applications pass-through