### PR TITLE
fix(mcp): prevent anyio cancel-scope leak that creeps gunicorn CPU to…

### DIFF
--- a/backend/src/intric/completion_models/infrastructure/completion_service.py
+++ b/backend/src/intric/completion_models/infrastructure/completion_service.py
@@ -305,11 +305,20 @@ class CompletionService:
             # Two-phase streaming pattern:
             # Phase 1: Create stream connection BEFORE returning (can raise exceptions)
             # This happens eagerly, so exceptions propagate before HTTP response starts
-            stream_obj = await model_adapter.prepare_streaming(
-                context=context,
-                model_kwargs=model_kwargs,
-                mcp_proxy=mcp_proxy,
-            )
+            try:
+                stream_obj = await model_adapter.prepare_streaming(
+                    context=context,
+                    model_kwargs=model_kwargs,
+                    mcp_proxy=mcp_proxy,
+                )
+            except BaseException:
+                # If stream prep fails, close the proxy here — the streaming_wrapper's
+                # finally block won't run because the generator is never reached.
+                # Without this, leaked MCP connections accumulate anyio task-group
+                # background tasks and creep CPU toward 100% over the worker's lifetime.
+                if mcp_proxy:
+                    await mcp_proxy.close()
+                raise
 
             # Phase 2: Create generator that iterates the pre-created stream
             # This generator yields error events for mid-stream failures

--- a/backend/src/intric/mcp_servers/infrastructure/client/mcp_client.py
+++ b/backend/src/intric/mcp_servers/infrastructure/client/mcp_client.py
@@ -355,9 +355,12 @@ class MCPClient:
     async def disconnect(self) -> None:
         """Disconnect from the MCP server.
 
-        Note: Due to anyio's task boundary restrictions, cleanup may fail if
-        disconnect is called from a different task than connect. In this case,
-        we just clear references and let GC handle cleanup.
+        Must run on the same asyncio.Task that called connect(). The MCP SDK's
+        streamablehttp_client uses anyio cancel scopes bound to the entering
+        task; calling __aexit__ from a different task fails the task-boundary
+        check and leaks the internal anyio TaskGroup's child tasks (the
+        persistent HTTP read/write loops). We log this case explicitly so
+        leaks are visible rather than disguised as a slow CPU climb.
         """
         # Clear session first
         session_ctx = self._session_context
@@ -367,18 +370,34 @@ class MCPClient:
         streams_ctx = self._streams_context
         self._streams_context = None
 
-        # Try to properly close contexts, but don't fail if task boundary issues
+        cleanup_errors: list[BaseException] = []
+
         try:
             if session_ctx:
                 await session_ctx.__aexit__(None, None, None)
-        except BaseException:
-            pass  # Task boundary issue or cleanup error - GC will handle
+        except BaseException as e:
+            cleanup_errors.append(e)
 
         try:
             if streams_ctx:
                 await streams_ctx.__aexit__(None, None, None)
-        except BaseException:
-            pass  # Task boundary issue or cleanup error - GC will handle
+        except BaseException as e:
+            cleanup_errors.append(e)
+
+        for err in cleanup_errors:
+            msg = str(err).lower()
+            if "cancel scope" in msg or "different task" in msg:
+                logger.error(
+                    "MCP cleanup task-boundary error for %s: %s. This leaks the "
+                    "streamablehttp_client TaskGroup; ensure connect() and "
+                    "disconnect() run on the same asyncio.Task.",
+                    self.mcp_server.name,
+                    err,
+                )
+            else:
+                logger.warning(
+                    "MCP cleanup error for %s: %s", self.mcp_server.name, err
+                )
 
         logger.debug(f"Disconnected from MCP server: {self.mcp_server.name}")
 

--- a/backend/src/intric/mcp_servers/infrastructure/proxy/mcp_proxy_session.py
+++ b/backend/src/intric/mcp_servers/infrastructure/proxy/mcp_proxy_session.py
@@ -64,6 +64,19 @@ class MCPProxySession:
         self._clients: dict[UUID, MCPClient] = {}
         self._connection_locks: dict[UUID, asyncio.Lock] = {}
 
