### PR TITLE
fix: reasoning_content AttributeError on non-reasoning models

### DIFF
--- a/backend/src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py
+++ b/backend/src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py
@@ -603,8 +603,9 @@ class TenantModelAdapter(CompletionModelAdapter):
 
                 # DEBUG: Log message details
                 logger.debug(f"[DEBUG] Message: {msg}")
-                if msg.reasoning_content:
-                    logger.debug(f"[DEBUG] reasoning_content: {msg.reasoning_content}")
+                reasoning = getattr(msg, "reasoning_content", None)
+                if reasoning:
+                    logger.debug(f"[DEBUG] reasoning_content: {reasoning}")
 
                 # Check if model wants to call MCP tools
                 if msg.tool_calls and mcp_proxy:


### PR DESCRIPTION
## Summary
- The pyright strict hardening in #325 replaced `hasattr(msg, "reasoning_content")` with direct attribute access `msg.reasoning_content`
- The runtime `Message` object from the OpenAI SDK doesn't have this attribute on non-reasoning models, causing `AttributeError` and failing all app runs
- Fix: use `getattr(msg, "reasoning_content", None)` for safe access