### PR TITLE
feat: Add Berget AI provider support

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -34,6 +34,8 @@ services:
     image: redis
     networks:
       - eneo
+    ports:
+      - "6379:6379"
     volumes:
       - redis_data:/data
 

--- a/backend/src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py
+++ b/backend/src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py
@@ -82,12 +82,20 @@ class TenantModelAdapter(CompletionModelAdapter):
         super().__init__(model)
         self.credential_resolver = credential_resolver
 
+        # Map provider types to LiteLLM provider names
+        # Berget is OpenAI-compatible, so use "openai" provider type
+        provider_mapping = {
+            "berget": "openai",
+            "gdm": "openai",
+        }
+        litellm_provider_type = provider_mapping.get(provider_type, provider_type)
+
         # Construct LiteLLM model name with provider prefix
         # LiteLLM requires the provider prefix to know which client to use
         # When using custom api_base, LiteLLM strips one prefix level and sends the rest to the API
         # Example: "openai/openai/gpt-4" -> sends "openai/gpt-4" to custom endpoint
-        self.litellm_model = f"{provider_type}/{model.name}"
-        self.provider_type = provider_type
+        self.litellm_model = f"{litellm_provider_type}/{model.name}"
+        self.provider_type = litellm_provider_type
 
     def _mask_sensitive_params(self, params: dict) -> dict:
         """Return copy of params with masked API key for safe logging."""

--- a/backend/src/intric/model_providers/domain/model_provider_service.py
+++ b/backend/src/intric/model_providers/domain/model_provider_service.py
@@ -250,8 +250,10 @@ class ModelProviderService:
                     # For other providers, try OpenAI-compatible /v1/models
                     endpoint = provider.config.get("endpoint", "").rstrip("/")
                     if endpoint:
+                        # Check if endpoint already ends with /v1, if so add /models, otherwise add /v1/models
+                        models_endpoint = f"{endpoint}/models" if endpoint.endswith("/v1") else f"{endpoint}/v1/models"
                         resp = await client.get(
-                            f"{endpoint}/v1/models",
+                            models_endpoint,
                             headers={"Authorization": f"Bearer {api_key}"},
                         )
                         resp.raise_for_status()

--- a/backend/src/intric/transcription_models/infrastructure/adapters/litellm_transcription.py
+++ b/backend/src/intric/transcription_models/infrastructure/adapters/litellm_transcription.py
@@ -43,11 +43,19 @@ class LiteLLMTranscriptionAdapter:
         self.credential_resolver = credential_resolver
         self.provider_type = provider_type
 
+        # Map provider types to LiteLLM provider names
+        # Berget is OpenAI-compatible, so use "openai" provider type
+        provider_mapping = {
+            "berget": "openai",
+            "gdm": "openai",
+        }
+        litellm_provider_type = provider_mapping.get(provider_type, provider_type)
+
         # Construct LiteLLM model name with provider prefix
         # LiteLLM requires the provider prefix to know which client to use
         # Users should set provider_type to a LiteLLM-compatible value
         # (e.g., "openai", "hosted_vllm" for OpenAI-compatible APIs)
-        self.litellm_model = f"{provider_type}/{model.model_name}"
+        self.litellm_model = f"{litellm_provider_type}/{model.model_name}"
 
         logger.debug(
             f"[LiteLLM] Initializing transcription adapter for model: {model.name} -> {self.litellm_model}"

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddCompletionModelDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddCompletionModelDialog.svelte
@@ -46,6 +46,7 @@
     { value: "cohere", label: "Cohere" },
     { value: "mistral", label: "Mistral AI" },
     { value: "hosted_vllm", label: "vLLM" },
+    { value: "berget", label: "Berget AI" },
   ];
 
   // Create options for provider select - add "Create New" option

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddEmbeddingModelDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddEmbeddingModelDialog.svelte
@@ -45,6 +45,7 @@
     { value: "anthropic", label: "Anthropic (Claude)" },
     { value: "gemini", label: "Google Gemini" },
     { value: "cohere", label: "Cohere" },
+    { value: "berget", label: "Berget AI" },
   ];
 
   const modelFamilies = [

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddTranscriptionModelDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddTranscriptionModelDialog.svelte
@@ -44,6 +44,7 @@
     { value: "anthropic", label: "Anthropic (Claude)" },
     { value: "gemini", label: "Google Gemini" },
     { value: "cohere", label: "Cohere" },
+    { value: "berget", label: "Berget AI" },
   ];
 
   const providerTypeStore = writable(providerTypes[0]);

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepCredentials.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepCredentials.svelte
@@ -54,8 +54,9 @@
   // Validation
   $: isAzure = providerType === "azure";
   $: isVllm = providerType === "hosted_vllm";
-  $: isKnownProvider = ["openai", "azure", "anthropic", "gemini", "cohere", "mistral", "hosted_vllm"].includes(providerType);
-  $: requiresEndpoint = isAzure || isVllm;
+  $: isBerget = providerType === "berget";
+  $: isKnownProvider = ["openai", "azure", "anthropic", "gemini", "cohere", "mistral", "hosted_vllm", "berget"].includes(providerType);
+  $: requiresEndpoint = isAzure || isVllm || isBerget;
   $: isValid =
     providerName.trim() !== "" &&
     apiKey.trim() !== "" &&

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepModels.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepModels.svelte
@@ -42,6 +42,7 @@
     moonshot: "chn",
     baidu: "chn",
     volcengine: "chn",
+    berget: "swe",
   };
 
   // Auto-focus first input on mount
@@ -103,7 +104,7 @@
   }
 
   // Providers that need live model listing from their API (not LiteLLM static data)
