### PR TITLE
feat: restrict integration permissions to AI Configurator and Owner

### DIFF
--- a/backend/alembic/versions/202602121000_rename_integration_permission.py
+++ b/backend/alembic/versions/202602121000_rename_integration_permission.py
@@ -1,0 +1,48 @@
+"""rename integration_knowledge_list permission to integrations
+
+Revision ID: rename_integration_perm
+Revises: add_integration_wrappers
+Create Date: 2026-02-12 10:00:00.000000
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "rename_integration_perm"
+down_revision = "add_integration_wrappers"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE roles
+        SET permissions = array_replace(permissions, 'integration_knowledge_list', 'integrations')
+        WHERE 'integration_knowledge_list' = ANY(permissions)
+        """
+    )
+    op.execute(
+        """
+        UPDATE predefined_roles
+        SET permissions = array_replace(permissions, 'integration_knowledge_list', 'integrations')
+        WHERE 'integration_knowledge_list' = ANY(permissions)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE roles
+        SET permissions = array_replace(permissions, 'integrations', 'integration_knowledge_list')
+        WHERE 'integrations' = ANY(permissions)
+        """
+    )
+    op.execute(
+        """
+        UPDATE predefined_roles
+        SET permissions = array_replace(permissions, 'integrations', 'integration_knowledge_list')
+        WHERE 'integrations' = ANY(permissions)
+        """
+    )

--- a/backend/src/intric/actors/actors/space_actor.py
+++ b/backend/src/intric/actors/actors/space_actor.py
@@ -371,7 +371,7 @@ class SpaceActor:
             SpaceResourceType.SERVICE: Permission.SERVICES,
             SpaceResourceType.COLLECTION: Permission.COLLECTIONS,
             SpaceResourceType.WEBSITE: Permission.WEBSITES,
-            SpaceResourceType.INTEGRATION_KNOWLEDGE: Permission.INTEGRATION_KNOWLEDGE_LIST,
+            SpaceResourceType.INTEGRATION_KNOWLEDGE: Permission.INTEGRATIONS,
         }
 
         return permission_map.get(resource_type)
@@ -455,7 +455,8 @@ class SpaceActor:
             permission = self._to_permisson(resource_type=resource_type)
             has_permission = permission in self.user.permissions if permission else False
             if not has_permission and not (
-                resource_type == SpaceResourceType.WEBSITE and action == SpaceAction.READ
+                resource_type in {SpaceResourceType.WEBSITE, SpaceResourceType.INTEGRATION_KNOWLEDGE}
+                and action == SpaceAction.READ
             ):
                 return False
 
@@ -736,25 +737,25 @@ class SpaceActor:
             resource_type=SpaceResourceType.WEBSITE,
         )
 
-    def can_read_integration_knowledge_list(self):
+    def can_read_integrations(self):
         return self.can_perform_action(
             action=SpaceAction.READ,
             resource_type=SpaceResourceType.INTEGRATION_KNOWLEDGE,
         )
 
-    def can_create_integration_knowledge_list(self):
+    def can_create_integrations(self):
         return self.can_perform_action(
             action=SpaceAction.CREATE,
             resource_type=SpaceResourceType.INTEGRATION_KNOWLEDGE,
         )
 
-    def can_delete_integration_knowledge_list(self):
+    def can_delete_integrations(self):
         return self.can_perform_action(
             action=SpaceAction.DELETE,
             resource_type=SpaceResourceType.INTEGRATION_KNOWLEDGE,
         )
 
-    def can_edit_integration_knowledge_list(self):
+    def can_edit_integrations(self):
         return self.can_perform_action(
             action=SpaceAction.EDIT,
             resource_type=SpaceResourceType.INTEGRATION_KNOWLEDGE,
@@ -890,10 +891,10 @@ class SpaceActor:
             can_toggle_insight=False,
         )
 
