### PR TITLE
feat(api-keys): gate v2 key creation on session + Permission.API_KEYS

### DIFF
--- a/backend/alembic/versions/202604281200_grant_api_keys_permission_to_owner.py
+++ b/backend/alembic/versions/202604281200_grant_api_keys_permission_to_owner.py
@@ -1,0 +1,46 @@
+"""Grant api_keys permission to existing Owner roles.
+
+Revision ID: 202604281200
+Revises: 202604231400
+Create Date: 2026-04-28
+
+Backfills the new ``Permission.API_KEYS`` bit onto every tenant's Owner role
+so existing tenants don't lose API-key creation when the new gate at
+``POST /api-keys`` lands. The YAML template at
+``backend/src/intric/server/dependencies/predefined_roles.yml`` already
+includes ``api_keys`` for new tenants — this migration covers the existing
+ones.
+
+Targets ``predefined_source = 'Owner'`` only. AI Configurator, User, and
+custom roles are intentionally untouched: tenant admins explicitly grant
+``api_keys`` to roles they want to delegate to.
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "202604281200"
+down_revision = "202604231400"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE roles
+        SET permissions = array_append(permissions, 'api_keys')
+        WHERE predefined_source = 'Owner'
+          AND NOT ('api_keys' = ANY(permissions));
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE roles
+        SET permissions = array_remove(permissions, 'api_keys')
+        WHERE predefined_source = 'Owner';
+        """
+    )

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -115,6 +115,7 @@ def add_tenant_user(
                 "websites",
                 "integrations",
                 "shared_spaces",
+                "api_keys",
             ]
             add_role_query = sql.SQL(
                 "INSERT INTO roles (name, permissions, tenant_id, predefined_source) "

--- a/backend/src/intric/authentication/api_key_router.py
+++ b/backend/src/intric/authentication/api_key_router.py
@@ -29,7 +29,11 @@ from intric.authentication.api_key_router_helpers import (
     raise_api_key_http_error,
 )
 from intric.authentication.api_key_v2_repo import ApiKeysV2Repository
-from intric.authentication.auth_dependencies import require_api_key_permission
+from intric.authentication.auth_dependencies import (
+    require_api_key_permission,
+    require_permission,
+    require_session_auth,
+)
 from intric.authentication.auth_models import (
     ApiKeyCreatedResponse,
     ApiKeyCreateRequest,
@@ -894,7 +898,13 @@ async def create_api_key(
     http_request: Request,
     payload: Annotated[ApiKeyCreateRequest, Body(examples=[_CREATE_API_KEY_EXAMPLE])],
     container: Annotated[Container, Depends(get_container(with_user=True))],
-    _guard: None = Depends(require_api_key_permission(ApiKeyPermission.ADMIN)),
+    _session_guard: None = Depends(require_session_auth),
+    _perm_guard: None = Depends(require_permission(Permission.API_KEYS)),
+    # Defense-in-depth: require_session_auth rejects API-key callers first, so
+    # this never fires for legitimate traffic. Kept so the route-coverage gate
+    # (tests/unit/test_api_key_route_coverage.py) stays green and so a future
+    # regression of the session guard cannot silently re-open the path.
+    _api_key_guard: None = Depends(require_api_key_permission(ApiKeyPermission.ADMIN)),
 ) -> ApiKeyCreatedResponse:
     lifecycle = container.api_key_lifecycle_service()
     ip_address, request_id, user_agent = extract_audit_context(http_request)

--- a/backend/src/intric/authentication/auth_dependencies.py
+++ b/backend/src/intric/authentication/auth_dependencies.py
@@ -154,6 +154,23 @@ def require_api_key_permission(
     return _api_key_permission_dep
 
 
+async def require_session_auth(
+    _: Annotated[UserInDB, Depends(get_current_active_user)],
+    request: Request,
+) -> None:
+    """Reject API-key-authenticated callers; require a session token.
+
+    Depends on ``get_current_active_user`` so authentication has run and
+    populated ``request.state.api_key`` (when applicable) by the time we
+    inspect it.
+    """
+    if getattr(request.state, "api_key", None) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This endpoint requires a session token.",
+        )
+
+
 ASSISTANTS_READ_OVERRIDES: frozenset[str] = frozenset(
     {
         "ask_assistant",

--- a/backend/src/intric/roles/permissions.py
+++ b/backend/src/intric/roles/permissions.py
@@ -26,6 +26,7 @@ class Permission(str, Enum):
     WEBSITES = "websites"
     INTEGRATIONS = "integrations"
     SHARED_SPACES = "shared_spaces"
+    API_KEYS = "api_keys"
 
 
 def validate_permissions(permission: Permission) -> Callable[[_F], _F]:

--- a/backend/src/intric/roles/permissions_mapper.py
+++ b/backend/src/intric/roles/permissions_mapper.py
@@ -15,4 +15,5 @@ PERMISSIONS_WITH_DESCRIPTION = {
     Permission.AI: "More in-depth AI configuration.",
     Permission.ADMIN: "Organization owner. Management of Users, Roles, and Groups.",
     Permission.SHARED_SPACES: "Create shared Spaces. Viewing, editing, and deleting shared Spaces are governed by space membership.",
+    Permission.API_KEYS: "Create API keys. Required for minting tenant, space, assistant, and app-scoped keys via the dashboard.",
 }

--- a/backend/src/intric/server/dependencies/predefined_roles.yml
+++ b/backend/src/intric/server/dependencies/predefined_roles.yml
@@ -32,3 +32,4 @@ roles:
       - websites
       - integrations
       - shared_spaces
+      - api_keys

--- a/backend/tests/integration/migrations/test_grant_api_keys_permission_round_trip.py
+++ b/backend/tests/integration/migrations/test_grant_api_keys_permission_round_trip.py
@@ -1,0 +1,244 @@
+"""Round-trip test for the grant_api_keys_permission_to_owner migration.
+
+Verifies that ``202604281200_grant_api_keys_permission_to_owner`` upgrades
+and downgrades cleanly, and that the permission diff is scoped exactly to
+roles whose ``predefined_source = 'Owner'``.
+
+Run alongside other migration round-trips:
+    pytest -m migration_isolation \
+        tests/integration/migrations/test_grant_api_keys_permission_round_trip.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from uuid import uuid4
+
+import psycopg2
+import pytest
+
+from alembic import command
+from alembic.config import Config
+
+pytestmark = [pytest.mark.integration, pytest.mark.migration_isolation]
+
+PRE_REVISION = "202604231400"
+GRANT_REVISION = "202604281200"
+
+
+def _alembic_cfg(database_url: str) -> Config:
+    backend_dir = Path(__file__).parent.parent.parent.parent
+    cfg = Config(str(backend_dir / "alembic.ini"))
+    cfg.set_main_option("sqlalchemy.url", database_url)
+    return cfg
+
+
+@pytest.fixture(autouse=True)
+def cleanup_database():
+    """Override shared cleanup_database so schema revisions persist across
+    downgrade/upgrade cycles within this module.
+    """
+    yield
+
+
+@pytest.fixture(autouse=True)
+def seed_default_models():
+    """Override shared seed_default_models — this module seeds its own data."""
+    yield
+
+
+@pytest.fixture
+def round_trip_db(test_settings):
+    cfg = _alembic_cfg(test_settings.sync_database_url)
+    conn = psycopg2.connect(
+        host=test_settings.postgres_host,
+        port=test_settings.postgres_port,
+        dbname=test_settings.postgres_db,
+        user=test_settings.postgres_user,
+        password=test_settings.postgres_password,
+    )
+    conn.autocommit = True
+
+    command.upgrade(cfg, GRANT_REVISION)
+
+    try:
+        yield {"conn": conn, "cfg": cfg}
+    finally:
+        conn.close()
+
+
+def _insert_tenant(conn, suffix: str) -> str:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO tenants (id, name, quota_limit, state)
+            VALUES (gen_random_uuid(), %s, 1000000, 'active')
+            RETURNING id
+            """,
+            (f"round-trip-{suffix}-{uuid4().hex[:8]}",),
+        )
+        return cur.fetchone()[0]
+
+
+def _insert_role(
+    conn,
+    *,
+    tenant_id: str,
+    name: str,
+    predefined_source: str | None,
+    permissions: list[str],
+) -> str:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO roles (
+                id, name, permissions, tenant_id, predefined_source,
+                created_at, updated_at
+            )
+            VALUES (gen_random_uuid(), %s, %s, %s, %s, now(), now())
+            RETURNING id
+            """,
+            (name, permissions, tenant_id, predefined_source),
+        )
+        return cur.fetchone()[0]
+
+
+def _get_permissions(conn, role_id: str) -> list[str]:
+    with conn.cursor() as cur:
+        cur.execute("SELECT permissions FROM roles WHERE id = %s", (role_id,))
+        row = cur.fetchone()
+        return list(row[0]) if row else []
+
+
+def _get_current_revision(conn) -> str | None:
+    with conn.cursor() as cur:
+        cur.execute("SELECT version_num FROM alembic_version")
+        row = cur.fetchone()
+        return row[0] if row else None
+
+
+class TestGrantApiKeysRoundTrip:
+    def test_upgrade_grants_only_owner_roles(self, round_trip_db):
+        """Upgrade adds api_keys to Owner roles and leaves siblings alone."""
+        conn = round_trip_db["conn"]
+        cfg = round_trip_db["cfg"]
+
+        command.downgrade(cfg, PRE_REVISION)
+
+        tenant_id = _insert_tenant(conn, "upgrade-grant")
+        owner_id = _insert_role(
+            conn,
+            tenant_id=tenant_id,
+            name="Owner",
+            predefined_source="Owner",
+            permissions=["admin", "shared_spaces"],
+        )
+        ai_id = _insert_role(
+            conn,
+            tenant_id=tenant_id,
+            name="AI Configurator",
+            predefined_source="AI Configurator",
+            permissions=["assistants"],
+        )
+        user_id = _insert_role(
+            conn,
+            tenant_id=tenant_id,
+            name="User",
+            predefined_source="User",
+            permissions=["assistants"],
+        )
+        custom_id = _insert_role(
+            conn,
+            tenant_id=tenant_id,
+            name="Custom",
+            predefined_source=None,
+            permissions=["assistants"],
+        )
+
+        command.upgrade(cfg, GRANT_REVISION)
+
+        assert _get_current_revision(conn) == GRANT_REVISION
+        assert "api_keys" in _get_permissions(conn, owner_id)
+        assert "api_keys" not in _get_permissions(conn, ai_id)
+        assert "api_keys" not in _get_permissions(conn, user_id)
+        assert "api_keys" not in _get_permissions(conn, custom_id)
+
+    def test_upgrade_is_idempotent(self, round_trip_db):
+        """Re-running upgrade against an already-granted Owner role is a no-op."""
+        conn = round_trip_db["conn"]
+        cfg = round_trip_db["cfg"]
+
+        command.downgrade(cfg, PRE_REVISION)
+
+        tenant_id = _insert_tenant(conn, "upgrade-idempotent")
+        owner_id = _insert_role(
+            conn,
+            tenant_id=tenant_id,
+            name="Owner",
+            predefined_source="Owner",
+            permissions=["admin", "api_keys"],
+        )
+
+        command.upgrade(cfg, GRANT_REVISION)
+
+        permissions = _get_permissions(conn, owner_id)
+        assert permissions.count("api_keys") == 1, permissions
+
+    def test_downgrade_removes_api_keys_only_from_owner(self, round_trip_db):
+        """Downgrade strips api_keys from Owner; siblings keep their values."""
+        conn = round_trip_db["conn"]
+        cfg = round_trip_db["cfg"]
+
+        tenant_id = _insert_tenant(conn, "downgrade-remove")
+        owner_id = _insert_role(
+            conn,
+            tenant_id=tenant_id,
+            name="Owner",
+            predefined_source="Owner",
+            permissions=["admin", "api_keys"],
+        )
+        ai_with_grant_id = _insert_role(
+            conn,
+            tenant_id=tenant_id,
+            name="AI Configurator",
+            predefined_source="AI Configurator",
+            permissions=["assistants", "api_keys"],
+        )
+        custom_with_grant_id = _insert_role(
+            conn,
+            tenant_id=tenant_id,
+            name="Custom",
+            predefined_source=None,
+            permissions=["api_keys"],
+        )
+
+        command.downgrade(cfg, PRE_REVISION)
+
+        assert _get_current_revision(conn) == PRE_REVISION
+        assert "api_keys" not in _get_permissions(conn, owner_id)
+        assert "api_keys" in _get_permissions(conn, ai_with_grant_id)
+        assert "api_keys" in _get_permissions(conn, custom_with_grant_id)
+
+    def test_round_trip_restores_grant_on_owner(self, round_trip_db):
+        """upgrade → downgrade → upgrade lands api_keys back on Owner roles."""
+        conn = round_trip_db["conn"]
+        cfg = round_trip_db["cfg"]
+
+        command.downgrade(cfg, PRE_REVISION)
+        tenant_id = _insert_tenant(conn, "round-trip")
+        owner_id = _insert_role(
+            conn,
+            tenant_id=tenant_id,
+            name="Owner",
+            predefined_source="Owner",
+            permissions=["admin"],
+        )
+
+        command.upgrade(cfg, GRANT_REVISION)
+        assert "api_keys" in _get_permissions(conn, owner_id)
+
+        command.downgrade(cfg, PRE_REVISION)
+        assert "api_keys" not in _get_permissions(conn, owner_id)
+
+        command.upgrade(cfg, GRANT_REVISION)
+        assert "api_keys" in _get_permissions(conn, owner_id)

--- a/backend/tests/integration/test_api_key_create_authorization.py
+++ b/backend/tests/integration/test_api_key_create_authorization.py
@@ -1,0 +1,128 @@
+"""Authorization tests for POST /api-keys.
+
+Verifies the session-only + ``Permission.API_KEYS`` gate that replaced
+the legacy ``ApiKeyPermission.ADMIN``-only guard. Two invariants:
+
+1. Session callers must hold ``Permission.API_KEYS`` to mint a key.
+2. API-key callers cannot mint keys at all — creation is UI-only.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from intric.users.user import UserAdd, UserState
+
+
+@pytest.fixture
+async def default_user(db_container):
+    async with db_container() as container:
+        user_repo = container.user_repo()
+        user = await user_repo.get_user_by_email("test@example.com")
+    return user
+
+
+@pytest.fixture
+async def default_user_token(db_container, patch_auth_service_jwt, default_user):
+    async with db_container() as container:
+        auth_service = container.auth_service()
+        token = auth_service.create_access_token_for_user(default_user)
+    return token
+
+
+@pytest.fixture
+async def user_without_api_keys_permission(db_container, default_user):
+    """User with no role assigned — has zero Permission bits."""
+    async with db_container() as container:
+        user_repo = container.user_repo()
+        user = await user_repo.add(
+            UserAdd(
+                email=f"no-api-keys-{uuid4().hex[:8]}@example.com",
+                username=f"no_api_keys_{uuid4().hex[:8]}",
+                state=UserState.ACTIVE,
+                tenant_id=default_user.tenant_id,
+            )
+        )
+    return user
+
+
+@pytest.fixture
+async def user_without_api_keys_token(
+    db_container, patch_auth_service_jwt, user_without_api_keys_permission
+):
+    async with db_container() as container:
+        auth_service = container.auth_service()
+        token = auth_service.create_access_token_for_user(
+            user_without_api_keys_permission
+        )
+    return token
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_owner_session_can_create_tenant_key(client, default_user_token):
+    """Owner role carries Permission.API_KEYS post-migration."""
+    response = await client.post(
+        "/api/v1/api-keys",
+        json={
+            "name": "Owner Key",
+            "key_type": "sk_",
+            "permission": "read",
+            "scope_type": "tenant",
+        },
+        headers={"Authorization": f"Bearer {default_user_token}"},
+    )
+    assert response.status_code == 201, response.text
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_user_without_api_keys_permission_cannot_create(
+    client, user_without_api_keys_token
+):
+    """Session call without Permission.API_KEYS → 403."""
+    response = await client.post(
+        "/api/v1/api-keys",
+        json={
+            "name": "Should Fail",
+            "key_type": "sk_",
+            "permission": "read",
+            "scope_type": "tenant",
+        },
+        headers={"Authorization": f"Bearer {user_without_api_keys_token}"},
+    )
+    assert response.status_code == 403, response.text
+    assert "api_keys" in response.json().get("detail", "").lower()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_api_key_caller_cannot_mint_new_key(client, default_user_token):
+    """An admin-level v2 API key cannot bootstrap another key — UI only."""
+    create_response = await client.post(
+        "/api/v1/api-keys",
+        json={
+            "name": "Bootstrap Admin",
+            "key_type": "sk_",
+            "permission": "admin",
+            "scope_type": "tenant",
+        },
+        headers={"Authorization": f"Bearer {default_user_token}"},
+    )
+    assert create_response.status_code == 201, create_response.text
+    secret = create_response.json()["secret"]
+
+    spawn_response = await client.post(
+        "/api/v1/api-keys",
+        json={
+            "name": "Spawned Key",
+            "key_type": "sk_",
+            "permission": "read",
+            "scope_type": "tenant",
+        },
+        headers={"X-API-Key": secret},
+    )
+    assert spawn_response.status_code == 403, spawn_response.text
+    assert "session token" in spawn_response.json().get("detail", "").lower()

--- a/backend/tests/integration/test_api_key_service_keys.py
+++ b/backend/tests/integration/test_api_key_service_keys.py
@@ -151,7 +151,13 @@ async def _remove_space_member(db_container, space_id: str, user_id: UUID):
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_service_key_creation_rejected_for_non_admin(client, regular_user_token):
-    """Non-admin user cannot create ownership=service keys."""
+    """A user without Permission.API_KEYS cannot create service-owned keys.
+
+    The role-level gate (require_permission(Permission.API_KEYS)) fires before
+    the policy-level "service keys require admin" check, so the underlying
+    rejection layer differs from earlier versions — but the security
+    invariant (unprivileged user → 403) is unchanged.
+    """
     resp = await _create_service_key(
         client,
         token=regular_user_token,
@@ -159,7 +165,6 @@ async def test_service_key_creation_rejected_for_non_admin(client, regular_user_
         permission="read",
     )
     assert resp.status_code == 403, resp.text
-    assert "admin" in resp.json()["message"].lower()
 
 
 @pytest.mark.integration

--- a/backend/tests/unittests/roles/test_permissions.py
+++ b/backend/tests/unittests/roles/test_permissions.py
@@ -14,11 +14,14 @@ from uuid import uuid4
 import pytest
 
 from intric.main.exceptions import UnauthorizedException
-from intric.roles.permissions import Permission, validate_permission, validate_permissions
+from intric.roles.permissions import (
+    Permission,
+    validate_permission,
+    validate_permissions,
+)
 from intric.roles.role import RoleInDB
 from intric.tenants.tenant import TenantInDB
 from intric.users.user import UserInDB
-
 
 _TEST_TENANT = TenantInDB(id=uuid4(), name="test", quota_limit=1024**3)
 
@@ -63,6 +66,7 @@ def _make_user_with_roles(*roles: RoleInDB) -> UserInDB:
 
 # --- Original decorator test ---
 
+
 class MockService:
     def __init__(self, user: UserInDB):
         self.user = user
@@ -89,6 +93,7 @@ async def test_validation_decorator():
 
 
 # --- validate_permission function tests ---
+
 
 class TestValidatePermission:
     """Test the validate_permission function for each permission."""
@@ -121,6 +126,7 @@ class TestPermissionsAreIndependent:
 
 # --- UserInDB.permissions aggregation tests ---
 
+
 class TestUserPermissionsAggregation:
     """UserInDB.permissions should combine permissions from all assigned roles."""
 
@@ -134,39 +140,48 @@ class TestUserPermissionsAggregation:
 
     def test_multiple_roles_combine_permissions(self):
         role1 = RoleInDB(
-            id=uuid4(), name="role1",
+            id=uuid4(),
+            name="role1",
             permissions=[Permission.ASSISTANTS, Permission.APPS],
             tenant_id=_TEST_TENANT.id,
         )
         role2 = RoleInDB(
-            id=uuid4(), name="role2",
+            id=uuid4(),
+            name="role2",
             permissions=[Permission.ADMIN, Permission.INSIGHTS],
             tenant_id=_TEST_TENANT.id,
         )
         user = _make_user_with_roles(role1, role2)
         assert user.permissions == {
-            Permission.ASSISTANTS, Permission.APPS,
-            Permission.ADMIN, Permission.INSIGHTS,
+            Permission.ASSISTANTS,
+            Permission.APPS,
+            Permission.ADMIN,
+            Permission.INSIGHTS,
         }
 
     def test_overlapping_permissions_are_deduplicated(self):
         role1 = RoleInDB(
-            id=uuid4(), name="role1",
+            id=uuid4(),
+            name="role1",
             permissions=[Permission.ASSISTANTS, Permission.ADMIN],
             tenant_id=_TEST_TENANT.id,
         )
         role2 = RoleInDB(
-            id=uuid4(), name="role2",
+            id=uuid4(),
+            name="role2",
             permissions=[Permission.ADMIN, Permission.INSIGHTS],
             tenant_id=_TEST_TENANT.id,
         )
         user = _make_user_with_roles(role1, role2)
         assert user.permissions == {
-            Permission.ASSISTANTS, Permission.ADMIN, Permission.INSIGHTS,
+            Permission.ASSISTANTS,
+            Permission.ADMIN,
+            Permission.INSIGHTS,
         }
 
 
 # --- Permission semantics ---
+
 
 class TestPermissionSemantics:
     """Document and verify expected behavior of the permissions system."""
@@ -174,9 +189,19 @@ class TestPermissionSemantics:
     def test_all_expected_permissions_exist(self):
         """Ensure all expected permissions are defined in the enum."""
         expected = {
-            "assistants", "group_chats", "apps", "services", "collections",
-            "insights", "AI", "editor", "admin", "websites", "integrations",
+            "assistants",
+            "group_chats",
+            "apps",
+            "services",
+            "collections",
+            "insights",
+            "AI",
+            "editor",
+            "admin",
+            "websites",
+            "integrations",
             "shared_spaces",
+            "api_keys",
         }
         actual = {p.value for p in Permission}
         assert actual == expected
@@ -202,13 +227,20 @@ class TestPermissionSemantics:
 
 # --- Template validation ---
 
+
 class TestRoleTemplates:
     """Verify predefined role templates have expected permissions."""
 
     @pytest.fixture
     def templates(self):
-        from intric.server.dependencies.predefined_roles import load_predefined_roles_from_config
-        return {t["name"]: set(t["permissions"]) for t in load_predefined_roles_from_config()}
+        from intric.server.dependencies.predefined_roles import (
+            load_predefined_roles_from_config,
+        )
+
+        return {
+            t["name"]: set(t["permissions"])
+            for t in load_predefined_roles_from_config()
+        }
 
     def test_owner_has_all_permissions(self, templates):
         """Owner template should include all permissions."""
@@ -237,4 +269,6 @@ class TestRoleTemplates:
     def test_all_templates_have_spaces(self, templates):
         """All templates should have spaces permission (current expected behavior)."""
         for name, perms in templates.items():
-            assert "shared_spaces" in perms, f"Template '{name}' missing shared_spaces permission"
+            assert "shared_spaces" in perms, (
+                f"Template '{name}' missing shared_spaces permission"
+            )

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -2792,5 +2792,9 @@
   "permission_admin_description": "Organization owner. Management of users, roles, and groups.",
   "permission_shared_spaces": "Shared spaces",
   "permission_shared_spaces_description": "Create shared spaces. Viewing, editing, and deleting shared spaces are governed by space membership.",
+  "permission_api_keys": "API keys",
+  "permission_api_keys_description": "Create API keys via the dashboard. Required to mint tenant, space, assistant, and app-scoped keys.",
+  "api_keys_no_create_permission": "Your role does not include API key creation. Contact a tenant admin if you need to mint a new key.",
+  "api_keys_no_create_permission_short": "API key creation is not part of your role.",
   "permissions_selected_count": "{selected} of {total} selected"
 }

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -2828,5 +2828,9 @@
   "permission_admin_description": "Organisationsägare. Hantering av användare, roller och grupper.",
   "permission_shared_spaces": "Delade ytor",
   "permission_shared_spaces_description": "Skapa delade ytor. Visning, redigering och borttagning av delade ytor styrs av ytmedlemskap.",
+  "permission_api_keys": "API-nycklar",
+  "permission_api_keys_description": "Skapa API-nycklar via gränssnittet. Krävs för att skapa nycklar med tenant-, yt-, assistent- eller app-omfattning.",
+  "api_keys_no_create_permission": "Din roll saknar behörighet att skapa API-nycklar. Kontakta en administratör om du behöver en ny nyckel.",
+  "api_keys_no_create_permission_short": "Att skapa API-nycklar ingår inte i din roll.",
   "permissions_selected_count": "{selected} av {total} valda"
 }

--- a/frontend/apps/web/src/lib/features/api-keys/ApiKeysSettingsSection.svelte
+++ b/frontend/apps/web/src/lib/features/api-keys/ApiKeysSettingsSection.svelte
@@ -11,12 +11,14 @@
     ExternalLink,
     RefreshCw,
     Bell,
-    BellOff
+    BellOff,
+    ShieldAlert
   } from "lucide-svelte";
   import { slide } from "svelte/transition";
   import ApiKeyTable from "../../../routes/(app)/account/api-keys/ApiKeyTable.svelte";
   import CreateApiKeyDialog from "$lib/features/api-keys/CreateApiKeyDialog.svelte";
   import ApiKeySecretDialog from "$lib/features/api-keys/ApiKeySecretDialog.svelte";
+  import * as Alert from "$lib/components/ui/alert/index.js";
   import ExpiringKeysBanner from "./ExpiringKeysBanner.svelte";
   import { getExpiringKeys, toDisplayItems } from "./expirationUtils";
   import { getAppContext } from "$lib/core/AppContext";
@@ -32,6 +34,7 @@
   const intric = getIntric();
   const { user, tenant } = getAppContext();
   const { forceRefresh: forceRefreshExpiringStore } = getExpiringKeysStore();
+  const canCreateApiKeys = user.hasPermission("api_keys");
 
   let {
     scopeType,
@@ -172,20 +175,30 @@
     </div>
   {:else if keys.length === 0}
     <!-- Empty state -->
-    <div class="border-default flex items-start gap-4 rounded-lg border px-5 py-5">
-      <Key class="text-muted mt-0.5 h-5 w-5 flex-shrink-0" />
-      <div class="flex flex-col gap-3">
-        <p class="text-secondary text-sm leading-relaxed">{getEmptyMessage()}</p>
-        <div>
-          <CreateApiKeyDialog
-            onCreated={handleCreated}
-            lockedScopeType={scopeType}
-            lockedScopeId={scopeId}
-            lockedScopeName={scopeName}
-            triggerVariant="outlined"
-          />
+    <div class="flex flex-col gap-3">
+      <div class="border-default flex items-start gap-4 rounded-lg border px-5 py-5">
+        <Key class="text-muted mt-0.5 h-5 w-5 flex-shrink-0" />
+        <div class="flex flex-col gap-3">
+          <p class="text-secondary text-sm leading-relaxed">{getEmptyMessage()}</p>
+          {#if canCreateApiKeys}
+            <div>
+              <CreateApiKeyDialog
+                onCreated={handleCreated}
+                lockedScopeType={scopeType}
+                lockedScopeId={scopeId}
+                lockedScopeName={scopeName}
+                triggerVariant="outlined"
+              />
+            </div>
+          {/if}
         </div>
       </div>
+      {#if !canCreateApiKeys}
+        <Alert.Root>
+          <ShieldAlert />
+          <Alert.Description>{m.api_keys_no_create_permission()}</Alert.Description>
+        </Alert.Root>
+      {/if}
     </div>
   {:else}
     <!-- Collapsible key list -->
@@ -267,13 +280,23 @@
 
       <!-- Footer actions -->
       <div class="border-dimmer flex items-center justify-between border-t px-5 py-3">
-        <CreateApiKeyDialog
-          onCreated={handleCreated}
-          lockedScopeType={scopeType}
-          lockedScopeId={scopeId}
-          lockedScopeName={scopeName}
-          triggerVariant="outlined"
-        />
+        {#if canCreateApiKeys}
+          <CreateApiKeyDialog
+            onCreated={handleCreated}
+            lockedScopeType={scopeType}
+            lockedScopeId={scopeId}
+            lockedScopeName={scopeName}
+            triggerVariant="outlined"
+          />
+        {:else}
+          <span
+            class="text-secondary inline-flex items-center gap-1.5 text-xs"
+            title={m.api_keys_no_create_permission()}
+          >
+            <ShieldAlert class="h-3.5 w-3.5" />
+            {m.api_keys_no_create_permission_short()}
+          </span>
+        {/if}
         <!-- eslint-disable svelte/no-navigation-without-resolve -- linked from settings module -->
         <a
           href="/account/api-keys"

--- a/frontend/apps/web/src/lib/features/api-keys/CreateApiKeyDialog.svelte
+++ b/frontend/apps/web/src/lib/features/api-keys/CreateApiKeyDialog.svelte
@@ -54,6 +54,7 @@
   const intric = getIntric();
   const { user } = getAppContext();
   const isAdmin = user.hasPermission("admin");
+  const canCreateApiKeys = user.hasPermission("api_keys");
 
   type DialogMode = "create" | "edit" | "view";
 
@@ -823,7 +824,7 @@
     if (!open) handleOpenChange(false);
   }}
 >
-  {#if isCreateMode}
+  {#if isCreateMode && canCreateApiKeys}
     <Dialog.Trigger>
       {#snippet child({ props })}
         <Button {...props} variant={triggerVariant === "outlined" ? "outline" : "default"}>

--- a/frontend/apps/web/src/routes/(app)/account/api-keys/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/account/api-keys/+page.svelte
@@ -26,6 +26,7 @@
   } = getAppContext();
   const intric = getIntric();
   const { forceRefresh: forceRefreshExpiringStore } = getExpiringKeysStore();
+  const canCreateApiKeys = user.hasPermission("api_keys");
 
   let keys = $state<ApiKeyV2[]>([]);
   let loading = $state(true);
@@ -214,6 +215,14 @@
               <CreateApiKeyDialog onCreated={handleCreated} />
             </div>
           </div>
+        {/if}
+
+        <!-- Permission notice -->
+        {#if !canCreateApiKeys}
+          <Alert.Root>
+            <ShieldAlert />
+            <Alert.Description>{m.api_keys_no_create_permission()}</Alert.Description>
+          </Alert.Root>
         {/if}
 
         <!-- Error Message -->

--- a/frontend/apps/web/src/routes/(app)/admin/legacy/roles/permission-labels.ts
+++ b/frontend/apps/web/src/routes/(app)/admin/legacy/roles/permission-labels.ts
@@ -58,6 +58,11 @@ export function getPermissionCopy(name: string, fallbackDescription: string): En
         label: m.permission_shared_spaces(),
         description: m.permission_shared_spaces_description()
       };
+    case "api_keys":
+      return {
+        label: m.permission_api_keys(),
+        description: m.permission_api_keys_description()
+      };
     default:
       // Unknown permission — degrade gracefully: reformat the key so
       // "unknown_permission" shows as "Unknown permission" rather than raw

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -12972,7 +12972,8 @@ export interface components {
       | "admin"
       | "websites"
       | "integrations"
-      | "shared_spaces";
+      | "shared_spaces"
+      | "api_keys";
     /** PermissionPublic */
     PermissionPublic: {
       name: components["schemas"]["Permission"];


### PR DESCRIPTION
## Changes

  **Backend**
  - New `Permission.API_KEYS` enum member, seeded onto the Owner role (predefined_roles.yml + `init_db.py` + reversible alembic backfill `202604281200`, scoped strictly to `predefined_source='Owner'`).
  - New `require_session_auth` dependency in `auth_dependencies.py` — rejects API-key-authenticated callers post-auth.
  - `POST /api-keys` swapped to `require_session_auth` + `require_permission(Permission.API_KEYS)`. Existing `require_api_key_permission(ApiKeyPermission.ADMIN)` retained as defense-in-depth so the route-coverage
  gate stays green.
  - Lifecycle endpoints (revoke / suspend / rotate / update) untouched — revoke must remain accessible without `api_keys` so a user can still kill their own leaked keys.
  - `permissions_mapper.py` updated so the new permission appears in `GET /roles/permissions/` and shows up as a toggle in the role editor.

  **Frontend**
  - `CreateApiKeyDialog` hides its trigger button when `!user.hasPermission("api_keys")`.
  - `/account/api-keys` shows a `ShieldAlert` info banner at the top when the user lacks the permission, so the user-dropdown link still leads somewhere legible.
  - Space-settings `ApiKeysSettingsSection` shows the same banner in the empty state and an inline `ShieldAlert` pill in the footer when the user has existing keys but cannot mint new ones.
  - New `permission_api_keys`, `permission_api_keys_description`, `api_keys_no_create_permission`, `api_keys_no_create_permission_short` translations in en + sv.
  - Regenerated `intric-js/src/types/schema.d.ts` so the new permission flows through the typed client.

  ## Why

  `POST /api-keys` had two privilege-escalation gaps on `develop`:

  1. **Session callers had no role-permission gate at all.** `require_api_key_permission(ApiKeyPermission.ADMIN)` only enforces when the *caller* is authenticating with another API key — bearer/session calls bypass
   it entirely. Any logged-in user could attempt tenant-scoped key creation, with only a weak `ensure_creator_authorized` actor check standing in the way for non-tenant scopes.
  2. **An admin-level v2 API key of any scope could mint keys of any other scope.** `POST /api-keys` does not declare `require_api_key_scope_check`, so a space-scoped ADMIN key could mint a tenant key — a clean
  persistence vector if a key leaked.

  Locking creation to **session-authenticated** callers closes the persistence vector. Gating those session callers on a **new `Permission.API_KEYS`** (rather than reusing `Permission.ADMIN`) decouples "can mint
  API keys" from "is a tenant admin" — the orthogonal-concerns goal of the unified-roles refactor (PR #348). Tenant admins can now delegate API-key minting to any role without handing out full admin.

  Why no fine-grained ladder (sk_/pk_/service split) yet: deliberate scope locking. The mechanism is in place — adding `API_KEYS_TENANT` / `API_KEYS_PUBLIC` / `API_KEYS_SERVICE` later is purely additive in the
  policy layer's `validate_create_request`.

  ## Testing

  - **New `test_api_key_create_authorization.py`** (3 cases): session caller with `Permission.API_KEYS` → 201; session caller without → 403 mentioning the missing permission; admin-level v2 API-key caller → 403
  mentioning "session token".
  - **New `test_grant_api_keys_permission_round_trip.py`** (4 cases): upgrade adds `api_keys` only to `predefined_source='Owner'` rows; AI Configurator / User / custom roles unchanged; upgrade is idempotent;
  downgrade strips it cleanly; full up→down→up preserves the bit.
  - **Existing `test_service_key_creation_rejected_for_non_admin`** updated — same security invariant (non-admin → 403), just enforced at the new earlier-firing role gate.
  - **Existing `test_permissions.py`** expected-set updated to include `api_keys`.
  - **Migration round-trip** verified manually inside the devcontainer (`alembic upgrade head && alembic downgrade -1 && alembic upgrade head`).
  - **245 API-key tests + 52 role tests + 4 migration round-trips** pass after changes; no regressions in the wider unit/integration suite.
  - **Frontend** `bun run check` clean; manual smoke in browser as Owner (create works), as a user without `api_keys` (banner visible, no Create button anywhere, existing keys still revocable).