### PR TITLE
fix(mcp): replay persisted tool calls to the LLM on follow-up turns

### DIFF
--- a/backend/src/intric/ai_models/completion_models/completion_model.py
+++ b/backend/src/intric/ai_models/completion_models/completion_model.py
@@ -67,6 +67,14 @@ class ToolCallMetadata:
     approved: Optional[bool] = None  # True=approved, False=denied, None=pending/auto
     # Additive state field for richer clients; legacy `approved` remains authoritative.
     result_status: Optional[str] = None
+    # Text extraction of the MCP tool result. Populated once the tool has executed
+    # so it can be persisted on the Question and replayed to the LLM on later turns.
+    result: Optional[str] = None
+    # The prefixed tool identifier the LLM sees when calling (e.g.
+    # `server__tool`). `tool_name` / `server_name` above are the split/display
+    # forms used by the UI; this field preserves the exact identifier needed
+    # to replay the tool_use so it matches the currently-registered tools.
+    mcp_tool_name: Optional[str] = None
 
 
 @dataclass
@@ -204,11 +212,31 @@ class CompletionModelResponse(BaseModel):
     usage: Optional[TokenUsage] = None
 
 
+class MessageToolCall(BaseModel):
+    """A replayable tool-use record for the LLM-facing Message.
+
+    Carries only the fields needed to reconstruct OpenAI-style tool_calls +
+    role:"tool" result messages in history. The persisted ToolCallInfo
+    (intric.questions.question) is a superset — this type deliberately excludes
+    approval metadata and non-replayable fields.
+
+    `tool_name` here is the LLM-visible prefixed identifier (e.g.
+    `server__tool`) — matching the currently-registered tools — not the
+    split/display form that the UI uses.
+    """
+
+    tool_call_id: str
+    tool_name: str
+    arguments: Optional[dict[str, object]] = None
+    result: str
+
+
 class Message(BaseModel):
     question: str
     answer: str
     images: list[File] = []
     generated_images: list[File] = []
+    tool_calls: list[MessageToolCall] = []
 
 
 class Context(BaseModel):

--- a/backend/src/intric/assistants/assistant_service.py
+++ b/backend/src/intric/assistants/assistant_service.py
@@ -718,6 +718,10 @@ class AssistantService:
                                     # Update existing entry with approval status
                                     existing.approved = tc.approved
                                     existing.result_status = tc.result_status
+                                    # The TOOL_CALL chunk after execution carries the
+                                    # tool output; keep it so later turns can replay.
+                                    if tc.result is not None:
+                                        existing.result = tc.result
                                 else:
                                     # Add new tool call
                                     tool_calls.append(
@@ -731,6 +735,8 @@ class AssistantService:
                                             tool_call_id=tc.tool_call_id or "",
                                             approved=tc.approved,
                                             result_status=tc.result_status,
+                                            result=tc.result,
+                                            mcp_tool_name=tc.mcp_tool_name,
                                         )
                                     )
                         yield chunk
@@ -749,6 +755,7 @@ class AssistantService:
                                         tool_call_id=tc.tool_call_id or "",
                                         approved=None,
                                         result_status=tc.result_status,
+                                        mcp_tool_name=tc.mcp_tool_name,
                                     )
                                 )
                         yield chunk
@@ -783,6 +790,7 @@ class AssistantService:
                                             approved=False,
                                             result_status=tc.result_status
                                             or "timeout_denied",
+                                            mcp_tool_name=tc.mcp_tool_name,
                                         )
                                     )
                         yield chunk

--- a/backend/src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py
+++ b/backend/src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py
@@ -430,13 +430,46 @@ class TenantModelAdapter(CompletionModelAdapter):
                     ),
                 }
             )
