### PR TITLE
fix: restore browser import breaking chat streaming

### DIFF
--- a/frontend/apps/web/src/lib/features/chat/ChatService.svelte.ts
+++ b/frontend/apps/web/src/lib/features/chat/ChatService.svelte.ts
@@ -1,3 +1,4 @@
+import { browser } from "$app/environment";
 import { PAGINATION } from "$lib/core/constants";
 import { toastError } from "$lib/core/errors";
 import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte";
@@ -382,7 +383,7 @@ export class ChatService {
         if (error instanceof IntricError) {
           message += `\n\`\`\`\n${error.code}: "${error.getReadableMessage()}"\n\`\`\``;
         } else if (error instanceof Object && "message" in error && "name" in error) {
-          message += `\n\`\`\`\n$"${error.name}: error.message}"\n\`\`\``;
+          message += `\n\`\`\`\n${error.name}: "${error.message}"\n\`\`\``;
         }
 
         this.currentConversation.messages[this.currentConversation.messages?.length - 1].answer =


### PR DESCRIPTION
## Summary
- Restores the `browser` import from `$app/environment` that was accidentally removed in #308 (bd2684b8)
- Without this import, the streaming `onText` callback throws a `ReferenceError`, causing chat responses to never render in the active conversation (only visible in history)
- Also fixes a malformed string interpolation in the streaming error handler

## Test plan
- [x] Send a question in a chat and verify the response streams in real-time
- [x] Verify the response is visible without needing to reload or navigate to history
- [x] Trigger a streaming error and verify the error message renders correctly