### PR TITLE
bugfix: allow listing mcp servers as a regular user

### DIFF
--- a/backend/src/intric/mcp_servers/application/mcp_server_settings_service.py
+++ b/backend/src/intric/mcp_servers/application/mcp_server_settings_service.py
@@ -87,7 +87,6 @@ class MCPServerSettingsService:
             decrypted[key] = self.encryption_service.decrypt(value)
         return decrypted
 
-    @validate_permissions(Permission.ADMIN)
     async def get_available_mcp_servers(self) -> list[MCPServer]:
         """Get all MCP servers for the current tenant (enabled and disabled)."""
         servers = await self.mcp_server_repo.query_by_tenant(


### PR DESCRIPTION
## Changes
Remove admin requirement to list mcp servers

## Why
As a non-admin user with admin access to a space settings couldnt be managed