-  const liveListProviders = new Set(["vllm"]);
+  const liveListProviders = new Set(["vllm", "berget"]);
 
   // Providers where LiteLLM names don't match user input (e.g. Azure uses deployment names)
   const noSuggestionsProviders = new Set(["azure"]);

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepProvider.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepProvider.svelte
@@ -29,7 +29,8 @@
     { type: "gemini", label: "Google Gemini", description: "Gemini Pro, Gemini Flash" },
     { type: "cohere", label: "Cohere", description: "Command, Embed models" },
     { type: "mistral", label: "Mistral AI", description: "Mistral, Mixtral models" },
-    { type: "hosted_vllm", label: "vLLM", description: "Self-hosted vLLM inference server" }
+    { type: "hosted_vllm", label: "vLLM", description: "Self-hosted vLLM inference server" },
+    { type: "berget", label: "Berget AI", description: "Swedish-hosted AI models" }
   ] as const;
 
   const featuredTypes = new Set(providerTypes.map((p) => p.type));

--- a/frontend/apps/web/src/routes/(app)/admin/models/ProviderDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/ProviderDialog.svelte
@@ -41,6 +41,7 @@
     { value: "cohere", label: "Cohere" },
     { value: "mistral", label: "Mistral AI" },
     { value: "hosted_vllm", label: "vLLM" },
+    { value: "berget", label: "Berget AI" },
   ];
 
   const providerTypeStore = writable(providerTypes[0]);
@@ -217,8 +218,8 @@
     error = null;
   }
 
-  // Endpoint is required for Azure and vLLM
-  $: requiresEndpoint = providerType === "azure" || providerType === "hosted_vllm";
+  // Endpoint is required for Azure, vLLM, and Berget
+  $: requiresEndpoint = providerType === "azure" || providerType === "hosted_vllm" || providerType === "berget";
 </script>
 
 <Dialog.Root {openController}>
@@ -332,6 +333,8 @@
             bind:value={endpoint}
             placeholder={providerType === "azure"
               ? "https://your-resource.openai.azure.com"
+              : providerType === "berget"
+              ? "api.berget.ai/v1"
               : "https://api.openai.com/v1 (default) or custom endpoint"}
             required={requiresEndpoint}
           />
@@ -342,6 +345,10 @@
           {:else if providerType === "azure"}
             <p class="text-muted-foreground text-xs mt-1">
               {m.endpoint_required_azure()}
+            </p>
+          {:else if providerType === "berget"}
+            <p class="text-muted-foreground text-xs mt-1">
+              https://api.berget.ai/v1
             </p>
           {:else}
             <p class="text-muted-foreground text-xs mt-1">

--- a/frontend/apps/web/src/routes/(app)/admin/models/components/ProviderGlyph.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/components/ProviderGlyph.svelte
@@ -6,7 +6,7 @@
    * Uses subtle tinted backgrounds to avoid harsh color blocks
    */
 
-  export let providerType: "openai" | "azure" | "anthropic" | "gemini" | "cohere" | string;
+  export let providerType: "openai" | "azure" | "anthropic" | "gemini" | "cohere" | "berget" | string;
   export let size: "sm" | "md" | "lg" = "md";
 
   // Size mappings
@@ -51,6 +51,11 @@
       bg: "bg-[oklch(94%_0.04_55)] dark:bg-[oklch(22%_0.06_55)]",
       fg: "text-[oklch(40%_0.15_55)] dark:text-[oklch(81%_0.14_55)]",
       border: "border-[oklch(84%_0.05_55)] dark:border-[oklch(35%_0.07_55)]"
+    },
+    berget: {
+      bg: "bg-[oklch(94%_0.05_180)] dark:bg-[oklch(23%_0.07_180)]",
+      fg: "text-[oklch(38%_0.18_180)] dark:text-[oklch(82%_0.16_180)]",
+      border: "border-[oklch(83%_0.06_180)] dark:border-[oklch(35%_0.09_180)]"
     },
     hosted_vllm: {
       bg: "bg-[oklch(93%_0.035_140)] dark:bg-[oklch(21%_0.06_140)]",


### PR DESCRIPTION
## Summary
- Add Berget AI as a supported model provider in the frontend UI
- Configure Berget as OpenAI-compatible provider for LiteLLM backend
- Enable automatic model listing from Berget API endpoint
- Fix model endpoint URL handling to correctly handle `/v1` suffix

<img width="1175" height="648" alt="image" src="https://github.com/user-attachments/assets/b6d0d97d-35cb-46cb-b063-e832fa34c139" />


## Changes

### Frontend
- Add Berget AI to all provider dropdown lists (ProviderDialog, AddWizard, Add*ModelDialogs)
- Add Berget AI icon and color scheme in ProviderGlyph component
- Configure Berget to require endpoint URL with correct placeholder
- Add Berget to live model providers for automatic model fetching
- Set default hosting to Sweden (swe) for Berget models

### Backend
- Map Berget provider to OpenAI for LiteLLM compatibility in completion and transcription adapters
- Fix models endpoint to handle `/v1` suffix correctly (avoids double `/v1/v1/models`)
- Update Redis port mapping in docker-compose for local development

## Testing
- Tested with Berget AI API key and endpoint
- Successfully listed models from `https://api.berget.ai/v1/models`
- Verified model validation works with models like `zai-org/GLM-4.7` and `openai/gpt-oss-120b`

## Benefits
Users can now:
- Configure Berget AI as a model provider through the Admin UI
- Automatically fetch available models from Berget API
- Use Berget's Swedish-hosted AI models for completion, embedding, and transcription tasks