### PR TITLE
Optimize admin/models capabilities loading and fix model sorting

### DIFF
--- a/backend/src/intric/model_providers/presentation/model_provider_router.py
+++ b/backend/src/intric/model_providers/presentation/model_provider_router.py
@@ -79,13 +79,23 @@ async def get_provider_capabilities(
         "audio_transcription": "transcription",
     }
 
-    # Extract YYYY-MM-DD date from model name for sorting by recency
-    _date_pattern = re.compile(r"(\d{4}-\d{2}-\d{2})")
+    # Date extraction for sorting by release date (newest first).
+    # LiteLLM has no release_date field, so we extract from model names.
+    # Supports: YYYY-MM-DD (OpenAI), YYYYMMDD (Anthropic), @YYYYMMDD (Vertex)
+    _date_dashed = re.compile(r"(\d{4})-(\d{2})-(\d{2})")
+    _date_compact = re.compile(r"(?:@|-)(\d{8})(?:\D|$)|(\d{8})$")
 
     def _extract_model_date(name: str) -> str:
-        """Extract date from model name, returns '0000-00-00' if none found."""
-        m = _date_pattern.search(name)
-        return m.group(1) if m else "0000-00-00"
+        """Extract date from model name, normalized to YYYYMMDD for sorting."""
+        # YYYY-MM-DD (e.g. gpt-4o-2024-08-06)
+        m = _date_dashed.search(name)
+        if m:
+            return f"{m.group(1)}{m.group(2)}{m.group(3)}"
+        # YYYYMMDD (e.g. claude-opus-4-6-20260205, vertex @20241022)
+        m = _date_compact.search(name)
+        if m:
+            return m.group(1) or m.group(2)
+        return "00000000"
 
     # Collect all models per provider per mode with metadata
     raw: dict[str, dict[str, dict[str, dict]]] = defaultdict(
@@ -149,7 +159,7 @@ async def get_provider_capabilities(
             for f in fields
         ]
 
-    # Build response sorted by release date (newest models first)
+    # Build response sorted by release date (newest first)
     providers = {}
     for provider, modes in raw.items():
         provider_data: dict = {

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -1993,7 +1993,7 @@
   "add_models": "Add Models",
   "add_models_description": "Add one or more models to this provider",
   "skip_for_now": "Skip for now",
-  "suggested_models": "Latest models",
+  "suggested_models": "Available models",
   "browse_all": "Browse all",
   "search_models": "Search models...",
   "no_models_found": "No models found",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -2028,7 +2028,7 @@
   "add_models": "Lägg till modeller",
   "add_models_description": "Lägg till en eller flera modeller till denna leverantör",
   "skip_for_now": "Hoppa över för nu",
-  "suggested_models": "Senaste modellerna",
+  "suggested_models": "Tillgängliga modeller",
   "browse_all": "Bläddra alla",
   "search_models": "Sök modeller...",
   "no_models_found": "Inga modeller hittades",

--- a/frontend/apps/web/src/routes/(app)/admin/models/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/+page.svelte
@@ -11,23 +11,10 @@
   import EmbeddingModelsTable from "./EmbeddingModelsTable.svelte";
   import TranscriptionModelsTable from "./TranscriptionModelsTable.svelte";
   import { m } from "$lib/paraglide/messages";
-  import { writable } from "svelte/store";
-  import AddCompletionModelDialog from "./AddCompletionModelDialog.svelte";
-  import AddEmbeddingModelDialog from "./AddEmbeddingModelDialog.svelte";
-  import AddTranscriptionModelDialog from "./AddTranscriptionModelDialog.svelte";
 
   export let data;
 
   setSecurityContext(data.securityClassifications);
-
-  let addCompletionModelDialogOpen = writable(false);
-  let addEmbeddingModelDialogOpen = writable(false);
-  let addTranscriptionModelDialogOpen = writable(false);
-
-  // Track which provider to preselect when opening add model dialogs
-  let preSelectedCompletionProviderId = writable<string | null>(null);
-  let preSelectedEmbeddingProviderId = writable<string | null>(null);
-  let preSelectedTranscriptionProviderId = writable<string | null>(null);
 </script>
 
 <svelte:head>
@@ -67,7 +54,3 @@
     </Page.Tab>
   </Page.Main>
 </Page.Root>
-
-<AddCompletionModelDialog openController={addCompletionModelDialogOpen} providers={data.providers} preSelectedProviderId={preSelectedCompletionProviderId} />
-<AddEmbeddingModelDialog openController={addEmbeddingModelDialogOpen} providers={data.providers} preSelectedProviderId={preSelectedEmbeddingProviderId} />
-<AddTranscriptionModelDialog openController={addTranscriptionModelDialogOpen} providers={data.providers} preSelectedProviderId={preSelectedTranscriptionProviderId} />

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddEmbeddingModelDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddEmbeddingModelDialog.svelte
@@ -11,6 +11,11 @@
   import { writable, type Writable } from "svelte/store";
   import { m } from "$lib/paraglide/messages";
   import { TriangleAlert } from "lucide-svelte";
+  import { onMount } from "svelte";
+  import {
+    getModelProviderCapabilities,
+    type ModelProviderCapabilities
+  } from "./modelProviderCapabilities";
 
   export let openController: Writable<boolean>;
   export let providers: any[] = [];
@@ -226,18 +231,33 @@
   $: requiresEndpoint = providerType === "azure";
 
   // Dynamic provider capabilities from LiteLLM
-  let capabilities: Record<string, { modes: string[], models: Record<string, string[]> }> = {};
+  let capabilities: ModelProviderCapabilities | null = null;
+  let capabilitiesLoading = false;
+
   async function loadCapabilities() {
+    if (capabilities || capabilitiesLoading) return;
+
+    capabilitiesLoading = true;
     try {
-      capabilities = await intric.modelProviders.getCapabilities();
+      capabilities = await getModelProviderCapabilities(intric);
     } catch {
       // Silently fail — warning just won't show
+    } finally {
+      capabilitiesLoading = false;
     }
   }
-  $: if ($openController) loadCapabilities();
+  onMount(() => {
+    const unsubscribe = openController.subscribe((open) => {
+      if (open) {
+        void loadCapabilities();
+      }
+    });
+
+    return unsubscribe;
+  });
 
   // Available embedding models for the selected provider
-  $: availableModels = (capabilities[selectedProviderType]?.models?.embedding ?? []).map((m: any) => typeof m === "string" ? m : m.name) as string[];
+  $: availableModels = (capabilities?.providers[selectedProviderType]?.models?.embedding ?? []).map((m: any) => typeof m === "string" ? m : m.name) as string[];
 
   function selectModel(model: string) {
     modelName = model;
@@ -253,9 +273,9 @@
   })();
 
   $: providerHasNoSupport = selectedProviderType !== ""
-    && Object.keys(capabilities).length > 0
-    && selectedProviderType in capabilities
-    && !capabilities[selectedProviderType]?.modes?.includes("embedding");
+    && !!capabilities
+    && selectedProviderType in capabilities.providers
+    && !capabilities.providers[selectedProviderType]?.modes?.includes("embedding");
 </script>
 
 <Dialog.Root {openController}>

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddTranscriptionModelDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddTranscriptionModelDialog.svelte
@@ -11,6 +11,11 @@
   import { writable, type Writable } from "svelte/store";
   import { m } from "$lib/paraglide/messages";
   import { TriangleAlert } from "lucide-svelte";
+  import { onMount } from "svelte";
+  import {
+    getModelProviderCapabilities,
+    type ModelProviderCapabilities
+  } from "./modelProviderCapabilities";
 
   export let openController: Writable<boolean>;
   export let providers: any[] = [];
@@ -206,18 +211,33 @@
   $: requiresEndpoint = providerType === "azure";
 
   // Dynamic provider capabilities from LiteLLM
-  let capabilities: Record<string, { modes: string[], models: Record<string, string[]> }> = {};
+  let capabilities: ModelProviderCapabilities | null = null;
+  let capabilitiesLoading = false;
+
   async function loadCapabilities() {
+    if (capabilities || capabilitiesLoading) return;
+
+    capabilitiesLoading = true;
     try {
-      capabilities = await intric.modelProviders.getCapabilities();
+      capabilities = await getModelProviderCapabilities(intric);
     } catch {
       // Silently fail — warning just won't show
+    } finally {
+      capabilitiesLoading = false;
     }
   }
-  $: if ($openController) loadCapabilities();
+  onMount(() => {
+    const unsubscribe = openController.subscribe((open) => {
+      if (open) {
+        void loadCapabilities();
+      }
+    });
+
+    return unsubscribe;
+  });
 
   // Available transcription models for the selected provider
-  $: availableModels = (capabilities[selectedProviderType]?.models?.transcription ?? []).map((m: any) => typeof m === "string" ? m : m.name) as string[];
+  $: availableModels = (capabilities?.providers[selectedProviderType]?.models?.transcription ?? []).map((m: any) => typeof m === "string" ? m : m.name) as string[];
 
   function selectModel(model: string) {
     modelName = model;
@@ -233,9 +253,9 @@
   })();
 
   $: providerHasNoSupport = selectedProviderType !== ""
