### PR TITLE
Move API key notifications to relational tables

### DIFF
--- a/backend/alembic/versions/202604081700_api_key_notification_tables.py
+++ b/backend/alembic/versions/202604081700_api_key_notification_tables.py
@@ -1,0 +1,446 @@
+"""Move API key notification state from JSON blobs to relational tables.
+
+Revision ID: api_key_notifications_rel_001
+Revises: svc_api_keys_001
+Create Date: 2026-04-08 17:00:00.000000
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "api_key_notifications_rel_001"
+down_revision = "svc_api_keys_001"
+branch_labels = None
+depends_on = None
+
+_TENANTS = sa.table(
+    "tenants",
+    sa.column("id", postgresql.UUID(as_uuid=True)),
+    sa.column("api_key_policy", postgresql.JSONB(astext_type=sa.Text())),
+)
+_SETTINGS = sa.table(
+    "settings",
+    sa.column("id", postgresql.UUID(as_uuid=True)),
+    sa.column("user_id", postgresql.UUID(as_uuid=True)),
+    sa.column("chatbot_widget", postgresql.JSONB(astext_type=sa.Text())),
+    sa.column("updated_at", sa.TIMESTAMP(timezone=True)),
+)
+_PREFERENCES = sa.table(
+    "api_key_notification_preferences",
+    sa.column("id", postgresql.UUID(as_uuid=True)),
+    sa.column("user_id", postgresql.UUID(as_uuid=True)),
+    sa.column("enabled", sa.Boolean()),
+    sa.column("days_before_expiry", sa.Integer()),
+    sa.column("auto_follow_published_assistants", sa.Boolean()),
+    sa.column("auto_follow_published_apps", sa.Boolean()),
+)
+_SUBSCRIPTIONS = sa.table(
+    "api_key_notification_subscriptions",
+    sa.column("id", postgresql.UUID(as_uuid=True)),
+    sa.column("user_id", postgresql.UUID(as_uuid=True)),
+    sa.column("target_type", sa.Text()),
+    sa.column("target_id", postgresql.UUID(as_uuid=True)),
+    sa.column("source", sa.Text()),
+)
+
+
+def _as_json_object(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return dict(value)
+    return {}
+
+
+def _as_json_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return list(value)
+    return []
+
+
+def _coerce_day_value(raw: Any, *, default: int | None = None) -> int | None:
+    if isinstance(raw, bool):
+        return default
+    if isinstance(raw, int):
+        return raw if raw > 0 else default
+    if isinstance(raw, float):
+        if raw.is_integer() and raw > 0:
+            return int(raw)
+        return default
+    if isinstance(raw, str):
+        try:
+            parsed = int(raw.strip())
+        except (AttributeError, TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
+    if isinstance(raw, list):
+        candidates = [
+            value for value in (_coerce_day_value(item) for item in raw) if value
+        ]
+        return max(candidates) if candidates else default
+    return default
+
+
+def _normalize_notification_policy(raw_policy: Any) -> dict[str, Any] | None:
+    if not isinstance(raw_policy, dict):
+        return None
+
+    updated_policy = dict(raw_policy)
+    notification_policy = updated_policy.get("notification_policy")
+    if not isinstance(notification_policy, dict):
+        return updated_policy
+
+    normalized_notification_policy = dict(notification_policy)
+    max_days = _coerce_day_value(
+        normalized_notification_policy.get("max_days_before_expiry")
+    )
+    if max_days is None:
+        normalized_notification_policy.pop("max_days_before_expiry", None)
+    else:
+        normalized_notification_policy["max_days_before_expiry"] = max_days
+
+    default_days = _coerce_day_value(
+        normalized_notification_policy.get("default_days_before_expiry"),
+        default=30,
+    )
+    if default_days is None:
+        default_days = 30
+    if max_days is not None:
+        default_days = min(default_days, max_days)
+    normalized_notification_policy["default_days_before_expiry"] = default_days
+    updated_policy["notification_policy"] = normalized_notification_policy
+    return updated_policy
+
+
+def _normalize_subscriptions(raw_items: Any) -> list[dict[str, Any]]:
+    deduped: dict[tuple[str, UUID], dict[str, Any]] = {}
+    for raw_item in _as_json_list(raw_items):
+        item = _as_json_object(raw_item)
+        raw_target_type = item.get("target_type")
+        raw_target_id = item.get("target_id")
+        if raw_target_type not in {"key", "assistant", "app", "space"}:
+            continue
+        if isinstance(raw_target_id, UUID):
+            target_id = raw_target_id
+        elif isinstance(raw_target_id, str):
+            try:
+                target_id = UUID(raw_target_id)
+            except ValueError:
+                continue
+        else:
+            continue
+        deduped[(str(raw_target_type), target_id)] = {
+            "target_type": str(raw_target_type),
+            "target_id": target_id,
+        }
+
+    return list(deduped.values())
+
+
+def upgrade() -> None:
+    op.create_table(
+        "api_key_notification_preferences",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column(
+            "days_before_expiry",
+            sa.Integer(),
+            nullable=False,
+            server_default="30",
+        ),
+        sa.Column(
+            "auto_follow_published_assistants",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column(
+            "auto_follow_published_apps",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.CheckConstraint(
+            "days_before_expiry > 0",
+            name="ck_api_key_notification_preferences_days_positive",
+        ),
+    )
+    op.create_index(
+        op.f("ix_api_key_notification_preferences_user_id"),
+        "api_key_notification_preferences",
+        ["user_id"],
+        unique=True,
+    )
+
+    op.create_table(
+        "api_key_notification_subscriptions",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("target_type", sa.Text(), nullable=False),
+        sa.Column("target_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("source", sa.Text(), nullable=False, server_default="manual"),
+        sa.CheckConstraint(
+            "target_type IN ('key', 'assistant', 'app', 'space')",
+            name="ck_api_key_notification_subscriptions_target_type",
+        ),
+        sa.CheckConstraint(
+            "source IN ('manual', 'auto_follow')",
+            name="ck_api_key_notification_subscriptions_source",
+        ),
+        sa.UniqueConstraint(
+            "user_id",
+            "target_type",
+            "target_id",
+            name="uq_api_key_notification_subscription_user_target",
+        ),
+    )
+    op.create_index(
+        op.f("ix_api_key_notification_subscriptions_user_id"),
+        "api_key_notification_subscriptions",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_api_key_notification_subscriptions_target_id"),
+        "api_key_notification_subscriptions",
+        ["target_id"],
+        unique=False,
+    )
+
+    bind = op.get_bind()
+
+    tenant_rows = bind.execute(
+        sa.select(_TENANTS.c.id, _TENANTS.c.api_key_policy)
+    ).all()
+    for tenant_id, api_key_policy in tenant_rows:
+        normalized_policy = _normalize_notification_policy(api_key_policy)
+        if normalized_policy is not None and normalized_policy != api_key_policy:
+            bind.execute(
+                sa.update(_TENANTS)
+                .where(_TENANTS.c.id == tenant_id)
+                .values(api_key_policy=normalized_policy)
+            )
+
+    settings_rows = bind.execute(
+        sa.select(
+            _SETTINGS.c.id,
+            _SETTINGS.c.user_id,
+            _SETTINGS.c.chatbot_widget,
+            _SETTINGS.c.updated_at,
+        ).order_by(_SETTINGS.c.user_id.asc(), _SETTINGS.c.updated_at.desc())
+    ).all()
+
+    migrated_users: set[Any] = set()
+    for settings_id, user_id, chatbot_widget, _updated_at in settings_rows:
+        widget = _as_json_object(chatbot_widget)
+        bucket = _as_json_object(widget.get("api_key_notifications"))
+
+        if user_id is not None and user_id not in migrated_users and bucket:
+            preferences = _as_json_object(bucket.get("preferences"))
+            if preferences:
+                bind.execute(
+                    sa.insert(_PREFERENCES).values(
+                        user_id=user_id,
+                        enabled=bool(preferences.get("enabled")),
+                        days_before_expiry=_coerce_day_value(
+                            preferences.get("days_before_expiry"),
+                            default=30,
+                        )
+                        or 30,
+                        auto_follow_published_assistants=bool(
+                            preferences.get("auto_follow_published_assistants")
+                        ),
+                        auto_follow_published_apps=bool(
+                            preferences.get("auto_follow_published_apps")
+                        ),
+                    )
+                )
+
+            for subscription in _normalize_subscriptions(bucket.get("subscriptions")):
+                bind.execute(
+                    sa.insert(_SUBSCRIPTIONS).values(
+                        user_id=user_id,
+                        target_type=subscription["target_type"],
+                        target_id=subscription["target_id"],
+                        source="manual",
+                    )
+                )
+
+            migrated_users.add(user_id)
+
+        if "api_key_notifications" in widget:
+            widget.pop("api_key_notifications", None)
+            bind.execute(
+                sa.update(_SETTINGS)
+                .where(_SETTINGS.c.id == settings_id)
+                .values(chatbot_widget=widget)
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+
+    tenant_rows = bind.execute(
+        sa.select(_TENANTS.c.id, _TENANTS.c.api_key_policy)
+    ).all()
+    for tenant_id, api_key_policy in tenant_rows:
+        tenant_policy = _as_json_object(api_key_policy)
+        notification_policy = _as_json_object(tenant_policy.get("notification_policy"))
+        if not notification_policy:
+            continue
+        default_days = _coerce_day_value(
+            notification_policy.get("default_days_before_expiry")
+        )
+        if default_days is None:
+            continue
+        notification_policy["default_days_before_expiry"] = [default_days]
+        tenant_policy["notification_policy"] = notification_policy
+        bind.execute(
+            sa.update(_TENANTS)
+            .where(_TENANTS.c.id == tenant_id)
+            .values(api_key_policy=tenant_policy)
+        )
+
+    settings_by_user: dict[Any, tuple[Any, dict[str, Any]]] = {}
+    settings_rows = bind.execute(
+        sa.select(
+            _SETTINGS.c.id,
+            _SETTINGS.c.user_id,
+            _SETTINGS.c.chatbot_widget,
+            _SETTINGS.c.updated_at,
+        ).order_by(_SETTINGS.c.user_id.asc(), _SETTINGS.c.updated_at.desc())
+    ).all()
+    for settings_id, user_id, chatbot_widget, _updated_at in settings_rows:
+        if user_id is None or user_id in settings_by_user:
+            continue
+        settings_by_user[user_id] = (settings_id, _as_json_object(chatbot_widget))
+
+    preferences_rows = bind.execute(
+        sa.select(
+            _PREFERENCES.c.user_id,
+            _PREFERENCES.c.enabled,
+            _PREFERENCES.c.days_before_expiry,
+            _PREFERENCES.c.auto_follow_published_assistants,
+            _PREFERENCES.c.auto_follow_published_apps,
+        )
+    ).all()
+    subscriptions_rows = bind.execute(
+        sa.select(
+            _SUBSCRIPTIONS.c.user_id,
+            _SUBSCRIPTIONS.c.target_type,
+            _SUBSCRIPTIONS.c.target_id,
+        )
+    ).all()
+
+    subscriptions_by_user: dict[Any, list[dict[str, Any]]] = defaultdict(list)
+    for user_id, target_type, target_id in subscriptions_rows:
+        subscriptions_by_user[user_id].append(
+            {"target_type": target_type, "target_id": str(target_id)}
+        )
+
+    for (
+        user_id,
+        enabled,
+        days_before_expiry,
+        auto_follow_published_assistants,
+        auto_follow_published_apps,
+    ) in preferences_rows:
+        settings_info = settings_by_user.get(user_id)
+        if settings_info is None:
+            insert_result = bind.execute(
+                sa.insert(_SETTINGS)
+                .values(
+                    user_id=user_id,
+                    chatbot_widget={},
+                )
+                .returning(_SETTINGS.c.id)
+            )
+            settings_id = insert_result.scalar_one()
+            widget: dict[str, Any] = {}
+            settings_by_user[user_id] = (settings_id, widget)
+        else:
+            settings_id, widget = settings_info
+
+        widget = dict(widget)
+        widget["api_key_notifications"] = {
+            "preferences": {
+                "enabled": enabled,
+                "days_before_expiry": [days_before_expiry],
+                "auto_follow_published_assistants": auto_follow_published_assistants,
+                "auto_follow_published_apps": auto_follow_published_apps,
+            },
+            "subscriptions": subscriptions_by_user.get(user_id, []),
+        }
+        bind.execute(
+            sa.update(_SETTINGS)
+            .where(_SETTINGS.c.id == settings_id)
+            .values(chatbot_widget=widget)
+        )
+
+    op.drop_index(
+        op.f("ix_api_key_notification_subscriptions_target_id"),
+        table_name="api_key_notification_subscriptions",
+    )
+    op.drop_index(
+        op.f("ix_api_key_notification_subscriptions_user_id"),
+        table_name="api_key_notification_subscriptions",
+    )
+    op.drop_table("api_key_notification_subscriptions")
+    op.drop_index(
+        op.f("ix_api_key_notification_preferences_user_id"),
+        table_name="api_key_notification_preferences",
+    )
+    op.drop_table("api_key_notification_preferences")

--- a/backend/src/intric/admin/admin_router.py
+++ b/backend/src/intric/admin/admin_router.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 import sqlalchemy as sa
 from fastapi import APIRouter, Body, Depends, HTTPException, Request, Response, status
+from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from intric.admin.admin_models import (
@@ -52,6 +53,7 @@ from intric.authentication.auth_models import (
     ExpiringKeysSummary,
     ExpiringKeySummaryItem,
     SuperApiKeyStatus,
+    normalize_notification_policy_payload,
 )
 from intric.database.tables.users_table import Users
 from intric.main.config import get_settings
@@ -1335,7 +1337,9 @@ async def get_api_key_notification_policy(
         if isinstance(notification_policy_raw, dict)
         else {}
     )
-    return ApiKeyNotificationPolicyResponse.model_validate(notification_policy)
+    return ApiKeyNotificationPolicyResponse.model_validate(
+        normalize_notification_policy_payload(notification_policy)
+    )
 
 
 @router.put(
@@ -1354,9 +1358,7 @@ async def update_api_key_notification_policy(
         ApiKeyNotificationPolicyUpdate,
         Body(
             ...,
-            examples=[
-                {"enabled": True, "default_days_before_expiry": [30, 14, 7, 3, 1]}
-            ],
+            examples=[{"enabled": True, "default_days_before_expiry": 30}],
         ),
     ],
     container: AdminContainer,
@@ -1377,14 +1379,33 @@ async def update_api_key_notification_policy(
 
     if not updates:
         return ApiKeyNotificationPolicyResponse.model_validate(
-            current_notification_policy
+            normalize_notification_policy_payload(current_notification_policy)
         )
 
-    merged_notification_policy = dict(current_notification_policy)
-    merged_notification_policy.update(updates)
-    normalized_policy = ApiKeyNotificationPolicyResponse.model_validate(
-        merged_notification_policy
+    merged_notification_policy = normalize_notification_policy_payload(
+        current_notification_policy
     )
+    merged_notification_policy.update(updates)
+    if (
+        "max_days_before_expiry" in updates
+        and "default_days_before_expiry" not in updates
+    ):
+        merged_notification_policy = normalize_notification_policy_payload(
+            merged_notification_policy
+        )
+
+    try:
+        normalized_policy = ApiKeyNotificationPolicyResponse.model_validate(
+            merged_notification_policy
+        )
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "code": "invalid_request",
+                "message": str(exc),
+            },
+        ) from exc
 
     tenant_service = container.tenant_service()
     before_policy: dict[str, object] = dict(tenant_policy)
@@ -1415,7 +1436,9 @@ async def update_api_key_notification_policy(
         if isinstance(after_notification_policy_raw, dict)
         else {}
     )
-    return ApiKeyNotificationPolicyResponse.model_validate(after_notification_policy)
+    return ApiKeyNotificationPolicyResponse.model_validate(
+        normalize_notification_policy_payload(after_notification_policy)
+    )
 
 
 @router.get(

--- a/backend/src/intric/authentication/api_key_notification_auto_follow.py
+++ b/backend/src/intric/authentication/api_key_notification_auto_follow.py
@@ -1,25 +1,23 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any, cast
 from uuid import UUID
 
-import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from intric.authentication.api_key_notification_repo import (
+    ApiKeyNotificationRepository,
+)
 from intric.authentication.auth_models import (
     ApiKeyNotificationPolicyResponse,
     ApiKeyNotificationPreferencesResponse,
     ApiKeyNotificationSubscription,
+    ApiKeyNotificationSubscriptionSource,
     ApiKeyNotificationTargetType,
+    normalize_notification_day_value,
+    normalize_notification_policy_payload,
 )
-from intric.database.tables.settings_table import Settings
 from intric.users.user import UserInDB
-
-_API_KEY_NOTIFICATIONS_BUCKET = "api_key_notifications"
-_SETTINGS_ID_COL: Any = getattr(Settings, "id")
-_SETTINGS_USER_ID_COL: Any = getattr(Settings, "user_id")
-_SETTINGS_CHATBOT_WIDGET_COL: Any = getattr(Settings, "chatbot_widget")
 
 
 def _as_json_object(value: Any) -> dict[str, Any]:
@@ -28,35 +26,27 @@ def _as_json_object(value: Any) -> dict[str, Any]:
     return {}
 
 
-def _as_json_list(value: Any) -> list[Any]:
-    if isinstance(value, list):
-        return cast(list[Any], value)
-    return []
-
-
 def _notification_policy_for_user(user: UserInDB) -> ApiKeyNotificationPolicyResponse:
     tenant = getattr(user, "tenant", None)
     tenant_api_key_policy = getattr(tenant, "api_key_policy", None)
     tenant_policy = _as_json_object(tenant_api_key_policy)
     raw_policy = _as_json_object(tenant_policy.get("notification_policy"))
-    return ApiKeyNotificationPolicyResponse.model_validate(raw_policy)
+    return ApiKeyNotificationPolicyResponse.model_validate(
+        normalize_notification_policy_payload(raw_policy)
+    )
 
 
 def _normalize_days_against_policy(
-    days: list[int], policy: ApiKeyNotificationPolicyResponse
-) -> list[int]:
-    max_days = policy.max_days_before_expiry
-    normalized = sorted(set(days), reverse=True)
-    if max_days is not None:
-        normalized = [day for day in normalized if day <= max_days]
-
-    if normalized:
-        return normalized
-
-    fallback = sorted(set(policy.default_days_before_expiry), reverse=True)
-    if max_days is not None:
-        fallback = [day for day in fallback if day <= max_days]
-    return fallback or [1]
+    days: object, policy: ApiKeyNotificationPolicyResponse
+) -> int:
+    normalized = normalize_notification_day_value(
+        days, default=policy.default_days_before_expiry
+    )
+    if normalized is None:
+        normalized = policy.default_days_before_expiry
+    if policy.max_days_before_expiry is not None:
+        normalized = min(normalized, policy.max_days_before_expiry)
+    return normalized
 
 
 def _default_preferences_from_policy(
@@ -65,15 +55,14 @@ def _default_preferences_from_policy(
     return ApiKeyNotificationPreferencesResponse(
         enabled=False,
         days_before_expiry=_normalize_days_against_policy(
-            policy.default_days_before_expiry,
-            policy,
+            policy.default_days_before_expiry, policy
         ),
         auto_follow_published_assistants=False,
         auto_follow_published_apps=False,
     )
 
 
-def _normalize_preferences(
+def _normalize_preferences(  # pyright: ignore[reportUnusedFunction]
     raw_preferences: Any,
     policy: ApiKeyNotificationPolicyResponse,
 ) -> ApiKeyNotificationPreferencesResponse:
@@ -99,52 +88,6 @@ def _normalize_preferences(
         auto_follow_published_apps=(
             parsed.auto_follow_published_apps
             and policy.allow_auto_follow_published_apps
-        ),
-    )
-
-
-def _normalize_subscriptions(
-    raw_subscriptions: Any,
-) -> list[ApiKeyNotificationSubscription]:
-    raw_items = _as_json_list(raw_subscriptions)
-    if not raw_items:
-        return []
-
-    deduped: dict[tuple[str, UUID], ApiKeyNotificationSubscription] = {}
-    for raw_item in raw_items:
-        item = _as_json_object(raw_item)
-        if not item:
-            continue
-        raw_target_type = item.get("target_type")
-        raw_target_id = item.get("target_id")
-        if not isinstance(raw_target_type, str):
-            continue
-
-        if isinstance(raw_target_id, UUID):
-            target_id = raw_target_id
-        elif isinstance(raw_target_id, str):
-            try:
-                target_id = UUID(raw_target_id)
-            except ValueError:
-                continue
-        else:
-            continue
-
-        try:
-            target_type = ApiKeyNotificationTargetType(raw_target_type)
-        except ValueError:
-            continue
-        subscription = ApiKeyNotificationSubscription(
-            target_type=target_type,
-            target_id=target_id,
-        )
-        deduped[(subscription.target_type.value, subscription.target_id)] = subscription
-
-    return sorted(
-        deduped.values(),
-        key=lambda subscription: (
-            subscription.target_type.value,
-            str(subscription.target_id),
         ),
     )
 
@@ -185,22 +128,10 @@ async def auto_follow_on_publish(
         return False
 
     policy = _notification_policy_for_user(user)
-    user_id = user.id
-    row_query = (
-        sa.select(_SETTINGS_ID_COL, _SETTINGS_CHATBOT_WIDGET_COL)
-        .where(_SETTINGS_USER_ID_COL == user_id)
-        .order_by(Settings.updated_at.desc())
-        .limit(1)
-    )
-    row = (await session.execute(row_query)).first()
-    if row is None:
-        return False
-
-    settings_id = cast(UUID, row[0])
-    existing_widget = _as_json_object(row[1])
-    bucket = _as_json_object(existing_widget.get(_API_KEY_NOTIFICATIONS_BUCKET))
-
-    preferences = _normalize_preferences(bucket.get("preferences"), policy)
+    repo = ApiKeyNotificationRepository(session=session)
+    preferences = await repo.get_preferences(user.id)
+    if preferences is None:
+        preferences = _default_preferences_from_policy(policy)
     if not _should_auto_follow(
         preferences=preferences,
         policy=policy,
@@ -208,39 +139,11 @@ async def auto_follow_on_publish(
     ):
         return False
 
-    subscriptions = _normalize_subscriptions(bucket.get("subscriptions"))
-    key = (target_type.value, target_id)
-    existing_keys = {
-        (subscription.target_type.value, subscription.target_id)
-        for subscription in subscriptions
-    }
-    if key in existing_keys:
-        return False
-
-    subscriptions.append(
-        ApiKeyNotificationSubscription(target_type=target_type, target_id=target_id)
-    )
-    subscriptions = sorted(
-        subscriptions,
-        key=lambda subscription: (
-            subscription.target_type.value,
-            str(subscription.target_id),
+    return await repo.add_subscription(
+        user_id=user.id,
+        subscription=ApiKeyNotificationSubscription(
+            target_type=target_type,
+            target_id=target_id,
         ),
+        source=ApiKeyNotificationSubscriptionSource.AUTO_FOLLOW,
     )
-
-    updated_widget: dict[str, Any] = dict(existing_widget)
-    updated_widget[_API_KEY_NOTIFICATIONS_BUCKET] = {
-        "preferences": preferences.model_dump(mode="json"),
-        "subscriptions": [
-            subscription.model_dump(mode="json") for subscription in subscriptions
-        ],
-        "auto_followed_at": datetime.now(timezone.utc).isoformat(),
-    }
-
-    await session.execute(
-        sa.update(Settings)
-        .where(_SETTINGS_ID_COL == settings_id)
-        .values(chatbot_widget=updated_widget)
-    )
-
-    return True

--- a/backend/src/intric/authentication/api_key_notification_repo.py
+++ b/backend/src/intric/authentication/api_key_notification_repo.py
@@ -1,0 +1,133 @@
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert
+
+from intric.authentication.auth_models import (
+    ApiKeyNotificationPreferencesResponse,
+    ApiKeyNotificationSubscription,
+    ApiKeyNotificationSubscriptionSource,
+    ApiKeyNotificationTargetType,
+)
+from intric.database.database import AsyncSession
+from intric.database.tables.api_key_notification_tables import (
+    ApiKeyNotificationPreference,
+    ApiKeyNotificationSubscriptionTable,
+)
+
+
+class ApiKeyNotificationRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get_preferences(
+        self,
+        user_id: UUID,
+    ) -> ApiKeyNotificationPreferencesResponse | None:
+        stmt = (
+            sa.select(ApiKeyNotificationPreference)
+            .where(ApiKeyNotificationPreference.user_id == user_id)
+            .limit(1)
+        )
+        record = await self.session.scalar(stmt)
+        if record is None:
+            return None
+
+        return ApiKeyNotificationPreferencesResponse(
+            enabled=record.enabled,
+            days_before_expiry=record.days_before_expiry,
+            auto_follow_published_assistants=record.auto_follow_published_assistants,
+            auto_follow_published_apps=record.auto_follow_published_apps,
+        )
+
+    async def upsert_preferences(
+        self,
+        *,
+        user_id: UUID,
+        preferences: ApiKeyNotificationPreferencesResponse,
+    ) -> ApiKeyNotificationPreferencesResponse:
+        stmt = (
+            insert(ApiKeyNotificationPreference)
+            .values(
+                user_id=user_id,
+                enabled=preferences.enabled,
+                days_before_expiry=preferences.days_before_expiry,
+                auto_follow_published_assistants=preferences.auto_follow_published_assistants,
+                auto_follow_published_apps=preferences.auto_follow_published_apps,
+            )
+            .on_conflict_do_update(
+                index_elements=[ApiKeyNotificationPreference.user_id],
+                set_={
+                    "enabled": preferences.enabled,
+                    "days_before_expiry": preferences.days_before_expiry,
+                    "auto_follow_published_assistants": preferences.auto_follow_published_assistants,
+                    "auto_follow_published_apps": preferences.auto_follow_published_apps,
+                },
+            )
+        )
+        await self.session.execute(stmt)
+        return preferences
+
+    async def list_subscriptions(
+        self,
+        user_id: UUID,
+    ) -> list[ApiKeyNotificationSubscription]:
+        stmt = (
+            sa.select(ApiKeyNotificationSubscriptionTable)
+            .where(ApiKeyNotificationSubscriptionTable.user_id == user_id)
+            .order_by(
+                ApiKeyNotificationSubscriptionTable.target_type.asc(),
+                ApiKeyNotificationSubscriptionTable.target_id.asc(),
+            )
+        )
+        rows = (await self.session.scalars(stmt)).all()
+        return [
+            ApiKeyNotificationSubscription(
+                target_type=ApiKeyNotificationTargetType(row.target_type),
+                target_id=row.target_id,
+            )
+            for row in rows
+        ]
+
+    async def add_subscription(
+        self,
+        *,
+        user_id: UUID,
+        subscription: ApiKeyNotificationSubscription,
+        source: ApiKeyNotificationSubscriptionSource = (
+            ApiKeyNotificationSubscriptionSource.MANUAL
+        ),
+    ) -> bool:
+        stmt = (
+            insert(ApiKeyNotificationSubscriptionTable)
+            .values(
+                user_id=user_id,
+                target_type=subscription.target_type.value,
+                target_id=subscription.target_id,
+                source=source.value,
+            )
+            .on_conflict_do_nothing(
+                index_elements=[
+                    ApiKeyNotificationSubscriptionTable.user_id,
+                    ApiKeyNotificationSubscriptionTable.target_type,
+                    ApiKeyNotificationSubscriptionTable.target_id,
+                ]
+            )
+            .returning(ApiKeyNotificationSubscriptionTable.id)
+        )
+        inserted_id = await self.session.scalar(stmt)
+        return inserted_id is not None
+
+    async def delete_subscription(
+        self,
+        *,
+        user_id: UUID,
+        target_type: str,
+        target_id: UUID,
+    ) -> None:
+        stmt = sa.delete(ApiKeyNotificationSubscriptionTable).where(
+            ApiKeyNotificationSubscriptionTable.user_id == user_id,
+            ApiKeyNotificationSubscriptionTable.target_type == target_type,
+            ApiKeyNotificationSubscriptionTable.target_id == target_id,
+        )
+        await self.session.execute(stmt)

--- a/backend/src/intric/authentication/api_key_router.py
+++ b/backend/src/intric/authentication/api_key_router.py
@@ -4,7 +4,6 @@ from datetime import datetime, timezone
 from typing import Annotated, Any, Literal, cast
 from uuid import UUID
 
-import sqlalchemy as sa
 from fastapi import (
     APIRouter,
     Body,
@@ -18,6 +17,9 @@ from fastapi import (
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from intric.authentication.api_key_lifecycle import ApiKeyLifecycleService
+from intric.authentication.api_key_notification_repo import (
+    ApiKeyNotificationRepository,
+)
 from intric.authentication.api_key_policy import ApiKeyPolicyService
 from intric.authentication.api_key_resolver import ApiKeyValidationError
 from intric.authentication.api_key_router_helpers import (
@@ -40,6 +42,7 @@ from intric.authentication.auth_models import (
     ApiKeyNotificationPreferencesUpdate,
     ApiKeyNotificationSubscription,
     ApiKeyNotificationSubscriptionListResponse,
+    ApiKeyNotificationSubscriptionSource,
     ApiKeyNotificationTargetType,
     ApiKeyOwnership,
     ApiKeyPermission,
@@ -53,8 +56,9 @@ from intric.authentication.auth_models import (
     ApiKeyV2InDB,
     ExpiringKeysSummary,
     ExpiringKeySummaryItem,
+    normalize_notification_day_value,
+    normalize_notification_policy_payload,
 )
-from intric.database.tables.settings_table import Settings
 from intric.main.container.container import Container
 from intric.roles.permissions import Permission
 from intric.server.dependencies.container import get_container
@@ -113,11 +117,6 @@ _STATE_CHANGE_EXAMPLE = {
     "reason_text": "Suspicious traffic detected from blocked IP range.",
 }
 
-_API_KEY_NOTIFICATIONS_BUCKET = "api_key_notifications"
-_SETTINGS_ID_COL: Any = getattr(Settings, "id")
-_SETTINGS_USER_ID_COL: Any = getattr(Settings, "user_id")
-_SETTINGS_CHATBOT_WIDGET_COL: Any = getattr(Settings, "chatbot_widget")
-
 
 def _as_json_object(value: Any) -> dict[str, Any]:
     if isinstance(value, dict):
@@ -125,35 +124,27 @@ def _as_json_object(value: Any) -> dict[str, Any]:
     return {}
 
 
-def _as_json_list(value: Any) -> list[Any]:
-    if isinstance(value, list):
-        return cast(list[Any], value)
-    return []
-
-
 def _notification_policy_for_user(user: UserInDB) -> ApiKeyNotificationPolicyResponse:
     tenant = getattr(user, "tenant", None)
     tenant_api_key_policy = getattr(tenant, "api_key_policy", None)
     tenant_policy = _as_json_object(tenant_api_key_policy)
     raw_policy = _as_json_object(tenant_policy.get("notification_policy"))
-    return ApiKeyNotificationPolicyResponse.model_validate(raw_policy)
+    return ApiKeyNotificationPolicyResponse.model_validate(
+        normalize_notification_policy_payload(raw_policy)
+    )
 
 
 def _normalize_days_against_policy(
-    days: list[int], policy: ApiKeyNotificationPolicyResponse
-) -> list[int]:
-    max_days = policy.max_days_before_expiry
-    normalized = sorted(set(days), reverse=True)
-    if max_days is not None:
-        normalized = [day for day in normalized if day <= max_days]
-
-    if normalized:
-        return normalized
-
-    fallback = sorted(set(policy.default_days_before_expiry), reverse=True)
-    if max_days is not None:
-        fallback = [day for day in fallback if day <= max_days]
-    return fallback or [1]
+    days: object, policy: ApiKeyNotificationPolicyResponse
+) -> int:
+    normalized = normalize_notification_day_value(
+        days, default=policy.default_days_before_expiry
+    )
+    if normalized is None:
+        normalized = policy.default_days_before_expiry
+    if policy.max_days_before_expiry is not None:
+        normalized = min(normalized, policy.max_days_before_expiry)
+    return normalized
 
 
 def _default_preferences_from_policy(
@@ -162,149 +153,67 @@ def _default_preferences_from_policy(
     return ApiKeyNotificationPreferencesResponse(
         enabled=False,
         days_before_expiry=_normalize_days_against_policy(
-            policy.default_days_before_expiry,
-            policy,
+            policy.default_days_before_expiry, policy
         ),
         auto_follow_published_assistants=False,
         auto_follow_published_apps=False,
     )
 
 
-def _normalize_notification_preferences(
-    raw_preferences: Any,
+def _apply_notification_policy(
+    preferences: ApiKeyNotificationPreferencesResponse,
     policy: ApiKeyNotificationPolicyResponse,
 ) -> ApiKeyNotificationPreferencesResponse:
-    fallback = _default_preferences_from_policy(policy)
-    if not isinstance(raw_preferences, dict):
-        return fallback
-
-    try:
-        parsed = ApiKeyNotificationPreferencesResponse.model_validate(raw_preferences)
-    except ValueError:
-        return fallback
-
     return ApiKeyNotificationPreferencesResponse(
-        enabled=parsed.enabled and policy.enabled,
+        enabled=preferences.enabled and policy.enabled,
         days_before_expiry=_normalize_days_against_policy(
-            parsed.days_before_expiry,
+            preferences.days_before_expiry,
             policy,
         ),
         auto_follow_published_assistants=(
-            parsed.auto_follow_published_assistants
+            preferences.auto_follow_published_assistants
             and policy.allow_auto_follow_published_assistants
         ),
         auto_follow_published_apps=(
-            parsed.auto_follow_published_apps
+            preferences.auto_follow_published_apps
             and policy.allow_auto_follow_published_apps
-        ),
-    )
-
-
-def _normalize_notification_subscriptions(
-    raw_subscriptions: Any,
-) -> list[ApiKeyNotificationSubscription]:
-    raw_items = _as_json_list(raw_subscriptions)
-    if not raw_items:
-        return []
-
-    deduped: dict[tuple[str, UUID], ApiKeyNotificationSubscription] = {}
-    for raw_item in raw_items:
-        item = _as_json_object(raw_item)
-        if not item:
-            continue
-        raw_target_type = item.get("target_type")
-        raw_target_id = item.get("target_id")
-        if not isinstance(raw_target_type, str):
-            continue
-        if isinstance(raw_target_id, UUID):
-            target_id = raw_target_id
-        elif isinstance(raw_target_id, str):
-            try:
-                target_id = UUID(raw_target_id)
-            except ValueError:
-                continue
-        else:
-            continue
-
-        try:
-            target_type = ApiKeyNotificationTargetType(raw_target_type)
-        except ValueError:
-            continue
-        subscription = ApiKeyNotificationSubscription(
-            target_type=target_type,
-            target_id=target_id,
-        )
-        deduped[(subscription.target_type.value, subscription.target_id)] = subscription
-
-    return sorted(
-        deduped.values(),
-        key=lambda subscription: (
-            subscription.target_type.value,
-            str(subscription.target_id),
         ),
     )
 
 
 async def _load_api_key_notification_settings(
     *,
-    session: AsyncSession,
+    repo: ApiKeyNotificationRepository,
     user_id: UUID,
     policy: ApiKeyNotificationPolicyResponse,
 ) -> tuple[ApiKeyNotificationPreferencesResponse, list[ApiKeyNotificationSubscription]]:
-    query = (
-        sa.select(_SETTINGS_CHATBOT_WIDGET_COL)
-        .where(_SETTINGS_USER_ID_COL == user_id)
-        .order_by(Settings.updated_at.desc())
-        .limit(1)
-    )
-    raw_widget = await session.scalar(query)
-    chatbot_widget = _as_json_object(raw_widget)
-
-    bucket = _as_json_object(chatbot_widget.get(_API_KEY_NOTIFICATIONS_BUCKET))
-    preferences = _normalize_notification_preferences(bucket.get("preferences"), policy)
-    subscriptions = _normalize_notification_subscriptions(bucket.get("subscriptions"))
+    preferences = await repo.get_preferences(user_id)
+    if preferences is None:
+        preferences = _default_preferences_from_policy(policy)
+    else:
+        preferences = _apply_notification_policy(preferences, policy)
+    subscriptions = await repo.list_subscriptions(user_id)
     return preferences, subscriptions
 
 
-async def _save_api_key_notification_settings(
+async def _save_notification_preferences(
     *,
-    session: AsyncSession,
+    repo: ApiKeyNotificationRepository,
     user_id: UUID,
     preferences: ApiKeyNotificationPreferencesResponse,
+) -> ApiKeyNotificationPreferencesResponse:
+    return await repo.upsert_preferences(user_id=user_id, preferences=preferences)
+
+
+def _sorted_subscriptions(
     subscriptions: list[ApiKeyNotificationSubscription],
-) -> None:
-    bucket_payload = {
-        "preferences": preferences.model_dump(mode="json"),
-        "subscriptions": [
-            subscription.model_dump(mode="json") for subscription in subscriptions
-        ],
-    }
-
-    row_query = (
-        sa.select(_SETTINGS_ID_COL, _SETTINGS_CHATBOT_WIDGET_COL)
-        .where(_SETTINGS_USER_ID_COL == user_id)
-        .order_by(Settings.updated_at.desc())
-        .limit(1)
-    )
-    row = (await session.execute(row_query)).first()
-    if row is None:
-        await session.execute(
-            sa.insert(Settings).values(
-                user_id=user_id,
-                chatbot_widget={_API_KEY_NOTIFICATIONS_BUCKET: bucket_payload},
-            )
-        )
-        return
-
-    settings_id = cast(UUID, row[0])
-    existing_widget = _as_json_object(row[1])
-    updated_widget: dict[str, Any] = dict(existing_widget)
-    updated_widget[_API_KEY_NOTIFICATIONS_BUCKET] = bucket_payload
-
-    await session.execute(
-        sa.update(Settings)
-        .where(_SETTINGS_ID_COL == settings_id)
-        .values(chatbot_widget=updated_widget)
+) -> list[ApiKeyNotificationSubscription]:
+    return sorted(
+        subscriptions,
+        key=lambda subscription: (
+            subscription.target_type.value,
+            str(subscription.target_id),
+        ),
     )
 
 
@@ -464,10 +373,10 @@ async def get_notification_preferences(
     container: Annotated[Container, Depends(get_container(with_user=True))],
 ) -> ApiKeyNotificationPreferencesResponse:
     user: UserInDB = container.user()
-    session = cast(AsyncSession, container.session())
+    repo: ApiKeyNotificationRepository = container.api_key_notification_repo()
     policy = _notification_policy_for_user(user)
     preferences, _subscriptions = await _load_api_key_notification_settings(
-        session=session,
+        repo=repo,
         user_id=user.id,
         policy=policy,
     )
@@ -488,16 +397,16 @@ async def get_notification_preferences(
 async def update_notification_preferences(
     request: Annotated[
         ApiKeyNotificationPreferencesUpdate,
-        Body(examples=[{"enabled": True, "days_before_expiry": [30, 14, 7, 3, 1]}]),
+        Body(examples=[{"enabled": True, "days_before_expiry": 30}]),
     ],
     container: Annotated[Container, Depends(get_container(with_user=True))],
     _guard: None = Depends(require_api_key_permission(ApiKeyPermission.WRITE)),
 ) -> ApiKeyNotificationPreferencesResponse:
     user: UserInDB = container.user()
-    session = cast(AsyncSession, container.session())
+    repo: ApiKeyNotificationRepository = container.api_key_notification_repo()
     policy = _notification_policy_for_user(user)
-    current_preferences, subscriptions = await _load_api_key_notification_settings(
-        session=session,
+    current_preferences, _subscriptions = await _load_api_key_notification_settings(
+        repo=repo,
         user_id=user.id,
         policy=policy,
     )
@@ -523,11 +432,10 @@ async def update_notification_preferences(
         ),
     )
 
-    await _save_api_key_notification_settings(
-        session=session,
+    await _save_notification_preferences(
+        repo=repo,
         user_id=user.id,
         preferences=updated_preferences,
-        subscriptions=subscriptions,
     )
     return updated_preferences
 
@@ -547,10 +455,10 @@ async def list_notification_subscriptions(
     container: Annotated[Container, Depends(get_container(with_user=True))],
 ) -> ApiKeyNotificationSubscriptionListResponse:
     user: UserInDB = container.user()
-    session = cast(AsyncSession, container.session())
+    repo: ApiKeyNotificationRepository = container.api_key_notification_repo()
     policy = _notification_policy_for_user(user)
     _preferences, subscriptions = await _load_api_key_notification_settings(
-        session=session,
+        repo=repo,
         user_id=user.id,
         policy=policy,
     )
@@ -576,9 +484,10 @@ async def upsert_notification_subscription(
 ) -> ApiKeyNotificationSubscriptionListResponse:
     user: UserInDB = container.user()
     repo: ApiKeysV2Repository = container.api_key_v2_repo()
+    notification_repo: ApiKeyNotificationRepository = (
+        container.api_key_notification_repo()
+    )
     policy: ApiKeyPolicyService = container.api_key_policy_service()
-    session = cast(AsyncSession, container.session())
-    notification_policy = _notification_policy_for_user(user)
 
     await _validate_notification_follow_target(
         target_type=target_type,
@@ -588,35 +497,17 @@ async def upsert_notification_subscription(
         policy=policy,
     )
 
-    preferences, current_subscriptions = await _load_api_key_notification_settings(
-        session=session,
-        user_id=user.id,
-        policy=notification_policy,
-    )
-    updated = {
-        (subscription.target_type.value, subscription.target_id): subscription
-        for subscription in current_subscriptions
-    }
     new_subscription = ApiKeyNotificationSubscription(
         target_type=target_type,
         target_id=target_id,
     )
-    updated[(new_subscription.target_type.value, new_subscription.target_id)] = (
-        new_subscription
-    )
-    subscriptions = sorted(
-        updated.values(),
-        key=lambda subscription: (
-            subscription.target_type.value,
-            str(subscription.target_id),
-        ),
-    )
-
-    await _save_api_key_notification_settings(
-        session=session,
+    await notification_repo.add_subscription(
         user_id=user.id,
-        preferences=preferences,
-        subscriptions=subscriptions,
+        subscription=new_subscription,
+        source=ApiKeyNotificationSubscriptionSource.MANUAL,
+    )
+    subscriptions = _sorted_subscriptions(
+        await notification_repo.list_subscriptions(user.id)
     )
     return ApiKeyNotificationSubscriptionListResponse(items=subscriptions)
 
@@ -639,28 +530,13 @@ async def delete_notification_subscription(
     _guard: None = Depends(require_api_key_permission(ApiKeyPermission.WRITE)),
 ) -> ApiKeyNotificationSubscriptionListResponse:
     user: UserInDB = container.user()
-    session = cast(AsyncSession, container.session())
-    policy = _notification_policy_for_user(user)
-    preferences, current_subscriptions = await _load_api_key_notification_settings(
-        session=session,
+    repo: ApiKeyNotificationRepository = container.api_key_notification_repo()
+    await repo.delete_subscription(
         user_id=user.id,
-        policy=policy,
+        target_type=target_type.value,
+        target_id=target_id,
     )
-    subscriptions = [
-        subscription
-        for subscription in current_subscriptions
-        if not (
-            subscription.target_type == target_type
-            and subscription.target_id == target_id
-        )
-    ]
-
-    await _save_api_key_notification_settings(
-        session=session,
-        user_id=user.id,
-        preferences=preferences,
-        subscriptions=subscriptions,
-    )
+    subscriptions = _sorted_subscriptions(await repo.list_subscriptions(user.id))
     return ApiKeyNotificationSubscriptionListResponse(items=subscriptions)
 
 
@@ -754,9 +630,11 @@ async def get_expiring_keys(
     followed_space_scope_ids: list[UUID] | None = None
 
     if mode == "subscribed":
-        session = cast(AsyncSession, container.session())
+        notification_repo: ApiKeyNotificationRepository = (
+            container.api_key_notification_repo()
+        )
         preferences, subscriptions = await _load_api_key_notification_settings(
-            session=session,
+            repo=notification_repo,
             user_id=user.id,
             policy=notification_policy,
         )

--- a/backend/src/intric/authentication/auth_models.py
+++ b/backend/src/intric/authentication/auth_models.py
@@ -1,15 +1,15 @@
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Literal, Optional
+from typing import Any, Literal, Optional, cast
 from uuid import UUID
 
 from pydantic import (
     BaseModel,
     ConfigDict,
     EmailStr,
-    Field,
     ValidationInfo,
     field_validator,
+    model_validator,
 )
 
 from intric.main.config import get_settings
@@ -123,6 +123,11 @@ class ApiKeyNotificationTargetType(str, Enum):
     ASSISTANT = "assistant"
     APP = "app"
     SPACE = "space"
+
+
+class ApiKeyNotificationSubscriptionSource(str, Enum):
+    MANUAL = "manual"
+    AUTO_FOLLOW = "auto_follow"
 
 
 class ApiKeyState(str, Enum):
@@ -306,19 +311,76 @@ class ApiKeyPolicyResponse(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
 
-def _validate_day_values(days: list[int], field_name: str) -> list[int]:
-    if not days:
-        raise ValueError(f"{field_name} must contain at least one day value.")
-    normalized = sorted(set(days), reverse=True)
-    for day in normalized:
-        if day <= 0:
-            raise ValueError(f"{field_name} values must be positive integers.")
-    return normalized
+def _coerce_legacy_notification_day_value(raw: Any) -> int | None:
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw if raw > 0 else None
+    if isinstance(raw, float):
+        if raw.is_integer() and raw > 0:
+            return int(raw)
+        return None
+    if isinstance(raw, str):
+        try:
+            parsed = int(raw.strip())
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed > 0 else None
+    if isinstance(raw, list):
+        candidates: list[int] = []
+        raw_items = cast(list[object], raw)
+        for raw_item in raw_items:
+            item: Any = raw_item
+            value = _coerce_legacy_notification_day_value(item)
+            if value is not None:
+                candidates.append(value)
+        return max(candidates) if candidates else None
+    return None
+
+
+def normalize_notification_day_value(
+    raw: Any, *, default: int | None = None
+) -> int | None:
+    value = _coerce_legacy_notification_day_value(raw)
+    if value is not None:
+        return value
+    return default
+
+
+def normalize_notification_policy_payload(raw_policy: Any) -> dict[str, Any]:
+    if not isinstance(raw_policy, dict):
+        return {}
+
+    normalized_policy: dict[str, Any] = dict(cast(dict[str, Any], raw_policy))
+    max_days = normalize_notification_day_value(
+        normalized_policy.get("max_days_before_expiry")
+    )
+    if max_days is None:
+        normalized_policy.pop("max_days_before_expiry", None)
+    else:
+        normalized_policy["max_days_before_expiry"] = max_days
+
+    default_days = normalize_notification_day_value(
+        normalized_policy.get("default_days_before_expiry"),
+        default=30,
+    )
+    if default_days is None:
+        default_days = 30
+    if max_days is not None:
+        default_days = min(default_days, max_days)
+    normalized_policy["default_days_before_expiry"] = default_days
+    return normalized_policy
+
+
+def _validate_day_value(day: int, field_name: str) -> int:
+    if day <= 0:
+        raise ValueError(f"{field_name} must be a positive integer.")
+    return day
 
 
 class ApiKeyNotificationPreferencesResponse(BaseModel):
     enabled: bool = False
-    days_before_expiry: list[int] = Field(default_factory=lambda: [30, 14, 7, 3, 1])
+    days_before_expiry: int = 30
     auto_follow_published_assistants: bool = False
     auto_follow_published_apps: bool = False
 
@@ -326,13 +388,13 @@ class ApiKeyNotificationPreferencesResponse(BaseModel):
 
     @field_validator("days_before_expiry")
     @classmethod
-    def _validate_days_before_expiry(cls, value: list[int]) -> list[int]:
-        return _validate_day_values(value, "days_before_expiry")
+    def _validate_days_before_expiry(cls, value: int) -> int:
+        return _validate_day_value(value, "days_before_expiry")
 
 
 class ApiKeyNotificationPreferencesUpdate(BaseModel):
     enabled: Optional[bool] = None
-    days_before_expiry: Optional[list[int]] = None
+    days_before_expiry: Optional[int] = None
     auto_follow_published_assistants: Optional[bool] = None
     auto_follow_published_apps: Optional[bool] = None
 
@@ -340,12 +402,10 @@ class ApiKeyNotificationPreferencesUpdate(BaseModel):
 
     @field_validator("days_before_expiry")
     @classmethod
-    def _validate_days_before_expiry(
-        cls, value: Optional[list[int]]
-    ) -> Optional[list[int]]:
+    def _validate_days_before_expiry(cls, value: Optional[int]) -> Optional[int]:
         if value is None:
             return value
-        return _validate_day_values(value, "days_before_expiry")
+        return _validate_day_value(value, "days_before_expiry")
 
 
 class ApiKeyNotificationSubscription(BaseModel):
@@ -363,9 +423,7 @@ class ApiKeyNotificationSubscriptionListResponse(BaseModel):
 
 class ApiKeyNotificationPolicyResponse(BaseModel):
     enabled: bool = True
-    default_days_before_expiry: list[int] = Field(
-        default_factory=lambda: [30, 14, 7, 3, 1]
-    )
+    default_days_before_expiry: int = 30
     max_days_before_expiry: Optional[int] = 365
     allow_auto_follow_published_assistants: bool = False
     allow_auto_follow_published_apps: bool = False
@@ -374,8 +432,8 @@ class ApiKeyNotificationPolicyResponse(BaseModel):
 
     @field_validator("default_days_before_expiry")
     @classmethod
-    def _validate_default_days_before_expiry(cls, value: list[int]) -> list[int]:
-        return _validate_day_values(value, "default_days_before_expiry")
+    def _validate_default_days_before_expiry(cls, value: int) -> int:
+        return _validate_day_value(value, "default_days_before_expiry")
 
     @field_validator("max_days_before_expiry")
     @classmethod
@@ -388,10 +446,21 @@ class ApiKeyNotificationPolicyResponse(BaseModel):
             raise ValueError(f"{info.field_name} must be a positive integer.")
         return value
 
+    @model_validator(mode="after")
+    def _validate_day_bounds(self) -> "ApiKeyNotificationPolicyResponse":
+        if (
+            self.max_days_before_expiry is not None
+            and self.default_days_before_expiry > self.max_days_before_expiry
+        ):
+            raise ValueError(
+                "default_days_before_expiry must be less than or equal to max_days_before_expiry."
+            )
+        return self
+
 
 class ApiKeyNotificationPolicyUpdate(BaseModel):
     enabled: Optional[bool] = None
-    default_days_before_expiry: Optional[list[int]] = None
+    default_days_before_expiry: Optional[int] = None
     max_days_before_expiry: Optional[int] = None
     allow_auto_follow_published_assistants: Optional[bool] = None
     allow_auto_follow_published_apps: Optional[bool] = None
@@ -401,11 +470,11 @@ class ApiKeyNotificationPolicyUpdate(BaseModel):
     @field_validator("default_days_before_expiry")
     @classmethod
     def _validate_default_days_before_expiry(
-        cls, value: Optional[list[int]]
-    ) -> Optional[list[int]]:
+        cls, value: Optional[int]
+    ) -> Optional[int]:
         if value is None:
             return value
-        return _validate_day_values(value, "default_days_before_expiry")
+        return _validate_day_value(value, "default_days_before_expiry")
 
     @field_validator("max_days_before_expiry")
     @classmethod
@@ -417,6 +486,18 @@ class ApiKeyNotificationPolicyUpdate(BaseModel):
         if value <= 0:
             raise ValueError(f"{info.field_name} must be a positive integer.")
         return value
+
+    @model_validator(mode="after")
+    def _validate_day_bounds(self) -> "ApiKeyNotificationPolicyUpdate":
+        if (
+            self.max_days_before_expiry is not None
+            and self.default_days_before_expiry is not None
+            and self.default_days_before_expiry > self.max_days_before_expiry
+        ):
+            raise ValueError(
+                "default_days_before_expiry must be less than or equal to max_days_before_expiry."
+            )
+        return self
 
 
 class SuperApiKeyStatus(BaseModel):

--- a/backend/src/intric/database/tables/__init__.py
+++ b/backend/src/intric/database/tables/__init__.py
@@ -3,6 +3,7 @@ from importlib import import_module
 _TABLE_MODULES = (
     "intric.database.tables.ai_models_table",
     "intric.database.tables.allowed_origins_table",
+    "intric.database.tables.api_key_notification_tables",
     "intric.database.tables.api_keys_table",
     "intric.database.tables.api_keys_v2_table",
     "intric.database.tables.audit_action_config_table",

--- a/backend/src/intric/database/tables/api_key_notification_tables.py
+++ b/backend/src/intric/database/tables/api_key_notification_tables.py
@@ -1,0 +1,82 @@
+from uuid import UUID
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    ForeignKey,
+    Integer,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from intric.database.tables.base_class import BasePublic
+
+
+class ApiKeyNotificationPreference(BasePublic):
+    __tablename__ = "api_key_notification_preferences"  # type: ignore[assignment]
+
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        unique=True,
+    )
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    days_before_expiry: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=30,
+    )
+    auto_follow_published_assistants: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+    )
+    auto_follow_published_apps: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "days_before_expiry > 0",
+            name="ck_api_key_notification_preferences_days_positive",
+        ),
+    )
+
+
+class ApiKeyNotificationSubscriptionTable(BasePublic):
+    __tablename__ = "api_key_notification_subscriptions"  # type: ignore[assignment]
+
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    target_type: Mapped[str] = mapped_column(Text, nullable=False)
+    target_id: Mapped[UUID] = mapped_column(nullable=False, index=True)
+    source: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="manual",
+        server_default="manual",
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "target_type IN ('key', 'assistant', 'app', 'space')",
+            name="ck_api_key_notification_subscriptions_target_type",
+        ),
+        CheckConstraint(
+            "source IN ('manual', 'auto_follow')",
+            name="ck_api_key_notification_subscriptions_source",
+        ),
+        UniqueConstraint(
+            "user_id",
+            "target_type",
+            "target_id",
+            name="uq_api_key_notification_subscription_user_target",
+        ),
+    )

--- a/backend/src/intric/main/container/container.py
+++ b/backend/src/intric/main/container/container.py
@@ -45,6 +45,9 @@ from intric.audit.infrastructure.audit_log_repo_impl import AuditLogRepositoryIm
 from intric.audit.infrastructure.audit_session_service import AuditSessionService
 from intric.authentication.api_key_lifecycle import ApiKeyLifecycleService
 from intric.authentication.api_key_maintenance import ApiKeyMaintenanceService
+from intric.authentication.api_key_notification_repo import (
+    ApiKeyNotificationRepository,
+)
 from intric.authentication.api_key_policy import ApiKeyPolicyService
 from intric.authentication.api_key_rate_limiter import ApiKeyRateLimiter
 from intric.authentication.api_key_repo import ApiKeysRepository
@@ -580,6 +583,10 @@ class Container(containers.DeclarativeContainer):
     )
 
     api_key_repo = providers.Factory(ApiKeysRepository, session=session)
+    api_key_notification_repo = providers.Factory(
+        ApiKeyNotificationRepository,
+        session=session,
+    )
     api_key_v2_repo = providers.Factory(ApiKeysV2Repository, session=session)
     group_repo = providers.Factory(GroupRepository, session=session)
     info_blob_repo = providers.Factory(InfoBlobRepository, session=session)

--- a/backend/tests/integration/test_api_key_auto_follow_publish.py
+++ b/backend/tests/integration/test_api_key_auto_follow_publish.py
@@ -101,7 +101,7 @@ async def test_publish_assistant_auto_follows_when_user_and_policy_allow(
         "/api/v1/api-keys/notification-preferences",
         json={
             "enabled": True,
-            "days_before_expiry": [14, 7, 1],
+            "days_before_expiry": 14,
             "auto_follow_published_assistants": True,
             "auto_follow_published_apps": False,
         },
@@ -144,7 +144,7 @@ async def test_notification_preferences_apply_policy_gates_and_persist(
         "/api/v1/api-keys/notification-preferences",
         json={
             "enabled": True,
-            "days_before_expiry": [14, 7, 1],
+            "days_before_expiry": 14,
             "auto_follow_published_assistants": True,
             "auto_follow_published_apps": True,
         },
@@ -186,7 +186,7 @@ async def test_publish_assistant_does_not_auto_follow_when_opt_out(
         "/api/v1/api-keys/notification-preferences",
         json={
             "enabled": True,
-            "days_before_expiry": [14, 7, 1],
+            "days_before_expiry": 14,
             "auto_follow_published_assistants": False,
             "auto_follow_published_apps": False,
         },
@@ -229,7 +229,7 @@ async def test_publish_assistant_auto_follow_is_idempotent_for_same_target(
         "/api/v1/api-keys/notification-preferences",
         json={
             "enabled": True,
-            "days_before_expiry": [14, 7, 1],
+            "days_before_expiry": 14,
             "auto_follow_published_assistants": True,
             "auto_follow_published_apps": False,
         },
@@ -282,7 +282,7 @@ async def test_publish_app_auto_follows_when_user_and_policy_allow(
         "/api/v1/api-keys/notification-preferences",
         json={
             "enabled": True,
-            "days_before_expiry": [21, 14, 7],
+            "days_before_expiry": 21,
             "auto_follow_published_assistants": False,
             "auto_follow_published_apps": True,
         },

--- a/backend/tests/unit/test_api_key_notification_auto_follow.py
+++ b/backend/tests/unit/test_api_key_notification_auto_follow.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from uuid import uuid4
 
 import pytest
 
 from intric.authentication.api_key_notification_auto_follow import (
     _normalize_preferences,
-    _normalize_subscriptions,
     _should_auto_follow,
 )
 from intric.authentication.auth_models import (
@@ -21,7 +19,7 @@ def _policy(
 ) -> ApiKeyNotificationPolicyResponse:
     payload = {
         "enabled": True,
-        "default_days_before_expiry": [30, 14, 7, 3, 1],
+        "default_days_before_expiry": 30,
         "max_days_before_expiry": 90,
         "allow_auto_follow_published_assistants": True,
         "allow_auto_follow_published_apps": True,
@@ -46,36 +44,20 @@ def test_normalize_preferences_applies_policy_bounds_and_flags():
     normalized = _normalize_preferences(raw, policy)
 
     assert normalized.enabled is True
-    assert normalized.days_before_expiry == [30, 14, 1]
+    assert normalized.days_before_expiry == 30
     assert normalized.auto_follow_published_assistants is True
     assert normalized.auto_follow_published_apps is False
 
 
 def test_normalize_preferences_defaults_to_opt_out_when_missing():
-    policy = _policy(default_days_before_expiry=[45, 20], max_days_before_expiry=40)
+    policy = _policy(default_days_before_expiry=45, max_days_before_expiry=40)
 
     normalized = _normalize_preferences(None, policy)
 
     assert normalized.enabled is False
-    assert normalized.days_before_expiry == [20]
+    assert normalized.days_before_expiry == 40
     assert normalized.auto_follow_published_assistants is False
     assert normalized.auto_follow_published_apps is False
-
-
-def test_normalize_subscriptions_dedupes_invalid_and_duplicate_items():
-    assistant_id = uuid4()
-    raw = [
-        {"target_type": "assistant", "target_id": str(assistant_id)},
-        {"target_type": "assistant", "target_id": str(assistant_id)},
-        {"target_type": "invalid", "target_id": "not-a-uuid"},
-        {"target_type": "app", "target_id": str(uuid4())},
-    ]
-
-    items = _normalize_subscriptions(raw)
-
-    assert len(items) == 2
-    assert items[0].target_type.value in {"app", "assistant"}
-    assert items[1].target_type.value in {"app", "assistant"}
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/test_api_key_notification_models.py
+++ b/backend/tests/unit/test_api_key_notification_models.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from intric.authentication.auth_models import (
+    ApiKeyNotificationPolicyResponse,
+    ApiKeyNotificationPolicyUpdate,
+    normalize_notification_day_value,
+    normalize_notification_policy_payload,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (30, 30),
+        ("14", 14),
+        ([30, 14, 7], 30),
+        ([14, "7", 1.0], 14),
+    ],
+)
+def test_normalize_notification_day_value_accepts_positive_values(raw, expected):
+    assert normalize_notification_day_value(raw, default=21) == expected
+
+
+@pytest.mark.parametrize("raw", [0, -1, "0", "abc", [], None, False, 1.5])
+def test_normalize_notification_day_value_falls_back_for_invalid_values(raw):
+    assert normalize_notification_day_value(raw, default=21) == 21
+
+
+def test_normalize_notification_policy_payload_clamps_legacy_default_to_max():
+    normalized = normalize_notification_policy_payload(
+        {
+            "enabled": True,
+            "default_days_before_expiry": [30, 14, 7],
+            "max_days_before_expiry": 14,
+        }
+    )
+
+    assert normalized["default_days_before_expiry"] == 14
+    assert normalized["max_days_before_expiry"] == 14
+
+
+def test_notification_policy_models_reject_default_above_max():
+    with pytest.raises(ValueError):
+        ApiKeyNotificationPolicyResponse.model_validate(
+            {
+                "enabled": True,
+                "default_days_before_expiry": 30,
+                "max_days_before_expiry": 14,
+            }
+        )
+
+    with pytest.raises(ValueError):
+        ApiKeyNotificationPolicyUpdate.model_validate(
+            {
+                "default_days_before_expiry": 30,
+                "max_days_before_expiry": 14,
+            }
+        )

--- a/frontend/apps/web/src/lib/features/api-keys/NotificationPreferences.svelte
+++ b/frontend/apps/web/src/lib/features/api-keys/NotificationPreferences.svelte
@@ -15,7 +15,6 @@
   import type { ExpiringKeyDisplayItem } from "$lib/features/api-keys/expirationUtils";
   import { Bell, BellOff, ShieldAlert } from "lucide-svelte";
   import { slide } from "svelte/transition";
-  import { SvelteSet } from "svelte/reactivity";
   import { getErrorMessage } from "$lib/core/errors/getErrorMessage";
 
   let { onExpiringItemsChanged, onError, onFollowedKeysChanged, onNotificationsEnabledChanged } =
@@ -29,26 +28,22 @@
   const intric = getIntric();
   const { forceRefresh: forceRefreshExpiringStore } = getExpiringKeysStore();
 
-  // Notification state
   let notificationsEnabled = $state(false);
-  let notificationDaysInput = $state("");
+  let notificationDays = $state(30);
+  let notificationDaysInput = $state("30");
   let autoFollowPublishedAssistants = $state(false);
   let autoFollowPublishedApps = $state(false);
   let notificationSettingsLoading = $state(true);
   let notificationSettingsSaving = $state(false);
-  let showCustomInput = $state(false);
 
-  // Policy state
   let notificationPolicyEnabled = $state<boolean | null>(null);
   let notificationPolicyMaxDays = $state<number | null>(null);
   let allowAutoFollowAssistants = $state<boolean | null>(null);
   let allowAutoFollowApps = $state<boolean | null>(null);
 
-  // Derived
   const reminderDayDefaults = [1, 3, 7, 14, 30];
-  const selectedReminderDays = $derived.by(() => parseDayValues(notificationDaysInput));
   const reminderDayOptions = $derived.by(() => {
-    const combined = Array.from(new Set([...reminderDayDefaults, ...selectedReminderDays]));
+    const combined = Array.from(new Set([...reminderDayDefaults, notificationDays]));
     const limited =
       notificationPolicyMaxDays != null && notificationPolicyMaxDays > 0
         ? combined.filter((day) => day <= notificationPolicyMaxDays!)
@@ -58,41 +53,40 @@
 
   const isPolicyBlocked = $derived(notificationPolicyEnabled === false);
 
-  function parseDayValues(value: string): number[] {
-    return Array.from(
-      new Set(
-        value
-          .split(/[,\s]+/)
-          .map((item) => Number(item))
-          .filter((item) => Number.isFinite(item) && item > 0)
-          .map((item) => Math.floor(item))
-      )
-    ).sort((a, b) => b - a);
+  function parseDayValue(value: string): number | null {
+    const parsed = Number(value.trim());
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      return null;
+    }
+    return Math.floor(parsed);
+  }
+
+  function syncDayState(value: number) {
+    notificationDays = value;
+    notificationDaysInput = String(value);
   }
 
   async function loadExpiring({
     enabled = notificationsEnabled,
     hasSubscriptions,
-    days = notificationDaysInput
+    days = notificationDays
   }: {
     enabled?: boolean;
     hasSubscriptions: boolean;
-    days?: string;
+    days?: number;
   }) {
     if (!enabled || !hasSubscriptions) {
       onExpiringItemsChanged([]);
       return;
     }
-    const parsedDays = parseDayValues(days);
-    const windowDays = parsedDays.length > 0 ? Math.max(...parsedDays) : 30;
     try {
       const summary = await intric.apiKeys.expiringSoon({
-        days: windowDays,
+        days,
         mode: "subscribed"
       });
       onExpiringItemsChanged(summaryToDisplayItems(summary.items));
     } catch {
-      // Non-critical — silent fail
+      // Non-critical
     }
   }
 
@@ -105,7 +99,7 @@
         getAdminNotificationPolicy(intric).catch(() => null)
       ]);
       notificationsEnabled = preferences.enabled;
-      notificationDaysInput = preferences.days_before_expiry.join(", ");
+      syncDayState(preferences.days_before_expiry);
       autoFollowPublishedAssistants = preferences.auto_follow_published_assistants;
       autoFollowPublishedApps = preferences.auto_follow_published_apps;
       notificationPolicyEnabled = policy?.enabled ?? null;
@@ -119,7 +113,7 @@
       await loadExpiring({
         enabled: preferences.enabled,
         hasSubscriptions,
-        days: preferences.days_before_expiry.join(", ")
+        days: preferences.days_before_expiry
       });
     } catch (error) {
       console.error(error);
@@ -136,7 +130,7 @@
     try {
       const updated = await updateNotificationPreferences(intric, { enabled: next });
       notificationsEnabled = updated.enabled;
-      notificationDaysInput = updated.days_before_expiry.join(", ");
+      syncDayState(updated.days_before_expiry);
       autoFollowPublishedAssistants = updated.auto_follow_published_assistants;
       autoFollowPublishedApps = updated.auto_follow_published_apps;
       onNotificationsEnabledChanged(updated.enabled);
@@ -155,43 +149,21 @@
     }
   }
 
-  let saveTimer: ReturnType<typeof setTimeout> | undefined;
-
-  function debouncedSaveDays() {
-    clearTimeout(saveTimer);
-    saveTimer = setTimeout(() => void saveNotificationDays(), 400);
-  }
-
-  function toggleReminderDay(day: number) {
-    if (notificationSettingsSaving) return;
-    const next = new SvelteSet(selectedReminderDays);
-    if (next.has(day)) {
-      next.delete(day);
-    } else {
-      next.add(day);
-    }
-    if (next.size === 0) {
-      next.add(day);
-    }
-    notificationDaysInput = Array.from(next)
-      .sort((a, b) => b - a)
-      .join(", ");
-    debouncedSaveDays();
-  }
-
-  async function saveNotificationDays() {
-    const parsed = parseDayValues(notificationDaysInput);
-    if (parsed.length === 0) {
+  async function saveNotificationDays(value?: number) {
+    const parsed = value ?? parseDayValue(notificationDaysInput);
+    if (!parsed) {
       onError(m.api_keys_notifications_days_validation());
+      notificationDaysInput = String(notificationDays);
       return;
     }
+
     notificationSettingsSaving = true;
     try {
       const updated = await updateNotificationPreferences(intric, {
         days_before_expiry: parsed
       });
       notificationsEnabled = updated.enabled;
-      notificationDaysInput = updated.days_before_expiry.join(", ");
+      syncDayState(updated.days_before_expiry);
       autoFollowPublishedAssistants = updated.auto_follow_published_assistants;
       autoFollowPublishedApps = updated.auto_follow_published_apps;
       if (!updated.enabled) {
@@ -201,6 +173,7 @@
     } catch (error: unknown) {
       console.error(error);
       onError(getErrorMessage(error));
+      notificationDaysInput = String(notificationDays);
     } finally {
       notificationSettingsSaving = false;
     }
@@ -220,7 +193,7 @@
         auto_follow_published_assistants: next
       });
       notificationsEnabled = updated.enabled;
-      notificationDaysInput = updated.days_before_expiry.join(", ");
+      syncDayState(updated.days_before_expiry);
       autoFollowPublishedAssistants = updated.auto_follow_published_assistants;
       autoFollowPublishedApps = updated.auto_follow_published_apps;
       if (next && !updated.auto_follow_published_assistants) {
@@ -250,7 +223,7 @@
         auto_follow_published_apps: next
       });
       notificationsEnabled = updated.enabled;
-      notificationDaysInput = updated.days_before_expiry.join(", ");
+      syncDayState(updated.days_before_expiry);
       autoFollowPublishedAssistants = updated.auto_follow_published_assistants;
       autoFollowPublishedApps = updated.auto_follow_published_apps;
       if (next && !updated.auto_follow_published_apps) {
@@ -266,7 +239,6 @@
     }
   }
 
-  // Expose a method for parent to trigger follow-change refresh
   export async function refreshSubscriptions() {
     try {
       const subscriptions = await listNotificationSubscriptions(intric);
@@ -289,7 +261,6 @@
 </script>
 
 <div class="border-default bg-primary overflow-hidden rounded-xl border shadow-sm">
-  <!-- Header -->
   <div class="flex items-center justify-between gap-4 px-5 py-3.5">
     <div class="flex min-w-0 items-center gap-3">
       <div
@@ -314,7 +285,6 @@
     </div>
   </div>
 
-  <!-- Policy-blocked banner -->
   {#if isPolicyBlocked}
     <div
       class="border-negative-default/20 bg-negative-dimmer/50 mx-5 mb-4 flex items-center gap-3 rounded-lg border px-4 py-3"
@@ -326,66 +296,51 @@
     </div>
   {/if}
 
-  <!-- Disabled hint -->
   {#if !notificationsEnabled && !isPolicyBlocked && !notificationSettingsLoading}
     <p class="text-muted px-5 pb-4 text-xs">
       {m.api_keys_notifications_enable_to_edit_hint()}
     </p>
   {/if}
 
-  <!-- Expanded body (only when enabled) -->
   {#if notificationsEnabled && !isPolicyBlocked}
     <div class="border-default space-y-4 border-t px-5 py-4" transition:slide={{ duration: 200 }}>
       <p class="text-secondary text-xs">
         {m.api_keys_notifications_settings_description()}
       </p>
 
-      <!-- Reminder schedule -->
       <div
         class="space-y-3"
         class:opacity-50={notificationSettingsSaving}
         class:pointer-events-none={notificationSettingsSaving}
       >
-        <!-- Quick day chips -->
         <div class="flex flex-wrap gap-1.5">
           {#each reminderDayOptions as day (day)}
-            {@const isSelected = selectedReminderDays.includes(day)}
             <button
               type="button"
               style="font-variant-numeric: tabular-nums"
-              class="focus-visible:ring-accent-default/50 inline-flex h-8 min-w-[42px] items-center justify-center rounded-lg px-3 text-xs font-medium transition-all focus-visible:ring-2 focus-visible:outline-none {isSelected
+              class="focus-visible:ring-accent-default/50 inline-flex h-8 min-w-[42px] items-center justify-center rounded-lg px-3 text-xs font-medium transition-all focus-visible:ring-2 focus-visible:outline-none {notificationDays ===
+              day
                 ? 'bg-accent-default text-on-fill shadow-sm'
                 : 'border-default bg-primary text-secondary hover:text-primary hover:border-stronger border'}"
-              aria-pressed={isSelected}
+              aria-pressed={notificationDays === day}
               aria-label={m.api_keys_notifications_day_chip_aria_label({ day })}
               disabled={notificationSettingsSaving}
-              onclick={() => toggleReminderDay(day)}
+              onclick={() => void saveNotificationDays(day)}
             >
               {day}d
             </button>
           {/each}
         </div>
 
-        <!-- Custom days disclosure -->
-        {#if showCustomInput}
-          <div class="max-w-[280px]" transition:slide={{ duration: 150 }}>
-            <Input.Text
-              bind:value={notificationDaysInput}
-              label={m.api_keys_notifications_days_label()}
-              placeholder="30, 14, 7, 3, 1"
-              disabled={notificationSettingsSaving}
-              on:blur={debouncedSaveDays}
-            />
-          </div>
-        {:else}
-          <button
-            type="button"
-            class="text-accent-default text-xs hover:underline"
-            onclick={() => (showCustomInput = true)}
-          >
-            {m.api_keys_notifications_customize_days()}
-          </button>
-        {/if}
+        <div class="max-w-[280px]">
+          <Input.Text
+            bind:value={notificationDaysInput}
+            label={m.api_keys_notifications_days_label()}
+            placeholder="30"
+            disabled={notificationSettingsSaving}
+            on:blur={() => void saveNotificationDays()}
+          />
+        </div>
 
         <p class="text-muted text-xs leading-relaxed">
           {m.api_keys_notifications_days_help()}
@@ -395,13 +350,11 @@
         </p>
       </div>
 
-      <!-- Auto-follow settings -->
       <div
         class="border-default space-y-3 border-t pt-4"
         class:opacity-50={notificationSettingsSaving}
         class:pointer-events-none={notificationSettingsSaving}
       >
-        <!-- Assistants -->
         <div class="flex items-start justify-between gap-4">
           <div class="min-w-0">
             <p class="text-primary text-sm font-medium">
@@ -425,7 +378,6 @@
           </div>
         </div>
 
-        <!-- Apps -->
         <div class="flex items-start justify-between gap-4">
           <div class="min-w-0">
             <p class="text-primary text-sm font-medium">
@@ -452,7 +404,6 @@
     </div>
   {/if}
 
-  <!-- SR-only live region -->
   <div class="sr-only" aria-live="polite">
     {notificationsEnabled
       ? m.api_keys_notifications_aria_enabled()

--- a/frontend/apps/web/src/lib/features/api-keys/expiringKeysStore.ts
+++ b/frontend/apps/web/src/lib/features/api-keys/expiringKeysStore.ts
@@ -83,7 +83,7 @@ function createExpiringKeysStore(data: {
       listNotificationSubscriptions(intric)
     ]);
     preferencesEnabled = preferences.enabled;
-    daysWindow = Math.max(...preferences.days_before_expiry, 1);
+    daysWindow = Math.max(preferences.days_before_expiry, 1);
     hasSubscriptions = subscriptions.length > 0;
     contextLoadedAt = Date.now();
   }

--- a/frontend/apps/web/src/lib/features/api-keys/notificationPreferences.test.ts
+++ b/frontend/apps/web/src/lib/features/api-keys/notificationPreferences.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "vitest";
+import { normalizePolicy, normalizePreferences } from "./notificationPreferences";
+
+test("normalizePreferences migrates legacy day arrays to a single max value", () => {
+  expect(
+    normalizePreferences({
+      enabled: true,
+      days_before_expiry: [30, 14, 7, 3, 1]
+    })
+  ).toMatchObject({
+    enabled: true,
+    days_before_expiry: 30
+  });
+});
+
+test("normalizePreferences falls back to default for invalid values", () => {
+  expect(
+    normalizePreferences({
+      days_before_expiry: 0
+    })
+  ).toMatchObject({
+    days_before_expiry: 30
+  });
+});
+
+test("normalizePolicy clamps default days to the tenant max", () => {
+  expect(
+    normalizePolicy({
+      default_days_before_expiry: [90, 30],
+      max_days_before_expiry: 30
+    })
+  ).toMatchObject({
+    default_days_before_expiry: 30,
+    max_days_before_expiry: 30
+  });
+});

--- a/frontend/apps/web/src/lib/features/api-keys/notificationPreferences.ts
+++ b/frontend/apps/web/src/lib/features/api-keys/notificationPreferences.ts
@@ -4,14 +4,14 @@ export type ApiKeyNotificationTargetType = "key" | "assistant" | "app" | "space"
 
 export interface ApiKeyNotificationPreferences {
   enabled: boolean;
-  days_before_expiry: number[];
+  days_before_expiry: number;
   auto_follow_published_assistants: boolean;
   auto_follow_published_apps: boolean;
 }
 
 export interface ApiKeyNotificationPolicy {
   enabled: boolean;
-  default_days_before_expiry: number[];
+  default_days_before_expiry: number;
   max_days_before_expiry: number | null;
   allow_auto_follow_published_assistants: boolean;
   allow_auto_follow_published_apps: boolean;
@@ -26,24 +26,25 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object";
 }
 
-function normalizeDayValues(raw: unknown): number[] {
-  if (!Array.isArray(raw)) return [];
-  return Array.from(
-    new Set(
-      raw
-        .map((value) => Number(value))
-        .filter((value) => Number.isFinite(value) && value > 0)
-        .map((value) => Math.floor(value))
-    )
-  ).sort((a, b) => b - a);
+function normalizeDayValue(raw: unknown, fallback: number): number {
+  if (Array.isArray(raw)) {
+    const values = raw.map((value) => normalizeDayValue(value, -1)).filter((value) => value > 0);
+    return values.length > 0 ? Math.max(...values) : fallback;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+
+  return Math.floor(parsed);
 }
 
 export function normalizePreferences(raw: unknown): ApiKeyNotificationPreferences {
   const data = isObject(raw) ? raw : {};
-  const days = normalizeDayValues(data.days_before_expiry);
   return {
     enabled: Boolean(data.enabled),
-    days_before_expiry: days.length > 0 ? days : [30, 14, 7, 3, 1],
+    days_before_expiry: normalizeDayValue(data.days_before_expiry, 30),
     auto_follow_published_assistants: Boolean(data.auto_follow_published_assistants),
     auto_follow_published_apps: Boolean(data.auto_follow_published_apps)
   };
@@ -51,13 +52,13 @@ export function normalizePreferences(raw: unknown): ApiKeyNotificationPreference
 
 export function normalizePolicy(raw: unknown): ApiKeyNotificationPolicy {
   const data = isObject(raw) ? raw : {};
-  const defaultDays = normalizeDayValues(data.default_days_before_expiry);
   const parsedMax = Number(data.max_days_before_expiry);
+  const maxDays = Number.isFinite(parsedMax) && parsedMax > 0 ? Math.floor(parsedMax) : null;
+  const defaultDays = normalizeDayValue(data.default_days_before_expiry, 30);
   return {
     enabled: data.enabled !== false,
-    default_days_before_expiry: defaultDays.length > 0 ? defaultDays : [30, 14, 7, 3, 1],
-    max_days_before_expiry:
-      Number.isFinite(parsedMax) && parsedMax > 0 ? Math.floor(parsedMax) : null,
+    default_days_before_expiry: maxDays ? Math.min(defaultDays, maxDays) : defaultDays,
+    max_days_before_expiry: maxDays,
     allow_auto_follow_published_assistants: Boolean(data.allow_auto_follow_published_assistants),
     allow_auto_follow_published_apps: Boolean(data.allow_auto_follow_published_apps)
   };

--- a/frontend/apps/web/src/routes/(app)/admin/api-keys/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/api-keys/+page.svelte
@@ -87,12 +87,12 @@
   let notificationPolicySaving = $state(false);
   let notificationPolicy = $state<ApiKeyNotificationPolicy>({
     enabled: true,
-    default_days_before_expiry: [30, 14, 7, 3, 1],
+    default_days_before_expiry: 30,
     max_days_before_expiry: 365,
     allow_auto_follow_published_assistants: false,
     allow_auto_follow_published_apps: false
   });
-  let notificationPolicyDaysInput = $state("30, 14, 7, 3, 1");
+  let notificationPolicyDaysInput = $state("30");
   let notificationPolicyMaxDaysInput = $state("365");
 
   // Quick filter chips
@@ -566,16 +566,12 @@
     }
   }
 
-  function parseDayValues(value: string): number[] {
-    return Array.from(
-      new Set(
-        value
-          .split(/[,\s]+/)
-          .map((item) => Number(item))
-          .filter((item) => Number.isFinite(item) && item > 0)
-          .map((item) => Math.floor(item))
-      )
-    ).sort((a, b) => b - a);
+  function parseDayValue(value: string): number | null {
+    const parsed = Number(value.trim());
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      return null;
+    }
+    return Math.floor(parsed);
   }
 
   async function loadNotificationPolicy() {
@@ -583,7 +579,7 @@
     try {
       const policy = await getAdminNotificationPolicy(intric);
       notificationPolicy = policy;
-      notificationPolicyDaysInput = policy.default_days_before_expiry.join(", ");
+      notificationPolicyDaysInput = String(policy.default_days_before_expiry);
       notificationPolicyMaxDaysInput = policy.max_days_before_expiry
         ? String(policy.max_days_before_expiry)
         : "";
@@ -632,13 +628,17 @@
   }
 
   async function saveNotificationPolicy() {
-    const parsedDefaultDays = parseDayValues(notificationPolicyDaysInput);
-    if (parsedDefaultDays.length === 0) {
+    const parsedDefaultDays = parseDayValue(notificationPolicyDaysInput);
+    if (!parsedDefaultDays) {
       errorMessage = m.api_keys_notifications_policy_days_validation();
       return;
     }
     const parsedMax = Number(notificationPolicyMaxDaysInput);
     const maxDays = Number.isFinite(parsedMax) && parsedMax > 0 ? Math.floor(parsedMax) : null;
+    if (maxDays != null && parsedDefaultDays > maxDays) {
+      errorMessage = "Default reminder days cannot exceed the tenant maximum.";
+      return;
+    }
 
     notificationPolicySaving = true;
     try {
@@ -651,7 +651,7 @@
         allow_auto_follow_published_apps: notificationPolicy.allow_auto_follow_published_apps
       });
       notificationPolicy = updated;
-      notificationPolicyDaysInput = updated.default_days_before_expiry.join(", ");
+      notificationPolicyDaysInput = String(updated.default_days_before_expiry);
       notificationPolicyMaxDaysInput = updated.max_days_before_expiry
         ? String(updated.max_days_before_expiry)
         : "";
@@ -1190,7 +1190,7 @@
           >
             <Input.Text
               bind:value={notificationPolicyDaysInput}
-              placeholder="30, 14, 7, 3, 1"
+              placeholder="30"
               disabled={notificationPolicyLoading || notificationPolicySaving}
               hiddenLabel
             />

--- a/frontend/apps/web/src/routes/(app)/admin/api-keys/AdminApiKeyActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/api-keys/AdminApiKeyActions.svelte
@@ -1,14 +1,28 @@
 <script lang="ts">
-  import type { ApiKeyCreatedResponse, ApiKeyUpdateRequest, ApiKeyV2 } from "@intric/intric-js";
+  import type {
+    ApiKeyCreatedResponse,
+    ApiKeyUpdateRequest,
+    ApiKeyV2,
+    ResourcePermissionLevel
+  } from "@intric/intric-js";
   import { Button, Dialog, Dropdown, Input, Select } from "@intric/ui";
   import { Ban, ChevronDown, MoreVertical, Pencil, RefreshCw, RotateCcw } from "lucide-svelte";
   import { getIntric } from "$lib/core/Intric";
   import { m } from "$lib/paraglide/messages";
   import { writable } from "svelte/store";
   import TagInput from "../../account/api-keys/TagInput.svelte";
+  import ExpirationPicker from "../../account/api-keys/ExpirationPicker.svelte";
   import { getErrorMessage } from "$lib/core/errors/getErrorMessage";
 
   const intric = getIntric();
+
+  type ResourcePermission = "none" | "read" | "write" | "admin";
+  type ResourcePermissionsPayload = {
+    assistants: ResourcePermission;
+    apps: ResourcePermission;
+    spaces: ResourcePermission;
+    knowledge: ResourcePermission;
+  };
 
   let { apiKey, onChanged, onSecret } = $props<{
     apiKey: ApiKeyV2;
@@ -19,6 +33,7 @@
   const showRevokeDialog = writable(false);
   const showSuspendDialog = writable(false);
   const showEditDialog = writable(false);
+
   let errorMessage = $state<string | null>(null);
   let reasonText = $state("");
   let editName = $state("");
@@ -27,13 +42,27 @@
   let editRateLimit = $state("");
   let editAllowedOrigins = $state<string[]>([]);
   let editAllowedIps = $state<string[]>([]);
+  let editExpiresAt = $state<string | null>(null);
+  let permissionMode = $state<"simple" | "fine-grained">("simple");
+  let assistantsPermission = $state<ResourcePermission>("none");
+  let appsPermission = $state<ResourcePermission>("none");
+  let spacesPermission = $state<ResourcePermission>("none");
+  let knowledgePermission = $state<ResourcePermission>("none");
   let showAdvanced = $state(false);
+
+  const permissionOrder: Record<ResourcePermission, number> = {
+    none: 0,
+    read: 1,
+    write: 2,
+    admin: 3
+  };
 
   const isActive = $derived(apiKey.state === "active");
   const isSuspended = $derived(apiKey.state === "suspended");
   const canRotate = $derived(apiKey.state === "active");
   const canEditPermission = $derived(apiKey.state === "active" || apiKey.state === "suspended");
   const canEditGuardrails = $derived(apiKey.state === "active" || apiKey.state === "suspended");
+  const canEditResourcePermissions = $derived(canEditPermission && apiKey.key_type === "sk_");
   const scopeLabel = $derived.by(() => {
     switch (apiKey.scope_type) {
       case "space":
@@ -56,6 +85,22 @@
     { value: "write", label: m.api_keys_permission_write() },
     { value: "admin", label: m.api_keys_permission_admin() }
   ]);
+  const resourcePermissionOptions = $derived([
+    { value: "none", label: m.api_keys_permission_no_access() },
+    { value: "read", label: m.api_keys_permission_read() },
+    { value: "write", label: m.api_keys_permission_write() },
+    { value: "admin", label: m.api_keys_permission_admin() }
+  ]);
+
+  $effect(() => {
+    if (permissionMode !== "fine-grained") {
+      return;
+    }
+    assistantsPermission = clampToPermission(assistantsPermission);
+    appsPermission = clampToPermission(appsPermission);
+    spacesPermission = clampToPermission(spacesPermission);
+    knowledgePermission = clampToPermission(knowledgePermission);
+  });
 
   function normalizeTags(values: string[] | null | undefined): string[] {
     return (values ?? []).map((value) => value.trim()).filter(Boolean);
@@ -66,6 +111,76 @@
     return a.every((value, index) => value === b[index]);
   }
 
+  function normalizeResourcePermission(value: unknown): ResourcePermission {
+    if (value === "read" || value === "write" || value === "admin") {
+      return value;
+    }
+    return "none";
+  }
+
+  function normalizeResourcePermissions(
+    resourcePermissions:
+      | ApiKeyV2["resource_permissions"]
+      | ApiKeyUpdateRequest["resource_permissions"]
+  ): ResourcePermissionsPayload {
+    return {
+      assistants: normalizeResourcePermission(resourcePermissions?.assistants),
+      apps: normalizeResourcePermission(resourcePermissions?.apps),
+      spaces: normalizeResourcePermission(resourcePermissions?.spaces),
+      knowledge: normalizeResourcePermission(resourcePermissions?.knowledge)
+    };
+  }
+
+  function toApiResourcePermissions(
+    resourcePermissions: ResourcePermissionsPayload | null
+  ): ApiKeyUpdateRequest["resource_permissions"] {
+    if (resourcePermissions === null) {
+      return null;
+    }
+    return {
+      assistants: resourcePermissions.assistants as ResourcePermissionLevel,
+      apps: resourcePermissions.apps as ResourcePermissionLevel,
+      spaces: resourcePermissions.spaces as ResourcePermissionLevel,
+      knowledge: resourcePermissions.knowledge as ResourcePermissionLevel
+    };
+  }
+
+  function compactResourcePermissions(
+    resourcePermissions: ResourcePermissionsPayload
+  ): ResourcePermissionsPayload | null {
+    const values = Object.values(resourcePermissions);
+    return values.some((value) => value !== "none") ? resourcePermissions : null;
+  }
+
+  function resourcePermissionsEqual(
+    a: ResourcePermissionsPayload | null,
+    b: ResourcePermissionsPayload | null
+  ): boolean {
+    if (a === null || b === null) {
+      return a === b;
+    }
+    return (
+      a.assistants === b.assistants &&
+      a.apps === b.apps &&
+      a.spaces === b.spaces &&
+      a.knowledge === b.knowledge
+    );
+  }
+
+  function clampToPermission(level: ResourcePermission): ResourcePermission {
+    if (permissionOrder[level] > permissionOrder[editPermission]) {
+      return editPermission;
+    }
+    return level;
+  }
+
+  function formatExpiration(value: string | null | undefined): string {
+    if (!value) {
+      return m.api_keys_exp_no_expiration();
+    }
+    return new Date(value).toLocaleString();
+  }
+
   function openEditDialog() {
     editName = apiKey.name;
     editDescription = apiKey.description ?? "";
@@ -73,8 +188,23 @@
     editRateLimit = apiKey.rate_limit?.toString() ?? "";
     editAllowedOrigins = normalizeTags(apiKey.allowed_origins);
     editAllowedIps = normalizeTags(apiKey.allowed_ips);
+    editExpiresAt = apiKey.expires_at ?? null;
+
+    const resourcePermissions = normalizeResourcePermissions(apiKey.resource_permissions);
+    assistantsPermission = resourcePermissions.assistants;
+    appsPermission = resourcePermissions.apps;
+    spacesPermission = resourcePermissions.spaces;
+    knowledgePermission = resourcePermissions.knowledge;
+    permissionMode =
+      apiKey.key_type === "sk_" && compactResourcePermissions(resourcePermissions)
+        ? "fine-grained"
+        : "simple";
+
     showAdvanced = Boolean(
-      apiKey.rate_limit || editAllowedOrigins.length > 0 || editAllowedIps.length > 0
+      apiKey.rate_limit ||
+        editAllowedOrigins.length > 0 ||
+        editAllowedIps.length > 0 ||
+        editExpiresAt
     );
     $showEditDialog = true;
   }
@@ -103,6 +233,24 @@
       updates.permission = editPermission;
     }
 
+    if (canEditResourcePermissions) {
+      const nextResourcePermissions =
+        permissionMode === "fine-grained"
+          ? compactResourcePermissions({
+              assistants: assistantsPermission,
+              apps: appsPermission,
+              spaces: spacesPermission,
+              knowledge: knowledgePermission
+            })
+          : null;
+      const currentResourcePermissions = compactResourcePermissions(
+        normalizeResourcePermissions(apiKey.resource_permissions)
+      );
+      if (!resourcePermissionsEqual(nextResourcePermissions, currentResourcePermissions)) {
+        updates.resource_permissions = toApiResourcePermissions(nextResourcePermissions);
+      }
+    }
+
     if (canEditGuardrails) {
       const normalizedRateLimit = editRateLimit.trim();
       const parsedRateLimit = normalizedRateLimit ? Number(normalizedRateLimit) : null;
@@ -116,6 +264,10 @@
       const currentRateLimit = apiKey.rate_limit ?? null;
       if (parsedRateLimit !== currentRateLimit) {
         updates.rate_limit = parsedRateLimit;
+      }
+
+      if ((editExpiresAt ?? null) !== (apiKey.expires_at ?? null)) {
+        updates.expires_at = editExpiresAt;
       }
 
       if (apiKey.key_type === "pk_") {
@@ -283,9 +435,10 @@
     <Dialog.Description>
       {m.api_keys_admin_edit_description()}
     </Dialog.Description>
-    <div class="mt-3 space-y-3">
+    <div class="mt-3 space-y-4">
       <Input.Text bind:value={editName} label={m.name()} />
       <Input.TextArea bind:value={editDescription} label={m.description()} rows={3} />
+
       {#if canEditPermission}
         <Select.Simple
           bind:value={editPermission}
@@ -303,6 +456,120 @@
         </div>
         <p class="text-muted text-xs">{m.api_keys_admin_edit_permission_disabled_hint()}</p>
       {/if}
+
+      {#if apiKey.key_type === "sk_"}
+        <div class="space-y-3 rounded-lg border border-slate-200/70 p-3">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-default text-sm font-medium">{m.api_keys_fine_grained()}</p>
+              <p class="text-muted text-xs">{m.api_keys_fine_grained_info()}</p>
+            </div>
+            {#if canEditResourcePermissions}
+              <div class="bg-subtle flex rounded-lg p-1">
+                <button
+                  type="button"
+                  class="rounded-md px-3 py-1.5 text-xs font-medium transition-colors {permissionMode ===
+                  'simple'
+                    ? 'bg-primary text-default shadow-sm'
+                    : 'text-muted hover:text-default'}"
+                  onclick={() => (permissionMode = "simple")}
+                >
+                  {m.api_keys_simple()}
+                </button>
+                <button
+                  type="button"
+                  class="rounded-md px-3 py-1.5 text-xs font-medium transition-colors {permissionMode ===
+                  'fine-grained'
+                    ? 'bg-primary text-default shadow-sm'
+                    : 'text-muted hover:text-default'}"
+                  onclick={() => (permissionMode = "fine-grained")}
+                >
+                  {m.api_keys_fine_grained()}
+                </button>
+              </div>
+            {/if}
+          </div>
+
+          {#if permissionMode === "fine-grained"}
+            <div class="grid gap-3 sm:grid-cols-2">
+              {#if canEditResourcePermissions}
+                <Select.Simple
+                  bind:value={assistantsPermission}
+                  options={resourcePermissionOptions}
+                  resourceName="assistants"
+                >
+                  {m.api_keys_resource_assistants()}
+                </Select.Simple>
+                <Select.Simple
+                  bind:value={appsPermission}
+                  options={resourcePermissionOptions}
+                  resourceName="apps"
+                >
+                  {m.api_keys_resource_applications()}
+                </Select.Simple>
+                <Select.Simple
+                  bind:value={spacesPermission}
+                  options={resourcePermissionOptions}
+                  resourceName="spaces"
+                >
+                  {m.api_keys_resource_spaces()}
+                </Select.Simple>
+                <Select.Simple
+                  bind:value={knowledgePermission}
+                  options={resourcePermissionOptions}
+                  resourceName="knowledge"
+                >
+                  {m.api_keys_resource_knowledge()}
+                </Select.Simple>
+              {:else}
+                <div>
+                  <p class="text-muted mb-1 text-xs">{m.api_keys_resource_assistants()}</p>
+                  <div
+                    class="border-default bg-subtle text-default rounded-md border px-3 py-2 text-sm"
+                  >
+                    {assistantsPermission}
+                  </div>
+                </div>
+                <div>
+                  <p class="text-muted mb-1 text-xs">{m.api_keys_resource_applications()}</p>
+                  <div
+                    class="border-default bg-subtle text-default rounded-md border px-3 py-2 text-sm"
+                  >
+                    {appsPermission}
+                  </div>
+                </div>
+                <div>
+                  <p class="text-muted mb-1 text-xs">{m.api_keys_resource_spaces()}</p>
+                  <div
+                    class="border-default bg-subtle text-default rounded-md border px-3 py-2 text-sm"
+                  >
+                    {spacesPermission}
+                  </div>
+                </div>
+                <div>
+                  <p class="text-muted mb-1 text-xs">{m.api_keys_resource_knowledge()}</p>
+                  <div
+                    class="border-default bg-subtle text-default rounded-md border px-3 py-2 text-sm"
+                  >
+                    {knowledgePermission}
+                  </div>
+                </div>
+              {/if}
+            </div>
+          {/if}
+        </div>
+      {/if}
+
+      <div>
+        <p class="text-muted mb-1 text-xs">{m.api_keys_expiration()}</p>
+        {#if canEditGuardrails}
+          <ExpirationPicker bind:value={editExpiresAt} disabled={!canEditGuardrails} />
+        {:else}
+          <div class="border-default bg-subtle text-default rounded-md border px-3 py-2 text-sm">
+            {formatExpiration(apiKey.expires_at)}
+          </div>
+        {/if}
+      </div>
 
       <div class="grid gap-3 sm:grid-cols-2">
         <div>

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -7056,7 +7056,7 @@ export interface components {
        */
       enabled?: boolean;
       /** Default Days Before Expiry */
-      default_days_before_expiry?: number[];
+      default_days_before_expiry?: number;
       /**
        * Max Days Before Expiry
        * @default 365
@@ -7078,7 +7078,7 @@ export interface components {
       /** Enabled */
       enabled?: boolean | null;
       /** Default Days Before Expiry */
-      default_days_before_expiry?: number[] | null;
+      default_days_before_expiry?: number | null;
       /** Max Days Before Expiry */
       max_days_before_expiry?: number | null;
       /** Allow Auto Follow Published Assistants */
@@ -7094,7 +7094,7 @@ export interface components {
        */
       enabled?: boolean;
       /** Days Before Expiry */
-      days_before_expiry?: number[];
+      days_before_expiry?: number;
       /**
        * Auto Follow Published Assistants
        * @default false
@@ -7111,7 +7111,7 @@ export interface components {
       /** Enabled */
       enabled?: boolean | null;
       /** Days Before Expiry */
-      days_before_expiry?: number[] | null;
+      days_before_expiry?: number | null;
       /** Auto Follow Published Assistants */
       auto_follow_published_assistants?: boolean | null;
       /** Auto Follow Published Apps */


### PR DESCRIPTION
## Summary
Moves API key notification user state out of JSON blobs and into relational tables, while simplifying reminder semantics from arrays to a single day threshold.

## What changed
- add `api_key_notification_preferences` and `api_key_notification_subscriptions` tables with an Alembic migration that moves existing notification state out of `settings.chatbot_widget.api_key_notifications`
- switch backend notification models and endpoints to a scalar `days_before_expiry` / `default_days_before_expiry` contract and route all preference/subscription reads and writes through a dedicated repository
- keep tenant notification policy in `api_key_policy.notification_policy`, but normalize legacy array payloads to a single scalar value
- update frontend notification preferences and admin policy UI to use a single reminder day value end to end
- extend the admin API key edit dialog so `expires_at` and `resource_permissions` can be updated without revoke/recreate
- restrict fine-grained resource permissions in the admin edit UI to `sk_` keys, matching backend policy enforcement
- harden the migration to skip corrupt legacy subscription IDs instead of failing the whole migration
- prevent admin policy updates from surfacing an uncontrolled server error when `max_days_before_expiry` is lowered below the previous default

## Why
The notification feature had started to accumulate hidden complexity in JSON blobs, plus model/UI drift around reminder arrays vs. single-value semantics. This change makes the data model explicit, easier to migrate, and easier to extend later if delivery channels are added.

## Validation
- `bun run test:unit -- src/lib/features/api-keys/notificationPreferences.test.ts`
- `bun run check`
- `uv run --directory backend ruff check src/intric/authentication/auth_models.py src/intric/authentication/api_key_router.py src/intric/authentication/api_key_notification_auto_follow.py src/intric/authentication/api_key_notification_repo.py src/intric/admin/admin_router.py tests/unit/test_api_key_notification_auto_follow.py tests/unit/test_api_key_notification_models.py tests/integration/test_api_key_auto_follow_publish.py`
- `uv run --directory backend pyright src/intric/authentication/auth_models.py`
- `uv run --directory backend alembic heads`

## Notes
Full backend `pytest` was not runnable in this environment because the local test setup is missing `libmagic`.
