### PR TITLE
fix(cors): return explicit origin instead of wildcard when credential…

### DIFF
--- a/backend/src/intric/server/main.py
+++ b/backend/src/intric/server/main.py
@@ -156,7 +156,6 @@ def get_application():
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
-        expose_headers=["*"],  # Expose all headers including session-related ones
         callback=get_origin,
     )
 
@@ -288,15 +287,10 @@ def get_application():
             # https://github.com/encode/starlette/blob/master/starlette/middleware/cors.py#L152
 
             response.headers.update(cors.simple_headers)
-            has_cookie = "cookie" in request.headers
 
-            # If request includes any cookie headers, then we must respond
-            # with the specific origin instead of '*'.
-            if cors.allow_all_origins and has_cookie:
+            if cors.allow_all_origins and cors.allow_credentials:
                 response.headers["Access-Control-Allow-Origin"] = origin
-
-            # If we only allow specific origins, then we have to mirror back
-            # the Origin header in the response.
+                response.headers.add_vary_header("Origin")
             elif not cors.allow_all_origins and await cors.is_allowed_origin(
                 origin=origin
             ):
@@ -357,9 +351,10 @@ def get_application():
                 callback=get_origin,
             )
             response.headers.update(cors.simple_headers)
-            has_cookie = "cookie" in request.headers
-            if cors.allow_all_origins and has_cookie:
+
+            if cors.allow_all_origins and cors.allow_credentials:
                 response.headers["Access-Control-Allow-Origin"] = origin
+                response.headers.add_vary_header("Origin")
             elif not cors.allow_all_origins and await cors.is_allowed_origin(
                 origin=origin
             ):

--- a/backend/src/intric/server/middleware/cors.py
+++ b/backend/src/intric/server/middleware/cors.py
@@ -1,11 +1,15 @@
-# Copied from https://github.com/encode/starlette/blob/master/starlette/middleware/cors.py
+# Based on https://github.com/encode/starlette/blob/main/starlette/middleware/cors.py
 # BSD-3-Clause license
+#
+# Extended with an async `callback` parameter for dynamic origin validation
+# (e.g. checking allowed origins from a database at runtime).
 
 from __future__ import annotations
 
 import functools
 import re
 import typing
+from collections.abc import Sequence
 
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.responses import PlainTextResponse, Response
@@ -19,14 +23,15 @@ class CORSMiddleware:
     def __init__(
         self,
         app: ASGIApp,
-        allow_origins: typing.Sequence[str] = (),
-        allow_methods: typing.Sequence[str] = ("GET",),
-        allow_headers: typing.Sequence[str] = (),
+        allow_origins: Sequence[str] = (),
+        allow_methods: Sequence[str] = ("GET",),
+        allow_headers: Sequence[str] = (),
         allow_credentials: bool = False,
         allow_origin_regex: str | None = None,
-        expose_headers: typing.Sequence[str] = (),
+        allow_private_network: bool = False,
+        expose_headers: Sequence[str] = (),
         max_age: int = 600,
-        callback: typing.Optional[typing.Callable[[str], bool]] = None,
+        callback: typing.Optional[typing.Callable[[str], typing.Awaitable[bool]]] = None,
     ) -> None:
         if "*" in allow_methods:
             allow_methods = ALL_METHODS
@@ -39,7 +44,7 @@ class CORSMiddleware:
         allow_all_headers = "*" in allow_headers
         preflight_explicit_allow_origin = not allow_all_origins or allow_credentials
 
-        simple_headers = {}
+        simple_headers: dict[str, str] = {}
         if allow_all_origins:
             simple_headers["Access-Control-Allow-Origin"] = "*"
         if allow_credentials:
@@ -47,7 +52,7 @@ class CORSMiddleware:
         if expose_headers:
             simple_headers["Access-Control-Expose-Headers"] = ", ".join(expose_headers)
 
-        preflight_headers = {}
+        preflight_headers: dict[str, str] = {}
         if preflight_explicit_allow_origin:
             # The origin value will be set in preflight_response() if it is allowed.
             preflight_headers["Vary"] = "Origin"
@@ -71,8 +76,10 @@ class CORSMiddleware:
         self.allow_headers = [h.lower() for h in allow_headers]
         self.allow_all_origins = allow_all_origins
         self.allow_all_headers = allow_all_headers
+        self.allow_credentials = allow_credentials
         self.preflight_explicit_allow_origin = preflight_explicit_allow_origin
         self.allow_origin_regex = compiled_allow_origin_regex
+        self.allow_private_network = allow_private_network
         self.simple_headers = simple_headers
         self.preflight_headers = preflight_headers
         self.callback = callback
@@ -106,7 +113,6 @@ class CORSMiddleware:
         ):
             return True
 
-        # Check static origins first
         if origin in self.allow_origins:
             return True
 
@@ -119,9 +125,12 @@ class CORSMiddleware:
         requested_origin = request_headers["origin"]
         requested_method = request_headers["access-control-request-method"]
         requested_headers = request_headers.get("access-control-request-headers")
+        requested_private_network = request_headers.get(
+            "access-control-request-private-network"
+        )
 
         headers = dict(self.preflight_headers)
-        failures = []
+        failures: list[str] = []
 
         if await self.is_allowed_origin(origin=requested_origin):
             if self.preflight_explicit_allow_origin:
@@ -143,6 +152,12 @@ class CORSMiddleware:
                 if header.strip() not in self.allow_headers:
                     failures.append("headers")
                     break
+
+        if requested_private_network is not None:
+            if self.allow_private_network:
+                headers["Access-Control-Allow-Private-Network"] = "true"
+            else:
+                failures.append("private-network")
 
         # We don't strictly need to use 400 responses here, since its up to
         # the browser to enforce the CORS policy, but its more informative
@@ -170,11 +185,10 @@ class CORSMiddleware:
         headers = MutableHeaders(scope=message)
         headers.update(self.simple_headers)
         origin = request_headers["Origin"]
-        has_cookie = "cookie" in request_headers
 
-        # If request includes any cookie headers, then we must respond
+        # If credentials are allowed, then we must respond
         # with the specific origin instead of '*'.
-        if self.allow_all_origins and has_cookie:
+        if self.allow_all_origins and self.allow_credentials:
             self.allow_explicit_origin(headers, origin)
 
         # If we only allow specific origins, then we have to mirror back


### PR DESCRIPTION
- Synced vendored CORS middleware with upstream Starlette, fixing a bug where Access-Control-Allow-Origin: * was returned alongside Access-Control-Allow-Credentials: true — a combination browsers reject per the
  CORS spec
  - Fixed the same bug in two inline exception handlers in main.py that duplicated the broken logic
  - Removed ineffective expose_headers=["*"] (wildcard is ignored by browsers when credentials are enabled)

  Problem

  When the frontend and backend are deployed on separate domains (i.e. without a shared reverse proxy), the browser sends cross-origin requests with credentials: 'include'. The old middleware only replaced the *
  origin with the specific origin when cookies were present on the request (has_cookie). On requests without cookies (e.g. before login, or when using header-based auth), the response contained:

  Access-Control-Allow-Origin: *
  Access-Control-Allow-Credentials: true

  Browsers reject this and block the response, surfacing as a CORS error.

  This does not affect deployments using a reverse proxy that serves both frontend and backend under the same domain, since those requests are same-origin and never trigger CORS.