### PR TITLE
fix: use conventional KB/MB/GB labels instead of KiB/MiB/GiB

### DIFF
--- a/backend/src/intric/apps/apps/app.py
+++ b/backend/src/intric/apps/apps/app.py
@@ -224,7 +224,7 @@ class App:
                     return False
 
             total_size = sum(file.size for file in files)
-            if total_size > 200 * 1024 * 1024:  # 200 MiB
+            if total_size > 200 * 1024 * 1024:  # 200 MB
                 return False
 
             for input_field in self.input_fields:

--- a/backend/src/intric/main/exceptions.py
+++ b/backend/src/intric/main/exceptions.py
@@ -172,7 +172,7 @@ class FileTooLargeException(Exception):
             return f"{value} bytes"
 
         size = float(value)
-        units = ("KiB", "MiB", "GiB", "TiB")
+        units = ("KB", "MB", "GB", "TB")
 
         for unit in units:
             size /= 1024

--- a/backend/tests/unittests/apps/test_app.py
+++ b/backend/tests/unittests/apps/test_app.py
@@ -161,50 +161,50 @@ def test_number_of_files_validation(
             26214400,
             3,
             True,
-        ),  # 3 files, 25 MiB each, total 75 MiB
+        ),  # 3 files, 25 MB each, total 75 MB
         (
             InputFieldType.TEXT_UPLOAD,
             26214400,
             4,
             False,
-        ),  # 4 files, 25 MiB each, total 100 MiB
+        ),  # 4 files, 25 MB each, total 100 MB
         (
             InputFieldType.TEXT_UPLOAD,
             26214400 + 1,
             1,
             False,
-        ),  # 1 file, just over 25 MiB
-        (InputFieldType.AUDIO_UPLOAD, 209715200, 1, True),  # 1 file, 200 MiB
+        ),  # 1 file, just over 25 MB
+        (InputFieldType.AUDIO_UPLOAD, 209715200, 1, True),  # 1 file, 200 MB
         (
             InputFieldType.AUDIO_UPLOAD,
             209715200,
             2,
             False,
-        ),  # 2 files, 200 MiB each, total 400 MiB
+        ),  # 2 files, 200 MB each, total 400 MB
         (
             InputFieldType.AUDIO_UPLOAD,
             209715200 + 1,
             1,
             False,
-        ),  # 1 file, just over 200 MiB
+        ),  # 1 file, just over 200 MB
         (
             InputFieldType.IMAGE_UPLOAD,
             20971520,
             2,
             True,
-        ),  # 2 files, 20 MiB each, total 40 MiB
+        ),  # 2 files, 20 MB each, total 40 MB
         (
             InputFieldType.IMAGE_UPLOAD,
             20971520,
             3,
             False,
-        ),  # 3 files, 20 MiB each, total 60 MiB
+        ),  # 3 files, 20 MB each, total 60 MB
         (
             InputFieldType.IMAGE_UPLOAD,
             20971520 + 1,
             1,
             False,
-        ),  # 1 file, just over 20 MiB
+        ),  # 1 file, just over 20 MB
     ],
 )
 def test_total_size_of_files_validation(

--- a/frontend/apps/web/src/lib/core/formatting/formatBytes.test.ts
+++ b/frontend/apps/web/src/lib/core/formatting/formatBytes.test.ts
@@ -14,20 +14,20 @@ test("Format bytes", () => {
 });
 
 test("Format kilobytes", () => {
-  expect(formatBytes(1024)).toEqual("1 KiB");
-  expect(formatBytes(1536)).toEqual("2 KiB");
+  expect(formatBytes(1024)).toEqual("1 KB");
+  expect(formatBytes(1536)).toEqual("2 KB");
 });
 
 test("Format megabytes", () => {
-  expect(formatBytes(1024 * 1024)).toEqual("1 MiB");
-  expect(formatBytes(1.5 * 1024 * 1024)).toEqual("2 MiB");
+  expect(formatBytes(1024 * 1024)).toEqual("1 MB");
+  expect(formatBytes(1.5 * 1024 * 1024)).toEqual("2 MB");
 });
 
 test("Format gigabytes", () => {
-  expect(formatBytes(1024 * 1024 * 1024)).toEqual("1 GiB");
+  expect(formatBytes(1024 * 1024 * 1024)).toEqual("1 GB");
 });
 
 test("Format with decimals", () => {
-  expect(formatBytes(1536, 1)).toEqual("1.5 KiB");
-  expect(formatBytes(1.5 * 1024 * 1024, 2)).toEqual("1.50 MiB");
+  expect(formatBytes(1536, 1)).toEqual("1.5 KB");
+  expect(formatBytes(1.5 * 1024 * 1024, 2)).toEqual("1.50 MB");
 });

--- a/frontend/apps/web/src/lib/core/formatting/formatBytes.ts
+++ b/frontend/apps/web/src/lib/core/formatting/formatBytes.ts
@@ -1,5 +1,6 @@
 /**
- * Format a size attribute in bytes as human-readable file size, e.g. `1024` will return `"1 KiB"`
+ * Format a size attribute in bytes as human-readable file size.
+ * Uses base-1024 with conventional KB/MB/GB labels.
  * Returns "- Bytes" for negative values
  */
 export function formatBytes(bytes: number, decimals = 0) {
@@ -8,7 +9,7 @@ export function formatBytes(bytes: number, decimals = 0) {
 
   const k = 1024;
   const dm = decimals < 0 ? 0 : decimals;
-  const sizes = ["Bytes", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"];
+  const sizes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
 
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 


### PR DESCRIPTION
## Summary
- Replace IEC binary prefixes (KiB, MiB, GiB) with conventional KB/MB/GB labels across frontend and backend
- Base-1024 calculation unchanged — only displayed unit labels are updated
- Aligns with the de facto standard used by GitHub, Dropbox, Google Drive, and virtually all web applications

## Changed files
- `frontend/.../formatting/formatBytes.ts` — label change in formatter
- `backend/.../main/exceptions.py` — label change in `FileSizeLimitExceeded._format_bytes()`
- `backend/.../apps/app.py` — comment update
- `backend/tests/.../test_app.py` — comment updates
- `frontend/.../formatting/formatBytes.test.ts` — test expectations updated

## Test plan
- [x] Frontend unit tests pass (7/7)
- [x] Backend unit tests pass (5/5)
- [x] Pyright typecheck passes (0 errors)
- [ ] Verify file size displays correctly in upload dialogs
- [ ] Verify storage overview shows KB/MB/GB labels