-    && Object.keys(capabilities).length > 0
-    && selectedProviderType in capabilities
-    && !capabilities[selectedProviderType]?.modes?.includes("transcription");
+    && !!capabilities
+    && selectedProviderType in capabilities.providers
+    && !capabilities.providers[selectedProviderType]?.modes?.includes("transcription");
 </script>
 
 <Dialog.Root {openController}>

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/AddWizard.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/AddWizard.svelte
@@ -14,6 +14,11 @@
   import StepCredentials from "./StepCredentials.svelte";
   import StepModels from "./StepModels.svelte";
   import type { ModelProviderPublic } from "@intric/intric-js";
+  import { onMount } from "svelte";
+  import {
+    getModelProviderCapabilities,
+    type ModelProviderCapabilities
+  } from "../modelProviderCapabilities";
 
   export let openController: Writable<boolean>;
   export let providers: ModelProviderPublic[] = [];
@@ -27,32 +32,14 @@
 
   // --- Capabilities (loaded once, shared across steps) ---
 
-  interface FieldDef {
-    name: string;
-    required: boolean;
-    secret: boolean;
-    in: "credentials" | "config";
-  }
-
-  interface ProviderCapability {
-    modes: string[];
-    models: Record<string, any[]>;
-    fields: FieldDef[];
-  }
-
-  interface Capabilities {
-    providers: Record<string, ProviderCapability>;
-    default_fields: FieldDef[];
-  }
-
-  let capabilities: Capabilities | null = null;
+  let capabilities: ModelProviderCapabilities | null = null;
   let capabilitiesLoading = false;
 
   async function loadCapabilities() {
     if (capabilities || capabilitiesLoading) return;
     capabilitiesLoading = true;
     try {
-      capabilities = await intric.modelProviders.getCapabilities() as Capabilities;
+      capabilities = await getModelProviderCapabilities(intric);
     } catch {
       // Silently fail — steps will fall back gracefully
     } finally {
@@ -60,10 +47,15 @@
     }
   }
 
