### PR TITLE
fix: isolate backend .venv in named Docker volume

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - REDIS_HOST=redis
     volumes:
       - ../:/workspace
+      # Isolate .venv from host to prevent host-side uv/python from corrupting it
+      - backend_venv:/workspace/backend/.venv
       # Mount Docker socket for testcontainers support
       - /var/run/docker.sock:/var/run/docker.sock
     # Docker group is created dynamically in post-create.sh with the correct GID
@@ -40,6 +42,7 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  backend_venv:
 
 networks:
   eneo:


### PR DESCRIPTION
## Summary
- Adds a named Docker volume (`backend_venv`) for `/workspace/backend/.venv` in the devcontainer
- Prevents host-side tools (uv, python) from corrupting the container's venv with mismatched Python versions (host runs 3.14, container runs 3.11)
- Eliminates repeated `uv sync` reinstalls on container restart

## Context
The `.venv` was shared between host and container via bind mount. Host-side tools would detect the broken symlinks and recreate the venv with the wrong Python version, causing the container to reinstall all dependencies on next start.

No impact on production (uses its own Dockerfile) or existing developers (transparent on next container rebuild).

## Test plan
- [ ] Rebuild devcontainer and verify `uv sync` only runs once (during `post-create.sh`)
- [ ] Restart container and verify dependencies are preserved without reinstall
- [ ] Verify `backend/.venv` on host is no longer modified by container operations