### PR TITLE
fix: load assistant/app attachments with text content

### DIFF
--- a/backend/src/intric/apps/apps/api/app_router.py
+++ b/backend/src/intric/apps/apps/api/app_router.py
@@ -21,7 +21,7 @@ from intric.authentication.api_key_notification_auto_follow import (
     auto_follow_on_publish,
 )
 from intric.authentication.auth_models import ApiKeyNotificationTargetType
-from intric.files.file_models import FileInfo
+from intric.files.file_models import File
 from intric.main.container.container import Container
 from intric.main.models import NOT_PROVIDED, PaginatedResponse, is_provided
 from intric.prompts.api.prompt_models import PromptSparse
@@ -128,8 +128,8 @@ async def update_app(
 
     # Helper function to track attachment changes
     def get_attachment_changes(
-        old_attachments: list[FileInfo] | None,
-        new_attachments: list[FileInfo] | None,
+        old_attachments: list[File] | None,
+        new_attachments: list[File] | None,
     ) -> tuple[list[AttachmentChange], list[AttachmentChange]]:
         """Compare attachment lists and return added/removed items."""
         old_items: dict[str, str] = {

--- a/backend/src/intric/apps/apps/app.py
+++ b/backend/src/intric/apps/apps/app.py
@@ -74,7 +74,7 @@ class App:
         transcription_model: "TranscriptionModel | None",
         completion_model_kwargs: ModelKwargs | None,
         input_fields: list[InputField],
-        attachments: list[FileInfo],
+        attachments: list[File],
         published: bool,
         source_template: AppTemplate | None = None,
         data_retention_days: Optional[int] = None,
@@ -156,11 +156,11 @@ class App:
         self._input_fields = input_fields
 
     @property
-    def attachments(self) -> list[FileInfo]:
+    def attachments(self) -> list[File]:
         return self._attachments
 
     @attachments.setter
-    def attachments(self, attachments: list[FileInfo]):
+    def attachments(self, attachments: list[File]):
         for attachment in attachments:
             if attachment.mimetype is None or not TextMimeTypes.has_value(
                 attachment.mimetype
@@ -181,7 +181,7 @@ class App:
         completion_model: "CompletionModel | CompletionModelSparse | None" = None,
         completion_model_kwargs: ModelKwargs | None = None,
         input_fields: list[InputField] | None = None,
-        attachments: list[FileInfo] | None = None,
+        attachments: list[File] | None = None,
         published: bool | None = None,
         transcription_model: "TranscriptionModel | None" = None,
         data_retention_days: Union[int, None, NotProvided] = NOT_PROVIDED,
@@ -317,9 +317,6 @@ class App:
             files=image_files + text_files,
             model=cast(AICompletionModel, self.completion_model),
             prompt=self._get_prompt_text(),
-            prompt_files=[
-                File.model_validate(attachment.model_dump())
-                for attachment in self.attachments
-            ],
+            prompt_files=self.attachments,
             model_kwargs=self.completion_model_kwargs,
         )

--- a/backend/src/intric/apps/apps/app_factory.py
+++ b/backend/src/intric/apps/apps/app_factory.py
@@ -9,7 +9,7 @@ from intric.ai_models.completion_models.completion_model import (
 from intric.apps.apps.api.app_models import InputField, InputFieldType
 from intric.apps.apps.app import App
 from intric.database.tables.app_table import Apps
-from intric.files.file_models import FileInfo
+from intric.files.file_models import File
 from intric.prompts.prompt import Prompt
 from intric.prompts.prompt_factory import PromptFactory
 from intric.spaces.space import Space
@@ -99,7 +99,7 @@ class AppFactory:
         input_fields: list[InputField],
         name: str | None = None,
         prompt: Prompt | None = None,
-        attachments: Sequence["FileInfo"] | None = None,
+        attachments: Sequence["File"] | None = None,
         transcription_model: TranscriptionModel | None = None,
     ) -> App:
         space_id = space.id
@@ -155,8 +155,7 @@ class AppFactory:
             for input_field in app_in_db.input_fields
         ]
         attachments = [
-            FileInfo.model_validate(attachment.file)
-            for attachment in app_in_db.attachments
+            File.model_validate(attachment.file) for attachment in app_in_db.attachments
         ]
         model_kwargs = self._create_model_kwargs(completion_model_kwargs)
 
@@ -218,8 +217,7 @@ class AppFactory:
             else None
         )
         attachments = [
-            FileInfo.model_validate(attachment.file)
-            for attachment in app_in_db.attachments
+            File.model_validate(attachment.file) for attachment in app_in_db.attachments
         ]
         model_kwargs = self._create_model_kwargs(completion_model_kwargs)
 