-            # Assistant response
-            messages.append(
-                {
-                    "role": "assistant",
-                    "content": msg.answer or "[image generated]",
-                }
-            )
+            # Assistant response. If the turn invoked tools, emit the assistant
+            # message with OpenAI-style `tool_calls` followed by a `role: tool`
+            # entry per call so the model can see its prior tool use on replay.
+            if msg.tool_calls:
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": msg.answer or None,
+                        "tool_calls": [
+                            {
+                                "id": tc.tool_call_id,
+                                "type": "function",
+                                "function": {
+                                    "name": tc.tool_name,
+                                    "arguments": (
+                                        json.dumps(tc.arguments)
+                                        if tc.arguments is not None
+                                        else ""
+                                    ),
+                                },
+                            }
+                            for tc in msg.tool_calls
+                        ],
+                    }
+                )
+                for tc in msg.tool_calls:
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tc.tool_call_id,
+                            "content": tc.result,
+                        }
+                    )
+            else:
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": msg.answer or "[image generated]",
+                    }
+                )
 
         # Add current question with images
         messages.append(
@@ -1114,6 +1147,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                                 tool_name=tname,
                                 arguments=args,
                                 tool_call_id=tc["id"],
+                                mcp_tool_name=name,
                             )
                         )
                     tool_args_by_call_id: dict[str, dict[str, Any] | None] = {}
@@ -1175,6 +1209,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                                         tool_call_id=tm.tool_call_id,
                                         approved=False,
                                         result_status="timeout_denied",
+                                        mcp_tool_name=tm.mcp_tool_name,
                                     )
                                     for tm in tool_metadata
                                 ],
@@ -1200,6 +1235,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                                             "timeout_denied" if timed_out else "denied"
                                         )
                                     ),
+                                    mcp_tool_name=tm.mcp_tool_name,
                                 )
                                 for tm in tool_metadata
                             ],
@@ -1226,6 +1262,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                                     tool_call_id=tm.tool_call_id,
                                     approved=tm.approved,
                                     result_status="approved",
+                                    mcp_tool_name=tm.mcp_tool_name,
                                 )
                                 for tm in tool_metadata
                             ],
@@ -1308,6 +1345,8 @@ class TenantModelAdapter(CompletionModelAdapter):
                                     tool_call_id=tc["id"],
                                     approved=True,
                                     result_status=result_status,
+                                    result=text,
+                                    mcp_tool_name=tc["function"]["name"],
                                 )
                             )
 
@@ -1352,6 +1391,8 @@ class TenantModelAdapter(CompletionModelAdapter):
                                 result_status=(
                                     "timeout_denied" if timed_out else "denied"
                                 ),
+                                result=json.dumps(denial_payload),
+                                mcp_tool_name=tc["function"]["name"],
                             )
                         )
 

--- a/backend/src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py
+++ b/backend/src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py
@@ -430,14 +430,16 @@ class TenantModelAdapter(CompletionModelAdapter):
                     ),
                 }
             )
-            # Assistant response. If the turn invoked tools, emit the assistant
-            # message with OpenAI-style `tool_calls` followed by a `role: tool`
-            # entry per call so the model can see its prior tool use on replay.
+            # Assistant response. If the turn invoked tools, emit the canonical
+            # OpenAI shape: a pre-tool assistant message with only `tool_calls`,
+            # one `role: tool` entry per call, then a post-tool assistant
+            # message with the final answer. This matches what the live flow
+            # produces during generation and keeps causal order intact.
             if msg.tool_calls:
                 messages.append(
                     {
                         "role": "assistant",
-                        "content": msg.answer or None,
+                        "content": None,
                         "tool_calls": [
                             {
                                 "id": tc.tool_call_id,
@@ -447,7 +449,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                                     "arguments": (
                                         json.dumps(tc.arguments)
                                         if tc.arguments is not None
-                                        else ""
+                                        else "{}"
                                     ),
                                 },
                             }
@@ -461,6 +463,13 @@ class TenantModelAdapter(CompletionModelAdapter):
                             "role": "tool",
                             "tool_call_id": tc.tool_call_id,
                             "content": tc.result,
+                        }
+                    )
+                if msg.answer:
+                    messages.append(
+                        {
+                            "role": "assistant",
+                            "content": msg.answer,
                         }
                     )
             else:

