### PR TITLE
fix: public keys can only have read permission

### DIFF
--- a/backend/src/intric/authentication/api_key_policy.py
+++ b/backend/src/intric/authentication/api_key_policy.py
@@ -111,11 +111,11 @@ class ApiKeyPolicyService:
                     )
 
         if request.key_type == ApiKeyType.PK:
-            if request.permission == ApiKeyPermission.ADMIN:
+            if request.permission != ApiKeyPermission.READ:
                 raise ApiKeyValidationError(
                     status_code=400,
                     code="invalid_request",
-                    message="pk_ keys cannot have admin permission.",
+                    message="pk_ keys can only have read permission.",
                 )
             if request.allowed_origins is None:
                 raise ApiKeyValidationError(
@@ -303,12 +303,12 @@ class ApiKeyPolicyService:
                 )
                 if (
                     key_type == ApiKeyType.PK
-                    and new_permission == ApiKeyPermission.ADMIN
+                    and new_permission != ApiKeyPermission.READ
                 ):
                     raise ApiKeyValidationError(
                         status_code=400,
                         code="invalid_request",
-                        message="pk_ keys cannot have admin permission.",
+                        message="pk_ keys can only have read permission.",
                     )
 
         if "allowed_origins" in updates:

--- a/backend/tests/unit/test_api_key_policy_service.py
+++ b/backend/tests/unit/test_api_key_policy_service.py
@@ -1,6 +1,7 @@
-import pytest
-from uuid import uuid4
 from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
 
 from intric.authentication.api_key_policy import ApiKeyPolicyService
 from intric.authentication.api_key_request_context import resolve_client_ip
@@ -214,7 +215,7 @@ async def test_update_request_rejects_empty_allowed_origins_for_pk():
 
 
 @pytest.mark.asyncio
-async def test_update_request_rejects_admin_permission_for_pk():
+async def test_update_request_rejects_non_read_permission_for_pk():
     service = ApiKeyPolicyService(
         allowed_origin_repo=DummyOriginRepo([]),
         space_service=DummySpaceService(),
@@ -227,15 +228,16 @@ async def test_update_request_rejects_admin_permission_for_pk():
         resource_permissions=None,
     )
 
-    with pytest.raises(ApiKeyValidationError) as exc:
-        await service.validate_update_request(
-            key=key,
-            updates={"permission": ApiKeyPermission.ADMIN.value},
-        )
+    for perm in (ApiKeyPermission.WRITE, ApiKeyPermission.ADMIN):
+        with pytest.raises(ApiKeyValidationError) as exc:
+            await service.validate_update_request(
+                key=key,
+                updates={"permission": perm.value},
+            )
 
-    assert exc.value.status_code == 400
-    assert exc.value.code == "invalid_request"
-    assert "cannot have admin permission" in exc.value.message
+        assert exc.value.status_code == 400
+        assert exc.value.code == "invalid_request"
+        assert "can only have read permission" in exc.value.message
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Changes
Only allow public keys with read permission to be created

## Why
public keys can only read resources

## Testing
Integration tests + manual creation via api



