### PR TITLE
fix(security): pin litellm to safe version, harden CI dependency controls

### DIFF
--- a/.github/workflows/pr_build_test.yml
+++ b/.github/workflows/pr_build_test.yml
@@ -54,9 +54,13 @@ jobs:
       - name: Set up Python
         run: uv python install 3.11
 
+      - name: Verify lockfile consistency
+        working-directory: ./backend
+        run: uv lock --check
+
       - name: Install dependencies
         working-directory: ./backend
-        run: uv sync --all-groups
+        run: uv sync --frozen --all-groups
 
       - name: Run unit tests
         working-directory: ./backend
@@ -89,9 +93,13 @@ jobs:
       - name: Set up Python
         run: uv python install 3.11
 
+      - name: Verify lockfile consistency
+        working-directory: ./backend
+        run: uv lock --check
+
       - name: Install dependencies
         working-directory: ./backend
-        run: uv sync --all-groups
+        run: uv sync --frozen --all-groups
 
       - name: Run integration tests
         working-directory: ./backend

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -29,11 +29,11 @@ jobs:
             exit 0
           fi
 
-          VALID_PREFIXES="^(feature|feat|fix|hotfix|chore|docs|test|refactor|ci)/"
+          VALID_PREFIXES="^(feature|feat|fix|hotfix|security|chore|docs|test|refactor|ci)/"
 
           if [[ ! "$BRANCH_NAME" =~ $VALID_PREFIXES ]]; then
             echo "❌ Branch name '$BRANCH_NAME' does not follow naming convention."
-            echo "Branch names should start with: feature/, feat/, fix/, hotfix/, chore/, docs/, test/, refactor/, or ci/"
+            echo "Branch names should start with: feature/, feat/, fix/, hotfix/, security/, chore/, docs/, test/, refactor/, or ci/"
             exit 1
           fi
 
@@ -79,15 +79,19 @@ jobs:
       - name: Set up Python
         run: uv python install 3.11
 
+      - name: Verify lockfile consistency
+        working-directory: ./backend
+        run: uv lock --check
+
       - name: Install dependencies
         working-directory: ./backend
-        run: uv sync
+        run: uv sync --frozen
 
       - name: Get changed Python files
         id: changed-files
         run: |
           # Get changed Python files in backend directory
-          CHANGED_FILES=$(git diff --name-only --diff-filter=AM origin/main...HEAD -- 'backend/**/*.py' | sed 's|^backend/||' | tr '\n' ' ')
+          CHANGED_FILES=$(git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }}...HEAD -- 'backend/**/*.py' | sed 's|^backend/||' | tr '\n' ' ')
           echo "files=$CHANGED_FILES" >> $GITHUB_OUTPUT
           echo "Changed Python files: $CHANGED_FILES"
           if [ -z "$CHANGED_FILES" ]; then
@@ -135,9 +139,13 @@ jobs:
       - name: Set up Python
         run: uv python install 3.11
 
+      - name: Verify lockfile consistency
+        working-directory: ./backend
+        run: uv lock --check
+
       - name: Install dependencies
         working-directory: ./backend
-        run: uv sync --group dev
+        run: uv sync --frozen --group dev
 
       - name: Run pyright on changed files
         working-directory: ./backend

--- a/.github/workflows/update_litellm.yml
+++ b/.github/workflows/update_litellm.yml
@@ -8,7 +8,13 @@ on:
   # schedule:
   #   # Every Monday at 08:00 UTC
   #   - cron: "0 8 * * 1"
-  workflow_dispatch: # Allow manual trigger (kept for when we re-enable)
+  workflow_dispatch:
+    inputs:
+      confirmed_safe_to_resume:
+        description: "Set to true ONLY after verifying litellm publishing pipeline is safe"
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   update:
@@ -18,6 +24,14 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Guard — require explicit confirmation
+        if: ${{ github.event.inputs.confirmed_safe_to_resume != 'true' }}
+        run: |
+          echo "❌ LiteLLM auto-update is paused due to supply chain attack (2026-03-24)."
+          echo "Set 'confirmed_safe_to_resume' to true only after verifying litellm publishing is safe."
+          echo "See: https://github.com/BerriAI/litellm/issues/24518"
+          exit 1
+
       - uses: actions/checkout@v4
 
       - name: Install uv

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 
     "tavily-python>=0.5.1,<0.6",
     "greenlet>=3.2.2,<4",
-    "litellm>=1.76.1,<=1.80.0",  # SECURITY: pinned to match v1.8.0 release. 1.82.7+ compromised (supply chain attack, 2026-03-24). See: https://github.com/BerriAI/litellm/issues/24518
+    "litellm==1.80.0",  # SECURITY: pinned to last known-safe version matching released image. 1.82.7+ compromised (supply chain attack, 2026-03-24). See: https://github.com/BerriAI/litellm/issues/24518
     "mcp>=1.2.0,<2", # Model Context Protocol SDK for MCP server integration
     "cryptography>=43.0.0,<44", # For Fernet encryption of HTTP auth passwords
     "httpx~=0.28.0",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1174,7 +1174,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.5,<4" },
     { name = "jsonschema", specifier = ">=4.19.2,<5" },
     { name = "langchain", specifier = ">=0.3.0,<0.4" },
-    { name = "litellm", specifier = ">=1.76.1,<=1.80.0" },
+    { name = "litellm", specifier = "==1.80.0" },
     { name = "mcp", specifier = ">=1.2.0,<2" },
     { name = "numpy", specifier = ">=1.24.2,<2" },
     { name = "orjson", specifier = ">=3.9,<4" },


### PR DESCRIPTION
## Summary

Preventive hardening after the LiteLLM PyPI supply-chain incident on March 24, 2026.

Eneo was not affected by the known compromised versions based on our current analysis. Our lockfile had LiteLLM `1.82.0`, and the released Eneo image `v1.8.0` includes LiteLLM `1.80.0`, both of which predate the compromised releases `1.82.7` and `1.82.8`.

This PR reduces dependency drift and prevents accidental upgrades while the upstream publishing situation remains under review.

## Why `1.80.0`

`1.82.0` was not compromised, but this PR intentionally steps back to `1.80.0` because it matches the currently released Eneo image. Aligning source, CI, and deployed artifacts reduces drift during incident response and makes behavior easier to reason about.

## Changes

- Pin `litellm` to `==1.80.0` in `backend/pyproject.toml`
- Regenerate `backend/uv.lock` to match the exact pin
- Add `uv lock --check` to backend CI jobs so dependency spec and lockfile cannot drift silently
- Change backend CI installs to `uv sync --frozen` so CI installs exactly what is locked
- Fix the PR lint changed-files diff to use the PR base SHA instead of always diffing against `main`
- Keep the LiteLLM updater workflow discoverable, but block manual execution unless `confirmed_safe_to_resume` is explicitly set
- Allow `security/` as a valid branch prefix in PR lint

## Why this helps

- Makes the resolved dependency set explicit
- Ensures CI uses the committed lockfile instead of re-resolving dependencies
- Reduces accidental exposure to upstream package changes
- Keeps future dependency updates intentional and reviewable

## Follow-up work

Out of scope for this PR:

- `pip-audit` / `osv-scanner`
- dependency review in CI
- SBOM generation
- GitHub Action SHA pinning across workflows

## References

- [LiteLLM tracking issue](https://github.com/BerriAI/litellm/issues/24518)
- [Original disclosure](https://github.com/BerriAI/litellm/issues/24512)
- Related work: PR #300