### PR TITLE
ci: simplify to develop + release branches, remove main branch

### DIFF
--- a/.github/workflows/build_and_push_images.yml
+++ b/.github/workflows/build_and_push_images.yml
@@ -5,22 +5,19 @@ name: Build and Push Docker Images
 #
 # Workflow Summary:
 # - develop branch → :develop image tag → external system deploys to dev (automatic)
-# - main branch → :main image tag → external system deploys to testing (automatic)
 # - v* tags → version image tags → external system handles production deployment (automatic)
 # - Any other branch → manually triggered via Actions tab (workflow_dispatch)
 # - v*-rc/beta/etc tags → pre-release version image tags (no :latest)
 #
 # Image Tags Created:
 # - Push to develop: ghcr.io/org/repo:develop, ghcr.io/org/repo:develop-abc1234
-# - Push to main: ghcr.io/org/repo:main, ghcr.io/org/repo:main-def5678
 # - Manual trigger on any branch: ghcr.io/org/repo:branch-name, ghcr.io/org/repo:branch-name-abc1234
-# - Tag v1.0.0: ghcr.io/org/repo:v1.0.0, ghcr.io/org/repo:latest
+# - Tag v1.0.0: ghcr.io/org/repo:v1.0.0, ghcr.io/org/repo:latest (only if highest version)
 # - Tag v1.0.0-rc: ghcr.io/org/repo:v1.0.0-rc (no :latest)
 
 on:
   push:
     branches:
-      - main
       - develop
     tags:
       - 'v*'  # Triggered when version tags are pushed
@@ -64,6 +61,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Validate tag is on correct release branch
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          # Extract major.minor from tag (e.g., v1.8.0-rc.1 → v1.8)
+          EXPECTED_BRANCH="release/$(echo "$TAG" | grep -oE '^v[0-9]+\.[0-9]+')"
+
+          # Check which branches contain this tag's commit
+          BRANCHES=$(git branch -r --contains HEAD | sed 's|origin/||' | xargs)
+
+          if [[ ! " $BRANCHES " =~ " $EXPECTED_BRANCH " ]]; then
+            echo "::error::Tag $TAG must be on branch $EXPECTED_BRANCH, but it was found on: $BRANCHES"
+            echo "Tags should only be created via GitHub Releases UI targeting the correct release branch."
+            exit 1
+          fi
+
+          echo "✅ Tag $TAG is correctly on $EXPECTED_BRANCH"
+
       - name: Determine build context
         id: build-context
         run: |
@@ -79,9 +94,6 @@ jobs:
               echo "is-release=true" >> $GITHUB_OUTPUT
               echo "is-prerelease=false" >> $GITHUB_OUTPUT
             fi
-          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "Building main branch for testing environment"
-            echo "is-release=false" >> $GITHUB_OUTPUT
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
             echo "Building develop branch for dev environment"
             echo "is-release=false" >> $GITHUB_OUTPUT
@@ -89,6 +101,18 @@ jobs:
             BRANCH_NAME="${GITHUB_REF#refs/heads/}"
             echo "Building branch: $BRANCH_NAME"
             echo "is-release=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check if tag is latest
+        id: check-latest
+        if: steps.build-context.outputs.is-release == 'true' && steps.build-context.outputs.is-prerelease == 'false'
+        run: |
+          CURRENT_TAG="${GITHUB_REF#refs/tags/}"
+          LATEST_TAG=$(git tag --list 'v*' --sort=-v:refname | grep -v '-' | head -1)
+          if [[ "$CURRENT_TAG" == "$LATEST_TAG" ]]; then
+            echo "is-latest=true" >> $GITHUB_OUTPUT
+          else
+            echo "is-latest=false" >> $GITHUB_OUTPUT
           fi
 
       # Backend build and push
