### PR TITLE
feat(model-providers): collapse dated model snapshots into rolling alias

### DIFF
--- a/backend/src/intric/model_providers/presentation/model_provider_router.py
+++ b/backend/src/intric/model_providers/presentation/model_provider_router.py
@@ -87,6 +87,24 @@ def serialize_fields(fields: list[FieldDefinition]) -> list[SerializedField]:
     ]
 
 
+# Trailing-date stripping for collapsing dated snapshots into their rolling alias.
+# Only matches at the END of the name so embedded dates like "gpt-4-0314" are untouched.
+_TRAILING_DATE_PATTERNS = (
+    re.compile(r"-\d{4}-\d{2}-\d{2}$"),  # OpenAI: gpt-4o-2024-08-06
+    re.compile(r"@\d{8}$"),  # Vertex: claude-3-5-sonnet@20240620
+    re.compile(r"-\d{8}$"),  # Anthropic: claude-opus-4-7-20260416
+)
+
+
+def strip_trailing_date(name: str) -> str | None:
+    """Return the alias (date suffix removed) if name ends with a date, else None."""
+    for pattern in _TRAILING_DATE_PATTERNS:
+        m = pattern.search(name)
+        if m:
+            return name[: m.start()]
+    return None
+
+
 def get_model_provider_service(
     user: CurrentUser,
     session: SessionDep,
@@ -215,6 +233,17 @@ async def get_provider_capabilities(
                 model_info["max_input_tokens"] = info.get("max_input_tokens")
                 model_info["output_vector_size"] = info.get("output_vector_size")
             raw[provider][mode][model_key] = model_info
+
+    # Collapse dated snapshots (e.g. "claude-opus-4-7-20260416") into their rolling
+    # alias (e.g. "claude-opus-4-7") when both exist in the same provider/mode.
+    # If only the dated form exists (no alias), keep it so the model stays reachable.
+    for modes in raw.values():
+        for models_dict in modes.values():
+            names_in_group = set(models_dict.keys())
+            for key in list(models_dict.keys()):
+                alias = strip_trailing_date(key)
+                if alias and alias in names_in_group:
+                    models_dict.pop(key, None)
 
     # Build response sorted by release date (newest first)
     providers: dict[str, ProviderCapabilities] = {}

--- a/backend/tests/unittests/model_providers/test_capabilities_collapse.py
+++ b/backend/tests/unittests/model_providers/test_capabilities_collapse.py
@@ -1,0 +1,84 @@
+"""End-to-end test of capabilities endpoint logic with a synthetic litellm.model_cost."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from intric.model_providers.presentation import model_provider_router
+
+
+@pytest.mark.asyncio
+async def test_capabilities_collapses_dated_snapshots_into_alias() -> None:
+    fake_cost: dict[str, dict[str, Any]] = {
+        # Anthropic: alias + dated snapshot. Dated should be collapsed away.
+        "claude-opus-4-7": {
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+            "max_input_tokens": 200000,
+            "max_output_tokens": 8000,
+        },
+        "claude-opus-4-7-20260416": {
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+            "max_input_tokens": 200000,
+            "max_output_tokens": 8000,
+        },
+        # Anthropic: dated-only (no alias) — must be retained.
+        "claude-3-haiku-20240307": {
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+            "max_input_tokens": 100000,
+            "max_output_tokens": 4000,
+        },
+        # OpenAI: alias + dated snapshot.
+        "gpt-4o": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "max_input_tokens": 128000,
+            "max_output_tokens": 16000,
+        },
+        "gpt-4o-2024-08-06": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "max_input_tokens": 128000,
+            "max_output_tokens": 16000,
+        },
+        # Latest alias (filtered by existing rule).
+        "gpt-4o-latest": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "max_input_tokens": 128000,
+            "max_output_tokens": 16000,
+        },
+        # Embedded numeric that is NOT a date (gpt-4-0314) — keep as-is.
+        "gpt-4-0314": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "max_input_tokens": 8000,
+            "max_output_tokens": 4000,
+        },
+    }
+
+    with patch.object(model_provider_router, "re", model_provider_router.re):
+        with patch("litellm.model_cost", fake_cost):
+            result = await model_provider_router.get_provider_capabilities(_user=None)  # type: ignore[arg-type]
+
+    providers = result["providers"]
+    assert isinstance(providers, dict)
+
+    anthropic_completion_names = {
+        m["name"] for m in providers["anthropic"]["models"]["completion"]
+    }
+    # Alias kept, dated-with-alias collapsed, dated-only kept
+    assert anthropic_completion_names == {
+        "claude-opus-4-7",
+        "claude-3-haiku-20240307",
+    }
+
+    openai_completion_names = {
+        m["name"] for m in providers["openai"]["models"]["completion"]
+    }
+    # gpt-4o (alias) kept, gpt-4o-2024-08-06 collapsed away,
+    # gpt-4o-latest filtered by -latest rule, gpt-4-0314 kept (not a date suffix)
+    assert openai_completion_names == {"gpt-4o", "gpt-4-0314"}

--- a/backend/tests/unittests/model_providers/test_strip_trailing_date.py
+++ b/backend/tests/unittests/model_providers/test_strip_trailing_date.py
@@ -1,0 +1,48 @@
+import pytest
+
+from intric.model_providers.presentation.model_provider_router import (
+    strip_trailing_date,
+)
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        # Anthropic dated snapshots
+        ("claude-opus-4-7-20260416", "claude-opus-4-7"),
+        ("claude-opus-4-6-20260205", "claude-opus-4-6"),
+        ("claude-3-haiku-20240307", "claude-3-haiku"),
+        # OpenAI dated snapshots
+        ("gpt-4o-2024-08-06", "gpt-4o"),
+        ("gpt-5.1-2025-11-13", "gpt-5.1"),
+        ("o3-2025-04-16", "o3"),
+        # Vertex @date format
+        ("vertex_ai/claude-3-5-sonnet@20240620", "vertex_ai/claude-3-5-sonnet"),
+        ("anthropic.claude-haiku-4-5@20251001", "anthropic.claude-haiku-4-5"),
+    ],
+)
+def test_strips_trailing_date_suffix(name: str, expected: str) -> None:
+    assert strip_trailing_date(name) == expected
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        # Plain alias names without dates
+        "claude-opus-4-7",
+        "gpt-4o",
+        "gemini-2.0-flash",
+        # Embedded short numeric suffix that is NOT a date (4-digit year+month, e.g. gpt-4-0314)
+        "gpt-4-0314",
+        # Bedrock version suffix
+        "anthropic.claude-opus-4-6-v1",
+        # Vertex @default (not a date)
+        "vertex_ai/claude-opus-4-6@default",
+        # 7-digit number (one short of YYYYMMDD)
+        "some-model-1234567",
+        # Date in the middle, not at end
+        "gpt-4o-2024-08-06-fine-tuned",
+    ],
+)
+def test_returns_none_when_no_trailing_date(name: str) -> None:
+    assert strip_trailing_date(name) is None


### PR DESCRIPTION
## Summary

In the admin "Add model" wizard, the model suggestions and Browse-all list come from a static catalog (`litellm.model_cost`) bundled with the litellm package. That catalog contains both the rolling alias name (e.g. `claude-opus-4-7`) **and** every dated snapshot (e.g. `claude-opus-4-7-20260416`) that LiteLLM has heard of. Many dated snapshots — especially preview/limited-rollout ones — are listed but **not callable** for most API keys, so users see them, pick them, and hit "model not found".

This PR collapses dated snapshots into their alias when both exist in the same provider/mode, so the user only sees the stable rolling name. Dated entries that have no alias counterpart (e.g. `claude-3-haiku-20240307`, `omni-moderation-2024-09-26`) are preserved so the model stays reachable.

### What this hides
- Anthropic: 6 dated dupes (e.g. `claude-opus-4-7-20260416` → use `claude-opus-4-7`)
- OpenAI: 64 dated dupes (e.g. `gpt-4o-2024-08-06` → use `gpt-4o`)
- Vertex Anthropic: 11 dated dupes (e.g. `vertex_ai/claude-sonnet-4@20250514`)
- Azure: 32 dated dupes
- Bedrock: 0 dupes (no aliases exist there)

### What stays visible
- All non-dated names (aliases, plain models)
- Dated names where no alias exists in the catalog (e.g. `claude-3-haiku-20240307`, `anthropic.claude-haiku-4-5@20251001`)
- Embedded numerics that aren't dates: `gpt-4-0314`, `claude-opus-4-6-v1`, `vertex_ai/claude-opus-4-6@default`

## Implementation

Single helper `strip_trailing_date(name)` returns the alias if `name` ends with a date suffix in any of three known formats (`-YYYY-MM-DD`, `@YYYYMMDD`, `-YYYYMMDD`), else `None`. After the existing collection loop in `get_provider_capabilities`, a small post-pass walks each provider/mode bucket and drops keys whose alias is present in the same bucket.

The trailing-anchor in each pattern (`$`) is what keeps `gpt-4-0314` and `-v1` safe.

## Test plan

- [x] `tests/unittests/model_providers/test_strip_trailing_date.py` — 16 cases covering Anthropic/OpenAI/Vertex date formats and ambiguous non-date suffixes
- [x] `tests/unittests/model_providers/test_capabilities_collapse.py` — full endpoint round-trip with synthetic `litellm.model_cost`, asserts collapse + retain semantics
- [x] Full backend unit suite: **1312 passed**
- [x] `pyright` on modified files: 0 errors, 0 warnings
- [ ] Manual: open admin → add model → Anthropic → verify only `claude-opus-4-7`, `claude-opus-4-6`, etc. appear (no `-2026...` rows)