### PR TITLE
chore: ignore Codex configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ specs/
 .speckit/
 .playwright-mcp/
 
+# OpenAI Codex configuration
+.codex
+AGENTS.md
+
 # ── GSD baseline (auto-generated) ──
 .gsd
 .gsd-id


### PR DESCRIPTION
## Summary
- Add OpenAI Codex local configuration files to `.gitignore`
- Ignore `.codex` and `AGENTS.md` so Codex-related files do not enter project source by accident

## Testing
- Not run; gitignore-only change.