--- a/backend/src/intric/completion_models/infrastructure/context_builder.py
+++ b/backend/src/intric/completion_models/infrastructure/context_builder.py
@@ -10,6 +10,7 @@ from intric.ai_models.completion_models.completion_model import (
     Context,
     FunctionDefinition,
     Message,
+    MessageToolCall,
 )
 from intric.completion_models.infrastructure.static_prompts import (
     HALLUCINATION_GUARD,
@@ -18,10 +19,57 @@ from intric.completion_models.infrastructure.static_prompts import (
 )
 from intric.files.file_models import File, FileType
 from intric.main.exceptions import QueryException
+from intric.questions.question import ToolCallInfo
 from intric.sessions.session import SessionInDB
 from intric.tokens.token_utils import (
     count_tokens,  # noqa: F401 — re-exported for external callers
 )
+
+
+def _replayable_tool_calls(
+    tool_calls: Optional[list[ToolCallInfo]],
+) -> list[MessageToolCall]:
+    """Filter persisted tool calls down to those that can be replayed to the LLM.
+
+    Replayable means the call has a stable id to pair with a result and a
+    concrete result payload. Denied calls are included — the result there is
+    the denial JSON, which lets the model see both the attempted invocation and
+    that the user refused it. Pending calls and legacy rows persisted before
+    `result` was captured have no payload and fall back to text-only replay.
+
+    The emitted `tool_name` is the prefixed MCP identifier (what the LLM sees
+    on the current turn's tool registration) — we prefer `mcp_tool_name` and
+    fall back to the split `tool_name` for legacy rows that predate this field.
+    """
+    if not tool_calls:
+        return []
+    replayable: list[MessageToolCall] = []
+    for tc in tool_calls:
+        if tc.tool_call_id is None or tc.tool_call_id == "":
+            continue
+        if tc.result is None:
+            continue
+        replayable.append(
+            MessageToolCall(
+                tool_call_id=tc.tool_call_id,
+                tool_name=tc.mcp_tool_name or tc.tool_name,
+                arguments=tc.arguments,
+                result=tc.result,
+            )
+        )
+    return replayable
+
+
+def _tool_calls_token_count(tool_calls: list[MessageToolCall], model_name: str) -> int:
+    """Count tokens contributed by replayed tool_use + tool_result blocks."""
+    total = 0
+    for tc in tool_calls:
+        arguments_json = json.dumps(tc.arguments) if tc.arguments is not None else ""
+        total += count_tokens(tc.tool_name, model_name)
+        total += count_tokens(arguments_json, model_name)
+        total += count_tokens(tc.result, model_name)
+    return total
+
 
 MIN_PERCENTAGE_KNOWLEDGE = (
     0.8  # Strive towards a minimum of 80% of the context as knowledge
@@ -381,9 +429,12 @@ class ContextBuilder:
             generated_images = self._get_files_by_type(
                 message.generated_files, FileType.IMAGE
             )
+            tool_calls = _replayable_tool_calls(message.tool_calls)
 
-            message_tokens = count_tokens(question, model_name) + count_tokens(
-                answer, model_name
+            message_tokens = (
+                count_tokens(question, model_name)
+                + count_tokens(answer, model_name)
+                + _tool_calls_token_count(tool_calls, model_name)
             )
 
             if len(messages) > min_len and total_tokens + message_tokens > max_tokens:
@@ -396,6 +447,7 @@ class ContextBuilder:
                     answer=answer,
                     images=images,
                     generated_images=generated_images,
+                    tool_calls=tool_calls,
                 ),
             )
 

--- a/backend/src/intric/questions/question.py
+++ b/backend/src/intric/questions/question.py
@@ -71,6 +71,15 @@ class ToolCallInfo(BaseModel):
     )
     # Additive execution status for newer clients. Keep `approved` for compatibility.
     result_status: Optional[str] = None