-    def get_integration_knowledge_list_permissions(self):
+    def get_integrations_permissions(self):
         return self._get_resource_permissions(
-            can_edit=self.can_edit_integration_knowledge_list(),
-            can_delete=self.can_delete_integration_knowledge_list(),
+            can_edit=self.can_edit_integrations(),
+            can_delete=self.can_delete_integrations(),
             can_publish=False,
             can_access_insight=False,
             can_toggle_insight=False,

--- a/backend/src/intric/integration/application/integration_knowledge_service.py
+++ b/backend/src/intric/integration/application/integration_knowledge_service.py
@@ -150,6 +150,11 @@ class IntegrationKnowledgeService:
         wrapper_name: str | None = None,
     ) -> tuple[IntegrationKnowledge, "JobInDb"]:
         space = await self.space_repo.one(id=space_id)
+
+        actor = self.actor_manager.get_space_actor_from_space(space)
+        if not actor.can_create_integrations():
+            raise UnauthorizedException()
+
         if not space.is_embedding_model_in_space(embedding_model_id=embedding_model_id):
             raise BadRequestException("No valid embedding model")
 
@@ -442,7 +447,7 @@ class IntegrationKnowledgeService:
 
         actor = self.actor_manager.get_space_actor_from_space(space)
 
-        if not actor.can_delete_integration_knowledge_list():
+        if not actor.can_delete_integrations():
             raise UnauthorizedException()
 
         # Check if knowledge belongs to this space
@@ -552,7 +557,7 @@ class IntegrationKnowledgeService:
         )
 
         actor = self.actor_manager.get_space_actor_from_space(space)
-        if not actor.can_edit_integration_knowledge_list():
+        if not actor.can_edit_integrations():
             raise UnauthorizedException()
 
         if knowledge.space_id != space.id:
@@ -668,7 +673,7 @@ class IntegrationKnowledgeService:
         )
         actor = self.actor_manager.get_space_actor_from_space(space)
 
-        if not actor.can_edit_integration_knowledge_list():
+        if not actor.can_edit_integrations():
             raise UnauthorizedException()
 
         # Only allow renaming from the space where knowledge was created
@@ -723,7 +728,7 @@ class IntegrationKnowledgeService:
 
         space = await self.space_repo.one(id=space_id)
         actor = self.actor_manager.get_space_actor_from_space(space)
