### PR TITLE
Replace browser alert() calls with toast notifications

### DIFF
--- a/frontend/apps/web/src/lib/core/editing/ResourceEditor.ts
+++ b/frontend/apps/web/src/lib/core/editing/ResourceEditor.ts
@@ -3,6 +3,7 @@ import { derived, get, readonly, writable } from "svelte/store";
 import { getAddedItems, getRemovedItems } from "./getChangedItems";
 import { getDiff, type CompareOptions, type Diff } from "./getDiff";
 import { applyDefaults, type AppliedDefaults, type Defaults } from "./applyDefaults";
+import { toast } from "$lib/components/toast";
 
 type Resource = Record<string, unknown> & { id: string };
 
@@ -86,7 +87,7 @@ export function createResourceEditor<T extends Resource, Defs extends Defaults<T
         });
       }
     } catch (e) {
-      alert("Error while trying to update!");
+      toast.error("Error while trying to update!");
       if (e instanceof IntricError) {
         console.error(e.getReadableMessage());
       }

--- a/frontend/apps/web/src/lib/features/ai-models/components/SelectCompletionModel.svelte
+++ b/frontend/apps/web/src/lib/features/ai-models/components/SelectCompletionModel.svelte
@@ -4,6 +4,7 @@
   import { Select } from "@intric/ui";
   import { writable, type Writable } from "svelte/store";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   /** Id of currently selected Completion Model */
   export let value: { id: string } | null | undefined;
@@ -29,7 +30,7 @@
       unsupportedModelSelected = true;
       if (browser) {
         setTimeout(() => {
-          alert(m.model_no_longer_supported());
+          toast.warning(m.model_no_longer_supported());
         }, 400);
       }
     }

--- a/frontend/apps/web/src/lib/features/ai-models/components/SelectEmbeddingModel.svelte
+++ b/frontend/apps/web/src/lib/features/ai-models/components/SelectEmbeddingModel.svelte
@@ -3,6 +3,7 @@
   import { Select } from "@intric/ui";
   import { writable, type Writable } from "svelte/store";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   // Id of currently selected Embedding Model
   export let value: { id: string } | null | undefined;
@@ -30,7 +31,7 @@
     if (!selectedModel) {
       unsupportedModelSelected = true;
       setTimeout(() => {
-        alert(m.embedding_model_no_longer_supported());
+        toast.warning(m.embedding_model_no_longer_supported());
       }, 400);
     }
     modelSelectStore = writable({

--- a/frontend/apps/web/src/lib/features/attachments/AttachmentManager.ts
+++ b/frontend/apps/web/src/lib/features/attachments/AttachmentManager.ts
@@ -2,6 +2,7 @@ import { derived, get, readable, writable, type Readable } from "svelte/store";
 import type { Intric, UploadedFile } from "@intric/intric-js";
 import { createContext } from "$lib/core/context";
 import { ATTACHMENTS } from "$lib/core/constants";
+import { toast } from "$lib/components/toast";
 
 export type Attachment = {
   id: string;
@@ -160,7 +161,7 @@ function createAttachmentManager(data: AttachmentManagerParams) {
         if (error instanceof Error && error.message.includes("Cancelled")) {
           console.warn(`Cancelled uppload for ${file.name}`);
         } else {
-          alert(`We encountered an error uploading the file ${file.name}\n${error}`);
+          toast.error(`We encountered an error uploading the file ${file.name}: ${error}`);
         }
         attachments.update(($attachments) => $attachments.filter((u) => u.id !== currentUpload));
       } finally {

--- a/frontend/apps/web/src/lib/features/attachments/components/AttachmentDropArea.svelte
+++ b/frontend/apps/web/src/lib/features/attachments/components/AttachmentDropArea.svelte
@@ -11,6 +11,7 @@
   export let isDragging: boolean;
   export let label = m.drop_files_here_to_upload();
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const { queueValidUploads } = getAttachmentManager();
 
@@ -36,7 +37,7 @@
     const errors = queueValidUploads([...selectedFiles]);
 
     if (errors) {
-      alert(errors.join("\n"));
+      toast.error(errors.join("\n"));
     }
   }
 </script>

--- a/frontend/apps/web/src/lib/features/attachments/components/AttachmentPreview.svelte
+++ b/frontend/apps/web/src/lib/features/attachments/components/AttachmentPreview.svelte
@@ -5,6 +5,7 @@
   import { Button, Dialog, Markdown } from "@intric/ui";
   import { getIntric } from "$lib/core/Intric";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   import type { Snippet } from "svelte";
 
@@ -58,7 +59,7 @@
     } catch (e) {
       loadError = true;
       console.error("Error loading file:", e);
-      alert(m.error_loading_file());
+      toast.error(m.error_loading_file());
     } finally {
       loadingFile = false;
     }
@@ -80,7 +81,7 @@
       window.open(response.url, "_blank");
     } catch (e) {
       console.error("Error generating download URL:", e);
-      alert(m.error_downloading_file());
+      toast.error(m.error_downloading_file());
     }
   }
 

--- a/frontend/apps/web/src/lib/features/attachments/components/AttachmentUploadIconButton.svelte
+++ b/frontend/apps/web/src/lib/features/attachments/components/AttachmentUploadIconButton.svelte
@@ -10,6 +10,7 @@
 
   export let label = m.select_documents_to_attach();
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   let selectedFiles: FileList;
 
   const {
@@ -23,7 +24,7 @@
     const errors = queueValidUploads([...selectedFiles]);
 
     if (errors) {
-      alert(errors.join("\n"));
+      toast.error(errors.join("\n"));
     }
   }
 </script>

--- a/frontend/apps/web/src/lib/features/attachments/components/AttachmentUploadTextButton.svelte
+++ b/frontend/apps/web/src/lib/features/attachments/components/AttachmentUploadTextButton.svelte
@@ -9,6 +9,7 @@
     queueValidUploads
   } = getAttachmentManager();
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   let fileInput: HTMLInputElement;
 
@@ -18,7 +19,7 @@
     const errors = queueValidUploads([...fileInput.files]);
 
     if (errors) {
-      alert(errors.join("\n"));
+      toast.error(errors.join("\n"));
     }
 
     fileInput.value = "";

--- a/frontend/apps/web/src/lib/features/chat/ChatService.svelte.ts
+++ b/frontend/apps/web/src/lib/features/chat/ChatService.svelte.ts
@@ -3,6 +3,7 @@ import { PAGINATION } from "$lib/core/constants";
 import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte";
 import { createClassContext } from "$lib/core/helpers/createClassContext";
 import { waitFor } from "$lib/core/waitFor";
+import { toast } from "$lib/components/toast";
 import {
   type ConversationSparse,
   type Assistant,
@@ -239,7 +240,7 @@ export class ChatService {
         this.newConversation();
       }
     } catch (e) {
-      if (browser) alert(`Error while deleting conversation with id ${conversation.id}`);
+      if (browser) toast.error(`Error while deleting conversation with id ${conversation.id}`);
       console.error(e);
     }
   }
@@ -259,7 +260,7 @@ export class ChatService {
       }
       return loaded;
     } catch (e) {
-      if (browser) alert(`Error while loading conversation with id ${conversation.id}`);
+      if (browser) toast.error(`Error while loading conversation with id ${conversation.id}`);
       console.error(e);
     }
   }