+    # Text extraction of the tool result. Required to replay tool use to the LLM
+    # on later turns. Absent on rows persisted before this field was introduced;
+    # such rows fall back to text-only replay (the model won't see the tool use).
+    result: Optional[str] = None
+    # The prefixed tool identifier the LLM sees when calling (e.g.
+    # `server__tool`). Needed for replay so the tool_use name matches the
+    # currently-registered tools. `tool_name` above is the unprefixed/display
+    # form used by the UI.
+    mcp_tool_name: Optional[str] = None
 
 
 class QuestionAdd(QuestionBase):

--- a/backend/tests/unittests/ai_models/test_context_builder.py
+++ b/backend/tests/unittests/ai_models/test_context_builder.py
@@ -5,7 +5,10 @@ from uuid import uuid4
 
 import pytest
 
-from intric.ai_models.completion_models.completion_model import Message
+from intric.ai_models.completion_models.completion_model import (
+    Message,
+    MessageToolCall,
+)
 from intric.completion_models.infrastructure.context_builder import (
     ContextBuilder,
     count_tokens,
@@ -16,6 +19,7 @@ from intric.completion_models.infrastructure.static_prompts import (
 )
 from intric.files.file_models import File, FileType
 from intric.main.exceptions import QueryException
+from intric.questions.question import ToolCallInfo
 
 QUESTION = "I have a question"
 
@@ -122,11 +126,13 @@ def test_context_with_messages(context_builder: ContextBuilder):
                 question="Question 1",
                 answer="Answer 1",
                 files=[],
+                tool_calls=None,
             ),
             MagicMock(
                 question="Question 2 with file",
                 answer="Answer 2",
                 files=[file],
+                tool_calls=None,
             ),
         ]
     )
@@ -185,11 +191,13 @@ def test_context_with_messages_and_images(context_builder: ContextBuilder):
                 question="Question 1",
                 answer="Answer 1",
                 files=[],
+                tool_calls=None,
             ),
             MagicMock(
                 question="Question 2 with image",
                 answer="Answer 2",
                 files=[image],
+                tool_calls=None,
             ),
         ]
     )