@@ -100,13 +124,12 @@ jobs:
           tags: |
             # Branch-based tags
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
-            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
-            type=ref,event=branch,enable=${{ github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/main' }}
+            type=ref,event=branch,enable=${{ github.ref != 'refs/heads/develop' }}
 
             # Version tags (only for releases)
             type=semver,pattern={{version}},enable=${{ steps.build-context.outputs.is-release == 'true' }}
 
-            type=raw,value=latest,enable=${{ steps.build-context.outputs.is-release == 'true' && steps.build-context.outputs.is-prerelease == 'false' }}
+            type=raw,value=latest,enable=${{ steps.check-latest.outputs.is-latest == 'true' }}
 
             # Git SHA for traceability (always included)
             type=sha,prefix={{branch}}-,format=short,enable=${{ github.ref_type == 'branch' }}
@@ -142,13 +165,12 @@ jobs:
           tags: |
             # Branch-based tags
             type=raw,value=develop,enable=${{ github.ref == 'refs/heads/develop' }}
-            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
-            type=ref,event=branch,enable=${{ github.ref != 'refs/heads/develop' && github.ref != 'refs/heads/main' }}
+            type=ref,event=branch,enable=${{ github.ref != 'refs/heads/develop' }}
 
             # Version tags (only for releases)
             type=semver,pattern={{version}},enable=${{ steps.build-context.outputs.is-release == 'true' }}
 
-            type=raw,value=latest,enable=${{ steps.build-context.outputs.is-release == 'true' && steps.build-context.outputs.is-prerelease == 'false' }}
+            type=raw,value=latest,enable=${{ steps.check-latest.outputs.is-latest == 'true' }}
 
             # Git SHA for traceability (always included)
             type=sha,prefix={{branch}}-,format=short,enable=${{ github.ref_type == 'branch' }}
@@ -206,20 +228,13 @@ jobs:
               echo "" >> $GITHUB_STEP_SUMMARY
               echo "✅ Ready for production deployment" >> $GITHUB_STEP_SUMMARY
             fi
-          elif [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            echo "### Testing Environment Build" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Backend:** \`${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:main\`" >> $GITHUB_STEP_SUMMARY
-            echo "**Frontend:** \`${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:main\`" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "🧪 Images will be deployed to testing environment by ArgoCD/deployment system" >> $GITHUB_STEP_SUMMARY
           elif [[ "${{ github.ref }}" == "refs/heads/develop" ]]; then
             echo "### Development Environment Build" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "**Backend:** \`${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:develop\`" >> $GITHUB_STEP_SUMMARY
             echo "**Frontend:** \`${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}:develop\`" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "🔧 Images will be deployed to dev environment by ArgoCD/deployment system" >> $GITHUB_STEP_SUMMARY
+            echo "🔧 Images will be deployed to dev environment" >> $GITHUB_STEP_SUMMARY
           else
             BRANCH_NAME="${GITHUB_REF#refs/heads/}"
             BRANCH_TAG="${BRANCH_NAME//\//-}"

--- a/.github/workflows/pr_build_test.yml
+++ b/.github/workflows/pr_build_test.yml
@@ -3,8 +3,8 @@ name: PR Build Test
 on:
   pull_request:
     branches:
-      - main
       - develop
+      - 'release/**'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -3,8 +3,8 @@ name: Pull Request Checks
 on:
   pull_request:
     branches:
-      - main
       - develop
+      - 'release/**'
     types:
       - opened
       - edited
@@ -24,8 +24,8 @@ jobs:
           BRANCH_NAME="${{ github.head_ref }}"
 
           # Skip branch naming check for long-lived branches
-          if [[ "$BRANCH_NAME" == "develop" ]]; then
-            echo "✅ Branch 'develop' is a long-lived branch - skipping naming convention check"
+          if [[ "$BRANCH_NAME" == "develop" || "$BRANCH_NAME" == release/* ]]; then
+            echo "✅ Long-lived branch - skipping naming convention check"
             exit 0
           fi
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -391,10 +391,12 @@ gitgraph
     commit id: "feat: add service layer"
     commit id: "feat: add API endpoints"
     commit id: "test: add comprehensive tests"
-    checkout main
+    checkout develop
     merge feature/new-assistant-type
     commit id: "merge: new assistant type"
 ```
+
+> Features always flow back to `develop`. Version tags live on `release/v1.X` branches, not on `develop`. See [DEPLOYMENT_WORKFLOW.md](./DEPLOYMENT_WORKFLOW.md) for the full release flow.
 
 **Branch Naming:**
 - `feature/description` - New features

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -384,7 +384,7 @@ bun run lint
 
 ```mermaid
 gitgraph
-    commit id: "main"
+    commit id: "develop"
     branch feature/new-assistant-type
     checkout feature/new-assistant-type
     commit id: "feat: add domain entity"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -319,7 +319,7 @@ docker compose up -d
 
 ### Upgrading Between Major Versions or After Long Gaps
 
-If upgrading from a very old image or across major versions (e.g., develop branch to main branch), you may encounter database migration issues.
+If upgrading from a very old image or across major versions (e.g., develop branch to release branch), you may encounter database migration issues.
 
 **Symptoms:**
 - "Unauthorized" errors in the frontend after upgrade

--- a/docs/DEPLOYMENT_WORKFLOW.md
+++ b/docs/DEPLOYMENT_WORKFLOW.md
@@ -346,7 +346,13 @@ This applies to all fixes on release branches — hotfixes, RC stabilization fix
 | `v*-rc/beta` tags | `:v1.8.0-rc.1` (no `:latest`) | Test environment / pre-release testing |
 | `v*` tags (stable) | `:v1.8.0`, `:latest` (if highest version) | Production releases |
 
-**Note:** The `:latest` tag is only applied when the tagged version is the highest semver release. Tagging `v1.7.4` on an older release branch will NOT overwrite `:latest` if `v1.8.0` already exists.
+**How `:latest` is decided:** Evaluated at tag-push time by comparing the new tag against all existing stable tags (`v*` excluding pre-releases like `-rc`, `-beta`) via semver sort. Only the highest stable version wins `:latest`.
+
+Consequences to be aware of:
+- Patching an older release (e.g. tagging `v1.7.4` while `v1.8.0` exists) will NOT overwrite `:latest` — the older patch correctly stays out of `:latest`.
+- If an out-of-order release happens (e.g. `v1.8.0` was tagged first, then later `v1.7.5` on the old branch), `:latest` still points to `v1.8.0` — the comparison is "highest at push time," not "most recently pushed."
+- RC / pre-release tags never receive `:latest`, regardless of version number.
+- If you ever need to move `:latest` to a different version (e.g. after yanking a bad release), you must retag manually in the registry — CI will not do it retroactively.
 
 ### Image Locations
 

--- a/docs/DEPLOYMENT_WORKFLOW.md
+++ b/docs/DEPLOYMENT_WORKFLOW.md
@@ -234,10 +234,15 @@ GitHub Actions builds `v1.7.4` images. The `:latest` tag is NOT overwritten if `
 
 **4. Cherry-pick the fix to develop:**
 
+Use the **squashed commit on the release branch** as the cherry-pick source, not the original commit from your `hotfix/*` branch. Because PRs are squash-merged, the commit on `release/v1.7` is the authoritative one; the hotfix branch's pre-squash SHA won't exist after the branch is deleted.
+
 ```bash
-git checkout develop
-git pull origin develop
-git cherry-pick <commit-hash>
+# Grab the SHA from the release branch (the squashed merge commit)
+git checkout release/v1.7 && git pull
+git log -1 --format=%H  # copy this SHA
+
+git checkout develop && git pull origin develop
+git cherry-pick <sha-from-release-branch>
 git push origin develop
 ```
 
@@ -280,26 +285,34 @@ Order matters: **oldest → newest → develop**. This minimizes merge conflicts
 
 **Example: security fix needed on v1.6, v1.7, and v1.8:**
 
+At each step, the `<commit-hash>` is the SHA of the **squashed merge commit on the branch you just merged into** — re-read it from that branch before cherry-picking forward.
+
 ```bash
 # 1. Fix on oldest affected branch
 git checkout release/v1.6
 git checkout -b hotfix/security-fix
 # ... fix ...
 git push origin hotfix/security-fix
-# PR → release/v1.6, merge
+# PR → release/v1.6, merge (squash)
 
-# 2. Cherry-pick forward
+# Grab the squashed SHA from release/v1.6
+git checkout release/v1.6 && git pull
+SHA=$(git log -1 --format=%H)
+
+# 2. Cherry-pick forward (re-read SHA from each branch after it lands)
 git checkout release/v1.7 && git pull
-git cherry-pick <commit-hash>
+git cherry-pick "$SHA"
 git push origin release/v1.7
+SHA=$(git log -1 --format=%H)  # new SHA on release/v1.7
 
 git checkout release/v1.8 && git pull
-git cherry-pick <commit-hash>
+git cherry-pick "$SHA"
 git push origin release/v1.8
+SHA=$(git log -1 --format=%H)  # new SHA on release/v1.8
 
 # 3. Cherry-pick to develop
 git checkout develop && git pull
-git cherry-pick <commit-hash>
+git cherry-pick "$SHA"
 git push origin develop
 ```
 
@@ -320,11 +333,16 @@ For each: **Releases** → **Draft a new release** → set tag, target, and rele
 After merging a hotfix PR to a release branch:
 
 1. **Immediately cherry-pick** the fix commit to `develop`
-2. If cherry-pick conflicts, create a PR to `develop` with the manual resolution
+2. **Use the squashed commit on the release branch as the source** — not the original commit from your `hotfix/*` branch (which won't survive the branch deletion)
+3. If cherry-pick conflicts, create a PR to `develop` with the manual resolution
 
 ```bash
+# Get the SHA from the release branch
+git checkout release/v1.7 && git pull
+git log -1 --format=%H  # this is the SHA to cherry-pick
+
 git checkout develop && git pull
-git cherry-pick <commit-hash>
+git cherry-pick <sha-from-release-branch>
 git push origin develop
 ```
 

--- a/docs/DEPLOYMENT_WORKFLOW.md
+++ b/docs/DEPLOYMENT_WORKFLOW.md
@@ -8,50 +8,62 @@ Welcome! This document describes our Git workflow and deployment process. Please
 - [Branch Strategy](#branch-strategy)
 - [Development Workflow](#development-workflow)
 - [Release Process](#release-process)
+- [Release Stabilization (RC Process)](#release-stabilization-rc-process)
 - [Hotfix Process](#hotfix-process)
+- [Backporting](#backporting)
+- [Security Patches Across Multiple Releases](#security-patches-across-multiple-releases)
+- [Backflow: Release to Develop](#backflow-release-to-develop)
+- [Support / Maintenance Policy](#support--maintenance-policy)
 - [Docker Images](#docker-images)
 - [FAQ](#faq)
 
 ## Overview
 
-We use a Git Flow-inspired workflow with automatic image builds and tag-based deployments. Our deployment systems (e.g., ArgoCD) watch for new image tags and deploy them automatically.
+We use a Git Flow-inspired workflow with **persistent release branches**. Every minor version gets a `release/v1.X` branch. Tags always live on release branches. Deployment systems watch for new image tags and deploy them automatically.
 
 ```mermaid
 graph LR
     A[Feature Branch] -->|PR| B[develop]
     B -->|Push| C[Build :develop image]
     C -->|Image Update| D[Deploy to Dev]
-    B -->|PR| E[main]
-    E -->|Push| F[Build :main image]
-    F -->|Image Update| G[Deploy to Testing]
-    E -->|Tag v*| H[Build :v1.0.0 image]
-    H -->|Manual Trigger| I[Deploy to Production]
+    B -->|Create branch| E[release/v1.8]
+    E -->|Tag v1.8.0-rc.1| F[Build :v1.8.0-rc.1 image]
+    F -->|Deploy| G[Test Environment]
+    E -->|Tag v1.8.0| H[Build :v1.8.0 image]
+    H -->|Deploy| I[Production]
+```
+
+```
+feature/* ──► develop ──► release/v1.8 ──► v1.8.0, v1.8.1, ...
+                     ──► release/v1.9 ──► v1.9.0, ...
+
+Backflow (patches):
+  release/v1.X (hotfix) ──cherry-pick──► develop
 ```
 
 ## Environments
 
-We maintain three environments:
-
 | Environment | Purpose | Branch/Tag | Image Tag | Deployment Method |
 |------------|---------|------------|-----------|-------------------|
 | **Development** | Latest features, may be unstable | `develop` | `:develop` | Auto (on image update) |
-| **Testing** | Pre-production testing | `main` | `:main` | Auto (on image update) |
-| **Production** | Live system | `v*` tags | `:v1.0.0` | Manual trigger |
+| **Test** | Pre-production testing via RC tags | `v*-rc.*` tags on `release/v1.X` | `:v1.8.0-rc.1` | Manual deploy |
+| **Production** | Live system | `v*` tags on `release/v1.X` | `:v1.8.0` | Manual deploy |
 
 ## Branch Strategy
 
-### Protected Branches
+### Long-lived Branches
 
 #### `develop`
 - Integration branch for new features
 - Always deployable to dev environment
 - Protected: requires PR with approval
 
-#### `main`
-- Release candidate branch
-- Always deployable to testing environment
-- Protected: requires PR with approval
-- Should only contain tested code from develop
+#### `release/v1.X`
+- Created from `develop` when ready to release or stabilize a minor version
+- Persistent home for all patches to that minor version
+- All version tags (`v1.X.Y`) live here
+- Test via RC tags (`:v1.8.0-rc.1`) before creating the final release
+- **Never merged back** — fixes flow to `develop` via cherry-pick only
 
 ### Supporting Branches
 
@@ -62,35 +74,12 @@ We maintain three environments:
 - Example: `feature/add-user-authentication`
 
 #### `hotfix/*`
-- Created from: `main` or production tag
-- Merged into: `main` (then cherry-picked to `develop`)
+- Created from: the target `release/v1.X` branch
+- Merged into: the target `release/v1.X` branch (then cherry-picked to `develop`)
 - Naming: `hotfix/issue-description`
 - Example: `hotfix/fix-payment-processing`
 
 ## Development Workflow
-
-### Visual Flow
-
-```mermaid
-gitGraph
-    commit id: "initial"
-    branch develop
-    checkout develop
-    branch feature/new-feature
-    checkout feature/new-feature
-    commit id: "add feature"
-    commit id: "fix tests"
-    checkout develop
-    merge feature/new-feature
-    branch feature/another-feature
-    checkout feature/another-feature
-    commit id: "other work"
-    checkout develop
-    merge feature/another-feature
-    checkout main
-    merge develop
-    commit id: "v1.0.0" tag: "v1.0.0"
-```
 
 ### Step-by-Step Guide
 
@@ -122,73 +111,30 @@ git push origin feature/your-feature-name
 #### 3. After PR Approval
 
 Once merged to develop:
-- ✅ GitHub Actions automatically builds Docker images tagged `:develop`
-- ✅ Images are automatically deployed to internal dev environment
-
-#### 4. Promote to Testing
-
-When features in develop are ready for testing:
-
-```bash
-# Team lead/maintainer creates PR from develop to main
-git checkout main
-git pull origin main
-git merge develop
-git push origin main
-```
-
-After merge to main:
-- ✅ GitHub Actions automatically builds Docker images tagged `:main`
-- ✅ Images are automatically deployed to internal testing environment
-- ✅ QA team can test
+- GitHub Actions automatically builds Docker images tagged `:develop`
+- Images are automatically deployed to internal dev environment
 
 ## Release Process
 
 ### Creating a Production Release
 
-```mermaid
-flowchart TB
-    A[Testing Complete] --> B{All Tests Pass?}
-    B -->|Yes| C[Tag Release on main]
-    B -->|No| D[Fix Issues in develop]
-    D --> E[Merge to main]
-    E --> A
-    C --> F[GitHub Actions builds images]
-    F --> G[Images tagged: v1.0.0, latest]
-    G --> H[Images available in registry]
-    H --> I[Trigger Production Deploy]
-    I --> J[Production Live]
-```
+Every release goes through at least one RC tag for testing. See [Release Stabilization (RC Process)](#release-stabilization-rc-process) for the full flow.
 
-#### Steps to Release
+Once the RC is stable, create the final release via GitHub UI:
 
-```bash
-# 1. Ensure you're on main with latest changes
-git checkout main
-git pull origin main
+1. Go to **Releases** → **Draft a new release**
+2. Click **Choose a tag** → type `v1.8.0` → select **Create new tag**
+3. Set **Target** to `release/v1.8`
+4. Set **Release title** to `v1.8.0`
+5. Write release notes (features, bug fixes, breaking changes)
+6. Leave **Set as pre-release** unchecked
+7. Click **Publish release**
 
-# 2. Create a version tag
-git tag -a v1.0.0 -m "Release version 1.0.0
+GitHub Actions will automatically build production images:
+- `ghcr.io/eneo-ai/eneo-backend:v1.8.0`
+- `ghcr.io/eneo-ai/eneo-frontend:v1.8.0`
 
-Features:
-- User authentication
-- Payment processing
-- Email notifications
-
-Bug fixes:
-- Fixed memory leak in worker
-- Resolved timezone issues"
-
-# 3. Push the tag
-git push origin v1.0.0
-
-# 4. GitHub Actions will build production images
-# Backend: ghcr.io/eneo-ai/eneo-backend:v1.0.0
-# Frontend: ghcr.io/eneo-ai/eneo-frontend:v1.0.0
-
-# 5. Deploy to production (manual process)
-# Use your deployment scripts/tools
-```
+Deploy to production by updating your deployment config to point at the new version tag.
 
 ### Semantic Versioning
 
@@ -198,90 +144,197 @@ We use semantic versioning: `MAJOR.MINOR.PATCH`
 - **MINOR** (1.0.0 → 1.1.0): New features (backwards compatible)
 - **PATCH** (1.0.0 → 1.0.1): Bug fixes
 
-Examples:
-- `v1.0.0` - First stable release
-- `v1.1.0` - Added new feature
-- `v1.1.1` - Fixed bug in v1.1.0
-- `v2.0.0` - Breaking API changes
+## Release Stabilization (RC Process)
+
+RC tags also live on the release branch. Create the release branch from `develop` when you're ready to **start** stabilizing:
+
+```
+develop ──► create release/v1.8
+                 │
+                 ├──► v1.8.0-rc.1 (tag, pre-release) → deploy to test env
+                 ├──► fix directly on branch or via PR
+                 ├──► v1.8.0-rc.2 (tag, pre-release)
+                 └──► v1.8.0 (final release)
+```
+
+**1. Create release branch from `develop`:**
+
+```bash
+git checkout develop && git pull
+git checkout -b release/v1.8
+git push origin release/v1.8
+```
+
+**2. Create the first RC via GitHub UI:**
+
+1. Go to **Releases** → **Draft a new release**
+2. Click **Choose a tag** → type `v1.8.0-rc.1` → select **Create new tag**
+3. Set **Target** to `release/v1.8`
+4. Set **Release title** to `v1.8.0-rc.1`
+5. Check **Set as pre-release**
+6. Click **Publish release**
+
+**3. Fix issues** directly on the release branch (or via `hotfix/*` PRs to `release/v1.8`)
+
+**4. Create subsequent RCs** the same way via GitHub Releases (tag `v1.8.0-rc.2`, target `release/v1.8`, mark as pre-release)
+
+**5. When stable, create the final release** via GitHub Releases:
+- Tag `v1.8.0`, target `release/v1.8`
+- Leave **Set as pre-release** unchecked
+- Add full release notes
+
+During stabilization, `develop` can continue receiving new features for the next release.
 
 ## Hotfix Process
 
-For critical production bugs that can't wait for the normal release cycle:
+One consistent flow for all hotfixes, regardless of which version is affected:
 
 ```mermaid
 flowchart TB
-    A[Production Bug Found] --> B[Create hotfix from tag/main]
+    A[Production Bug Found] --> B[Create hotfix from release/v1.X]
     B --> C[Fix Bug]
-    C --> D[Test Fix]
-    D --> E{Fix Works?}
-    E -->|No| C
-    E -->|Yes| F[PR to main]
-    F --> G[Merge to main]
-    G --> H[New :main image built]
-    H --> I[Auto-deploy to Testing]
-    I --> J[Verify in Testing]
-    J --> K[Tag new version]
-    K --> L[New version image built]
-    L --> M[Trigger Production Deploy]
-    M --> N[Cherry-pick to develop]
+    C --> D[PR to release/v1.X]
+    D --> E[Merge to release/v1.X]
+    E --> F[Tag new patch version]
+    F --> G[Build versioned image]
+    G --> H[Deploy to Production]
+    H --> I[Cherry-pick fix to develop]
 ```
 
 ### Hotfix Example
 
+**1. Create hotfix from the affected release branch:**
+
 ```bash
-# 1. Create hotfix from current production version
-git checkout tags/v1.0.0  # or from main if it hasn't moved ahead
+git checkout release/v1.7
+git pull origin release/v1.7
 git checkout -b hotfix/fix-critical-bug
 
-# 2. Make your fix
-# ... edit files ...
+# Make your fix
 git add .
 git commit -m "fix: resolve critical payment processing error"
 
-# 3. Push and create PR to main
+# Push and create PR to the release branch
 git push origin hotfix/fix-critical-bug
-# Create PR on GitHub: hotfix/fix-critical-bug → main
+# Create PR on GitHub: hotfix/fix-critical-bug → release/v1.7
+```
 
-# 4. After PR merge, main auto-deploys to testing
+**2. After PR merge, create the patch release via GitHub UI:**
 
-# 5. Once verified in testing, tag the release
-git checkout main
-git pull origin main
-git tag -a v1.0.1 -m "Hotfix: Payment processing error"
-git push origin v1.0.1
+1. Go to **Releases** → **Draft a new release**
+2. Click **Choose a tag** → type `v1.7.4` → select **Create new tag**
+3. Set **Target** to `release/v1.7`
+4. Set **Release title** to `v1.7.4`
+5. Describe the fix in the release notes
+6. Click **Publish release**
 
-# 6. Deploy v1.0.1 to production
+GitHub Actions builds `v1.7.4` images. The `:latest` tag is NOT overwritten if `v1.8.0` already exists.
 
-# 7. Ensure fix is in develop
+**3. Deploy** `v1.7.4` to the affected production instance.
+
+**4. Cherry-pick the fix to develop:**
+
+```bash
 git checkout develop
 git pull origin develop
-git cherry-pick <commit-hash>  # or merge main if no conflicts
+git cherry-pick <commit-hash>
 git push origin develop
 ```
 
-### Hotfix for Old Versions
+## Backporting
 
-If you need to patch an old version (e.g., v1.0.0) while v2.0.0 is in production:
+When a bug is fixed on `develop` but also affects an older release:
+
+**1. Cherry-pick the fix to the release branch:**
 
 ```bash
-# 1. Create hotfix from the old tag
-git checkout tags/v1.0.0
-git checkout -b hotfix/v1.0.1-security-fix
+git log --oneline develop  # identify the fix commit
+git checkout release/v1.7
+git pull origin release/v1.7
+git cherry-pick <commit-hash>
+git push origin release/v1.7
 
-# 2. Make fix and commit
-git commit -am "fix: security vulnerability"
-
-# 3. Tag directly on hotfix branch
-git tag -a v1.0.1 -m "Security patch for v1.0.0"
-
-# 4. Push branch and tag
-git push origin hotfix/v1.0.1-security-fix
-git push origin v1.0.1
-
-# 5. GitHub Actions builds v1.0.1
-# 6. Deploy v1.0.1 where needed
-# 7. Cherry-pick fix to develop and main
+# If conflicts, resolve them and create a PR instead:
+git checkout -b fix/backport-xyz
+git push origin fix/backport-xyz
+# Create PR: fix/backport-xyz → release/v1.7
 ```
+
+**2. After the fix lands on the release branch, tag via GitHub UI:**
+
+1. Go to **Releases** → **Draft a new release**
+2. Tag: `v1.7.5`, Target: `release/v1.7`
+3. Describe the backported fix
+4. Click **Publish release**
+
+## Security Patches Across Multiple Releases
+
+When a security fix must go to multiple supported releases:
+
+1. **Fix on the oldest affected release branch first**
+2. **Cherry-pick forward** to each newer release branch
+3. **Cherry-pick to `develop`**
+4. **Tag new patch versions** on each affected release branch
+
+Order matters: **oldest → newest → develop**. This minimizes merge conflicts since newer branches are closer to develop.
+
+**Example: security fix needed on v1.6, v1.7, and v1.8:**
+
+```bash
+# 1. Fix on oldest affected branch
+git checkout release/v1.6
+git checkout -b hotfix/security-fix
+# ... fix ...
+git push origin hotfix/security-fix
+# PR → release/v1.6, merge
+
+# 2. Cherry-pick forward
+git checkout release/v1.7 && git pull
+git cherry-pick <commit-hash>
+git push origin release/v1.7
+
+git checkout release/v1.8 && git pull
+git cherry-pick <commit-hash>
+git push origin release/v1.8
+
+# 3. Cherry-pick to develop
+git checkout develop && git pull
+git cherry-pick <commit-hash>
+git push origin develop
+```
+
+**Then create releases for each branch via GitHub UI:**
+
+| Tag | Target | Pre-release? |
+|-----|--------|-------------|
+| `v1.6.3` | `release/v1.6` | No |
+| `v1.7.5` | `release/v1.7` | No |
+| `v1.8.1` | `release/v1.8` | No |
+
+For each: **Releases** → **Draft a new release** → set tag, target, and release notes → **Publish release**.
+
+## Backflow: Release to Develop
+
+**Every fix that lands on a release branch must also be cherry-picked to `develop`.** If you skip this, the fix will be missing in the next release.
+
+After merging a hotfix PR to a release branch:
+
+1. **Immediately cherry-pick** the fix commit to `develop`
+2. If cherry-pick conflicts, create a PR to `develop` with the manual resolution
+
+```bash
+git checkout develop && git pull
+git cherry-pick <commit-hash>
+git push origin develop
+```
+
+This applies to all fixes on release branches — hotfixes, RC stabilization fixes, backported patches, and security fixes.
+
+## Support / Maintenance Policy
+
+- **Supported:** current release + 1 previous minor version (receives bug fixes and security patches)
+- **EOL:** older release branches can be deleted after confirming no customers depend on them
+- Review and update this policy as the team/customer base grows
 
 ## Docker Images
 
@@ -290,23 +343,25 @@ git push origin v1.0.1
 | Source | Docker Tags | Purpose |
 |--------|------------|---------|
 | `develop` branch | `:develop`, `:develop-{sha}` | Development testing |
-| `main` branch | `:main`, `:main-{sha}` | Pre-production testing |
-| `v*` tags | `:v1.0.0`, `:latest` | Production releases |
+| `v*-rc/beta` tags | `:v1.8.0-rc.1` (no `:latest`) | Test environment / pre-release testing |
+| `v*` tags (stable) | `:v1.8.0`, `:latest` (if highest version) | Production releases |
+
+**Note:** The `:latest` tag is only applied when the tagged version is the highest semver release. Tagging `v1.7.4` on an older release branch will NOT overwrite `:latest` if `v1.8.0` already exists.
 
 ### Image Locations
 
 ```bash
 # Backend Images
-ghcr.io/eneo-ai/eneo-backend:develop  # Latest from develop
-ghcr.io/eneo-ai/eneo-backend:main     # Latest from main
-ghcr.io/eneo-ai/eneo-backend:v1.0.0   # Specific release
-ghcr.io/eneo-ai/eneo-backend:latest   # Latest release
+ghcr.io/eneo-ai/eneo-backend:develop      # Latest from develop
+ghcr.io/eneo-ai/eneo-backend:v1.8.0-rc.1  # RC for testing
+ghcr.io/eneo-ai/eneo-backend:v1.8.0       # Specific release
+ghcr.io/eneo-ai/eneo-backend:latest       # Highest stable release
 
 # Frontend Images
-ghcr.io/eneo-ai/eneo-frontend:develop # Latest from develop
-ghcr.io/eneo-ai/eneo-frontend:main    # Latest from main
-ghcr.io/eneo-ai/eneo-frontend:v1.0.0  # Specific release
-ghcr.io/eneo-ai/eneo-frontend:latest  # Latest release
+ghcr.io/eneo-ai/eneo-frontend:develop      # Latest from develop
+ghcr.io/eneo-ai/eneo-frontend:v1.8.0-rc.1  # RC for testing
+ghcr.io/eneo-ai/eneo-frontend:v1.8.0       # Specific release
+ghcr.io/eneo-ai/eneo-frontend:latest       # Highest stable release
 ```
 
 ## FAQ
@@ -314,14 +369,20 @@ ghcr.io/eneo-ai/eneo-frontend:latest  # Latest release
 ### Q: When should I create a feature branch?
 **A:** For any change that adds functionality, fixes a bug, or modifies behavior. Even small changes should go through a PR for code review.
 
-### Q: Can I push directly to develop or main?
-**A:** No. Both branches are protected and require pull requests with approvals.
+### Q: Can I push directly to develop or release branches?
+**A:** No. All long-lived branches are protected and require pull requests with approvals.
+
+### Q: Where and how do I create version tags?
+**A:** Always on a `release/v1.X` branch. Use **GitHub Releases** (not the CLI) to create tags — this gives you release notes, pre-release marking, and a clean audit trail. See [Quick Command Reference](#creating-tags-github-ui).
 
 ### Q: How do I know what version to tag?
-**A:** Check the latest tag with `git tag --list 'v*' --sort=-v:refname | head -1`. Then:
+**A:** Check the latest tag on the repo's **Releases** page or with `git tag --list 'v*' --sort=-v:refname | head -1`. Then:
 - Breaking changes → increment MAJOR
 - New features → increment MINOR
 - Bug fixes → increment PATCH
+
+### Q: What if I need to patch an old version?
+**A:** Use the same hotfix flow — create a `hotfix/*` branch from the relevant `release/v1.X`, PR to the release branch, merge, tag. No special handling needed.
 
 ### Q: What if I need to test something quickly?
 **A:** Create a feature branch and PR to develop. Once merged, it auto-deploys to dev environment.
@@ -333,20 +394,22 @@ git push origin --delete feature/old-feature
 git branch -d feature/old-feature
 ```
 
+### Q: Can I delete old release branches?
+**A:** Only if the version is EOL (see [Support / Maintenance Policy](#support--maintenance-policy)). Confirm no customers depend on that version first.
+
 ### Q: How do I rollback production?
 **A:** Deploy the previous version tag:
 ```bash
 # Check available versions
 git tag --list 'v*' --sort=-v:refname
 
-# Deploy previous version (e.g., v1.0.0 if v1.0.1 has issues)
-# Use your deployment tool with v1.0.0 images
+# Deploy previous version (e.g., v1.7.3 if v1.8.0 has issues)
+# Use your deployment tool with v1.7.3 images
 ```
 
-### Q: What's the difference between testing and staging?
-**A:** In our workflow, "testing" IS our staging environment - it's the last stop before production.
-
 ## Quick Command Reference
+
+### Git commands
 
 ```bash
 # Start new feature
@@ -357,20 +420,29 @@ git checkout -b feature/my-feature
 git checkout feature/my-feature
 git merge develop
 
-# Create release
-git checkout main && git pull
-git tag -a v1.0.0 -m "Release v1.0.0"
-git push origin v1.0.0
+# Create release branch
+git checkout develop && git pull
+git checkout -b release/v1.8
+git push origin release/v1.8
 
-# Emergency hotfix
-git checkout main && git pull
+# Hotfix any version
+git checkout release/v1.7 && git pull
 git checkout -b hotfix/critical-fix
-# ... fix ...
-git push origin hotfix/critical-fix
-# Create PR, merge, tag, deploy
-
-# Check what's deployed where
-docker images | grep eneo
+# ... fix, push, PR to release/v1.7, merge ...
+# Then tag via GitHub UI (see below)
+# Cherry-pick to develop
 ```
+
+### Creating tags (GitHub UI)
+
+Always create tags through **GitHub Releases** rather than the CLI. This gives you release notes, pre-release marking, and a consistent audit trail.
+
+| Action | Tag | Target branch | Pre-release? |
+|--------|-----|--------------|-------------|
+| New release | `v1.8.0` | `release/v1.8` | No |
+| Release candidate | `v1.8.0-rc.1` | `release/v1.8` | Yes |
+| Hotfix patch | `v1.7.4` | `release/v1.7` | No |
+
+**Steps:** Repo → **Releases** → **Draft a new release** → type new tag → select target branch → write notes → set pre-release if RC → **Publish release**
 
 ---


### PR DESCRIPTION
## Summary

  Introduces a structured release flow using persistent release/v1.X branches. Previously, all work happened on develop and main. Now releases go through a dedicated branch with RC
  tags for testing before final release.

  Flow:
  feature/* → develop → release/v1.X → RC tags (testing) → release tags (production)

##  Key changes

  - Remove main from all workflow triggers — main is no longer part of the release flow
  - Remove develop branch push builds from PR target branches where not needed
  - Image builds only via tags — no branch push builds except develop; testing is done by creating RC tags (v1.8.0-rc.1) via GitHub Releases UI
  - Add tag-branch validation — the build workflow fails if a v1.X.* tag is not on the correct release/v1.X branch, preventing accidental mis-targeting
  - Fix pr_lint diff base — was hardcoded to origin/main, now uses origin/${{ github.base_ref }} to correctly diff against the PR's actual target branch
  - Rewrite deployment workflow docs — full rewrite of DEPLOYMENT_WORKFLOW.md covering the new flow, including hotfix, backporting, security patches, and cherry-pick-to-develop
  guidance

##  How releases work

  1. Create release/v1.X branch from develop
  2. Tag v1.X.0-rc.1 via GitHub Releases UI (mark as pre-release) → builds image → deploy to test
  3. Fix issues on release branch, create more RCs as needed
  4. Tag v1.X.0 (final release) → builds production image
  5. Cherry-pick any release branch fixes back to develop

##  Hotfixes

  1. Create hotfix/* branch from the affected release/v1.X
  2. PR to release branch, merge
  3. Tag new patch version via GitHub Releases UI
  4. Cherry-pick fix to develop