--- a/frontend/apps/web/src/lib/features/group-chats/components/GroupChatAssistantListAddDialog.svelte
+++ b/frontend/apps/web/src/lib/features/group-chats/components/GroupChatAssistantListAddDialog.svelte
@@ -10,6 +10,7 @@
   import { Button, Dialog, Input, Select } from "@intric/ui";
   import { writable } from "svelte/store";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   type AssistantTool = GroupChat["tools"]["assistants"][number];
   type Props = {
@@ -60,7 +61,7 @@
         onclick={() => {
           if (selectedAssistant) {
             if (!user_description && selectedAssistant.default_description === null) {
-              alert(m.description_required_to_add_assistant());
+              toast.warning(m.description_required_to_add_assistant());
               return;
             }
             addAssistantToGroup({ ...selectedAssistant, user_description });

--- a/frontend/apps/web/src/lib/features/group-chats/components/GroupChatAssistantListEditDialog.svelte
+++ b/frontend/apps/web/src/lib/features/group-chats/components/GroupChatAssistantListEditDialog.svelte
@@ -10,6 +10,7 @@
   import { Button, Dialog, Input } from "@intric/ui";
   import { writable } from "svelte/store";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   type AssistantTool = GroupChat["tools"]["assistants"][number];
   type Props = {
@@ -59,7 +60,7 @@
           const user_description =
             descriptionProxy.value.trim() === "" ? null : descriptionProxy.value;
           if (!user_description && !assistant.default_description) {
-            alert(m.description_required_for_assistant());
+            toast.warning(m.description_required_for_assistant());
             return;
           }
           updateAssistant({ ...assistant, user_description });

--- a/frontend/apps/web/src/lib/features/integrations/IntegrationAuthService.svelte.ts
+++ b/frontend/apps/web/src/lib/features/integrations/IntegrationAuthService.svelte.ts
@@ -3,6 +3,7 @@ import { getIntric } from "$lib/core/Intric";
 import type { Intric, UserIntegration } from "@intric/intric-js";
 import { onMount } from "svelte";
 import { SvelteMap } from "svelte/reactivity";
+import { toast } from "$lib/components/toast";
 
 /**
  * Service for handling OAuth authentication flows for external integrations.
@@ -131,14 +132,14 @@ export class IntegrationAuthService {
       const missing = [];
       if (!code) missing.push("code");
       if (!integrationId) missing.push("state");
-      alert(`Missing required fields: ${missing.join(", ")}`);
+      toast.warning(`Missing required fields: ${missing.join(", ")}`);
       return;
     }
 
     // Find and validate request
     const request = this.#authRequests.get(integrationId);
     if (!request) {
-      alert(`No auth request found for state ${integrationId}`);
+      toast.error(`No auth request found for state ${integrationId}`);
       return;
     }
 

--- a/frontend/apps/web/src/lib/features/integrations/components/UserConnectedSplitButton.svelte
+++ b/frontend/apps/web/src/lib/features/integrations/components/UserConnectedSplitButton.svelte
@@ -6,6 +6,7 @@
   import { Button, Dialog, Dropdown } from "@intric/ui";
   import { writable } from "svelte/store";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   type Props = {
     integration: UserIntegration;
@@ -19,7 +20,7 @@
   async function disconnect() {
     const { id } = integration;
     if (!id) {
-      alert(m.integration_not_setup_correctly());
+      toast.warning(m.integration_not_setup_correctly());
       return;
     }
     await intric.integrations.user.disconnect({ id });

--- a/frontend/apps/web/src/lib/features/integrations/confluence/ConfluenceImportDialog.svelte
+++ b/frontend/apps/web/src/lib/features/integrations/confluence/ConfluenceImportDialog.svelte
@@ -11,6 +11,7 @@
   import { createCombobox } from "@melt-ui/svelte";
   import type { IntegrationImportDialogProps } from "../IntegrationData";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   type PreviewOption = {
     label: string;
@@ -39,7 +40,7 @@
     const { id } = integration;
 
     if (!id) {
-      alert(m.you_need_to_configure_this_integration_before_using_it());
+      toast.warning(m.you_need_to_configure_this_integration_before_using_it());
       goBack();
       return;
     }
@@ -89,7 +90,7 @@
     } catch (error) {
       const errorMessage =
         error instanceof IntricError ? error.getReadableMessage() : String(error);
-      alert(errorMessage);
+      toast.error(errorMessage);
     }
   });
 

--- a/frontend/apps/web/src/lib/features/integrations/sharepoint/SharePointAppConfigDialog.svelte
+++ b/frontend/apps/web/src/lib/features/integrations/sharepoint/SharePointAppConfigDialog.svelte
@@ -5,6 +5,7 @@
   import { IntricError } from "@intric/intric-js";
   import { Button, Dialog, Input } from "@intric/ui";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { writable, type Writable } from "svelte/store";
   import { AlertTriangle } from "lucide-svelte";
   import SharePointAppDeleteDialog from "./SharePointAppDeleteDialog.svelte";
@@ -87,7 +88,7 @@
     testResult = null;
 
     if (!clientId || !clientSecret || !tenantDomain) {
-      alert(m.fill_required_fields());
+      toast.warning(m.fill_required_fields());
       return;
     }
 
@@ -109,14 +110,14 @@
       testResult = result;
 
         if (!result.success) {
-          alert(
+          toast.error(
           m.connection_test_failed({ message: result.error_message || m.unknown_error() })
           );
         }
     } catch (error) {
       const errorMessage =
         error instanceof IntricError ? error.getReadableMessage() : String(error);
-      alert(m.failed_to_test_credentials({ message: errorMessage }));
+      toast.error(m.failed_to_test_credentials({ message: errorMessage }));
       testResult = {
         success: false,
         error_message: errorMessage,
@@ -127,7 +128,7 @@
   // Save configuration
   const saveConfig = createAsyncState(async () => {
     if (!clientId || !clientSecret || !tenantDomain) {
-      alert(m.fill_required_fields());
+      toast.warning(m.fill_required_fields());
       return;
     }
 
@@ -151,14 +152,14 @@
     } catch (error) {
       const errorMessage =
         error instanceof IntricError ? error.getReadableMessage() : String(error);
-      alert(m.failed_to_save_configuration({ message: errorMessage }));
+      toast.error(m.failed_to_save_configuration({ message: errorMessage }));
     }
   });
 
   // Update client secret only
   const updateSecret = createAsyncState(async () => {
     if (!existingConfig || !newClientSecret) {
-      alert(m.fill_required_fields());
+      toast.warning(m.fill_required_fields());
       return;
     }
 
@@ -183,14 +184,14 @@
     } catch (error) {
       const errorMessage =
         error instanceof IntricError ? error.getReadableMessage() : String(error);
-      alert(m.failed_to_save_configuration({ message: errorMessage }));
+      toast.error(m.failed_to_save_configuration({ message: errorMessage }));
     }
   });
 
   // Start service account OAuth flow
   const startServiceAccountOAuth = createAsyncState(async () => {
     if (!clientId || !clientSecret || !tenantDomain) {
-      alert(m.fill_required_fields());
+      toast.warning(m.fill_required_fields());
       return;
     }
 
@@ -223,7 +224,7 @@
     } catch (error) {
       const errorMessage =
         error instanceof IntricError ? error.getReadableMessage() : String(error);
-      alert(m.failed_to_start_oauth({ message: errorMessage }));
+      toast.error(m.failed_to_start_oauth({ message: errorMessage }));
     }
   });
 

--- a/frontend/apps/web/src/lib/features/integrations/sharepoint/SharepointImportDialog.svelte
+++ b/frontend/apps/web/src/lib/features/integrations/sharepoint/SharepointImportDialog.svelte
@@ -13,6 +13,7 @@
   import { createCombobox } from "@melt-ui/svelte";
   import type { IntegrationImportDialogProps } from "../IntegrationData";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import SharePointFolderTree from "./SharePointFolderTree.svelte";
   import { buildSharePointSelectionKey, normalizeSharePointPath } from "./selectionKey";
 
@@ -135,7 +136,7 @@
     const { id } = integration;
 
     if (!id) {
-      alert(m.you_need_to_configure_this_integration_before_using_it());
+      toast.warning(m.you_need_to_configure_this_integration_before_using_it());
       goBack();
       return;
     }
@@ -324,7 +325,7 @@
       startFastUpdatePolling();
 
       if (createdItems.length === 0) {
-        alert(m.sharepoint_batch_import_all_failed({ failed: failedItems.length }));
+        toast.error(m.sharepoint_batch_import_all_failed({ failed: failedItems.length }));
         return;
       }
 
@@ -344,7 +345,7 @@
     } catch (error) {
       const errorMessage =
         error instanceof IntricError ? error.getReadableMessage() : String(error);
-      alert(errorMessage);
+      toast.error(errorMessage);
     }
   });
 

--- a/frontend/apps/web/src/lib/features/jobs/JobManager.ts
+++ b/frontend/apps/web/src/lib/features/jobs/JobManager.ts
@@ -5,6 +5,7 @@ import type { Intric, Job } from "@intric/intric-js";
 import { derived, writable } from "svelte/store";
 
 import { m } from "$lib/paraglide/messages";
+import { toast } from "$lib/components/toast";
 export { getJobManager, initJobManager, jobCompletionEvents };
 
 // Global store for job completion events (can be subscribed to from any component)
@@ -231,7 +232,7 @@ function createJobManager(data: { intric: Intric }) {
               error instanceof Error && error.message
                 ? error.message
                 : fallbackMessage;
-            alert(`${fallbackMessage}: ${upload.file.name}\n${message}`);
+            toast.error(`${fallbackMessage}: ${upload.file.name}: ${message}`);
             runningUploads.delete(uploadId);
             upload.status = "failed";
             upload.errorMessage = message;

--- a/frontend/apps/web/src/lib/features/knowledge/components/BlobPreview.svelte
+++ b/frontend/apps/web/src/lib/features/knowledge/components/BlobPreview.svelte
@@ -5,6 +5,7 @@
   import { Button, Dialog, Markdown } from "@intric/ui";
   import { getIntric } from "$lib/core/Intric";
   import * as m from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   export let blob: InfoBlob;
   export let index: number | undefined = undefined;
   export let isTableView = false;
@@ -26,7 +27,7 @@
       } catch (e) {
         loadError = true;
         console.error("Error retrieving blob content:", e);
-        alert("Error retrieving reference, see console for details.");
+        toast.error("Error retrieving reference, see console for details.");
       }
       loadingBlob = false;
     }

--- a/frontend/apps/web/src/lib/features/prompts/PromptManager.ts
+++ b/frontend/apps/web/src/lib/features/prompts/PromptManager.ts
@@ -8,6 +8,7 @@ import { createContext } from "$lib/core/context";
 import { writable, get } from "svelte/store";
 import type { Intric, Prompt, PromptSparse } from "@intric/intric-js";
 import { browser } from "$app/environment";
+import { toast } from "$lib/components/toast";
 
 const [getPromptManager, setPromptManager] =
   createContext<ReturnType<typeof createPromptManager>>("Prompt version history");
@@ -58,7 +59,7 @@ function createPromptManager(params: PromptManagerParams) {
         previewedPrompt.set(null);
       }
     } catch (e) {
-      alert(`Error deleting prompt with id: ${id}`);
+      toast.error(`Error deleting prompt with id: ${id}`);
     }
   }
 

--- a/frontend/apps/web/src/lib/features/publishing/components/PublishingDialog.svelte
+++ b/frontend/apps/web/src/lib/features/publishing/components/PublishingDialog.svelte
@@ -4,6 +4,7 @@
   import { writable } from "svelte/store";
   import { getSpacesManager } from "$lib/features/spaces/SpacesManager";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const { refreshCurrentSpace } = getSpacesManager();
 
@@ -33,7 +34,7 @@
       }
       $openController = false;
     } catch (e) {
-      alert(m.could_not_change_status({ name: resource.name }));
+      toast.error(m.could_not_change_status({ name: resource.name }));
       console.error(e);
     }
   }

--- a/frontend/apps/web/src/lib/features/publishing/components/PublishingSetting.svelte
+++ b/frontend/apps/web/src/lib/features/publishing/components/PublishingSetting.svelte
@@ -5,6 +5,7 @@
   import { IconLoadingSpinner } from "@intric/icons/loading-spinner";
   import PublishingStatusChip from "./PublishingStatusChip.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   export let resource: PublishableResource;
   export let endpoints: PublishableResourceEndpoints;
@@ -18,7 +19,7 @@
       try {
         resource = await endpoints.publish(resource);
       } catch (e) {
-        alert(m.could_not_publish({ name: resource.name }));
+        toast.error(m.could_not_publish({ name: resource.name }));
       }
       isLoading = false;
       return resource;
@@ -28,7 +29,7 @@
       try {
         resource = await endpoints.unpublish(resource);
       } catch (e) {
-        alert(m.could_not_unpublish({ name: resource.name }));
+        toast.error(m.could_not_unpublish({ name: resource.name }));
       }
       isLoading = false;
       return resource;

--- a/frontend/apps/web/src/lib/features/security-classifications/components/ModelClassificationDialog.svelte
+++ b/frontend/apps/web/src/lib/features/security-classifications/components/ModelClassificationDialog.svelte
@@ -19,6 +19,7 @@
   import { invalidate } from "$app/navigation";
   import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   type Props = {
     model: CompletionModel | EmbeddingModel | TranscriptionModel;
@@ -45,7 +46,7 @@
       invalidate("admin:models:load");
       $openController = false;
     } catch (error) {
-      alert(error instanceof IntricError ? error.getReadableMessage() : String(error));
+      toast.error(error instanceof IntricError ? error.getReadableMessage() : String(error));
     }
   });
 </script>

--- a/frontend/apps/web/src/lib/features/security-classifications/components/MultipleModelsClassificationDialog.svelte
+++ b/frontend/apps/web/src/lib/features/security-classifications/components/MultipleModelsClassificationDialog.svelte
@@ -19,6 +19,7 @@
   import { Button } from "@intric/ui";
   import { IconChevronRight } from "@intric/icons/chevron-right";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   type Props =
     | {
@@ -65,7 +66,7 @@
       // @ts-expect-error doesnt understand [type]
       await intric.models.update({ [type]: model, update: { security_classification } });
     } catch (error) {
-      alert(error instanceof IntricError ? error.getReadableMessage() : String(error));
+      toast.error(error instanceof IntricError ? error.getReadableMessage() : String(error));
     }
   }
 
@@ -123,7 +124,7 @@
                         model.security_classification = next;
                         classifiedCount = countClassifiedModels();
                       } catch (error) {
-                        alert(error);
+                        toast.error(error instanceof Error ? error.message : String(error));
                       }
                     }}
                   ></SelectSecurityClassification>

--- a/frontend/apps/web/src/lib/features/security-classifications/components/SecurityClassificationActions.svelte
+++ b/frontend/apps/web/src/lib/features/security-classifications/components/SecurityClassificationActions.svelte
@@ -16,6 +16,7 @@
   import { IconArrowDownToLine } from "@intric/icons/arrow-down-to-line";
   import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   type Props = {
     classification: SecurityClassification;
@@ -47,7 +48,7 @@
       await security.deleteClassification(classification);
       $showDeleteDialog = false;
     } catch (error) {
-      alert(error instanceof IntricError ? error.getReadableMessage() : String(error));
+      toast.error(error instanceof IntricError ? error.getReadableMessage() : String(error));
     }
   });
 
@@ -61,7 +62,7 @@
       });
       $showEditDialog = false;
     } catch (error) {
-      alert(error instanceof IntricError ? error.getReadableMessage() : String(error));
+      toast.error(error instanceof IntricError ? error.getReadableMessage() : String(error));
     }
   });
 </script>

--- a/frontend/apps/web/src/lib/features/security-classifications/components/SecurityClassificationCreateDialog.svelte
+++ b/frontend/apps/web/src/lib/features/security-classifications/components/SecurityClassificationCreateDialog.svelte
@@ -11,6 +11,7 @@
   import { IntricError } from "@intric/intric-js";
   import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   let name = $state("");
   let description = $state("");
@@ -25,7 +26,7 @@
       name = "";
       description = "";
     } catch (error) {
-      alert(error instanceof IntricError ? error.getReadableMessage() : String(error));
+      toast.error(error instanceof IntricError ? error.getReadableMessage() : String(error));
     }
   });
 </script>

--- a/frontend/apps/web/src/lib/features/security-classifications/components/SecurityClassificationEnabledSetting.svelte
+++ b/frontend/apps/web/src/lib/features/security-classifications/components/SecurityClassificationEnabledSetting.svelte
@@ -12,6 +12,7 @@
   import { Settings } from "$lib/components/layout";
   import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const security = getSecurityClassificationService();
 
@@ -31,7 +32,7 @@
       await security.enable();
       $showEnableDialog = false;
     } catch (e) {
-      alert(e instanceof IntricError ? e.getReadableMessage() : String(e));
+      toast.error(e instanceof IntricError ? e.getReadableMessage() : String(e));
     }
   });
 
@@ -40,7 +41,7 @@
       await security.disable();
       $showDisableDialog = false;
     } catch (e) {
-      alert(e instanceof IntricError ? e.getReadableMessage() : String(e));
+      toast.error(e instanceof IntricError ? e.getReadableMessage() : String(e));
     }
   });
 </script>

--- a/frontend/apps/web/src/lib/features/spaces/SpacesManager.ts
+++ b/frontend/apps/web/src/lib/features/spaces/SpacesManager.ts
@@ -8,6 +8,7 @@ import { goto } from "$app/navigation";
 import { createContext } from "$lib/core/context";
 import type { Intric, ResourcePermission, Space, SpaceSparse } from "@intric/intric-js";
 import { derived, get, writable, type Readable } from "svelte/store";
+import { toast } from "$lib/components/toast";
 
 const [getSpacesManager, setSpacesManager] = createContext<ReturnType<typeof SpacesManager>>(
   "Manages spaces / projects"
@@ -101,7 +102,7 @@ function SpacesManager(data: SpacesManagerParams) {
       refreshSpaces();
       return newSpace;
     } catch (e) {
-      alert(`Error creating new space ${space.name}`);
+      toast.error(`Error creating new space ${space.name}`);
       console.error(e);
     }
     return null;
@@ -128,7 +129,7 @@ function SpacesManager(data: SpacesManagerParams) {
       }
       return updatedSpace;
     } catch (e) {
-      alert(`Error updating space ${id}`);
+      toast.error(`Error updating space ${id}`);
       console.error(e);
     }
   }
@@ -142,7 +143,7 @@ function SpacesManager(data: SpacesManagerParams) {
         goto("/spaces/list");
       }
     } catch (e) {
-      alert(`Error deleting space ${space.id}`);
+      toast.error(`Error deleting space ${space.id}`);
       console.error(e);
     }
   }
@@ -159,7 +160,7 @@ function SpacesManager(data: SpacesManagerParams) {
         return $currentSpace;
       });
     } catch (e) {
-      alert("Error updating default assistant.");
+      toast.error("Error updating default assistant.");
       console.error(e);
     }
   }

--- a/frontend/apps/web/src/lib/features/templates/TemplateController.ts
+++ b/frontend/apps/web/src/lib/features/templates/TemplateController.ts
@@ -1,5 +1,6 @@
 import { createContext } from "$lib/core/context";
 import { m } from "$lib/paraglide/messages";
+import { toast } from "$lib/components/toast";
 import { type GroupSparse, type TemplateAdditionalField } from "@intric/intric-js";
 import { derived, get, writable } from "svelte/store";
 import { type Attachment } from "../attachments/AttachmentManager";
@@ -89,7 +90,7 @@ function createTemplateController(data: TemplateControllerParams) {
         const res = await adapter.createNew({ name: $name });
         onResourceCreated(res);
       } catch (e) {
-        alert(`Error: Couldn't create ${$name}\n${e}`);
+        toast.error(`Couldn't create ${$name}: ${e}`);
       }
       return;
     }
@@ -115,7 +116,7 @@ function createTemplateController(data: TemplateControllerParams) {
             })
           });
         } else {
-          alert(
+          toast.warning(
             "This template can only create relevant responses if you supply the required knowledge. Please configure the knowledge below or choose a different template."
           );
           return;
@@ -126,7 +127,7 @@ function createTemplateController(data: TemplateControllerParams) {
         const isUploadRunning = $selectedAttachments.some((attachment) => !attachment.fileRef);
 
         if (isUploadRunning) {
-          alert(
+          toast.warning(
             "Please wait until all uploads are finished or cancel running uploads berfore proceeding."
           );
           return;
@@ -140,7 +141,7 @@ function createTemplateController(data: TemplateControllerParams) {
             })
           });
         } else {
-          alert(
+          toast.warning(
             "This template can only create relevant responses if you upload the required attachments. Please add relevant attachments or choose a different template."
           );
           return;
@@ -158,7 +159,7 @@ function createTemplateController(data: TemplateControllerParams) {
       selectedAttachments.set([]);
       onResourceCreated(res);
     } catch (e) {
-      alert(`Error: Couldn't create ${$name} from template ${$template.name}\n${e}`);
+      toast.error(`Couldn't create ${$name} from template ${$template.name}: ${e}`);
     }
   }
 

--- a/frontend/apps/web/src/lib/features/templates/components/gallery/TemplateLanguageSwitcher.svelte
+++ b/frontend/apps/web/src/lib/features/templates/components/gallery/TemplateLanguageSwitcher.svelte
@@ -3,6 +3,7 @@
   import SwedishFlag from "./SwedishFlag.svelte";
   import { IconChevronUpDown } from "@intric/icons/chevron-up-down";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const availableLanguages = {
     sv: {
@@ -15,7 +16,7 @@
   let selectedLanguage: Language = "sv";
   function setLanguage(lang: string) {
     if (!Object.hasOwn(availableLanguages, lang)) {
-      alert(`Language ${lang} is not available.`);
+      toast.warning(`Language ${lang} is not available.`);
     }
     selectedLanguage = lang as Language;
   }

--- a/frontend/apps/web/src/routes/(app)/account/UpdateUserName.svelte
+++ b/frontend/apps/web/src/routes/(app)/account/UpdateUserName.svelte
@@ -8,6 +8,7 @@
   import { getAppContext } from "$lib/core/AppContext";
   import { Dialog, Button, Input } from "@intric/ui";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const { updateUserInfo } = getAppContext();
 
@@ -32,7 +33,7 @@
       await updateUserInfo({ firstName, lastName, displayName });
       $isOpen = false;
     } catch (e) {
-      alert(m.error_updating_user_info());
+      toast.error(m.error_updating_user_info());
     }
   }
 

--- a/frontend/apps/web/src/routes/(app)/account/api-keys/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/account/api-keys/+page.svelte
@@ -5,6 +5,7 @@
   import { getIntric } from "$lib/core/Intric";
   import { Button, Dialog } from "@intric/ui";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const {
     user,
@@ -45,7 +46,7 @@
         <Button
           on:click={() => {
             if (!apiKey) {
-              alert(m.no_api_key_found_generate());
+              toast.warning(m.no_api_key_found_generate());
               return;
             }
             navigator.clipboard.writeText(apiKey);

--- a/frontend/apps/web/src/routes/(app)/account/integrations/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/account/integrations/+page.svelte
@@ -10,6 +10,7 @@
   import UserConnectedSplitButton from "$lib/features/integrations/components/UserConnectedSplitButton.svelte";
   import { getAppContext } from "$lib/core/AppContext";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { localizeHref } from "$lib/paraglide/runtime";
 
   const { data }: PageProps = $props();
@@ -25,7 +26,7 @@
   const auth = new IntegrationAuthService({
     onConnected(result) {
       if (!result.success) {
-        alert(result.error);
+        toast.error(result.error instanceof Error ? result.error.message : String(result.error));
         return;
       }
 

--- a/frontend/apps/web/src/routes/(app)/admin/integrations/SharePointSubscriptions.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/integrations/SharePointSubscriptions.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Button } from "@intric/ui";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte";
   import type { IntricClient } from "@intric/intric-js";
   import dayjs from "dayjs";
@@ -47,7 +48,7 @@
       subscriptions = Array.isArray(response) ? response : [];
     } catch (error) {
       console.error("Failed to load SharePoint subscriptions:", error);
-      alert(m.sharepoint_subscriptions_load_error());
+      toast.error(m.sharepoint_subscriptions_load_error());
       subscriptions = [];
     } finally {
       loading = false;
@@ -66,27 +67,27 @@
       const result: SubscriptionRenewalResult = await intric.integrations.admin.sharepoint.renewExpiredSubscriptions();
 
       if (result.recreated > 0 && result.failed === 0) {
-        alert(
+        toast.success(
           m.sharepoint_subscriptions_renewed_success({
             count: result.recreated
           })
         );
       } else if (result.failed > 0) {
-        alert(
+        toast.error(
           m.sharepoint_subscriptions_renewed_partial({
             failed: result.failed,
             errors: result.errors.join(", ")
           })
         );
       } else if (result.expired_count === 0) {
-        alert(m.sharepoint_subscriptions_none_expired());
+        toast.info(m.sharepoint_subscriptions_none_expired());
       }
 
       // Reload subscriptions
       await loadSubscriptions();
     } catch (error) {
       console.error("Failed to renew expired subscriptions:", error);
-      alert(m.sharepoint_subscriptions_renew_error());
+      toast.error(m.sharepoint_subscriptions_renew_error());
     } finally {
       renewingAll = false;
     }
@@ -99,13 +100,13 @@
 
     try {
       await intric.integrations.admin.sharepoint.recreateSubscription({ id: subscription.id });
-      alert(m.sharepoint_subscription_renewed_success());
+      toast.success(m.sharepoint_subscription_renewed_success());
 
       // Reload subscriptions
       await loadSubscriptions();
     } catch (error) {
       console.error(`Failed to renew subscription ${subscription.id}:`, error);
-      alert(m.sharepoint_subscription_renew_error());
+      toast.error(m.sharepoint_subscription_renew_error());
     } finally {
       renewingSubscriptionIds.delete(subscription.id);
       renewingSubscriptionIds = renewingSubscriptionIds; // Trigger reactivity

--- a/frontend/apps/web/src/routes/(app)/admin/legacy/roles/RoleEditor.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/legacy/roles/RoleEditor.svelte
@@ -11,6 +11,7 @@
   import type { Permission, Role } from "@intric/intric-js";
   import { Dialog, Button, Input } from "@intric/ui";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const intric = getIntric();
 
@@ -52,7 +53,7 @@
       invalidate("admin:roles:load");
       $showDialog = false;
     } catch (error) {
-      alert(error);
+      toast.error(error instanceof Error ? error.message : String(error));
       console.error(error);
     }
     isProcessing = false;
@@ -66,7 +67,7 @@
       $showDialog = false;
       editableRole.updateWithValue(emptyRole);
     } catch (error) {
-      alert(error);
+      toast.error(error instanceof Error ? error.message : String(error));
       console.error(error);
     }
     isProcessing = false;

--- a/frontend/apps/web/src/routes/(app)/admin/legacy/user-groups/UserGroupActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/legacy/user-groups/UserGroupActions.svelte
@@ -13,6 +13,7 @@
   import { getIntric } from "$lib/core/Intric";
   import { invalidate } from "$app/navigation";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   export let userGroup: UserGroup;
 
@@ -27,7 +28,7 @@
       invalidate("admin:user-groups:load");
       $showDeleteDialog = false;
     } catch (e) {
-      alert(m.could_not_delete_user_group());
+      toast.error(m.could_not_delete_user_group());
       console.error(e);
     }
     isDeleting = false;

--- a/frontend/apps/web/src/routes/(app)/admin/legacy/user-groups/UserGroupEditor.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/legacy/user-groups/UserGroupEditor.svelte
@@ -11,6 +11,7 @@
   import type { UserGroup } from "@intric/intric-js";
   import { Dialog, Button, Input } from "@intric/ui";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const emptyUserGroup: UserGroup = {
     id: "",
@@ -48,7 +49,7 @@
       invalidate("admin:user-groups:load");
       $showDialog = false;
     } catch (error) {
-      alert(error);
+      toast.error(error instanceof Error ? error.message : String(error));
       console.error(error);
     }
     isProcessing = false;
@@ -62,7 +63,7 @@
       $showDialog = false;
       editableUserGroup.updateWithValue(emptyUserGroup);
     } catch (error) {
-      alert(error);
+      toast.error(error instanceof Error ? error.message : String(error));
       console.error(error);
     }
     isProcessing = false;

--- a/frontend/apps/web/src/routes/(app)/admin/legacy/user-groups/UserGroupMembersEditor.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/legacy/user-groups/UserGroupMembersEditor.svelte
@@ -11,6 +11,7 @@
   import { Dialog, Button } from "@intric/ui";
   import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte.ts";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { IconSearch } from "@intric/icons/search";
   import { IconTrash } from "@intric/icons/trash";
   import { IconCheck } from "@intric/icons/check";
@@ -65,7 +66,7 @@
       selectedUsers = [];
       searchQuery = "";
     } catch (e) {
-      alert(m.could_not_add_user_to_group());
+      toast.error(m.could_not_add_user_to_group());
       console.error(e);
     }
   });
@@ -75,7 +76,7 @@
       await intric.userGroups.removeUser({ userGroup, user });
       invalidate("admin:user-groups:load");
     } catch (e) {
-      alert(m.could_not_remove_user_from_group());
+      toast.error(m.could_not_remove_user_from_group());
       console.error(e);
     }
   });

--- a/frontend/apps/web/src/routes/(app)/admin/templates/TemplateActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/templates/TemplateActions.svelte
@@ -9,6 +9,7 @@
   import { Button, Dropdown } from "@intric/ui";
   import { MoreVertical, Edit, Trash2, RotateCcw, ArrowUpToLine, ArrowDownToLine } from "lucide-svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { writable } from "svelte/store";
   import { goto, invalidate } from "$app/navigation";
   import { getIntric } from "$lib/core/Intric";
@@ -43,7 +44,7 @@
       await invalidate("/admin/templates");
     } catch (e) {
       console.error("Error toggling default status:", e);
-      alert(m.error_changing_default_status?.() || "Error changing default status");
+      toast.error(m.error_changing_default_status?.() || "Error changing default status");
     }
   }
 </script>

--- a/frontend/apps/web/src/routes/(app)/admin/templates/edit/app/[id]/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/templates/edit/app/[id]/+page.svelte
@@ -4,6 +4,7 @@
   import { Button, Input } from "@intric/ui";
   import { goto } from "$app/navigation";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { localizeHref } from "$lib/paraglide/runtime";
   import SelectAIModelV2 from "$lib/features/ai-models/components/SelectAIModelV2.svelte";
   import SelectBehaviourV2 from "$lib/features/ai-models/components/SelectBehaviourV2.svelte";
@@ -90,12 +91,12 @@
 
   async function handleUpdateTemplate() {
     if (!name || !category) {
-      alert(m.category_required());
+      toast.warning(m.category_required());
       return;
     }
 
     if (!inputType) {
-      alert(m.input_type_required());
+      toast.warning(m.input_type_required());
       return;
     }
 
@@ -130,7 +131,7 @@
       goto("/admin/templates?success=template_updated");
     } catch (error) {
       console.error("Failed to update template:", error);
-      alert("Failed to update template");
+      toast.error("Failed to update template");
     } finally {
       isSaving = false;
     }

--- a/frontend/apps/web/src/routes/(app)/admin/templates/edit/assistant/[id]/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/templates/edit/assistant/[id]/+page.svelte
@@ -3,6 +3,7 @@
   import { Button, Input } from "@intric/ui";
   import { goto } from "$app/navigation";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { localizeHref } from "$lib/paraglide/runtime";
   import SelectAIModelV2 from "$lib/features/ai-models/components/SelectAIModelV2.svelte";
   import SelectBehaviourV2 from "$lib/features/ai-models/components/SelectBehaviourV2.svelte";
@@ -59,7 +60,7 @@
 
   async function handleUpdateTemplate() {
     if (!name || !category) {
-      alert(m.category_required());
+      toast.warning(m.category_required());
       return;
     }
 
@@ -95,7 +96,7 @@
       goto("/admin/templates?success=template_updated");
     } catch (error) {
       console.error("Failed to update template:", error);
-      alert("Failed to update template");
+      toast.error("Failed to update template");
     } finally {
       isSaving = false;
     }

--- a/frontend/apps/web/src/routes/(app)/admin/templates/new/app/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/templates/new/app/+page.svelte
@@ -4,6 +4,7 @@
   import { Button, Input } from "@intric/ui";
   import { goto } from "$app/navigation";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { localizeHref } from "$lib/paraglide/runtime";
   import SelectAIModelV2 from "$lib/features/ai-models/components/SelectAIModelV2.svelte";
   import SelectBehaviourV2 from "$lib/features/ai-models/components/SelectBehaviourV2.svelte";
@@ -81,12 +82,12 @@
 
   async function handleCreateTemplate() {
     if (!name || !category) {
-      alert(m.category_required());
+      toast.warning(m.category_required());
       return;
     }
 
     if (!inputType) {
-      alert(m.input_type_required());
+      toast.warning(m.input_type_required());
       return;
     }
 
@@ -120,7 +121,7 @@
       goto("/admin/templates?success=template_created");
     } catch (error) {
       console.error("Failed to create template:", error);
-      alert(m.failed_to_create_template());
+      toast.error(m.failed_to_create_template());
     } finally {
       isSaving = false;
     }

--- a/frontend/apps/web/src/routes/(app)/admin/templates/new/assistant/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/templates/new/assistant/+page.svelte
@@ -3,6 +3,7 @@
   import { Button, Input, Tooltip } from "@intric/ui";
   import { goto } from "$app/navigation";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { localizeHref } from "$lib/paraglide/runtime";
   import SelectAIModelV2 from "$lib/features/ai-models/components/SelectAIModelV2.svelte";
   import SelectBehaviourV2 from "$lib/features/ai-models/components/SelectBehaviourV2.svelte";
@@ -38,7 +39,7 @@
 
   async function handleCreateTemplate() {
     if (!name || !category) {
-      alert(m.category_required());
+      toast.warning(m.category_required());
       return;
     }
 
@@ -73,7 +74,7 @@
       goto("/admin/templates?success=template_created");
     } catch (error) {
       console.error("Failed to create template:", error);
-      alert(m.failed_to_create_template());
+      toast.error(m.failed_to_create_template());
     } finally {
       isSaving = false;
     }

--- a/frontend/apps/web/src/routes/(app)/admin/users/editor/InviteLinkDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/users/editor/InviteLinkDialog.svelte
@@ -3,6 +3,7 @@
   import { getAppContext } from "$lib/core/AppContext";
   import { Button, Dialog } from "@intric/ui";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const { tenant } = getAppContext();
 
@@ -19,7 +20,7 @@
         copyButtonText = m.copy_invite_link();
       }, 2000);
     } catch (error) {
-      alert(m.could_not_copy_link());
+      toast.error(m.could_not_copy_link());
     }
   }
 

--- a/frontend/apps/web/src/routes/(app)/admin/users/editor/InviteUser.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/users/editor/InviteUser.svelte
@@ -7,6 +7,7 @@
   import { getAppContext } from "$lib/core/AppContext";
   import InviteLinkDialog from "./InviteLinkDialog.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const intric = getIntric();
   const { defaultRoles } = getAdminUserCtx();
@@ -30,7 +31,7 @@
       $showDialog = false;
       $showInviteLink = true;
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
     }
   }
 </script>

--- a/frontend/apps/web/src/routes/(app)/admin/users/editor/SelectUserGroups.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/users/editor/SelectUserGroups.svelte
@@ -12,6 +12,7 @@
   import type { UserGroup } from "@intric/intric-js";
   import { createCombobox } from "@melt-ui/svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   // Array of all currently selected collections
   export let selectedGroups: UserGroup[];
@@ -37,7 +38,7 @@
         selectedGroups = selectedGroups.toSpliced(index, 1);
       }
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
       console.error(e);
     }
   }
@@ -58,7 +59,7 @@
           $selected = undefined;
         }
       } catch (e) {
-        alert(e);
+        toast.error(e instanceof Error ? e.message : String(e));
         console.error(e);
       }
     }

--- a/frontend/apps/web/src/routes/(app)/admin/users/editor/UserEditor.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/users/editor/UserEditor.svelte
@@ -14,6 +14,7 @@
   import { getIntric } from "$lib/core/Intric";
   import { getAdminUserCtx } from "../ctx";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const intric = getIntric();
 
@@ -85,7 +86,7 @@
 
   async function updateUser() {
     if (!user.username) {
-      alert(m.cant_edit_user_without_username());
+      toast.warning(m.cant_edit_user_without_username());
       return;
     }
     const update = {
@@ -105,7 +106,7 @@
       userPassword = "";
       showDialog.set(false);
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
     }
   }
 
@@ -126,7 +127,7 @@
       invalidate("admin:users:load");
       showDialog.set(false);
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
     }
   }
 </script>

--- a/frontend/apps/web/src/routes/(app)/dashboard/app/[appId]/DashboardAppRunView.svelte
+++ b/frontend/apps/web/src/routes/(app)/dashboard/app/[appId]/DashboardAppRunView.svelte
@@ -13,6 +13,7 @@
   import DashboardAppInput from "./DashboardAppInput.svelte";
   import { formatEmojiTitle } from "$lib/core/formatting/formatEmojiTitle";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const intric = getIntric();
 
@@ -38,7 +39,7 @@
   let isSubmitting = false;
   async function createRun() {
     if (inputs.files.length === 0 && !inputs.text) {
-      alert(m.input_required_to_run_app());
+      toast.warning(m.input_required_to_run_app());
       return;
     }
 
@@ -60,7 +61,7 @@
     } catch (err) {
       const msg = err instanceof IntricError ? err.getReadableMessage() : err;
       console.error(err);
-      alert(m.error_running_app({ msg }));
+      toast.error(m.error_running_app({ msg }));
       isSubmitting = false;
     }
   }

--- a/frontend/apps/web/src/routes/(app)/dashboard/app/[appId]/results/[resultId]/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/dashboard/app/[appId]/results/[resultId]/+page.svelte
@@ -16,6 +16,7 @@
   import { getIntric } from "$lib/core/Intric.js";
   import { browser } from "$app/environment";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { localizeHref } from "$lib/paraglide/runtime";
   import { fade, fly } from "svelte/transition";
   import { quadInOut } from "svelte/easing";
@@ -34,7 +35,7 @@
 
   async function downloadAsText(text?: string | null) {
     if (!text) {
-      alert(m.not_output_to_save());
+      toast.warning(m.not_output_to_save());
       return;
     }
     const file = new Blob([text], { type: "application/octet-stream;charset=utf-8" });
@@ -71,7 +72,7 @@
     if (text) {
       navigator.clipboard.writeText(text);
     } else {
-      alert(m.no_copyable_output());
+      toast.warning(m.no_copyable_output());
     }
   }
 

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/AppActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/AppActions.svelte
@@ -11,6 +11,7 @@
   import { IconArrowDownToLine } from "@intric/icons/arrow-down-to-line";
   import { IconArrowUpToLine } from "@intric/icons/arrow-up-to-line";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { localizeHref } from "$lib/paraglide/runtime";
 
   export let app: AppSparse;
@@ -29,7 +30,7 @@
       refreshCurrentSpace();
       $showDeleteDialog = false;
     } catch (e) {
-      alert(m.could_not_delete_app());
+      toast.error(m.could_not_delete_app());
       console.error(e);
     }
     isProcessing = false;

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/[appId]/results/ResultAction.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/[appId]/results/ResultAction.svelte
@@ -6,6 +6,7 @@
   import { getIntric } from "$lib/core/Intric";
   import { getResultTitle } from "$lib/features/apps/getResultTitle";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   export let result: Pick<AppRun, "id" | "input">;
   export let onResultDeleted: ((result: Pick<AppRun, "id" | "input">) => void) | undefined =
@@ -21,7 +22,7 @@
       onResultDeleted?.(result);
       $showDeleteDialog = false;
     } catch (e) {
-      alert(m.could_not_delete_result());
+      toast.error(m.could_not_delete_result());
       console.error(e);
     }
     isProcessing = false;

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/[appId]/results/[resultId]/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/[appId]/results/[resultId]/+page.svelte
@@ -21,6 +21,7 @@
   import { getIntric } from "$lib/core/Intric.js";
   import { browser } from "$app/environment";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { localizeHref } from "$lib/paraglide/runtime";
   dayjs.extend(utc);
 
@@ -40,7 +41,7 @@
 
   async function downloadAsText(text?: string | null) {
     if (!text) {
-      alert(m.not_output_to_save());
+      toast.warning(m.not_output_to_save());
       return;
     }
     const file = new Blob([text], { type: "application/octet-stream;charset=utf-8" });
@@ -80,7 +81,7 @@
       navigator.clipboard.writeText(text);
       setTimeout(() => {}, 2000);
     } else {
-      alert(m.no_copyable_output());
+      toast.warning(m.no_copyable_output());
     }
   }
 

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/[appId]/run/AppRunView.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/[appId]/run/AppRunView.svelte
@@ -14,6 +14,7 @@
   import AppInput from "./AppInput.svelte";
   import { formatEmojiTitle } from "$lib/core/formatting/formatEmojiTitle";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const intric = getIntric();
   const {
@@ -49,7 +50,7 @@
   let isSubmitting = false;
   async function createRun() {
     if (inputs.files.length === 0 && !inputs.text) {
-      alert(m.input_required_to_run_app());
+      toast.warning(m.input_required_to_run_app());
       return;
     }
 
@@ -73,7 +74,7 @@
     } catch (err) {
       const msg = err instanceof IntricError ? err.getReadableMessage() : err;
       console.error(err);
-      alert(m.error_running_app({ msg }));
+      toast.error(m.error_running_app({ msg }));
       isSubmitting = false;
     }
   }

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/[appId]/run/AudioRecorder.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/[appId]/run/AudioRecorder.svelte
@@ -6,6 +6,7 @@
 
   import dayjs from "dayjs";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   type RecordingStopReason = "manual" | "limit" | "stall" | "error";
 
@@ -528,7 +529,7 @@
             class="cursor-pointer text-xs font-medium underline underline-offset-2 transition-colors text-negative-default hover:text-negative-stronger text-left"
             on:click={() => {
               console.warn("Recording diagnostics:", recordingStats);
-              alert(m.diagnostics_logged_console());
+              toast.info(m.diagnostics_logged_console());
             }}
           >
             {m.view_diagnostics()}

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/[appId]/run/InputAudioRecording.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/[appId]/run/InputAudioRecording.svelte
@@ -11,6 +11,7 @@
   import AudioRecorder from "./AudioRecorder.svelte";
   import AttachmentItem from "$lib/features/attachments/components/AttachmentItem.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { fade } from "svelte/transition";
 
   export let description = m.record_audio_device();
@@ -57,7 +58,7 @@
 
   async function saveAudioFile() {
     if (!audioFile) {
-      alert(m.recording_not_found());
+      toast.error(m.recording_not_found());
       return;
     }
     const suggestedName = audioFile.name;
@@ -72,7 +73,7 @@
           return;
         }
         console.error("Failed to save recording:", error);
-        alert(m.recording_save_failed());
+        toast.error(m.recording_save_failed());
       }
     } else {
       const a = document.createElement("a");
@@ -122,12 +123,12 @@
         variant="primary"
         on:click={() => {
           if (!audioFile) {
-            alert(m.recording_not_found());
+            toast.error(m.recording_not_found());
             return;
           }
           const errors = queueValidUploads([audioFile]);
           if (errors) {
-            alert(errors);
+            toast.error(Array.isArray(errors) ? errors.join("\n") : String(errors));
           } else {
             showSuccess = true;
             setTimeout(() => (showSuccess = false), 1500);

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/[appId]/run/InputUpload.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/apps/[appId]/run/InputUpload.svelte
@@ -5,6 +5,7 @@
   import { getExplicitAttachmentRules } from "$lib/features/attachments/getAttachmentRules";
   import AttachmentItem from "$lib/features/attachments/components/AttachmentItem.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   export let input: App["input_fields"][number];
   export let description: string | undefined = undefined;
@@ -27,7 +28,7 @@
     const errors = queueValidUploads([...fileInput.files], attachmentRules);
 
     if (errors) {
-      alert(errors.join("\n"));
+      toast.error(errors.join("\n"));
     }
 
     fileInput.value = "";

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/assistants/AssistantActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/assistants/AssistantActions.svelte
@@ -12,6 +12,7 @@
   import { IconArrowUpToLine } from "@intric/icons/arrow-up-to-line";
   import { IconArrowDownToLine } from "@intric/icons/arrow-down-to-line";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { localizeHref } from "$lib/paraglide/runtime";
 
   export let assistant: AssistantSparse;
@@ -30,7 +31,7 @@
       refreshCurrentSpace("applications");
       $showDeleteDialog = false;
     } catch (e) {
-      alert(m.could_not_delete_assistant());
+      toast.error(m.could_not_delete_assistant());
       console.error(e);
     }
     isProcessing = false;
@@ -44,7 +45,7 @@
       refreshCurrentSpace();
       $showMoveDialog = false;
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
       console.error(e);
     }
     isProcessing = false;

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/assistants/CreateNew.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/assistants/CreateNew.svelte
@@ -11,6 +11,7 @@
   import { Button, Dialog, Dropdown, Input } from "@intric/ui";
   import { writable } from "svelte/store";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   let { data }: { data: { settings: Settings } } = $props();
 
@@ -44,7 +45,7 @@
       $showCreateGroupChatDialog = false;
     } catch (error) {
       const message = error instanceof IntricError ? error.getReadableMessage() : String(error);
-      alert(message);
+      toast.error(message);
     }
   }
 </script>

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/assistants/GroupChatActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/assistants/GroupChatActions.svelte
@@ -12,6 +12,7 @@
   import { IconArrowDownToLine } from "@intric/icons/arrow-down-to-line";
   import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { localizeHref } from "$lib/paraglide/runtime";
 
   export let groupChat: GroupChatSparse;
@@ -29,7 +30,7 @@
       refreshCurrentSpace("applications");
       $showDeleteDialog = false;
     } catch (e) {
-      alert(m.could_not_delete_group_chat());
+      toast.error(m.could_not_delete_group_chat());
       console.error(e);
     }
   });

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/+page.svelte
@@ -14,6 +14,7 @@
   import SyncHistoryDialog from "./integrations/SyncHistoryDialog.svelte";
   import ImportKnowledgeDialog from "$lib/features/integrations/components/import/ImportKnowledgeDialog.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import type { IntegrationKnowledge } from "@intric/intric-js";
   import { jobCompletionEvents } from "$lib/features/jobs/JobManager";
 
@@ -69,9 +70,8 @@
 
       // Only show alert if there were errors
       if (response.failed > 0) {
-        alert(
-          `${response.queued} website${response.queued > 1 ? 's' : ''} queued, ${response.failed} failed.\n` +
-          `Check console for error details.`
+        toast.error(
+          `${response.queued} website${response.queued > 1 ? 's' : ''} queued, ${response.failed} failed. Check console for error details.`
         );
         console.error("Bulk recrawl errors:", response.errors);
       }
@@ -80,7 +80,7 @@
       $selectedWebsiteIds = new Set();
       refreshCurrentSpace();
     } catch (e) {
-      alert("Failed to trigger bulk recrawl: " + e);
+      toast.error("Failed to trigger bulk recrawl: " + (e instanceof Error ? e.message : String(e)));
       console.error(e);
     }
     isBulkRecrawling = false;

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/collections/CollectionActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/collections/CollectionActions.svelte
@@ -10,6 +10,7 @@
   import { getIntric } from "$lib/core/Intric";
   import { derived } from "svelte/store";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const {
     refreshCurrentSpace,
@@ -27,7 +28,7 @@
       refreshCurrentSpace();
       $showDeleteDialog = false;
     } catch (e) {
-      alert(m.could_not_delete_collection());
+      toast.error(m.could_not_delete_collection());
       console.error(e);
     }
   }
@@ -40,7 +41,7 @@
       refreshCurrentSpace();
       $showMoveDialog = false;
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
       console.error(e);
     }
     isProcessing = false;

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/collections/CollectionEditor.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/collections/CollectionEditor.svelte
@@ -5,6 +5,7 @@
   import { getSpacesManager } from "$lib/features/spaces/SpacesManager";
   import { Dialog, Button, Input } from "@intric/ui";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const intric = getIntric();
   const {
@@ -30,7 +31,7 @@
       refreshCurrentSpace();
       $showDialog = false;
     } catch (error) {
-      alert(error);
+      toast.error(error instanceof Error ? error.message : String(error));
       console.error(error);
     }
     isProcessing = false;
@@ -52,7 +53,7 @@
       $showDialog = false;
       await goto(`/spaces/${routeId}/knowledge/collections/${newCollection.id}`);
     } catch (error) {
-      alert(error);
+      toast.error(error instanceof Error ? error.message : String(error));
       console.error(error);
     }
     isProcessing = false;

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/collections/[collectionId]/BlobActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/collections/[collectionId]/BlobActions.svelte
@@ -7,6 +7,7 @@
   import { IconEllipsis } from "@intric/icons/ellipsis";
   import { IconEdit } from "@intric/icons/edit";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const intric = getIntric();
   export let blob: InfoBlob;
@@ -22,7 +23,7 @@
       invalidate("blobs:list");
       return true;
     } catch (e) {
-      alert(m.could_not_change_title_to({ title: updatableTitle }));
+      toast.error(m.could_not_change_title_to({ title: updatableTitle }));
       console.error(e);
       return false;
     }
@@ -34,7 +35,7 @@
       invalidate("blobs:list");
       return true;
     } catch (e) {
-      alert(m.could_not_delete_file({ fileName: blob.metadata.title ?? m.this_file() }));
+      toast.error(m.could_not_delete_file({ fileName: blob.metadata.title ?? m.this_file() }));
       console.error(e);
       return false;
     }

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/collections/[collectionId]/BlobCreate.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/collections/[collectionId]/BlobCreate.svelte
@@ -5,6 +5,7 @@
   import { type Group } from "@intric/intric-js";
   import { Button, Dialog, Input } from "@intric/ui";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   export let disabled = false;
   export let collection: Group;
@@ -30,7 +31,7 @@
       text = title = "";
       return;
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
     }
   }
 

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/collections/[collectionId]/BlobUpload.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/collections/[collectionId]/BlobUpload.svelte
@@ -7,6 +7,7 @@
   import { Button, Dialog, Input } from "@intric/ui";
   import { formatBytes } from "$lib/core/formatting/formatBytes";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const {
     limits,
@@ -121,7 +122,7 @@
       files = [];
       return;
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
     }
   }
 
@@ -142,7 +143,7 @@
     <Dialog.Title>{m.upload_files()}</Dialog.Title>
     <Dialog.Description hidden></Dialog.Description>
 
-    <Input.Files bind:files {acceptedMimeTypes}></Input.Files>
+    <Input.Files bind:files {acceptedMimeTypes} on:showsupportedtypes={(e) => toast.info(e.detail.message)}></Input.Files>
 
     {#if validationErrors.length > 0}
       <div class="bg-negative-dimmer text-negative-default mt-3 rounded-md px-3 py-2 text-sm">

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/integrations/IntegrationActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/integrations/IntegrationActions.svelte
@@ -8,6 +8,7 @@
   import { getSpacesManager } from "$lib/features/spaces/SpacesManager";
   import { getIntric } from "$lib/core/Intric";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   export let knowledgeItem: IntegrationKnowledge;
 
@@ -32,7 +33,7 @@
       refreshCurrentSpace();
       $showDeleteDialog = false;
     } catch (e) {
-      alert(m.integration_delete_error());
+      toast.error(m.integration_delete_error());
       console.error(e);
     }
     isDeleting = false;
@@ -49,7 +50,7 @@
       refreshCurrentSpace();
       $showRenameDialog = false;
     } catch (e) {
-      alert(m.integration_rename_error());
+      toast.error(m.integration_rename_error());
       console.error(e);
     }
     isRenaming = false;

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/integrations/SharePointWrapperActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/integrations/SharePointWrapperActions.svelte
@@ -2,6 +2,7 @@
   import { getIntric } from "$lib/core/Intric";
   import { getSpacesManager } from "$lib/features/spaces/SpacesManager";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { IconEdit } from "@intric/icons/edit";
   import { IconEllipsis } from "@intric/icons/ellipsis";
   import { IconTrash } from "@intric/icons/trash";
@@ -45,7 +46,7 @@
       $showRenameDialog = false;
     } catch (error) {
       console.error(error);
-      alert(m.integration_rename_error());
+      toast.error(m.integration_rename_error());
     } finally {
       isRenaming = false;
     }
@@ -62,7 +63,7 @@
       $showDeleteDialog = false;
     } catch (error) {
       console.error(error);
-      alert(m.integration_delete_error());
+      toast.error(m.integration_delete_error());
     } finally {
       isDeleting = false;
     }

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/websites/WebsiteActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/websites/WebsiteActions.svelte
@@ -10,6 +10,7 @@
   import { getIntric } from "$lib/core/Intric";
   import { derived } from "svelte/store";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   export let website: WebsiteSparse;
 
@@ -28,7 +29,7 @@
       refreshCurrentSpace();
       $showDeleteDialog = false;
     } catch (e) {
-      alert(m.could_not_delete_crawl());
+      toast.error(m.could_not_delete_crawl());
       console.error(e);
     }
     isProcessing = false;
@@ -42,7 +43,7 @@
       refreshCurrentSpace();
       $showMoveDialog = false;
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
       console.error(e);
     }
     isProcessing = false;

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/websites/WebsiteEditor.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/websites/WebsiteEditor.svelte
@@ -6,6 +6,7 @@
   import { type Website } from "@intric/intric-js";
   import { Dialog, Button, Input, Select, Tooltip } from "@intric/ui";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { tick } from "svelte";
   import { writable, type Writable } from "svelte/store";
 
@@ -199,7 +200,7 @@
       refreshCurrentSpace();
       $showDialog = false;
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
       console.error(e);
     }
     isProcessing = false;
@@ -233,7 +234,7 @@
       refreshCurrentSpace();
       $showDialog = false;
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
       console.error(e);
     }
     isProcessing = false;

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/websites/[id]/CrawlCreateRun.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/knowledge/websites/[id]/CrawlCreateRun.svelte
@@ -5,6 +5,7 @@
   import type { Website } from "@intric/intric-js";
   import { Button, Dialog, Tooltip } from "@intric/ui";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   export let website: Website;
   export let isDisabled = false;
@@ -24,7 +25,7 @@
       $showDialog = false;
     } catch (error) {
       console.error(error);
-      alert(m.error_creating_crawl_run());
+      toast.error(m.error_creating_crawl_run());
     }
   }
 </script>

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/members/AddGroupMember.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/members/AddGroupMember.svelte
@@ -13,6 +13,7 @@
   import { createCombobox } from "@melt-ui/svelte";
   import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte.ts";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { IconGroup } from "@intric/icons/group";
 
   const {
@@ -79,7 +80,7 @@
       $showDialog = false;
       $selected = undefined;
     } catch (e) {
-      alert(m.could_not_add_group());
+      toast.error(m.could_not_add_group());
       console.error(e);
     }
   });

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/members/AddMember.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/members/AddMember.svelte
@@ -15,6 +15,7 @@
   import { UserList } from "./AddMember.svelte.ts";
   import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte.ts";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const {
     refreshCurrentSpace,
@@ -59,7 +60,7 @@
       $showDialog = false;
       $selected = undefined;
     } catch (e) {
-      alert(m.could_not_add_new_member());
+      toast.error(m.could_not_add_new_member());
       console.error(e);
     }
   });

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/members/GroupMemberRole.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/members/GroupMemberRole.svelte
@@ -16,6 +16,7 @@
   import { IconLoadingSpinner } from "@intric/icons/loading-spinner";
   import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   type GroupMember = Space["group_members"]["items"][number];
   type RoleOption = { label: string; value: SpaceRole["value"] };
@@ -59,7 +60,7 @@
       // Will cause an update in the parent page and remove this component instance from the tree
       refreshCurrentSpace();
     } catch (e) {
-      alert(m.couldnt_remove_group());
+      toast.error(m.couldnt_remove_group());
       console.error(e);
     }
   });
@@ -73,7 +74,7 @@
       // Await refreshing as that will update the actual label
       await refreshCurrentSpace();
     } catch (e) {
-      alert(m.couldnt_change_role());
+      toast.error(m.couldnt_change_role());
       console.error(e);
       // Reset selected
       $selected = { value: groupMember.role };

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/members/MemberRole.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/members/MemberRole.svelte
@@ -16,6 +16,7 @@
   import { IconLoadingSpinner } from "@intric/icons/loading-spinner";
   import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   type Member = Space["members"]["items"][number];
   type RoleOption = { label: string; value: SpaceRole["value"] };
@@ -59,7 +60,7 @@
       // Will cause an update in the parent page and remove this component instance form the tree
       refreshCurrentSpace();
     } catch (e) {
-      alert(m.couldnt_remove_user());
+      toast.error(m.couldnt_remove_user());
       console.error(e);
     }
   });
@@ -73,7 +74,7 @@
       // Await refreshing as that will update the actual label
       await refreshCurrentSpace();
     } catch (e) {
-      alert(m.couldnt_change_role());
+      toast.error(m.couldnt_change_role());
       console.error(e);
       // Reset selected
       $selected = { value: member.role };

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/services/CreateService.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/services/CreateService.svelte
@@ -4,6 +4,7 @@
   import { getSpacesManager } from "$lib/features/spaces/SpacesManager";
   import { Button, Dialog, Input } from "@intric/ui";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   const {
     state: { currentSpace },
@@ -32,7 +33,7 @@
         goto(`/spaces/${$currentSpace.routeId}/services/${service.id}?tab=edit`);
       }
     } catch (e) {
-      alert(m.error_creating_new_service());
+      toast.error(m.error_creating_new_service());
       console.error(e);
     }
     isProcessing = false;

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/services/ServiceActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/services/ServiceActions.svelte
@@ -9,6 +9,7 @@
   import { getSpacesManager } from "$lib/features/spaces/SpacesManager";
   import { derived } from "svelte/store";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import { localizeHref } from "$lib/paraglide/runtime";
 
   export let service: ServiceSparse;
@@ -28,7 +29,7 @@
       refreshCurrentSpace();
       $showDeleteDialog = false;
     } catch (e) {
-      alert(m.could_not_delete_service());
+      toast.error(m.could_not_delete_service());
       console.error(e);
     }
     isProcessing = false;
@@ -46,7 +47,7 @@
       refreshCurrentSpace();
       $showMoveDialog = false;
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
       console.error(e);
     }
     isProcessing = false;

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/services/[serviceId]/EditService.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/services/[serviceId]/EditService.svelte
@@ -14,6 +14,7 @@
   } from "$lib/features/ai-models/ModelBehaviours";
   import SelectBehaviourCustom from "$lib/features/ai-models/components/SelectBehaviourCustom.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   export let service: Service;
 
@@ -67,7 +68,7 @@
       invalidate("service:get");
     } catch (e) {
       if (e instanceof IntricError) {
-        alert(e.message);
+        toast.error(e.message);
         console.error(e);
       }
     }

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/+page.svelte
@@ -21,6 +21,7 @@
   import ChangeSecurityClassification from "./ChangeSecurityClassification.svelte";
   import EditRetentionPolicy from "./EditRetentionPolicy.svelte";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
   import IconUpload from "$lib/features/icons/IconUpload.svelte";
   import { fade } from "svelte/transition";
 
@@ -131,7 +132,7 @@
   async function deleteSpace() {
     if (deleteConfirmation === "") return;
     if (deleteConfirmation !== $currentSpace.name) {
-      alert(m.wrong_space_name());
+      toast.warning(m.wrong_space_name());
       return;
     }
     isDeleting = true;
@@ -141,7 +142,7 @@
     try {
       await spaces.deleteSpace($currentSpace);
     } catch (e) {
-      alert(m.error_deleting_space());
+      toast.error(m.error_deleting_space());
       console.error(e);
     }
     clearTimeout(deletionMessageTimeout);

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/ChangeSecurityClassification.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/ChangeSecurityClassification.svelte
@@ -10,6 +10,7 @@
   import { Button, Dialog } from "@intric/ui";
   import { writable } from "svelte/store";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   type Props = { classifications: SecurityClassification[]; onUpdateDone: () => void };
 
@@ -63,7 +64,7 @@
       onUpdateDone?.();
       $showDryRunDialog = false;
     } catch (error) {
-      alert(error instanceof IntricError ? error.getReadableMessage() : String(error));
+      toast.error(error instanceof IntricError ? error.getReadableMessage() : String(error));
     }
   });
 </script>

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/SelectCompletionModels.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/SelectCompletionModels.svelte
@@ -13,6 +13,7 @@
   import { Settings } from "$lib/components/layout";
   import { sortModels } from "$lib/features/ai-models/sortModels";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   export let selectableModels: (CompletionModel & {
     meets_security_classification?: boolean | null | undefined;
@@ -49,7 +50,7 @@
         await updateSpace({ completion_models: newModels });
       }
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
     }
     loading.delete(model.id);
     loading = loading;

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/SelectEmbeddingModels.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/SelectEmbeddingModels.svelte
@@ -13,6 +13,7 @@
   import { Settings } from "$lib/components/layout";
   import { sortModels } from "$lib/features/ai-models/sortModels";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   export let selectableModels: (EmbeddingModel & {
     meets_security_classification?: boolean | null | undefined;
@@ -51,7 +52,7 @@
         await updateSpace({ embedding_models: newModels });
       }
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
     }
     loading.delete(model.id);
     loading = loading;

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/SelectTranscriptionModels.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/SelectTranscriptionModels.svelte
@@ -13,6 +13,7 @@
   import { Settings } from "$lib/components/layout";
   import { sortModels } from "$lib/features/ai-models/sortModels";
   import { m } from "$lib/paraglide/messages";
+  import { toast } from "$lib/components/toast";
 
   export let selectableModels: (TranscriptionModel & {
     meets_security_classification?: boolean | null | undefined;
@@ -49,7 +50,7 @@
         await updateSpace({ transcription_models: newModels });
       }
     } catch (e) {
-      alert(e);
+      toast.error(e instanceof Error ? e.message : String(e));
     }
     loading.delete(model.id);
     loading = loading;

--- a/frontend/packages/ui/src/lib/Input/Files.svelte
+++ b/frontend/packages/ui/src/lib/Input/Files.svelte
@@ -179,10 +179,11 @@
       <div class="text-secondary pt-2 text-sm">
         Click <button
           on:click={() => {
-            alert(
-              "Currently we support the following MIME types for uploading:\n" +
+            dispatch("showsupportedtypes", {
+              message:
+                "Currently we support the following MIME types for uploading:\n" +
                 acceptedMimeTypes.join("\n")
-            );
+            });
           }}
           class="hover:bg-hover-default pointer-events-auto underline">here</button
         > to see a list of supported filetypes.


### PR DESCRIPTION
## Summary

- Replace all 145 `alert()` calls across 82 frontend files with the existing toast notification system (`$lib/components/toast`)
- Uses `toast.error()` for errors, `toast.warning()` for validation messages, `toast.success()` for confirmations, `toast.info()` for informational messages
- UI package `Files.svelte` uses event dispatch + consumer handles toast since it can't import app-level modules

## Affected areas

| Area | Files |
|------|-------|
| Admin (users, templates, integrations, legacy) | 14 |
| Spaces (services, apps, knowledge, members, settings, assistants) | 33 |
| Lib features (attachments, publishing, chat, security, integrations, templates, spaces, models) | 29 |
| Dashboard, account | 5 |
| UI package | 1 |

## Test plan

- [ ] Verify toast notifications appear correctly on error scenarios (e.g. failed API calls)
- [ ] Verify validation warnings show as warning toasts (e.g. missing required fields)
- [ ] Verify success messages show as success toasts (e.g. SharePoint subscription renewed)
- [ ] Verify toasts auto-dismiss and can be manually closed
- [ ] Verify no `alert()` calls remain
- [ ] Verify "supported filetypes" link in file upload shows toast via event dispatch

Closes #273