-        if not actor.can_edit_integration_knowledge_list():
+        if not actor.can_edit_integrations():
             raise UnauthorizedException()
 
         owned_items = await self._get_owned_wrapper_knowledge(
@@ -747,7 +752,7 @@ class IntegrationKnowledgeService:
         """Delete all owned knowledge items in a wrapper."""
         space = await self.space_repo.one(id=space_id)
         actor = self.actor_manager.get_space_actor_from_space(space)
-        if not actor.can_delete_integration_knowledge_list():
+        if not actor.can_delete_integrations():
             raise UnauthorizedException()
 
         owned_items = await self._get_owned_wrapper_knowledge(

--- a/backend/src/intric/roles/permissions.py
+++ b/backend/src/intric/roles/permissions.py
@@ -22,7 +22,7 @@ class Permission(str, Enum):
     EDITOR = "editor"
     ADMIN = "admin"
     WEBSITES = "websites"
-    INTEGRATION_KNOWLEDGE_LIST = "integration_knowledge_list"
+    INTEGRATIONS = "integrations"
 
 
 def validate_permissions(permission: Permission):

--- a/backend/src/intric/roles/permissions_mapper.py
+++ b/backend/src/intric/roles/permissions_mapper.py
@@ -11,6 +11,7 @@ PERMISSIONS_WITH_DESCRIPTION = {
     Permission.COLLECTIONS: "Management of Collections. Create, Update, and Delete Collections.",
     Permission.WEBSITES: "Management of Websites. Create, Update, and Delete Websites",
     Permission.INSIGHTS: "See Insights about your Organization.",
+    Permission.INTEGRATIONS: "Management of Integrations. Create, Update, and Delete Integration Knowledge.",
     Permission.AI: "More in-depth AI configuration.",
     Permission.ADMIN: "Organization owner. Management of Users, Roles, and Groups.",
 }

--- a/backend/src/intric/server/dependencies/predefined_roles.yml
+++ b/backend/src/intric/server/dependencies/predefined_roles.yml
@@ -5,7 +5,6 @@ roles:
       - group_chats
       - apps
       - collections
-      - integration_knowledge_list
 
   - name: 'AI Configurator'
     permissions:
@@ -16,8 +15,8 @@ roles:
       - collections
       - AI
       - websites
-      - integration_knowledge_list
-  
+      - integrations
+
   - name: 'Owner'
     permissions:
       - admin
@@ -29,4 +28,4 @@ roles:
       - insights
       - AI
       - websites
-      - integration_knowledge_list
+      - integrations

--- a/backend/src/intric/spaces/api/space_assembler.py
+++ b/backend/src/intric/spaces/api/space_assembler.py
@@ -78,7 +78,7 @@ class SpaceAssembler:
             website.permissions = actor.get_website_permissions()
 
         for knowledge in space.integration_knowledge_list:
-            knowledge.permissions = actor.get_integration_knowledge_list_permissions()
+            knowledge.permissions = actor.get_integrations_permissions()
 
     def _get_assistant_permissions(self, space: Space):
         actor = self.actor_manager.get_space_actor_from_space(space=space)
@@ -156,11 +156,11 @@ class SpaceAssembler:
         actor = self.actor_manager.get_space_actor_from_space(space=space)
         permissions = []
 
-        if actor.can_read_integration_knowledge_list():
+        if actor.can_read_integrations():
             permissions.append(ResourcePermission.READ)
-        if actor.can_create_integration_knowledge_list():
+        if actor.can_create_integrations():
             permissions.append(ResourcePermission.CREATE)
-        if actor.can_delete_integration_knowledge_list():
+        if actor.can_delete_integrations():
             permissions.append(ResourcePermission.DELETE)
 
         return permissions

--- a/backend/tests/integration/test_knowledge_permissions.py
+++ b/backend/tests/integration/test_knowledge_permissions.py
@@ -41,7 +41,7 @@ def _space_from_db(db_space: Spaces) -> Space:
 class TestOrganizationKnowledgePermissions:
     """Test permissions for organization space knowledge operations."""
 
-    @pytest.mark.skip(reason="SpaceActor missing can_create_integration_knowledge method - requires implementation")
+    @pytest.mark.skip(reason="Requires database fixtures - not a unit test")
     async def test_only_org_admin_can_create_knowledge(
         self, db_container, tenant_factory, user_factory, user_integration_factory, embedding_model_factory
     ):
@@ -106,11 +106,11 @@ class TestOrganizationKnowledgePermissions:
             )
 
             # Verify permissions
-            assert admin_actor.can_create_integration_knowledge() is True
-            assert editor_actor.can_create_integration_knowledge() is False
-            assert viewer_actor.can_create_integration_knowledge() is False
+            assert admin_actor.can_create_integrations() is True
+            assert editor_actor.can_create_integrations() is False
+            assert viewer_actor.can_create_integrations() is False
 
-    @pytest.mark.skip(reason="SpaceActor missing can_delete_integration_knowledge_list method - requires implementation")
+    @pytest.mark.skip(reason="Requires database fixtures - not a unit test")
     async def test_only_org_admin_can_delete_knowledge(
         self, db_container, tenant_factory, user_factory, user_integration_factory, embedding_model_factory
     ):
@@ -175,15 +175,15 @@ class TestOrganizationKnowledgePermissions:
             )
 
             # Verify delete permissions
-            assert admin_actor.can_delete_integration_knowledge_list() is True
-            assert editor_actor.can_delete_integration_knowledge_list() is False
-            assert viewer_actor.can_delete_integration_knowledge_list() is False
+            assert admin_actor.can_delete_integrations() is True
+            assert editor_actor.can_delete_integrations() is False
+            assert viewer_actor.can_delete_integrations() is False
 
 
 class TestChildSpaceKnowledgePermissions:
     """Test permissions for distributed knowledge in child spaces."""
 
