### PR TITLE
stop autoloading venv twice

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 			"settings": {
 				"python.defaultInterpreterPath": "/workspace/backend/.venv/bin/python",
 				"python.pythonPath": "/workspace/backend/.venv/bin/python",
-				"python.terminal.activateEnvironment": true,
+				"python.terminal.activateEnvironment": false,
 				"[python]": {
 					"editor.defaultFormatter": "charliermarsh.ruff"
 				}


### PR DESCRIPTION
## Why
When starting the devcontainer, the venv activate command runs asynchronously and cancels any running command in the terminal