+        # Servers that failed to connect or errored mid-session. Tracked instead
+        # of dropping clients from the cache: drops would leak the underlying
+        # streamablehttp_client whose anyio cancel scope can only be exited from
+        # its owner task.
+        self._failed_server_ids: set[UUID] = set()
+
+        # The asyncio.Task that opened the first MCP connection. All subsequent
+        # connect/disconnect calls must run on this task — the MCP SDK's
+        # streamablehttp_client uses anyio cancel scopes that raise RuntimeError
+        # if entered and exited from different tasks. Captured lazily on first
+        # connect because session construction is synchronous.
+        self._owner_task: asyncio.Task[Any] | None = None
+
         # Build tool registry from DB (no connections needed)
         self._tool_registry: dict[str, tuple[MCPServer, str]] = {}
         self._tools_for_llm: list[dict[str, Any]] = []
@@ -167,8 +180,15 @@ class MCPProxySession:
         async with _CIRCUIT_BREAKER_LOCK:
             _CIRCUIT_BREAKER_STATE.pop(server_id, None)
 
-    def _evict_client(self, server_id: UUID) -> None:
-        self._clients.pop(server_id, None)
+    def _mark_server_failed(self, server_id: UUID) -> None:
+        """Mark a server unusable for the rest of this session.
+
+        We do NOT drop the client from the cache — that would orphan the
+        streamablehttp_client's anyio TaskGroup (its read/write loops keep
+        running until __aexit__ is called on the streams context). close()
+        will disconnect every cached client at session end, on the owner task.
+        """
+        self._failed_server_ids.add(server_id)
 
     def _truncate_tool_result(self, result: dict[str, Any]) -> dict[str, Any]:
         max_chars = _settings.mcp_tool_output_max_chars
@@ -230,11 +250,36 @@ class MCPProxySession:
         server, original_tool_name = self._tool_registry[prefixed_tool_name]
         return (server.name, original_tool_name)
 
+    def _capture_owner_task(self) -> None:
+        """Bind this proxy session to the current asyncio.Task on first connect.
+
+        Any later connect or disconnect from a different task would create or
+        destroy anyio cancel scopes across task boundaries, which raises
+        RuntimeError inside the MCP SDK and silently leaks its TaskGroup
+        children (the persistent HTTP read/write loops).
+        """
+        current = asyncio.current_task()
+        if self._owner_task is None:
+            self._owner_task = current
+        elif current is not self._owner_task:
+            logger.error(
+                "[MCPProxy] MCP lifecycle call from non-owner task — this would "
+                "leak anyio cancel scopes. owner=%s current=%s. Refusing to "
+                "connect; the cached client (if any) will be cleaned up by close().",
+                self._owner_task,
+                current,
+            )
+            raise MCPClientError(
+                "MCP proxy session called from a task other than its owner; "
+                "refusing to connect to avoid anyio cancel-scope leak."
+            )
+
     async def _get_or_create_client(self, server: MCPServer) -> MCPClient:
         """
         Get existing client or create new connection (lazy).
 
-        Thread-safe via per-server locks.
+        Must run on the proxy session's owner task. Thread-safe via per-server
+        locks.
 
         Args:
             server: MCP server to connect to
@@ -243,9 +288,11 @@ class MCPProxySession:
             Connected MCPClient instance
 
         Raises:
-            MCPClientError: If connection fails
+            MCPClientError: If connection fails or called from a non-owner task
         """
         server_id = server.id
+
+        self._capture_owner_task()
 
         # Get or create lock for this server
         if server_id not in self._connection_locks:
@@ -317,8 +364,39 @@ class MCPProxySession:
                 "is_error": True,
             }
 
-        # Get or create connection (lazy)
-        client = await self._get_or_create_client(server)
+        if server.id in self._failed_server_ids:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "External tool service temporarily unavailable. Please retry later.",
+                    }
+                ],
+                "is_error": True,
+            }
+
+        # Use cached client only. Connecting here is unsafe: this method runs
+        # under asyncio.gather (see call_tools_parallel), which dispatches each
+        # call onto a separate Task. Entering streamablehttp_client's anyio
+        # cancel scope from that task would leak when close() runs from the
+        # owner task. Pre-connect happens sequentially in call_tools_parallel.
+        client = self._clients.get(server.id)
+        if client is None:
+            logger.warning(
+                "[MCPProxy] No connected client for '%s'; pre-connect did not run "
+                "or failed",
+                server.name,
+            )
+            self._mark_server_failed(server.id)
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "External tool service temporarily unavailable. Please retry later.",
+                    }
+                ],
+                "is_error": True,
+            }
 
         try:
             # Execute tool with timing