-    @pytest.mark.skip(reason="SpaceActor missing can_read_integration_knowledge_list method - requires implementation")
+    @pytest.mark.skip(reason="Requires database fixtures - not a unit test")
     async def test_viewer_can_read_distributed_knowledge(
         self, db_container, tenant_factory, user_factory, user_integration_factory, embedding_model_factory
     ):
@@ -236,7 +236,7 @@ class TestChildSpaceKnowledgePermissions:
             )
 
             # VIEWER can read knowledge
-            assert viewer_actor.can_read_integration_knowledge_list() is True
+            assert viewer_actor.can_read_integrations() is True
 
     async def test_viewer_cannot_delete_distributed_knowledge(
         self, db_container, tenant_factory, user_factory, user_integration_factory, embedding_model_factory
@@ -290,9 +290,9 @@ class TestChildSpaceKnowledgePermissions:
             )
 
             # VIEWER cannot delete
-            assert viewer_actor.can_delete_integration_knowledge_list() is False
+            assert viewer_actor.can_delete_integrations() is False
 
-    @pytest.mark.skip(reason="SpaceActor missing can_delete_integration_knowledge_list method - requires implementation")
+    @pytest.mark.skip(reason="Requires database fixtures - not a unit test")
     async def test_editor_can_delete_distributed_knowledge(
         self, db_container, tenant_factory, user_factory
     ):
@@ -345,9 +345,9 @@ class TestChildSpaceKnowledgePermissions:
             )
 
             # EDITOR can delete
-            assert editor_actor.can_delete_integration_knowledge_list() is True
+            assert editor_actor.can_delete_integrations() is True
 
-    @pytest.mark.skip(reason="SpaceActor missing can_delete_integration_knowledge_list method - requires implementation")
+    @pytest.mark.skip(reason="Requires database fixtures - not a unit test")
     async def test_admin_can_delete_distributed_knowledge(
         self, db_container, tenant_factory, user_factory
     ):
@@ -400,4 +400,4 @@ class TestChildSpaceKnowledgePermissions:
             )
 
             # ADMIN can delete
-            assert admin_actor.can_delete_integration_knowledge_list() is True
+            assert admin_actor.can_delete_integrations() is True

--- a/backend/tests/unittests/integration/application/test_integration_knowledge_service.py
+++ b/backend/tests/unittests/integration/application/test_integration_knowledge_service.py
@@ -93,7 +93,7 @@ class TestUpdateKnowledgeName:
         integration_knowledge: MagicMock,
     ):
         """Test successful rename of integration knowledge."""
-        actor.can_edit_integration_knowledge_list.return_value = True
+        actor.can_edit_integrations.return_value = True
         new_name = "New Knowledge Name"
 
         await service.update_knowledge_name(
@@ -116,7 +116,7 @@ class TestUpdateKnowledgeName:
         integration_knowledge: MagicMock,
     ):
         """Test that users without edit permission cannot rename."""
-        actor.can_edit_integration_knowledge_list.return_value = False
+        actor.can_edit_integrations.return_value = False
 
         with pytest.raises(UnauthorizedException):
             await service.update_knowledge_name(
@@ -136,7 +136,7 @@ class TestUpdateKnowledgeName:
         integration_knowledge: MagicMock,
     ):
         """Test that knowledge cannot be renamed from a different space."""
-        actor.can_edit_integration_knowledge_list.return_value = True
+        actor.can_edit_integrations.return_value = True
         # Knowledge belongs to a different space
         integration_knowledge.space_id = uuid4()
 
@@ -158,7 +158,7 @@ class TestUpdateKnowledgeName:
         integration_knowledge: MagicMock,
     ):
         """Test that renaming does not change the original_name field."""
-        actor.can_edit_integration_knowledge_list.return_value = True
+        actor.can_edit_integrations.return_value = True
         original = integration_knowledge.original_name
         new_name = "New Knowledge Name"
 
@@ -180,7 +180,7 @@ class TestUpdateKnowledgeName:
         integration_knowledge: MagicMock,
     ):
         """Test that knowledge is fetched from repo for update (to get created_at)."""
