### PR TITLE
fix: handle stale core.hooksPath in devcontainer post-create

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -34,7 +34,12 @@ uv sync --reinstall-package intric
 # Install pre-commit globally and setup hooks
 cd /workspace
 uv tool install pre-commit
-pre-commit install
+LOCAL_HOOKS_PATH="$(git config --local --get core.hooksPath || true)"
+if [ -n "$LOCAL_HOOKS_PATH" ] && [ ! -d "$LOCAL_HOOKS_PATH" ]; then
+    echo "Resetting repo-local core.hooksPath ('$LOCAL_HOOKS_PATH') to Git default for the devcontainer"
+    git config --local --unset-all core.hooksPath
+fi
+pre-commit install --overwrite
 
 # Install Bun
 curl -fsSL https://bun.com/install | bash -s "bun-v1.3.0"


### PR DESCRIPTION
## Summary
- Fixes devcontainer `post-create.sh` failing when the host has `core.hooksPath` set to a path that doesn't exist inside the container
- Previously, `pre-commit install` would fail and `set -e` would abort the entire script, preventing bun install and frontend setup from running
- Now resets the local hooksPath when it points to a missing directory, then installs hooks with `--overwrite` for idempotency

## Test plan
- [ ] Rebuild devcontainer and verify post-create completes without errors
- [ ] Verify pre-commit hooks are installed
- [ ] Verify bun and frontend dependencies are set up correctly