### PR TITLE
fix bug

### DIFF
--- a/backend/src/intric/spaces/domain/resource_mover_service.py
+++ b/backend/src/intric/spaces/domain/resource_mover_service.py
@@ -90,7 +90,7 @@ class ResourceMoverService:
                 "User does not have permission to create collections in the space"
             )
 
-        await self.group_service.import_group_to_space(
+        await self.group_service.move_group_owner_to_space(
             group_id=collection_id,
             space_id=space_id,
         )


### PR DESCRIPTION
## Why
When moving a knowledge source between two shared spaces, it doesnt get moved when pressing move. This fixes the issue.
