### PR TITLE
feat(api-keys): default to active and share state filter component

### DIFF
--- a/frontend/apps/web/src/lib/features/api-keys/ApiKeyStateFilter.svelte
+++ b/frontend/apps/web/src/lib/features/api-keys/ApiKeyStateFilter.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { m } from "$lib/paraglide/messages";
+  import {
+    getStateStyle,
+    type ApiKeyStateFilterValue
+  } from "$lib/features/api-keys/apiKeyTableUtils";
+
+  let {
+    value = $bindable<ApiKeyStateFilterValue>(""),
+    class: className = "",
+    onChange
+  }: {
+    value?: ApiKeyStateFilterValue;
+    class?: string;
+    onChange?: (next: ApiKeyStateFilterValue) => void;
+  } = $props();
+
+  const options = $derived<{ value: ApiKeyStateFilterValue; label: string }[]>([
+    { value: "", label: m.api_keys_admin_state_all() },
+    { value: "active", label: m.api_keys_admin_state_active() },
+    { value: "suspended", label: m.api_keys_admin_state_suspended() },
+    { value: "expired", label: m.api_keys_admin_state_expired() },
+    { value: "revoked", label: m.api_keys_admin_state_revoked() }
+  ]);
+
+  function select(next: ApiKeyStateFilterValue) {
+    if (value === next) return;
+    value = next;
+    onChange?.(next);
+  }
+</script>
+
+<div
+  role="group"
+  aria-label={m.api_keys_admin_label_state()}
+  class="flex flex-wrap gap-2 {className}"
+>
+  {#each options as option (option.value)}
+    {@const isActive = value === option.value}
+    <button
+      type="button"
+      onclick={() => select(option.value)}
+      aria-pressed={isActive}
+      class="inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-all
+             {isActive
+        ? 'border-accent-default bg-accent-default/10 text-accent-default ring-accent-default/20 ring-2'
+        : 'border-default bg-primary text-muted hover:border-dimmer hover:text-default'}"
+    >
+      {#if option.value}
+        <span
+          class="h-2 w-2 rounded-full {getStateStyle(option.value).dotClasses}"
+          aria-hidden="true"
+        ></span>
+      {/if}
+      {option.label}
+    </button>
+  {/each}
+</div>

--- a/frontend/apps/web/src/lib/features/api-keys/apiKeyTableUtils.ts
+++ b/frontend/apps/web/src/lib/features/api-keys/apiKeyTableUtils.ts
@@ -1,4 +1,4 @@
-import type { ApiKeyV2 } from "@intric/intric-js";
+import type { ApiKeyState, ApiKeyV2 } from "@intric/intric-js";
 import { m } from "$lib/paraglide/messages";
 import { getLocale } from "$lib/paraglide/runtime";
 import {
@@ -52,6 +52,9 @@ export type ApiKeyUsageResponse = {
   limit?: number;
   next_cursor?: string | null;
 };
+
+// "" represents "All states" in filter UIs
+export type ApiKeyStateFilterValue = ApiKeyState | "";
 
 // ---------------------------------------------------------------------------
 // Status / state helpers

--- a/frontend/apps/web/src/routes/(app)/account/api-keys/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/account/api-keys/+page.svelte
@@ -12,6 +12,8 @@
   import { Key, AlertCircle, RefreshCw, Search, X, ShieldAlert } from "lucide-svelte";
   import ExpiringKeysBanner from "$lib/features/api-keys/ExpiringKeysBanner.svelte";
   import NotificationPreferences from "$lib/features/api-keys/NotificationPreferences.svelte";
+  import ApiKeyStateFilter from "$lib/features/api-keys/ApiKeyStateFilter.svelte";
+  import type { ApiKeyStateFilterValue } from "$lib/features/api-keys/apiKeyTableUtils";
   import type { ExpiringKeyDisplayItem } from "$lib/features/api-keys/expirationUtils";
   import { getExpiringKeysStore } from "$lib/features/api-keys/expiringKeysStore";
   import { Button } from "$lib/components/ui/button/index.js";
@@ -31,6 +33,7 @@
   let loading = $state(true);
   let errorMessage = $state<string | null>(null);
   let searchQuery = $state("");
+  let stateFilter = $state<ApiKeyStateFilterValue>("active");
   let secretDialogOpen = $state(false);
   let latestSecret = $state<string | null>(null);
   let secretSource = $state<"created" | "rotated">("created");
@@ -63,7 +66,10 @@
     loading = true;
     errorMessage = null;
     try {
-      const response = await intric.apiKeys.list({ limit: 100 });
+      const response = await intric.apiKeys.list({
+        limit: 100,
+        state: stateFilter || null
+      });
       keys = response.items ?? [];
       nextCursor = response.next_cursor ?? null;
     } catch (error: unknown) {
@@ -78,7 +84,11 @@
     if (!nextCursor || loadingMore) return;
     loadingMore = true;
     try {
-      const response = await intric.apiKeys.list({ limit: 100, cursor: nextCursor });
+      const response = await intric.apiKeys.list({
+        limit: 100,
+        cursor: nextCursor,
+        state: stateFilter || null
+      });
       keys = [...keys, ...(response.items ?? [])];
       nextCursor = response.next_cursor ?? null;
     } catch (error: unknown) {
@@ -309,6 +319,11 @@
                 <CreateApiKeyDialog onCreated={handleCreated} />
               </div>
             </div>
+            <ApiKeyStateFilter
+              bind:value={stateFilter}
+              onChange={() => void loadKeys()}
+              class="mt-3"
+            />
           </div>
 
           <div class="p-4">

--- a/frontend/apps/web/src/routes/(app)/admin/api-keys/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/api-keys/+page.svelte
@@ -19,6 +19,8 @@
   import SuperKeyStatusPanel from "./SuperKeyStatusPanel.svelte";
   import ScopeResourceSelector from "$lib/features/api-keys/ScopeResourceSelector.svelte";
   import ApiKeySecretDialog from "$lib/features/api-keys/ApiKeySecretDialog.svelte";
+  import ApiKeyStateFilter from "$lib/features/api-keys/ApiKeyStateFilter.svelte";
+  import type { ApiKeyStateFilterValue } from "$lib/features/api-keys/apiKeyTableUtils";
   import {
     Filter,
     X,
@@ -52,7 +54,7 @@
 
   // Filter states
   let scopeType = $state("");
-  let stateFilter = $state("");
+  let stateFilter = $state<ApiKeyStateFilterValue>("active");
   let keyType = $state("");
   let scopeId = $state<string | null>(null);
   let createdByUserId = $state("");
@@ -92,30 +94,10 @@
   let notificationPolicyDaysInput = $state("30");
   let notificationPolicyMaxDaysInput = $state("365");
 
-  // Quick filter chips
+  // Quick filter chips — state lives in <ApiKeyStateFilter>; key class stays here
   const quickFilters = $derived([
-    {
-      label: m.api_keys_admin_quick_active(),
-      filter: { state: "active" },
-      color: "green" as const
-    },
-    {
-      label: m.api_keys_admin_quick_suspended(),
-      filter: { state: "suspended" },
-      color: "yellow" as const
-    },
-    {
-      label: m.api_keys_admin_quick_expired(),
-      filter: { state: "expired" },
-      color: "gray" as const
-    },
-    {
-      label: m.api_keys_admin_quick_revoked(),
-      filter: { state: "revoked" },
-      color: "red" as const
-    },
-    { label: m.api_keys_admin_quick_secret(), filter: { keyType: "sk_" }, color: "blue" as const },
-    { label: m.api_keys_admin_quick_public(), filter: { keyType: "pk_" }, color: "orange" as const }
+    { label: m.api_keys_admin_quick_secret(), filter: { keyType: "sk_" } },
+    { label: m.api_keys_admin_quick_public(), filter: { keyType: "pk_" } }
   ]);
 
   const scopeOptions = $derived([
@@ -124,14 +106,6 @@
     { value: "space", label: m.api_keys_admin_scope_space() },
     { value: "assistant", label: m.api_keys_admin_scope_assistant() },
     { value: "app", label: m.api_keys_admin_scope_app() }
-  ]);
-
-  const stateOptions = $derived([
-    { value: "", label: m.api_keys_admin_state_all() },
-    { value: "active", label: m.api_keys_admin_state_active() },
-    { value: "suspended", label: m.api_keys_admin_state_suspended() },
-    { value: "revoked", label: m.api_keys_admin_state_revoked() },
-    { value: "expired", label: m.api_keys_admin_state_expired() }
   ]);
 
   const keyTypeOptions = $derived([
@@ -470,7 +444,7 @@
 
   function resetFilters() {
     scopeType = "";
-    stateFilter = "";
+    stateFilter = "active";
     keyType = "";
     scopeId = null;
     expiresWithinDays = "";
@@ -483,20 +457,13 @@
     void loadKeys({ reset: true });
   }
 
-  function applyQuickFilter(filter: { state?: string; keyType?: string }) {
-    if (filter.state) {
-      stateFilter = stateFilter === filter.state ? "" : filter.state;
-    }
-    if (filter.keyType) {
-      keyType = keyType === filter.keyType ? "" : filter.keyType;
-    }
+  function applyQuickFilter(filter: { keyType: string }) {
+    keyType = keyType === filter.keyType ? "" : filter.keyType;
     void loadKeys({ reset: true });
   }
 
-  function isQuickFilterActive(filter: { state?: string; keyType?: string }): boolean {
-    if (filter.state) return stateFilter === filter.state;
-    if (filter.keyType) return keyType === filter.keyType;
-    return false;
+  function isQuickFilterActive(filter: { keyType: string }): boolean {
+    return keyType === filter.keyType;
   }
 
   function handleSecret(
@@ -942,18 +909,8 @@
                   >
                     {#if qf.filter.keyType === "sk_"}
                       <Lock class="h-3 w-3" />
-                    {:else if qf.filter.keyType === "pk_"}
-                      <Globe class="h-3 w-3" />
                     {:else}
-                      <span
-                        class="h-2 w-2 rounded-full
-                             {qf.color === 'green' ? 'bg-positive-default' : ''}
-                             {qf.color === 'yellow' ? 'bg-warning-default' : ''}
-                             {qf.color === 'gray' ? 'bg-tertiary' : ''}
-                             {qf.color === 'red' ? 'bg-negative-default' : ''}
-                             {qf.color === 'blue' ? 'bg-accent-default' : ''}
-                             {qf.color === 'orange' ? 'bg-warning-default' : ''}"
-                      ></span>
+                      <Globe class="h-3 w-3" />
                     {/if}
                     {qf.label}
                     {#if isActive}
@@ -997,19 +954,9 @@
                 />
 
                 <!-- Row 2: lifecycle state + key class -->
-                <Field.Field>
-                  <Field.Label for="filter-state">{m.api_keys_admin_label_state()}</Field.Label>
-                  <Select.Root type="single" bind:value={stateFilter}>
-                    <Select.Trigger id="filter-state">
-                      {stateOptions.find((o) => o.value === stateFilter)?.label ??
-                        m.api_keys_admin_state_all()}
-                    </Select.Trigger>
-                    <Select.Content>
-                      {#each stateOptions as opt (opt.value)}
-                        <Select.Item value={opt.value} label={opt.label}>{opt.label}</Select.Item>
-                      {/each}
-                    </Select.Content>
-                  </Select.Root>
+                <Field.Field class="md:col-span-2">
+                  <Field.Label>{m.api_keys_admin_label_state()}</Field.Label>
+                  <ApiKeyStateFilter bind:value={stateFilter} />
                 </Field.Field>
                 <Field.Field>
                   <Field.Label for="filter-key-type">


### PR DESCRIPTION
## Summary
- Default the API key state filter to **Active** on both the user (\`/account/api-keys\`) and admin (\`/admin/api-keys\`) lists, so revoked/expired keys no longer dominate the first view.
- Add the user list's first state filter — previously only the admin page could filter by state.
- Extract the filter into a shared \`ApiKeyStateFilter\` chip-toggle component so both pages use the same UI and state semantics.
- Drop the redundant state quick-filter chips and the \`<Select>\` state field from the admin page (the new component replaces them); the \`pk_\`/\`sk_\` quick filters stay.

The filter sends \`state\` server-side via \`intric.apiKeys.list\` / \`apiKeys.admin.list\` (the param already existed in the SDK), so pagination and total counts stay correct.

## Test plan
- [ ] \`/account/api-keys\`: only active keys are shown by default; switching to "All" / "Revoked" / "Expired" reloads the list with the right server-side filter.
- [ ] \`/admin/api-keys\`: same default + chips, plus the \`Active filter count\` badge increments when a non-default state is picked.
- [ ] Reset filters returns the admin page to "Active" (not "All").
- [ ] Status dot color of each chip matches the table's \`ApiKeyStateBadge\` for the same state.
- [ ] Pagination (Load more) keeps the active state filter on subsequent pages.