### PR TITLE
fix(deployment): bump Traefik to floating v3 tag for Docker API compatibility

### DIFF
--- a/docs/deployment/docker-compose.yml
+++ b/docs/deployment/docker-compose.yml
@@ -31,7 +31,7 @@ name: eneo
 
 services:
   traefik:
-    image: traefik:v3.0
+    image: traefik:v3
     container_name: eneo_traefik
     restart: unless-stopped
     command:


### PR DESCRIPTION
## Vad

Byter Traefik från `traefik:v3.0` till `traefik:v3` i referenskonfigurationen. Floating-taggen följer senaste 3.x.y, så vi får minor + patch automatiskt utan major-bumpar.

## Varför

Användare med modern Docker Engine (28+, släppt 2025) får detta fel direkt vid uppstart:

```
client version 1.24 is too old. Minimum supported API version is 1.44
```

Orsak: Traefik-containern är själv en Docker API-klient (läser labels via `/var/run/docker.sock`). Imagen `traefik:v3.0` har ett gammalt inbyggt klientbibliotek som förhandlar API 1.24 — Engine 28+ stödjer minst 1.44. `docker pull` hjälper inte eftersom `v3.0` bara får patches inom 3.0.x.

Med `v3` pickas både den uppdaterade Docker-klienten och framtida CVE-fixar upp automatiskt. Konsekvent med övriga rörliga taggar i samma fil (`pgvector:pg16`, `redis:7-alpine`).

## Säkerhet

Nettoeffekt positiv: Traefik är en säkerhetsgräns (TLS, ingress) och `v3` ger automatiska CVE-patches. Liten avvägning mot reproducerbarhet, mitigerat av att detta är en referenskonfig som varje deployment kör isolerat.

## Test plan

- [ ] `docker compose pull` på fräsch host hämtar 3.x (≥ 3.6)
- [ ] Traefik startar utan API-versionsfel på Docker Engine 28+
- [ ] Let's Encrypt + labels fungerar (samma syntax v3.0 → v3.x)
- [ ] Smoke-test: frontend och backend nås via HTTPS