@@ -337,11 +415,11 @@ class MCPProxySession:
                 await self._record_success(server.id)
             return self._truncate_tool_result(result)
         except MCPClientError:
-            self._evict_client(server.id)
+            self._mark_server_failed(server.id)
             await self._record_failure(server.id)
             raise
         except Exception:
-            self._evict_client(server.id)
+            self._mark_server_failed(server.id)
             await self._record_failure(server.id)
             raise
 
@@ -375,12 +453,22 @@ class MCPProxySession:
                 server, _ = self._tool_registry[tool_name]
                 servers_needed[server.id] = server
 
-        # Connect to all needed servers in parallel (lazy - only if not already connected)
-        if servers_needed:
-            connect_tasks = [
-                self._get_or_create_client(server) for server in servers_needed.values()
-            ]
-            await asyncio.gather(*connect_tasks, return_exceptions=True)
+        # Pre-connect SEQUENTIALLY in this task. Sequential is required:
+        # streamablehttp_client uses anyio cancel scopes bound to the connecting
+        # task. asyncio.gather would dispatch each connect to its own gather
+        # task — close() later runs from the proxy session's owning task and
+        # anyio's task-boundary check would silently leak the underlying HTTP
+        # read/write loops, creeping CPU toward 100% over the worker's lifetime.
+        for server in servers_needed.values():
+            if server.id in self._clients or server.id in self._failed_server_ids:
+                continue
+            try:
+                await self._get_or_create_client(server)
+            except Exception as exc:
+                logger.warning(
+                    f"[MCPProxy] Failed to pre-connect to '{server.name}': {exc}"
+                )
+                self._mark_server_failed(server.id)
 
         # Execute all tool calls in parallel
         async def execute_single(
@@ -409,9 +497,27 @@ class MCPProxySession:
         return list(results)
 
     async def close(self):
-        """Close all connections."""
+        """Close all connections.
+
+        Must run on the owner task (the task that opened the connections).
+        Calling from a different task triggers anyio's task-boundary check
+        inside streamablehttp_client and silently leaks its TaskGroup
+        children. We log loudly when that happens so future regressions are
+        visible instead of masquerading as a slow CPU climb.
+        """
         if not self._clients:
+            self._failed_server_ids.clear()
             return
+
+        current = asyncio.current_task()
+        if self._owner_task is not None and current is not self._owner_task:
+            logger.error(
+                "[MCPProxy] close() called from non-owner task — anyio cancel "
+                "scopes inside streamablehttp_client will fail to exit and leak. "
+                "owner=%s current=%s",
+                self._owner_task,
+                current,
+            )
 
         for server_id, client in self._clients.items():
             try:
@@ -421,6 +527,7 @@ class MCPProxySession:
 
         connection_count = len(self._clients)
         self._clients.clear()
+        self._failed_server_ids.clear()
         logger.debug(
             f"[MCPProxy] Session closed, {connection_count} connection(s) cleaned up"
         )

--- a/backend/tests/unit/test_mcp_proxy_session_resilience.py
+++ b/backend/tests/unit/test_mcp_proxy_session_resilience.py
@@ -32,7 +32,12 @@ def _make_server(name: str = "server") -> MCPServer:
 
 
 @pytest.mark.asyncio
-async def test_call_tool_evicts_dead_client_on_mcp_error():
+async def test_call_tool_marks_server_failed_but_keeps_client_for_close():
+    """On MCP error, the client must stay in _clients so close() can disconnect
+    it on the owner task. Dropping it would orphan the streamablehttp_client's
+    anyio TaskGroup (its HTTP read/write loops keep running until __aexit__
+    on the streams context). Subsequent calls should short-circuit via the
+    failed-server set."""
     server = _make_server()
     proxy = MCPProxySession([server])
 
@@ -44,6 +49,30 @@ async def test_call_tool_evicts_dead_client_on_mcp_error():
     with pytest.raises(MCPClientError):
         await proxy.call_tool("server__tool", {"q": "x"})
 
+    assert server.id in proxy._clients, (
+        "Client must remain cached so close() can disconnect it on the owner task"
+    )
+    assert server.id in proxy._failed_server_ids
+
+    # Subsequent call short-circuits without invoking the dead client again
+    result = await proxy.call_tool("server__tool", {"q": "x"})
+    assert result["is_error"] is True
+    assert dead_client.call_tool.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_call_tool_returns_error_when_no_client_cached():
+    """call_tool must NOT trigger a connect (it runs under asyncio.gather, on a
+    task other than the proxy's owner task). When no pre-connected client is
+    in the cache, return an error result."""
+    server = _make_server()
+    proxy = MCPProxySession([server])
+    # No pre-connect happened — _clients is empty.
+
+    result = await proxy.call_tool("server__tool", {"q": "x"})
+
+    assert result["is_error"] is True
+    assert server.id in proxy._failed_server_ids
     assert server.id not in proxy._clients
 
 


### PR DESCRIPTION
## Problem

  Production gunicorn workers running eneo-backend 1.8.x slowly drift to 100% CPU
  over hours/days. A worker restart fixes it. The drift correlates with tenants
  that actively use MCP tools.

  ### Root cause

  Each successful streaming MCP tool call leaks the underlying
  `streamablehttp_client`'s internal anyio TaskGroup. The chain:

  1. `MCPProxySession.call_tools_parallel` used `asyncio.gather` to pre-connect
     to MCP servers in parallel. `gather` wraps each coroutine in a fresh
     `asyncio.Task`, so `streamablehttp_client.__aenter__` ran on a gather-task.
  2. The MCP SDK's transport uses anyio cancel scopes that bind to the
     *entering* task and spawn persistent HTTP read/write loops as TaskGroup
     children.
  3. When the streaming response finished, `streaming_wrapper`'s `finally`
     called `mcp_proxy.close() → client.disconnect() →
     streams_context.__aexit__()`, but on the *request* task — not the
     gather-task that entered the scope.
  4. anyio's `CancelScope.__exit__` raised
     `RuntimeError: Attempted to exit cancel scope in a different task than it
     was entered in`.
  5. `MCPClient.disconnect` swallowed the exception with `except BaseException:
     pass` ("we just clear references and let GC handle cleanup"). But the
     anyio TaskGroup's child tasks remain scheduled on the event loop —
     Python's GC can't collect tasks that are still referenced by the loop.

  Each leaked stream does low-rate read polling, HTTP keep-alives, and reconnect
  attempts. With every request, a few more zombie tasks pile up. Eventually the
  event loop dispatches to thousands of them per second → 100% CPU.

  `_evict_client` had a similar problem: dropping a broken client from the cache
  on error abandoned its anyio scope without ever exiting it, since `close()`
  only iterates what's still in `_clients`.

  ### Why a restart fixed it

  Killing the worker process killed every leaked anyio task at once. The CPU
  returned to baseline until enough new MCP calls accumulated again.

  ## Solution

  Make `MCPProxySession` task-bound: connect and disconnect must happen on the
  same `asyncio.Task` so anyio cancel scopes can exit cleanly.

  - Capture the proxy's owner task lazily on first connect.
  - Replace the connect-`gather` in `call_tools_parallel` with **sequential**
    awaits inside the calling task — connects now bind their cancel scopes to
    the proxy's owner task.
  - `call_tool` no longer triggers connect (it runs under `asyncio.gather`,
    on a different task). It uses the cache only; if no client is pre-connected
    it short-circuits with an error. Pre-connect is the sole connect path.
  - Replace `_evict_client` with `_mark_server_failed`: failed servers are
    tracked in a session-scoped set instead of dropping the client from the
    cache. `close()` then disconnects every cached client on the owner task,
    including the broken ones.
  - `close()` logs an error if invoked on a non-owner task — surfaces future
    regressions immediately instead of leaking silently.
  - `MCPClient.disconnect` now logs cleanup errors via `logger.error` /
    `logger.warning` instead of swallowing them — specifically detects
    "cancel scope" / "different task" messages so any future task-boundary
    regression is visible in production logs.
  - Symmetric proxy cleanup in `complete_streaming`: a failure during
    `prepare_streaming` now closes the proxy in a `try/except`, matching the
    non-streaming path's `try/finally`.