### PR TITLE
fix: handle group-only members in space assembler

### DIFF
--- a/backend/src/intric/spaces/api/space_assembler.py
+++ b/backend/src/intric/spaces/api/space_assembler.py
@@ -235,7 +235,11 @@ class SpaceAssembler:
         if not space.members:
             return []
 
-        return [space.members[self.user.id]] + [
+        current_user = space.members.get(self.user.id)
+        if current_user is None:
+            return list(space.members.values())
+
+        return [current_user] + [
             member for member in space.members.values() if member.id != self.user.id
         ]
 


### PR DESCRIPTION
## Summary
- Users accessing a space through group membership (not direct membership) caused a `KeyError` in `_sort_members` when their user ID wasn't found in `space.members`
- Changed direct dict access to `.get()` with a fallback that returns the members list without sorting the current user first

## Test plan
- [ ] Verify that a user with only group membership can view a space without 500 error
- [ ] Verify that a direct member still appears first in the members list

Fixes #235