-        actor.can_edit_integration_knowledge_list.return_value = True
+        actor.can_edit_integrations.return_value = True
 
         await service.update_knowledge_name(
             space_id=integration_knowledge.space_id,
@@ -196,7 +196,7 @@ class TestUpdateKnowledgeName:
 
 class TestWrapperOperations:
     async def test_update_wrapper_name_updates_all_owned_items(self, actor, space):
-        actor.can_edit_integration_knowledge_list.return_value = True
+        actor.can_edit_integrations.return_value = True
 
         wrapper_id = uuid4()
         first = MagicMock(spec=IntegrationKnowledge)
@@ -249,7 +249,7 @@ class TestWrapperOperations:
         assert len(result) == 2
 
     async def test_remove_wrapper_knowledge_deletes_all_owned_items(self, actor, space):
-        actor.can_delete_integration_knowledge_list.return_value = True
+        actor.can_delete_integrations.return_value = True
 
         wrapper_id = uuid4()
         first = MagicMock(spec=IntegrationKnowledge)
@@ -369,7 +369,7 @@ class TestRemoveKnowledge:
         self, actor, space, sharepoint_knowledge_user_oauth
     ):
         """Test that user_oauth integration uses oauth_token_repo for token."""
-        actor.can_delete_integration_knowledge_list.return_value = True
+        actor.can_delete_integrations.return_value = True
         space.get_integration_knowledge.return_value = sharepoint_knowledge_user_oauth
         space.tenant_space_id = uuid4()  # Not an org space
 
@@ -418,7 +418,7 @@ class TestRemoveKnowledge:
         tenant_app_client_credentials,
     ):
         """Test that tenant_app integration uses tenant_app_auth_service for token."""
-        actor.can_delete_integration_knowledge_list.return_value = True
+        actor.can_delete_integrations.return_value = True
         space.get_integration_knowledge.return_value = sharepoint_knowledge_tenant_app
         space.tenant_space_id = uuid4()  # Not an org space
 
@@ -463,7 +463,7 @@ class TestRemoveKnowledge:
         self, actor, space, sharepoint_knowledge_tenant_app, tenant_app_service_account
     ):
         """Test that service account integration uses service_account_auth_service for token."""
-        actor.can_delete_integration_knowledge_list.return_value = True
+        actor.can_delete_integrations.return_value = True
         space.get_integration_knowledge.return_value = sharepoint_knowledge_tenant_app
         space.tenant_space_id = uuid4()  # Not an org space
 