@@ -221,6 +229,229 @@ def test_get_error_on_too_long_question_and_prompt(context_builder: ContextBuild
         context_builder.build_context(
             input_str=input_str, prompt=prompt_str, max_tokens=7
         )
+
+
+def _question_mock(question: str, answer: str, tool_calls=None) -> MagicMock:
+    return MagicMock(
+        question=question,
+        answer=answer,
+        files=[],
+        generated_files=[],
+        tool_calls=tool_calls,
+    )
+
+
+def test_context_replays_tool_calls_with_result(context_builder: ContextBuilder):
+    tool_call = ToolCallInfo(
+        server_name="Time",
+        tool_name="get_current_time",
+        arguments={"timezone": "Europe/Stockholm"},
+        tool_call_id="call_1",
+        approved=True,
+        result_status="succeeded",
+        result="13:28",
+        mcp_tool_name="time__get_current_time",
+    )
+    session = MagicMock(
+        questions=[_question_mock("What time?", "13:28 in Sundsvall.", [tool_call])]
+    )
+
+    context = context_builder.build_context(
+        input_str=QUESTION, session=session, max_tokens=10000
+    )
+
+    assert len(context.messages) == 1
+    # The replayed tool_name must be the LLM-visible prefixed form — it has to
+    # match the currently-registered tools. The split/display `tool_name`
+    # (`get_current_time`) stays in ToolCallInfo for UI rendering only.
+    assert context.messages[0].tool_calls == [
+        MessageToolCall(
+            tool_call_id="call_1",
+            tool_name="time__get_current_time",
+            arguments={"timezone": "Europe/Stockholm"},
+            result="13:28",
+        )
+    ]
+
+
+def test_tool_call_falls_back_to_split_name_for_legacy_rows(
+    context_builder: ContextBuilder,
+):
+    # Rows persisted before mcp_tool_name existed still have `tool_name` (the
+    # split form). We fall back so they remain replayable, even if the name
+    # won't perfectly match the currently-registered tools.
+    legacy = ToolCallInfo(
+        server_name="Time",
+        tool_name="get_current_time",
+        arguments=None,
+        tool_call_id="call_legacy",
+        approved=True,
+        result="13:28",
+        mcp_tool_name=None,
+    )
+    session = MagicMock(questions=[_question_mock("What time?", "13:28.", [legacy])])
+
+    context = context_builder.build_context(
+        input_str=QUESTION, session=session, max_tokens=10000
+    )
+
+    assert context.messages[0].tool_calls[0].tool_name == "get_current_time"
+
+
+def test_legacy_tool_call_without_result_falls_back_to_text(
+    context_builder: ContextBuilder,
+):
+    # Rows persisted before the `result` field existed have no result.
+    legacy = ToolCallInfo(
+        server_name="time",
+        tool_name="get_current_time",
+        arguments={"timezone": "Europe/Stockholm"},
+        tool_call_id="call_legacy",
+        approved=True,
+        result_status="succeeded",
+        result=None,
+    )
+    session = MagicMock(questions=[_question_mock("What time?", "13:28.", [legacy])])
+
+    context = context_builder.build_context(
+        input_str=QUESTION, session=session, max_tokens=10000
+    )
+
+    assert context.messages[0].tool_calls == []
+
+
+def test_denied_tool_call_is_replayed_with_denial_payload(
+    context_builder: ContextBuilder,
+):
+    # Denied calls must still be replayed so the model knows it attempted a
+    # tool call and the user refused — otherwise it confabulates about what
+    # happened on the next turn.
+    denied = ToolCallInfo(
+        server_name="shell",
+        tool_name="rm",
+        arguments={"path": "/"},
+        tool_call_id="call_denied",
+        approved=False,
+        result_status="denied",
+        result='{"denied": true, "user_reason": "no"}',
+    )
+    session = MagicMock(questions=[_question_mock("Delete root", "Refused.", [denied])])
+
+    context = context_builder.build_context(
+        input_str=QUESTION, session=session, max_tokens=10000
+    )
+
+    assert context.messages[0].tool_calls == [
+        MessageToolCall(
+            tool_call_id="call_denied",
+            tool_name="rm",
+            arguments={"path": "/"},
+            result='{"denied": true, "user_reason": "no"}',
+        )
+    ]
+
+
+def test_pending_tool_call_without_result_is_not_replayed(
+    context_builder: ContextBuilder,
+):
+    # Pending-approval rows reach the DB with result=None. Nothing to replay.
+    pending = ToolCallInfo(
+        server_name="time",
+        tool_name="get_current_time",
+        arguments={"tz": "Europe/Stockholm"},
+        tool_call_id="call_pending",
+        approved=None,
+        result_status=None,
+        result=None,
+    )
+    session = MagicMock(questions=[_question_mock("Tid?", "", [pending])])
+
+    context = context_builder.build_context(
+        input_str=QUESTION, session=session, max_tokens=10000
+    )
+
+    assert context.messages[0].tool_calls == []
+
+
+def test_tool_call_without_id_is_not_replayed(context_builder: ContextBuilder):
+    # Pairing tool_use/tool_result requires a stable id; drop if missing.
+    tc = ToolCallInfo(
+        server_name="time",
+        tool_name="get_current_time",
+        arguments=None,
+        tool_call_id=None,
+        approved=True,
+        result_status="succeeded",
+        result="13:28",
+    )
+    session = MagicMock(questions=[_question_mock("What time?", "13:28.", [tc])])
+
+    context = context_builder.build_context(
+        input_str=QUESTION, session=session, max_tokens=10000
+    )
+
+    assert context.messages[0].tool_calls == []
+
+
+def test_parallel_tool_calls_in_one_turn(context_builder: ContextBuilder):
+    tc1 = ToolCallInfo(
+        server_name="time",
+        tool_name="get_current_time",
+        arguments={"tz": "Europe/Stockholm"},
+        tool_call_id="call_a",
+        approved=True,
+        result="13:28",
+    )
+    tc2 = ToolCallInfo(
+        server_name="weather",
+        tool_name="get_weather",
+        arguments={"city": "Sundsvall"},
+        tool_call_id="call_b",
+        approved=True,
+        result="4°C, clear",
+    )
+    session = MagicMock(
+        questions=[_question_mock("Time and weather?", "13:28, 4°C clear.", [tc1, tc2])]
+    )
+
+    context = context_builder.build_context(
+        input_str=QUESTION, session=session, max_tokens=10000
+    )
+
+    assert [tc.tool_call_id for tc in context.messages[0].tool_calls] == [
+        "call_a",
+        "call_b",
+    ]
+
+
+def test_tool_result_tokens_reported_in_history_token_count(
+    context_builder: ContextBuilder,
+):
+    # A tool result contributes to the history token budget. The test compares
+    # `_build_messages` output with and without a tool result on the newest turn
+    # — same max_tokens, same everything else — and asserts the tool-result
+    # variant reports more tokens used.
+    tc_with_result = ToolCallInfo(
+        server_name="s",
+        tool_name="t",
+        arguments=None,
+        tool_call_id="call_big",
+        approved=True,
+        result="x " * 500,
+    )
+    turn_with = _question_mock("Q", "A", tool_calls=[tc_with_result])
+    turn_without = _question_mock("Q", "A", tool_calls=None)
+
+    _, tokens_without = context_builder._build_messages(
+        session=MagicMock(questions=[turn_without]),
+        max_tokens=10000,
+    )
+    _, tokens_with = context_builder._build_messages(
+        session=MagicMock(questions=[turn_with]),
+        max_tokens=10000,
+    )
+
+    assert tokens_with > tokens_without
 
 
 def test_truncate_knowledge_if_too_many_chunks(context_builder: ContextBuilder):

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -14957,6 +14957,10 @@ export interface components {
       approved?: boolean | null;
       /** Result Status */
       result_status?: string | null;
+      /** Result */
+      result?: string | null;
+      /** Mcp Tool Name */
+      mcp_tool_name?: string | null;
     };
     /**
      * ToolChangePublic
@@ -21302,6 +21306,10 @@ export interface operations {
                     approved?: boolean | null;
                     /** Result Status */
                     result_status?: string | null;
+                    /** Result */
+                    result?: string | null;
+                    /** Mcp Tool Name */
+                    mcp_tool_name?: string | null;
                   };
                 };
               }
@@ -21347,6 +21355,10 @@ export interface operations {
                     approved?: boolean | null;
                     /** Result Status */
                     result_status?: string | null;
+                    /** Result */
+                    result?: string | null;
+                    /** Mcp Tool Name */
+                    mcp_tool_name?: string | null;
                   };
                 };
               }
@@ -21392,6 +21404,10 @@ export interface operations {
                     approved?: boolean | null;
                     /** Result Status */
                     result_status?: string | null;
+                    /** Result */
+                    result?: string | null;
+                    /** Mcp Tool Name */
+                    mcp_tool_name?: string | null;
                   };
                 };
               }


### PR DESCRIPTION
## Changes
- Persist tool result text alongside the call (schemaless on JSONB)
- Capture the LLM-visible prefixed tool name so replayed identifiers
    match currently-registered tools
- Emit OpenAI-style tool_calls + role:tool messages from replay
- Include denied/timeout calls with their denial payload so the model
    sees both the attempt and the refusal
- Count tool content toward the history token budget
- Legacy rows fall back to text-only replay

## Why
Tool invocations were persisted for UI display but stripped from the  context builder, so on the next turn the model saw only plain text and  would confabulate about its prior tool use.