-  // Load capabilities when dialog opens
-  $: if ($openController && !capabilities) {
-    loadCapabilities();
-  }
+  onMount(() => {
+    const unsubscribe = openController.subscribe((open) => {
+      if (open) {
+        void loadCapabilities();
+      }
+    });
+
+    return unsubscribe;
+  });
 
   // Derive provider fields for StepCredentials based on selected provider type
   $: providerFields = (() => {

--- a/frontend/apps/web/src/routes/(app)/admin/models/CompletionModelsTable.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/CompletionModelsTable.svelte
@@ -18,7 +18,7 @@
   import { getChartColour } from "$lib/features/ai-models/components/ModelNameAndVendor.svelte";
   import { m } from "$lib/paraglide/messages";
 
-  import { writable, type Writable } from "svelte/store";
+  import { writable } from "svelte/store";
   import { Button } from "@intric/ui";
   import { Plus } from "lucide-svelte";
   import ProviderDialog from "./ProviderDialog.svelte";
@@ -29,8 +29,6 @@
   export let completionModels: CompletionModel[];
   export let providers: ModelProviderPublic[] = [];
   export let favoriteProviders: string[] = [];
-  export let addModelDialogOpen: Writable<boolean> | undefined = undefined;
-  export let preSelectedProviderId: Writable<string | null> | undefined = undefined;
 
   const addWizardOpen = writable(false);
   // Pre-selected provider for "Add Model" from provider dropdown
@@ -253,6 +251,7 @@
               <ProviderActions
                 {provider}
                 onAddModel={handleAddModelToProvider}
+                onEditProvider={handleEditProvider}
               />
             {/if}
           </div>

--- a/frontend/apps/web/src/routes/(app)/admin/models/EmbeddingModelsTable.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/EmbeddingModelsTable.svelte
@@ -18,7 +18,7 @@
   import ProviderStatusBadge from "./components/ProviderStatusBadge.svelte";
   import { getChartColour } from "$lib/features/ai-models/components/ModelNameAndVendor.svelte";
   import { m } from "$lib/paraglide/messages";
-  import { writable, type Writable } from "svelte/store";
+  import { writable } from "svelte/store";
   import { Button } from "@intric/ui";
   import { Plus } from "lucide-svelte";
   import { AddWizard } from "./AddWizard/index.js";
@@ -28,8 +28,6 @@
   export let embeddingModels: EmbeddingModel[];
   export let providers: ModelProviderPublic[] = [];
   export let favoriteProviders: string[] = [];
-  export let addModelDialogOpen: Writable<boolean> | undefined = undefined;
-  export let preSelectedProviderId: Writable<string | null> | undefined = undefined;
 
   const addWizardOpen = writable(false);
   // Pre-selected provider for "Add Model" from provider dropdown
@@ -243,6 +241,7 @@
               <ProviderActions
                 {provider}
                 onAddModel={handleAddModelToProvider}
+                onEditProvider={handleEditProvider}
               />
             {/if}
           </div>

--- a/frontend/apps/web/src/routes/(app)/admin/models/ProviderActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/ProviderActions.svelte
@@ -7,17 +7,16 @@
   import { getIntric } from "$lib/core/Intric";
   import { invalidate } from "$app/navigation";
   import { writable } from "svelte/store";
-  import { Plus, Pencil, Trash2, AlertTriangle, Loader2, Box, Sparkles, AudioLines } from "lucide-svelte";
-  import ProviderDialog from "./ProviderDialog.svelte";
+  import { Pencil, Trash2, AlertTriangle, Loader2, Box, Sparkles, AudioLines } from "lucide-svelte";
   import { m } from "$lib/paraglide/messages";
 
   export let provider: ModelProviderPublic;
   /** Pass this to open AddCompletionModelDialog with this provider pre-selected */
   export let onAddModel: ((providerId: string) => void) | undefined = undefined;
+  export let onEditProvider: ((provider: ModelProviderPublic) => void) | undefined = undefined;
 
   const intric = getIntric();
 
-  const showEditDialog = writable(false);
   const showDeleteConfirm = writable(false);
   let isDeleting = false;
   let deleteError: string | null = null;
@@ -120,7 +119,7 @@
       is={item}
       padding="icon-leading"
       on:click={() => {
-        $showEditDialog = true;
+        onEditProvider?.(provider);
       }}
     >
       <Pencil class="h-4 w-4" />
@@ -141,9 +140,6 @@
     </Button>
   </Dropdown.Menu>
 </Dropdown.Root>
-
-<!-- Edit Provider Dialog -->
-<ProviderDialog openController={showEditDialog} {provider} />
 
 <!-- Delete Confirmation Dialog -->
 <Dialog.Root openController={showDeleteConfirm}>

--- a/frontend/apps/web/src/routes/(app)/admin/models/ProviderDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/ProviderDialog.svelte
@@ -11,6 +11,11 @@
   import ProviderGlyph from "./components/ProviderGlyph.svelte";
   import { toast } from "$lib/components/toast";
   import { onMount } from "svelte";
+  import {
+    getModelProviderCapabilities,
+    type ModelProviderCapabilities,
+    type ModelProviderFieldDef
+  } from "./modelProviderCapabilities";
 
   export let openController: Writable<boolean>;
   /** If provided, dialog is in edit mode. If null/undefined, dialog is in add mode. */
@@ -19,26 +24,30 @@
   const intric = getIntric();
 
   // --- Capabilities ---
-  interface FieldDef {
-    name: string;
-    required: boolean;
-    secret: boolean;
-    in: "credentials" | "config";
-  }
+  let capabilities: ModelProviderCapabilities | null = null;
+  let capabilitiesLoading = false;
 
-  interface Capabilities {
-    providers: Record<string, { modes: string[]; models: Record<string, any[]>; fields: FieldDef[] }>;
-    default_fields: FieldDef[];
-  }
+  async function loadCapabilities() {
+    if (capabilities || capabilitiesLoading) return;
 
-  let capabilities: Capabilities | null = null;
-
-  onMount(async () => {
+    capabilitiesLoading = true;
     try {
-      capabilities = await intric.modelProviders.getCapabilities() as Capabilities;
+      capabilities = await getModelProviderCapabilities(intric);
     } catch {
       // Silently fail — fall back to hardcoded defaults
+    } finally {
+      capabilitiesLoading = false;
     }
+  }
+
+  onMount(() => {
+    const unsubscribe = openController.subscribe((open) => {
+      if (open) {
+        void loadCapabilities();
+      }
+    });
+
+    return unsubscribe;
   });
 
   // Build provider type options from capabilities (or fallback)
@@ -79,7 +88,7 @@
   })();
 
   // Fallback fields when capabilities haven't loaded
-  const fallbackFields: FieldDef[] = [
+  const fallbackFields: ModelProviderFieldDef[] = [
     { name: "api_key", required: true, secret: true, in: "credentials" },
     { name: "endpoint", required: false, secret: false, in: "config" },
   ];
@@ -429,7 +438,7 @@
       <Button
         variant="primary"
         on:click={handleSubmit}
-        disabled={isSubmitting}
+        disabled={isSubmitting || capabilitiesLoading}
         class="min-w-[120px]"
       >
         {#if isSubmitting}

--- a/frontend/apps/web/src/routes/(app)/admin/models/TranscriptionModelsTable.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/TranscriptionModelsTable.svelte
@@ -18,7 +18,7 @@
   import ProviderStatusBadge from "./components/ProviderStatusBadge.svelte";
   import { getChartColour } from "$lib/features/ai-models/components/ModelNameAndVendor.svelte";
   import { m } from "$lib/paraglide/messages";
-  import { writable, type Writable } from "svelte/store";
+  import { writable } from "svelte/store";
   import { Button } from "@intric/ui";
   import { Plus } from "lucide-svelte";
   import { AddWizard } from "./AddWizard/index.js";
@@ -28,8 +28,6 @@
   export let transcriptionModels: TranscriptionModel[];
   export let providers: ModelProviderPublic[] = [];
   export let favoriteProviders: string[] = [];
-  export let addModelDialogOpen: Writable<boolean> | undefined = undefined;
-  export let preSelectedProviderId: Writable<string | null> | undefined = undefined;
 
   const addWizardOpen = writable(false);
   // Pre-selected provider for "Add Model" from provider dropdown
@@ -243,6 +241,7 @@
               <ProviderActions
                 {provider}
                 onAddModel={handleAddModelToProvider}
+                onEditProvider={handleEditProvider}
               />
             {/if}
           </div>

--- a/frontend/apps/web/src/routes/(app)/admin/models/modelProviderCapabilities.ts
+++ b/frontend/apps/web/src/routes/(app)/admin/models/modelProviderCapabilities.ts
@@ -1,0 +1,44 @@
+import type { Intric } from "@intric/intric-js";
+
+export interface ModelProviderFieldDef {
+  name: string;
+  required: boolean;
+  secret: boolean;
+  in: "credentials" | "config";
+}
+
+export type CapabilityModel = string | { name?: string; [key: string]: unknown };
+
+export interface ModelProviderCapability {
+  modes: string[];
+  models: Record<string, CapabilityModel[]>;
+  fields: ModelProviderFieldDef[];
+}
+
+export interface ModelProviderCapabilities {
+  providers: Record<string, ModelProviderCapability>;
+  default_fields: ModelProviderFieldDef[];
+}
+
+let capabilitiesCache: ModelProviderCapabilities | null = null;
+let capabilitiesPromise: Promise<ModelProviderCapabilities> | null = null;
+
+export async function getModelProviderCapabilities(intric: Intric): Promise<ModelProviderCapabilities> {
+  if (capabilitiesCache) {
+    return capabilitiesCache;
+  }
+
+  if (!capabilitiesPromise) {
+    capabilitiesPromise = intric.modelProviders.getCapabilities()
+      .then((capabilities) => {
+        capabilitiesCache = capabilities as ModelProviderCapabilities;
+        return capabilitiesCache;
+      })
+      .catch((error) => {
+        capabilitiesPromise = null;
+        throw error;
+      });
+  }
+
+  return capabilitiesPromise;
+}


### PR DESCRIPTION
## Summary

- **Fix capabilities request spam**: Moved `ProviderDialog` from per-provider-row instances to a single shared instance per table. Previously, opening `/admin/models` triggered `providers × tabs` capabilities requests on page load. Now capabilities are lazy-loaded only when a dialog is actually opened, with a shared module-level cache to deduplicate concurrent calls.

- **Remove dead code**: Removed the old `AddCompletionModelDialog`, `AddEmbeddingModelDialog`, `AddTranscriptionModelDialog` components from `+page.svelte` (replaced by `AddWizard` inside each table component). Cleaned up unused `addModelDialogOpen` and `preSelectedProviderId` props from table components.

- **Fix model date sorting**: The capabilities endpoint sorted models by release date, but only supported `YYYY-MM-DD` format (OpenAI). Anthropic models use `YYYYMMDD` (e.g. `claude-opus-4-6-20260205`) and Vertex uses `@YYYYMMDD` — both were unrecognized and sorted arbitrarily. Now all three formats are supported.

- **Block submit during capabilities loading**: Prevents saving a provider with incomplete field definitions if capabilities haven't loaded yet (edge case on slow networks).

- **Rename "Latest models" → "Available models"**: The label was misleading since we can't guarantee date-based ordering for all providers.

## Test plan

- [ ] Open `/admin/models` and verify no `GET /capabilities/` requests in network tab on page load
- [ ] Open an "Add model" wizard or "Edit provider" dialog — verify capabilities load on open
- [ ] Verify model suggestions are sorted newest-first for Anthropic and OpenAI providers
- [ ] Edit an Azure provider — verify all config fields (api_version, deployment_name) are present
- [ ] Verify submit button is disabled briefly while capabilities load on dialog open