### PR TITLE
fix: set resource permissions before building sparse space model with…

### DIFF
--- a/backend/src/intric/spaces/api/space_assembler.py
+++ b/backend/src/intric/spaces/api/space_assembler.py
@@ -430,6 +430,7 @@ class SpaceAssembler:
         )
 
         if include_applications:
+            self._set_permissions_on_resources(space)
             default_assistant = None
             if getattr(space, "default_assistant", None) is not None:
                 default_assistant = self.assistant_assembler.from_assistant_to_default_assistant_model(


### PR DESCRIPTION
The sparse space model path was missing the _set_permissions_on_resources call, causing an AttributeError when accessing app.permissions during the include_applications flow.