@@ -521,7 +521,7 @@ class TestRemoveKnowledge:
         The subscription cleanup failure is caught and logged, but does not
         prevent the knowledge from being deleted.
         """
-        actor.can_delete_integration_knowledge_list.return_value = True
+        actor.can_delete_integrations.return_value = True
         space.get_integration_knowledge.return_value = sharepoint_knowledge_tenant_app
         space.tenant_space_id = uuid4()  # Not an org space
 
@@ -1322,7 +1322,7 @@ class TestTriggerFullSync:
     async def test_trigger_full_sync_user_oauth_queues_job(
         self, actor, space, sharepoint_knowledge_user_oauth
     ):
-        actor.can_edit_integration_knowledge_list.return_value = True
+        actor.can_edit_integrations.return_value = True
         space.get_integration_knowledge.return_value = sharepoint_knowledge_user_oauth
 
         space_repo = AsyncMock()
@@ -1391,7 +1391,7 @@ class TestTriggerFullSync:
     async def test_trigger_full_sync_continues_if_subscription_ensure_fails(
         self, actor, space, sharepoint_knowledge_user_oauth
     ):
-        actor.can_edit_integration_knowledge_list.return_value = True
+        actor.can_edit_integrations.return_value = True
         space.get_integration_knowledge.return_value = sharepoint_knowledge_user_oauth
 
         space_repo = AsyncMock()
@@ -1441,7 +1441,7 @@ class TestTriggerFullSync:
     async def test_trigger_full_sync_tenant_app_requires_admin_permission(
         self, actor, space, sharepoint_knowledge_tenant_app
     ):
-        actor.can_edit_integration_knowledge_list.return_value = True
+        actor.can_edit_integrations.return_value = True
         space.get_integration_knowledge.return_value = sharepoint_knowledge_tenant_app
 
         non_admin_user = MagicMock()
@@ -1486,7 +1486,7 @@ class TestTriggerFullSync:
     async def test_trigger_full_sync_rejects_non_sharepoint_knowledge(
         self, actor, space
     ):
-        actor.can_edit_integration_knowledge_list.return_value = True
+        actor.can_edit_integrations.return_value = True
 
         knowledge = MagicMock(spec=IntegrationKnowledge)
         knowledge.id = uuid4()

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -119,6 +119,7 @@
   "capabilities": "Capabilities",
   "cards": "Cards",
   "knowledge": "Knowledge",
+  "knowledge_create_no_permission": "You don't have permission to add {resourceType}. Contact your administrator to change your role.",
   "noPagesFound": "No pages found",
   "pageCount": "{count} pages",
   "collections": "Collections",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -119,6 +119,7 @@
   "capabilities": "Kapaciteter",
   "cards": "Kort",
   "knowledge": "Kunskap",
+  "knowledge_create_no_permission": "Du har inte behörighet att lägga till {resourceType}. Kontakta din administratör för att ändra din roll.",
   "noPagesFound": "Inga sidor hittades",
   "pageCount": "{count} sidor",
   "collections": "Samlingar",

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/+page.svelte
@@ -127,6 +127,10 @@
     <Page.Flex>
       {#if $selectedTab === "collections" && $currentSpace.hasPermission("create", "collection")}
         <CollectionEditor mode="create" collection={undefined}></CollectionEditor>
+      {:else if $selectedTab === "collections" && !$currentSpace.hasPermission("create", "collection")}
+        <p class="text-secondary max-w-72 text-right text-xs">
+          {m.knowledge_create_no_permission({ resourceType: m.collections().toLowerCase() })}
+        </p>
       {:else if $selectedTab === "websites" && $currentSpace.hasPermission("create", "website")}
         {#if $selectedWebsiteIds.size > 0}
           <Button
@@ -142,6 +146,10 @@
         {:else}
           <WebsiteEditor mode="create"></WebsiteEditor>
         {/if}
+      {:else if $selectedTab === "websites" && !$currentSpace.hasPermission("create", "website")}
+        <p class="text-secondary max-w-72 text-right text-xs">
+          {m.knowledge_create_no_permission({ resourceType: m.websites().toLowerCase() })}
+        </p>
       {:else if $selectedTab === "integrations" && $currentSpace.hasPermission("create", "integrationKnowledge")}
         {#if data.availableIntegrations.length > 0}
           <ImportKnowledgeDialog></ImportKnowledgeDialog>
@@ -162,6 +170,10 @@
             </Button>
           {/if}
         {/if}
+      {:else if $selectedTab === "integrations" && !$currentSpace.hasPermission("create", "integrationKnowledge")}
+        <p class="text-secondary max-w-72 text-right text-xs">
+          {m.knowledge_create_no_permission({ resourceType: m.integrations().toLowerCase() })}
+        </p>
       {/if}
     </Page.Flex>
   </Page.Header>


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                                                                              
  - Show an informative message in the knowledge page header when the user lacks create permission for collections, websites, or integrations
  - Previously the "Add" button would silently disappear, making it look like a bug                                                                                                                                                                                       
  - The message is displayed as subtle right-aligned text in the header area where the create button would normally appear                                                                                                                                                
                                                                                                                                                                                                                                                                          
  ## Changes                                                                                                                                                                                                                                                              
  - **Translation keys** (`en.json`, `sv.json`): Added `knowledge_create_no_permission` with `{resourceType}` parameter
  - **Knowledge page** (`+page.svelte`): Added `{:else if}` branches for each tab (collections, websites, integrations) that render the no-permission message when the user can read but not create