### PR TITLE
feat(space-admin-keys): only allow rotation of your own keys and serv…

### DIFF
--- a/backend/src/intric/authentication/api_key_lifecycle.py
+++ b/backend/src/intric/authentication/api_key_lifecycle.py
@@ -162,6 +162,7 @@ class ApiKeyLifecycleService:
             key = await self._get_key_or_404(key_id=key_id, tenant_id=user.tenant_id)
             if not skip_manage_authorization:
                 await self.policy_service.ensure_manage_authorized(key=key)
+                await self.policy_service.ensure_ownership_authorized(key=key)
             await self.policy_service.validate_key_state(key=key)
         except ApiKeyValidationError as exc:
             await self._log_lifecycle_failure(
@@ -265,6 +266,7 @@ class ApiKeyLifecycleService:
             key = await self._get_key_or_404(key_id=key_id, tenant_id=user.tenant_id)
             if not skip_manage_authorization:
                 await self.policy_service.ensure_manage_authorized(key=key)
+                await self.policy_service.ensure_ownership_authorized(key=key)
         except ApiKeyValidationError as exc:
             await self._log_lifecycle_failure(
                 action=ActionType.API_KEY_UPDATED,
@@ -423,6 +425,7 @@ class ApiKeyLifecycleService:
             key = await self._get_key_or_404(key_id=key_id, tenant_id=user.tenant_id)
             if not skip_manage_authorization:
                 await self.policy_service.ensure_manage_authorized(key=key)
+                await self.policy_service.ensure_ownership_authorized(key=key)
         except ApiKeyValidationError as exc:
             await self._log_lifecycle_failure(
                 action=ActionType.API_KEY_SUSPENDED,
@@ -535,6 +538,7 @@ class ApiKeyLifecycleService:
             key = await self._get_key_or_404(key_id=key_id, tenant_id=user.tenant_id)
             if not skip_manage_authorization:
                 await self.policy_service.ensure_manage_authorized(key=key)
+                await self.policy_service.ensure_ownership_authorized(key=key)
         except ApiKeyValidationError as exc:
             await self._log_lifecycle_failure(
                 action=ActionType.API_KEY_REACTIVATED,
@@ -642,6 +646,7 @@ class ApiKeyLifecycleService:
             key = await self._get_key_or_404(key_id=key_id, tenant_id=user.tenant_id)
             if not skip_manage_authorization:
                 await self.policy_service.ensure_manage_authorized(key=key)
+                await self.policy_service.ensure_ownership_authorized(key=key)
         except ApiKeyValidationError as exc:
             await self._log_lifecycle_failure(
                 action=ActionType.API_KEY_REVOKED,

--- a/backend/src/intric/authentication/api_key_lifecycle.py
+++ b/backend/src/intric/authentication/api_key_lifecycle.py
@@ -189,6 +189,7 @@ class ApiKeyLifecycleService:
 
         record = await self.api_key_repo.create(
             tenant_id=key.tenant_id,
+            ownership=key.ownership,
             owner_user_id=key.owner_user_id,
             created_by_user_id=user.id,
             scope_type=key.scope_type,

--- a/backend/src/intric/authentication/api_key_policy.py
+++ b/backend/src/intric/authentication/api_key_policy.py
@@ -374,8 +374,22 @@ class ApiKeyPolicyService:
                         message="Public keys (pk_) do not support fine-grained resource permissions.",
                     )
 
+    async def ensure_ownership_authorized(self, *, key: ApiKeyV2InDB):
+        """Service keys: any scope-authorized user can manage.
+        User keys: only the owner can manage."""
+        if ApiKeyOwnership(key.ownership) == ApiKeyOwnership.SERVICE:
+            return
+        user = self._require_user()
+        if key.owner_user_id == user.id:
+            return
+        raise ApiKeyValidationError(
+            status_code=403,
+            code="insufficient_permission",
+            message="You do not have permission to manage another user's personal API key.",
+        )
+
     async def ensure_manage_authorized(self, *, key: ApiKeyV2InDB):
-        return await self.ensure_creator_authorized(
+        await self.ensure_creator_authorized(
             scope_type=ApiKeyScopeType(key.scope_type),
             scope_id=key.scope_id,
         )

--- a/backend/tests/unit/test_api_key_lifecycle_service.py
+++ b/backend/tests/unit/test_api_key_lifecycle_service.py
@@ -269,7 +269,9 @@ async def test_rotate_key_uses_default_when_policy_grace_period_is_null(user):
     repo.create.return_value = new_key
     repo.update.return_value = key
     policy = SimpleNamespace(
-        ensure_manage_authorized=AsyncMock(), validate_key_state=AsyncMock()
+        ensure_manage_authorized=AsyncMock(),
+        ensure_ownership_authorized=AsyncMock(),
+        validate_key_state=AsyncMock(),
     )
     audit = AsyncMock()
 

--- a/backend/tests/unit/test_api_key_lifecycle_service.py
+++ b/backend/tests/unit/test_api_key_lifecycle_service.py
@@ -42,7 +42,9 @@ async def test_suspend_logs_audit(user):
     repo = AsyncMock()
     repo.get.return_value = key
     repo.update.return_value = key
-    policy = SimpleNamespace(ensure_manage_authorized=AsyncMock())
+    policy = SimpleNamespace(
+        ensure_manage_authorized=AsyncMock(), ensure_ownership_authorized=AsyncMock()
+    )
     audit = AsyncMock()
 
     service = ApiKeyLifecycleService(
@@ -69,7 +71,9 @@ async def test_revoke_logs_audit(user):
     repo = AsyncMock()
     repo.get.return_value = key
     repo.update.return_value = key
-    policy = SimpleNamespace(ensure_manage_authorized=AsyncMock())
+    policy = SimpleNamespace(
+        ensure_manage_authorized=AsyncMock(), ensure_ownership_authorized=AsyncMock()
+    )
     audit = AsyncMock()
 
     service = ApiKeyLifecycleService(
@@ -99,7 +103,9 @@ async def test_rotate_logs_audit(user):
     repo.create.return_value = new_key
     repo.update.return_value = key
     policy = SimpleNamespace(
-        ensure_manage_authorized=AsyncMock(), validate_key_state=AsyncMock()
+        ensure_manage_authorized=AsyncMock(),
+        ensure_ownership_authorized=AsyncMock(),
+        validate_key_state=AsyncMock(),
     )
     audit = AsyncMock()
 
@@ -136,6 +142,7 @@ async def test_update_revoked_key_allows_metadata_only(user):
     repo.update.return_value = updated_key
     policy = SimpleNamespace(
         ensure_manage_authorized=AsyncMock(),
+        ensure_ownership_authorized=AsyncMock(),
         validate_update_request=AsyncMock(),
     )
     audit = AsyncMock()
@@ -166,6 +173,7 @@ async def test_update_revoked_key_rejects_policy_fields(user):
     repo.get.return_value = key
     policy = SimpleNamespace(
         ensure_manage_authorized=AsyncMock(),
+        ensure_ownership_authorized=AsyncMock(),
         validate_update_request=AsyncMock(),
     )
     audit = AsyncMock()
@@ -196,7 +204,9 @@ async def test_double_revoke_is_idempotent(user):
     )
     repo = AsyncMock()
     repo.get.return_value = key
-    policy = SimpleNamespace(ensure_manage_authorized=AsyncMock())
+    policy = SimpleNamespace(
+        ensure_manage_authorized=AsyncMock(), ensure_ownership_authorized=AsyncMock()
+    )
     audit = AsyncMock()
 
     service = ApiKeyLifecycleService(
@@ -225,7 +235,9 @@ async def test_rotate_key_with_existing_grace_period(user):
     repo.create.return_value = new_key
     repo.update.return_value = key
     policy = SimpleNamespace(
-        ensure_manage_authorized=AsyncMock(), validate_key_state=AsyncMock()
+        ensure_manage_authorized=AsyncMock(),
+        ensure_ownership_authorized=AsyncMock(),
+        validate_key_state=AsyncMock(),
     )
     audit = AsyncMock()
 
@@ -300,7 +312,9 @@ async def test_rotate_serializes_resource_permissions_for_repo_create(user):
     repo.create.return_value = new_key
     repo.update.return_value = key
     policy = SimpleNamespace(
-        ensure_manage_authorized=AsyncMock(), validate_key_state=AsyncMock()
+        ensure_manage_authorized=AsyncMock(),
+        ensure_ownership_authorized=AsyncMock(),
+        validate_key_state=AsyncMock(),
     )
     audit = AsyncMock()
 

--- a/frontend/apps/web/src/lib/features/api-keys/ApiKeyActionMenu.svelte
+++ b/frontend/apps/web/src/lib/features/api-keys/ApiKeyActionMenu.svelte
@@ -37,7 +37,8 @@
     onViewRequested,
     isFollowed = false,
     isFollowedViaScope = false,
-    onFollowChanged
+    onFollowChanged,
+    currentUserId = undefined
   } = $props<{
     apiKey: ApiKeyV2;
     mode?: "user" | "admin";
@@ -48,6 +49,7 @@
     isFollowed?: boolean;
     isFollowedViaScope?: boolean;
     onFollowChanged?: () => void | Promise<void>;
+    currentUserId?: string;
   }>();
 
   let showRevokeDialog = $state(false);
@@ -64,6 +66,15 @@
   const canRotate = $derived(apiKey.state === "active");
   const isAdmin = $derived(mode === "admin");
   const reasonCode = $derived(isAdmin ? ("admin_action" as const) : ("user_request" as const));
+  // In user mode, personal keys can only be managed by their owner; service keys are
+  // manageable by any scope-authorized user. Admin mode bypasses ownership (scope
+  // authorization is enforced by the backend instead).
+  const canManage = $derived(
+    isAdmin ||
+      !currentUserId ||
+      apiKey.ownership === "service" ||
+      apiKey.owner_user_id === currentUserId
+  );
 
   function formatLastUsed(lastUsedAt: string | null | undefined): string | null {
     if (!lastUsedAt) return null;
@@ -219,7 +230,7 @@
       {/if}
 
       {#if canRotate}
-        <DropdownMenu.Item onclick={openRotateDialog}>
+        <DropdownMenu.Item onclick={openRotateDialog} disabled={!canManage}>
           <RotateCcw />
           {isAdmin ? m.api_keys_admin_action_rotate() : m.api_keys_action_rotate()}
         </DropdownMenu.Item>
@@ -249,6 +260,7 @@
           onclick={() => {
             showSuspendDialog = true;
           }}
+          disabled={!canManage}
         >
           <Ban />
           {isAdmin ? m.api_keys_admin_action_suspend() : m.api_keys_action_suspend()}
@@ -256,7 +268,7 @@
       {/if}
 
       {#if isSuspended}
-        <DropdownMenu.Item onclick={reactivateKey}>
+        <DropdownMenu.Item onclick={reactivateKey} disabled={!canManage}>
           <RefreshCw />
           {isAdmin ? m.api_keys_admin_action_reactivate() : m.api_keys_action_reactivate()}
         </DropdownMenu.Item>
@@ -270,6 +282,7 @@
           onclick={() => {
             showRevokeDialog = true;
           }}
+          disabled={!canManage}
         >
           <Ban />
           {isAdmin ? m.api_keys_admin_action_revoke() : m.api_keys_action_revoke()}

--- a/frontend/apps/web/src/lib/features/api-keys/ApiKeysSettingsSection.svelte
+++ b/frontend/apps/web/src/lib/features/api-keys/ApiKeysSettingsSection.svelte
@@ -259,6 +259,7 @@
                 await forceRefreshExpiringStore();
               }}
               scopeNames={{ [scopeId]: scopeName }}
+              currentUserId={user.id}
             />
           </div>
         </div>

--- a/frontend/apps/web/src/routes/(app)/account/api-keys/ApiKeyActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/account/api-keys/ApiKeyActions.svelte
@@ -9,7 +9,8 @@
     onSecret,
     isFollowed = false,
     isFollowedViaScope = false,
-    onFollowChanged
+    onFollowChanged,
+    currentUserId = undefined
   } = $props<{
     apiKey: ApiKeyV2;
     onChanged: () => void;
@@ -17,6 +18,7 @@
     isFollowed?: boolean;
     isFollowedViaScope?: boolean;
     onFollowChanged?: () => void | Promise<void>;
+    currentUserId?: string;
   }>();
 
   let showViewDialog = $state(false);
@@ -30,6 +32,7 @@
   {isFollowed}
   {isFollowedViaScope}
   {onFollowChanged}
+  {currentUserId}
   onViewRequested={() => {
     showViewDialog = true;
   }}

--- a/frontend/apps/web/src/routes/(app)/account/api-keys/ApiKeyTable.svelte
+++ b/frontend/apps/web/src/routes/(app)/account/api-keys/ApiKeyTable.svelte
@@ -57,7 +57,8 @@
     followedKeyIds = new Set<string>(),
     scopeFollowed = false,
     onFollowChanged,
-    scopeNames = {}
+    scopeNames = {},
+    currentUserId = undefined
   } = $props<{
     keys: ApiKeyV2[];
     loading: boolean;
@@ -67,6 +68,7 @@
     scopeFollowed?: boolean;
     onFollowChanged?: () => void | Promise<void>;
     scopeNames?: Record<string, string>;
+    currentUserId?: string;
   }>();
 
   // Track expanded rows (SvelteSet is already reactive — no $state wrapper needed)
@@ -317,6 +319,7 @@
                 isFollowed={followedKeyIds?.has(key.id) ?? false}
                 isFollowedViaScope={scopeFollowed && !(followedKeyIds?.has(key.id) ?? false)}
                 {onFollowChanged}
+                {currentUserId}
               />
             </div>
           </div>


### PR DESCRIPTION
## Changes
Only allow users to rotate own + service keys on spaces

## Screenshots
Disable options on other users keys
<img width="296" height="191" alt="Screenshot 2026-04-13 at 10 29 54" src="https://github.com/user-attachments/assets/ed4bf0b3-5ef7-452a-890b-9b6be6e07e37" />

Confirmation dialog on rotate
<img width="492" height="201" alt="Screenshot 2026-04-13 at 13 11 45" src="https://github.com/user-attachments/assets/68a6c7ef-9d21-42d5-a4d5-cddda12f37ed" />