--- a/backend/src/intric/apps/apps/app_repo.py
+++ b/backend/src/intric/apps/apps/app_repo.py
@@ -11,7 +11,7 @@ from intric.apps.apps.app import App
 from intric.apps.apps.app_factory import AppFactory
 from intric.database.database import AsyncSession
 from intric.database.tables.app_table import Apps, AppsFiles, AppsPrompts, InputFields
-from intric.files.file_models import FileInfo
+from intric.files.file_models import File
 from intric.prompts.prompt import Prompt
 from intric.prompts.prompt_repo import PromptRepository
 from intric.transcription_models.domain.transcription_model_repo import (
@@ -112,9 +112,7 @@ class AppRepository:
 
         await self.session.execute(stmt)
 
-    async def _set_attachments(
-        self, app_in_db: Apps, attachments: list[FileInfo]
-    ) -> None:
+    async def _set_attachments(self, app_in_db: Apps, attachments: list[File]) -> None:
         # Delete all
         stmt = sa.delete(AppsFiles).where(AppsFiles.app_id == app_in_db.id)
         await self.session.execute(stmt)

--- a/backend/src/intric/apps/apps/app_service.py
+++ b/backend/src/intric/apps/apps/app_service.py
@@ -140,7 +140,7 @@ class AppService:
         # Validate incoming data
         template.validate_wizard_data(template_data=template_data)
 
-        attachments = await self.file_service.get_file_infos(
+        attachments = await self.file_service.get_files_by_ids(
             file_ids=template_data.get_ids_by_type(wizard_type=WizardType.attachments)
         )
 
@@ -284,7 +284,7 @@ class AppService:
 
         attachments = None
         if attachment_ids is not None:
-            attachments = await self.file_service.get_file_infos(
+            attachments = await self.file_service.get_files_by_ids(
                 [attachment.id for attachment in attachment_ids]
             )
 

--- a/backend/src/intric/assistants/assistant.py
+++ b/backend/src/intric/assistants/assistant.py
@@ -8,7 +8,7 @@ from intric.assistants.api.assistant_models import AssistantType
 from intric.base.base_entity import Entity
 from intric.completion_models.domain.completion_model import CompletionModel
 from intric.completion_models.infrastructure.completion_service import CompletionService
-from intric.files.file_models import File, FileInfo, FileType
+from intric.files.file_models import File, FileType
 from intric.files.text import TextMimeTypes
 from intric.info_blobs.info_blob import InfoBlobChunkInDBWithScore
 from intric.main.exceptions import (
@@ -59,7 +59,7 @@ class Assistant(Entity):
         logging_enabled: bool,
         websites: list["Website"],
         collections: list["Collection"],
-        attachments: list[FileInfo],
+        attachments: list[File],
         published: bool,
         integration_knowledge_list: list["IntegrationKnowledge"] | None = None,
         mcp_servers: list["MCPServer"] | None = None,
@@ -164,7 +164,7 @@ class Assistant(Entity):
         return self._attachments
 
     @attachments.setter
-    def attachments(self, attachments: list[FileInfo]):
+    def attachments(self, attachments: list[File]):
         for attachment in attachments:
             mimetype = attachment.mimetype or ""
             if mimetype.split(";")[0].strip() not in TextMimeTypes.values():
@@ -236,7 +236,7 @@ class Assistant(Entity):
         prompt: Prompt | None = None,
         completion_model: CompletionModel | None = None,
         completion_model_kwargs: ModelKwargs | None = None,
-        attachments: list[FileInfo] | None = None,
+        attachments: list[File] | None = None,
         logging_enabled: bool | None = None,
         collections: list["Collection"] | None = None,
         websites: list["Website"] | None = None,
@@ -320,7 +320,7 @@ class Assistant(Entity):
             text_input=question,
             files=files or [],
             prompt=prompt or self.get_prompt_text(),
-            prompt_files=cast(list[File], self.attachments),
+            prompt_files=self.attachments,
             info_blob_chunks=info_blob_chunks or [],
             session=session,
             stream=stream,
@@ -376,7 +376,7 @@ class Assistant(Entity):
             text_input=question,
             files=files or [],
             prompt=self.get_prompt_text(),
-            prompt_files=cast(list[File], self.attachments),
+            prompt_files=self.attachments,
             info_blob_chunks=datastore_result.chunks,
             session=session,
             stream=stream,

--- a/backend/src/intric/assistants/assistant_factory.py
+++ b/backend/src/intric/assistants/assistant_factory.py
@@ -9,7 +9,7 @@ from intric.assistants.assistant import Assistant
 from intric.completion_models.domain.completion_model import CompletionModel
 from intric.database.tables.assistant_table import Assistants
 from intric.database.tables.prompts_table import Prompts
-from intric.files.file_models import FileInfo
+from intric.files.file_models import File
 from intric.main.logging import get_logger
 from intric.mcp_servers.infrastructure.mappers.mcp_server_mapper import MCPServerMapper
 from intric.prompts.prompt_factory import PromptFactory
@@ -49,7 +49,7 @@ class AssistantFactory:
         completion_model: CompletionModel | None = None,
         completion_model_kwargs: ModelKwargs | None = None,
         logging_enabled: bool = False,
-        attachments: list["FileInfo"] | None = None,
+        attachments: list["File"] | None = None,
         collections: list["Collection"] | None = None,
         integration_knowledge_list: list["IntegrationKnowledge"] | None = None,
         template: AssistantTemplate | None = None,
@@ -112,7 +112,7 @@ class AssistantFactory:
             )
 
         attachments = [
-            FileInfo.model_validate(attachment.file)
+            File.model_validate(attachment.file)
             for attachment in assistant_in_db.attachments
         ]
 
@@ -196,7 +196,7 @@ class AssistantFactory:
             )
 
         attachments = [
-            FileInfo.model_validate(attachment.file)
+            File.model_validate(attachment.file)
             for attachment in assistant_in_db.attachments
         ]
 

--- a/backend/src/intric/assistants/assistant_repo.py
+++ b/backend/src/intric/assistants/assistant_repo.py
@@ -31,7 +31,7 @@ from intric.database.tables.integration_table import (
 from intric.database.tables.prompts_table import Prompts, PromptsAssistants
 from intric.database.tables.users_table import Users
 from intric.database.tables.websites_table import CrawlRuns, Websites
-from intric.files.file_models import FileInfo
+from intric.files.file_models import File
 from intric.main.exceptions import BadRequestException
 from intric.prompts.prompt import Prompt
 
@@ -155,7 +155,7 @@ class AssistantRepository:
         return await self.session.scalar(stmt)
 
     async def _set_attachments(
-        self, assistant_in_db: Assistants, attachments: list[FileInfo]
+        self, assistant_in_db: Assistants, attachments: list[File]
     ):
         # Delete all
         stmt = sa.delete(AssistantsFiles).where(

--- a/backend/src/intric/assistants/assistant_service.py
+++ b/backend/src/intric/assistants/assistant_service.py
@@ -258,7 +258,7 @@ class AssistantService:
         template.validate_assistant_wizard_data(template_data=template_data)
         assert space.id is not None
 
-        attachments = await self.file_service.get_file_infos(
+        attachments = await self.file_service.get_files_by_ids(
             file_ids=template_data.get_ids_by_type(wizard_type=WizardType.attachments)
         )
         collections = [
@@ -385,7 +385,7 @@ class AssistantService:
 
         attachments = None
         if attachment_ids is not None:
-            attachments = await self.file_service.get_file_infos(attachment_ids)
+            attachments = await self.file_service.get_files_by_ids(attachment_ids)
 
         group_entities = None
         if groups is not None:


### PR DESCRIPTION
fix: load assistant/app attachments with text content

## Changes
  Load attachments as full File objects (restoring pre-pyright-strict
  behavior), tighten the domain types from list[FileInfo] to list[File],
  and drop the misleading cast(list[File], self.attachments) that hid
  the mismatch. Switched the create/update service flows to
  get_files_by_ids so the types line up end-to-end.

## Why
  Assistant and App factories were loading prompt attachments as
  FileInfo (metadata only), then downstream code tried to read .text
  off them — raising AttributeError on assistants and a pydantic
  ValidationError on apps whenever a configured text attachment was
  used in a chat/run.
