### PR TITLE
disable mcp when knowledge attached to assistant

### DIFF
--- a/backend/src/intric/assistants/assistant.py
+++ b/backend/src/intric/assistants/assistant.py
@@ -13,6 +13,7 @@ from intric.completion_models.infrastructure.completion_service import Completio
 from intric.files.file_models import File, FileInfo, FileType
 from intric.files.text import TextMimeTypes
 from intric.info_blobs.info_blob import InfoBlobChunkInDBWithScore
+from intric.services.service import DatastoreResult
 from intric.main.exceptions import (
     BadRequestException,
     NoModelSelectedException,
@@ -333,15 +334,20 @@ class Assistant(Entity):
         # Fill half the context
         num_chunks = self.completion_model.token_limit // 200 // 2 if version == 2 else 30
 
-        datastore_result = await references_service.get_references(
-            question=question,
-            session=session,
-            collections=self.collections,
-            websites=self.websites,
-            integration_knowledge_list=self.integration_knowledge_list,
-            num_chunks=num_chunks,
-            version=version,
-        )
+        if self.has_knowledge():
+            datastore_result = await references_service.get_references(
+                question=question,
+                session=session,
+                collections=self.collections,
+                websites=self.websites,
+                integration_knowledge_list=self.integration_knowledge_list,
+                num_chunks=num_chunks,
+                version=version,
+            )
+        else:
+            datastore_result = DatastoreResult(
+                chunks=[], no_duplicate_chunks=[], info_blobs=[]
+            )
 
         response = await completion_service.get_response(
             model=self.completion_model,
@@ -357,7 +363,7 @@ class Assistant(Entity):
             version=version,
             use_image_generation=self.is_default,
             web_search_results=web_search_results,
-            mcp_servers=self.mcp_servers,
+            mcp_servers=[] if self.has_knowledge() else self.mcp_servers,
             require_tool_approval=require_tool_approval,
         )
 

--- a/backend/tests/unittests/assistants/test_assistant.py
+++ b/backend/tests/unittests/assistants/test_assistant.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -228,3 +228,79 @@ def test_update_metadata_json(assistant: Assistant):
 
     assistant.update(metadata_json=NOT_PROVIDED)
     assert assistant.metadata_json is None
+
+
+@pytest.fixture
+def assistant_with_model():
+    completion_model = MagicMock()
+    completion_model.token_limit = 4000
+    completion_model.vision = False
+    return Assistant(
+        id=None,
+        user=MagicMock(),
+        name="test",
+        space_id=MagicMock(),
+        prompt=MagicMock(),
+        completion_model=completion_model,
+        completion_model_kwargs=ModelKwargs(),
+        logging_enabled=False,
+        websites=[],
+        collections=[],
+        attachments=[],
+        published=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ask_skips_mcp_when_knowledge_present(assistant_with_model):
+    embedding_model = MagicMock(id=1)
+    assistant_with_model.mcp_servers = [MagicMock()]
+    assistant_with_model.collections = [MagicMock(embedding_model=embedding_model)]
+    assistant_with_model.websites = [MagicMock(embedding_model=embedding_model)]
+
+    references_service = MagicMock()
+    references_service.get_references = AsyncMock()
+
+    completion_service = MagicMock()
+    completion_service.get_response = AsyncMock(return_value=MagicMock())
+
+    await assistant_with_model.ask(
+        question="test",
+        references_service=references_service,
+        completion_service=completion_service,
+        version=2,
+    )
+
+    # Knowledge retrieval should be called
+    references_service.get_references.assert_called_once()
+    # MCP servers should be excluded from completion call
+    call_kwargs = completion_service.get_response.call_args.kwargs
+    assert call_kwargs["mcp_servers"] == []
+
+
+@pytest.mark.asyncio
+async def test_ask_uses_mcp_when_no_knowledge(assistant_with_model):
+    mcp_servers = [MagicMock()]
+    assistant_with_model.mcp_servers = mcp_servers
+    assistant_with_model.collections = []
+    assistant_with_model.websites = []
+
+    references_service = MagicMock()
+    references_service.get_references = AsyncMock()
+
+    completion_service = MagicMock()
+    completion_service.get_response = AsyncMock(return_value=MagicMock())
+
+    response, datastore_result = await assistant_with_model.ask(
+        question="test",
+        references_service=references_service,
+        completion_service=completion_service,
+        version=2,
+    )
+
+    # Knowledge retrieval should be skipped
+    references_service.get_references.assert_not_called()
+    assert datastore_result.chunks == []
+    # MCP servers should be passed to completion call
+    call_kwargs = completion_service.get_response.call_args.kwargs
+    assert call_kwargs["mcp_servers"] == mcp_servers

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -1805,6 +1805,7 @@
   "failed_create_mcp_server": "Failed to create MCP server. Please try again.",
   "failed_update_mcp_server": "Failed to update MCP server. Please try again.",
   "enable_mcp_in_space_settings": "Enable MCP servers in space settings first.",
+  "mcp_disabled_when_knowledge_active": "MCP servers are not available when knowledge (collections, websites, integrations) is attached. Remove knowledge to enable MCP servers.",
   "add_model_provider": "Add Model Provider",
   "edit_provider": "Edit Provider",
   "delete_provider": "Delete Provider",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -1840,6 +1840,7 @@
   "failed_create_mcp_server": "Kunde inte skapa MCP-server. Försök igen.",
   "failed_update_mcp_server": "Kunde inte uppdatera MCP-server. Försök igen.",
   "enable_mcp_in_space_settings": "Aktivera MCP-servrar i space-inställningarna först.",
+  "mcp_disabled_when_knowledge_active": "MCP-servrar är inte tillgängliga när kunskap (samlingar, webbplatser, integrationer) är bifogad. Ta bort kunskap för att aktivera MCP-servrar.",
   "add_model_provider": "Lägg till modelleverantör",
   "edit_provider": "Redigera leverantör",
   "delete_provider": "Ta bort leverantör",

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/assistants/[assistantId]/edit/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/assistants/[assistantId]/edit/+page.svelte
@@ -405,6 +405,7 @@
         {/if}
       </Settings.Group>
 
+      {@const hasKnowledge = ($update.groups?.length ?? 0) > 0 || ($update.websites?.length ?? 0) > 0 || ($update.integration_knowledge_list?.length ?? 0) > 0}
       <Settings.Group title={m.mcp_servers()}>
         <Settings.Row
           title={m.mcp_servers()}
@@ -415,7 +416,14 @@
             discardChanges("mcp_tools");
           }}
         >
-          <SelectMCPServers bind:selectedMCPServers={$update.mcp_servers} bind:selectedMCPTools={$update.mcp_tools} selectedModel={$update.completion_model} />
+          {#if hasKnowledge}
+            <p class="label-warning border-label-default bg-label-dimmer text-label-stronger mb-2 rounded-md border px-2 py-1 text-sm">
+              <span class="font-bold">{m.warning()}:&nbsp;</span>{m.mcp_disabled_when_knowledge_active()}
+            </p>
+          {/if}
+          <div class={hasKnowledge ? 'opacity-50 pointer-events-none' : ''}>
+            <SelectMCPServers bind:selectedMCPServers={$update.mcp_servers} bind:selectedMCPTools={$update.mcp_tools} selectedModel={$update.completion_model} />
+          </div>
        </Settings.Row>
       </Settings.Group>
 


### PR DESCRIPTION
## Changes
Disable MCP servers on assistant when knowledge present

## Why
safeguard to not allow llm to answer questions from pre-trained data

## Screenshots
<img width="961" height="326" alt="Screenshot 2026-03-10 at 12 42 23" src="https://github.com/user-attachments/assets/ee626f92-15c6-4123-ac82-855af4177eac" />


