### PR TITLE
fix: correctly identify transcription model type when editing via nam…

### DIFF
--- a/frontend/apps/web/src/routes/(app)/admin/models/CompletionModelsTable.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/CompletionModelsTable.svelte
@@ -50,7 +50,7 @@
       accessor: (model) => model,
       header: m.name(),
       cell: (item) => {
-        return createRender(ModelNameCell, { model: item.value });
+        return createRender(ModelNameCell, { model: item.value, type: "completionModel" });
       },
       plugins: {
         sort: {

--- a/frontend/apps/web/src/routes/(app)/admin/models/EmbeddingModelsTable.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/EmbeddingModelsTable.svelte
@@ -48,7 +48,7 @@
       accessor: (model) => model,
       header: m.name(),
       cell: (item) => {
-        return createRender(ModelNameCell, { model: item.value });
+        return createRender(ModelNameCell, { model: item.value, type: "embeddingModel" });
       },
       plugins: {
         sort: {

--- a/frontend/apps/web/src/routes/(app)/admin/models/ModelNameCell.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/ModelNameCell.svelte
@@ -9,19 +9,7 @@
   import { m } from "$lib/paraglide/messages";
 
   export let model: CompletionModel | EmbeddingModel | TranscriptionModel;
-
-  // Determine model type from properties
-  function getModelType(): "completionModel" | "embeddingModel" | "transcriptionModel" {
-    if ("vision" in model || "reasoning" in model || "token_limit" in model) {
-      return "completionModel";
-    }
-    if ("family" in model) {
-      return "embeddingModel";
-    }
-    return "transcriptionModel";
-  }
-
-  $: modelType = getModelType();
+  export let type: "completionModel" | "embeddingModel" | "transcriptionModel";
   $: isTenantModel = model.provider_id != null;
 
   const showEditDialog = writable(false);
@@ -56,5 +44,5 @@
 </div>
 
 {#if isTenantModel}
-  <EditModelDialog {model} type={modelType} openController={showEditDialog} />
+  <EditModelDialog {model} {type} openController={showEditDialog} />
 {/if}

--- a/frontend/apps/web/src/routes/(app)/admin/models/ProviderActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/ProviderActions.svelte
@@ -48,34 +48,20 @@
     return model.name;
   }
 
-  function getModelTypeLabel(model: any): string {
-    if ("token_limit" in model || "vision" in model || "reasoning" in model) {
-      return m.completion_model();
-    }
-    if ("family" in model) {
-      return m.embedding_model();
-    }
-    return m.transcription_model();
-  }
-
-  function getModelTypeIcon(model: any): typeof Sparkles {
-    if ("token_limit" in model || "vision" in model || "reasoning" in model) {
-      return Sparkles;
-    }
-    if ("family" in model) {
-      return Box;
-    }
-    return AudioLines;
-  }
-
-  function getModelTypeRaw(model: any): "completion" | "embedding" | "transcription" {
-    if ("token_limit" in model || "vision" in model || "reasoning" in model) {
-      return "completion";
-    }
-    if ("family" in model) {
-      return "embedding";
-    }
-    return "transcription";
+  function tagModels(
+    models: any[],
+    type: "completion" | "embedding" | "transcription",
+    label: string,
+    icon: typeof Sparkles
+  ) {
+    return models
+      .filter((model) => model.provider_id === provider.id)
+      .map((model) => ({
+        name: getModelName(model),
+        type: label,
+        typeRaw: type,
+        icon
+      }));
   }
 
   async function loadProviderModels() {
@@ -85,21 +71,12 @@
 
     try {
       const models = await intric.models.list();
-      const allModels = [
-        ...models.completionModels,
-        ...models.embeddingModels,
-        ...models.transcriptionModels
-      ];
 
-      providerModels = allModels
-        .filter((model) => model.provider_id === provider.id)
-        .map((model) => ({
-          name: getModelName(model),
-          type: getModelTypeLabel(model),
-          typeRaw: getModelTypeRaw(model),
-          icon: getModelTypeIcon(model)
-        }))
-        .sort((a, b) => a.name.localeCompare(b.name));
+      providerModels = [
+        ...tagModels(models.completionModels, "completion", m.completion_model(), Sparkles),
+        ...tagModels(models.embeddingModels, "embedding", m.embedding_model(), Box),
+        ...tagModels(models.transcriptionModels, "transcription", m.transcription_model(), AudioLines)
+      ].sort((a, b) => a.name.localeCompare(b.name));
     } catch (e: any) {
       modelsLoadError = e.message || m.failed_to_load_models();
     } finally {

--- a/frontend/apps/web/src/routes/(app)/admin/models/TranscriptionModelsTable.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/TranscriptionModelsTable.svelte
@@ -48,7 +48,7 @@
       accessor: (model) => model,
       header: m.name(),
       cell: (item) => {
-        return createRender(ModelNameCell, { model: item.value });
+        return createRender(ModelNameCell, { model: item.value, type: "transcriptionModel" });
       },
       plugins: {
         sort: {


### PR DESCRIPTION
## Changes
Replace property-based model type inference with explicit type props passed from table components, and refactor ProviderActions to derive model types from the already-separated API response arrays.

## Why
ModelNameCell used "family" in model to detect embedding models, but transcription models also have a family field. This caused transcription models to be misidentified as embedding models when clicking the
  name to edit, resulting in a 404 from hitting the wrong API endpoint. The three-dot menu worked because it received the correct type as a prop from the parent table.
