### PR TITLE
Fix reasoning model kwarg capability toggle

### DIFF
--- a/backend/src/intric/ai_models/completion_models/completion_model.py
+++ b/backend/src/intric/ai_models/completion_models/completion_model.py
@@ -308,6 +308,29 @@ class ModelKwargs(BaseModel):
     frequency_penalty: Optional[float] = None
     top_k: Optional[int] = None
 
+    def filter_unsupported(self, supported: SupportedModelKwargs) -> "ModelKwargs":
+        # Strip stored values whose capability is currently disabled so a kwarg
+        # saved while the capability was enabled (e.g. reasoning_effort on a
+        # model whose reasoning flag was later turned off) does not leak to the
+        # provider. response_format is intentionally unmanaged here — it is not
+        # a SupportedModelKwargs field.
+        updates: dict[str, None] = {}
+        for field_name in (
+            "temperature",
+            "top_p",
+            "reasoning_effort",
+            "verbosity",
+            "presence_penalty",
+            "frequency_penalty",
+            "top_k",
+        ):
+            capability = getattr(supported, field_name)
+            if not capability.supported and getattr(self, field_name) is not None:
+                updates[field_name] = None
+        if not updates:
+            return self
+        return self.model_copy(update=updates)
+
 
 class CompletionModelSparse(CompletionModelBase, InDB):
     provider_type: Optional[str] = None

--- a/backend/src/intric/apps/apps/app_factory.py
+++ b/backend/src/intric/apps/apps/app_factory.py
@@ -181,6 +181,10 @@ class AppFactory:
             File.model_validate(attachment.file) for attachment in app_in_db.attachments
         ]
         model_kwargs = self._create_model_kwargs(completion_model_kwargs)
+        if model_kwargs is not None and completion_model is not None:
+            model_kwargs = model_kwargs.filter_unsupported(
+                completion_model.supported_model_kwargs
+            )
 
         source_template = (
             self.app_template_factory.create_app_template(app_in_db.template)
@@ -258,6 +262,10 @@ class AppFactory:
             ),
             None,
         )
+        if model_kwargs is not None and completion_model is not None:
+            model_kwargs = model_kwargs.filter_unsupported(
+                completion_model.get_supported_model_kwargs()
+            )
 
         transcription_model = next(
             (

--- a/backend/src/intric/assistants/assistant_factory.py
+++ b/backend/src/intric/assistants/assistant_factory.py
@@ -127,6 +127,10 @@ class AssistantFactory:
         completion_model_kwargs = ModelKwargs.model_validate(
             completion_model_kwargs_raw
         )
+        if completion_model is not None:
+            completion_model_kwargs = completion_model_kwargs.filter_unsupported(
+                completion_model.get_supported_model_kwargs()
+            )
 
         source_template = (
             self.assistant_template_factory.create_assistant_template(
@@ -236,6 +240,10 @@ class AssistantFactory:
             ),
             None,
         )
+        if completion_model is not None:
+            completion_model_kwargs = completion_model_kwargs.filter_unsupported(
+                completion_model.get_supported_model_kwargs()
+            )
 
         source_template = (
             self.assistant_template_factory.create_assistant_template(

--- a/backend/src/intric/completion_models/domain/model_kwargs_capabilities.py
+++ b/backend/src/intric/completion_models/domain/model_kwargs_capabilities.py
@@ -1,7 +1,8 @@
 """Completion-model parameter controls.
 
-Resolution order is explicit metadata, reasoning fallback, tenant/LiteLLM
-sampling controls, then legacy temperature-only behavior.
+Resolution order is explicit metadata constrained by core model flags, reasoning
+fallback, tenant/LiteLLM sampling controls, then legacy temperature-only
+behavior.
 """
 
 from __future__ import annotations
@@ -79,6 +80,19 @@ def _tenant_supported_model_kwargs() -> SupportedModelKwargs:
     )
 
 
+def _apply_model_capability_flags(
+    supported_model_kwargs: SupportedModelKwargs,
+    *,
+    reasoning: bool,
+) -> SupportedModelKwargs:
+    if reasoning:
+        return supported_model_kwargs
+
+    return supported_model_kwargs.model_copy(
+        update={"reasoning_effort": ModelKwargCapability()}
+    )
+
+
 def coerce_model_kwargs_capabilities(
     model_kwargs_capabilities: object | None,
     *,
@@ -121,15 +135,24 @@ def resolve_supported_model_kwargs(
         tenant_id=tenant_id,
     )
     if override is not None:
-        return override
+        return _apply_model_capability_flags(override, reasoning=reasoning)
 
     if reasoning:
-        return _default_supported_model_kwargs(reasoning=reasoning)
+        return _apply_model_capability_flags(
+            _default_supported_model_kwargs(reasoning=reasoning),
+            reasoning=reasoning,
+        )
 
     # Tenant models run through LiteLLM with drop_params=True, so this contract
     # can expose the common sampling controls without duplicating provider
     # support tables in the frontend.
     if provider_type or litellm_model_name:
-        return _tenant_supported_model_kwargs()
+        return _apply_model_capability_flags(
+            _tenant_supported_model_kwargs(),
+            reasoning=reasoning,
+        )
 
-    return _default_supported_model_kwargs(reasoning=reasoning)
+    return _apply_model_capability_flags(
+        _default_supported_model_kwargs(reasoning=reasoning),
+        reasoning=reasoning,
+    )

--- a/backend/tests/unit/test_completion_model_kwargs_capabilities.py
+++ b/backend/tests/unit/test_completion_model_kwargs_capabilities.py
@@ -15,6 +15,7 @@ from intric.ai_models.completion_models.completion_model import (
     CompletionModelSecurityStatus,
     CompletionModelSparse,
     CompletionModelUpdate,
+    ModelKwargs,
 )
 from intric.completion_models.domain.completion_model import (
     CompletionModel as CompletionModelDomain,
@@ -103,6 +104,35 @@ def test_reasoning_flag_disables_stored_reasoning_effort_capability():
 
     assert model.supported_model_kwargs.reasoning_effort.supported is False
     assert model.supported_model_kwargs.verbosity.supported is True
+
+
+def test_filter_unsupported_strips_disabled_kwargs():
+    model = _completion_model_sparse(name="gpt-5.1", reasoning=False)
+    kwargs = ModelKwargs(temperature=0.4, reasoning_effort="high", verbosity="low")
+
+    filtered = kwargs.filter_unsupported(model.supported_model_kwargs)
+
+    assert filtered.temperature == 0.4
+    assert filtered.reasoning_effort is None
+    assert filtered.verbosity is None
+
+
+def test_filter_unsupported_returns_self_when_all_supported():
+    model = _completion_model_sparse(name="gpt-5.1", reasoning=True)
+    kwargs = ModelKwargs(reasoning_effort="medium")
+
+    filtered = kwargs.filter_unsupported(model.supported_model_kwargs)
+
+    assert filtered is kwargs
+
+
+def test_filter_unsupported_preserves_response_format():
+    model = _completion_model_sparse(reasoning=False)
+    kwargs = ModelKwargs(response_format={"type": "json_object"})
+
+    filtered = kwargs.filter_unsupported(model.supported_model_kwargs)
+
+    assert filtered.response_format == {"type": "json_object"}
 
 
 def test_reasoning_fallback_is_name_agnostic():

--- a/backend/tests/unit/test_completion_model_kwargs_capabilities.py
+++ b/backend/tests/unit/test_completion_model_kwargs_capabilities.py
@@ -83,6 +83,28 @@ def test_capability_override_wins_over_model_name_and_reasoning_flag():
     assert model.supported_model_kwargs.verbosity.supported is False
 
 
+def test_reasoning_flag_disables_stored_reasoning_effort_capability():
+    model = _completion_model_sparse(
+        name="gpt-5.1",
+        reasoning=False,
+        model_kwargs_capabilities={
+            "reasoning_effort": {
+                "supported": True,
+                "control": "select",
+                "options": ["low", "medium", "high"],
+            },
+            "verbosity": {
+                "supported": True,
+                "control": "select",
+                "options": ["low", "medium", "high"],
+            },
+        },
+    )
+
+    assert model.supported_model_kwargs.reasoning_effort.supported is False
+    assert model.supported_model_kwargs.verbosity.supported is True
+
+
 def test_reasoning_fallback_is_name_agnostic():
     model = _completion_model_sparse(name="gpt-5.1", reasoning=True)
 
@@ -336,7 +358,7 @@ def test_public_completion_model_preserves_litellm_capabilities():
         deployment_name=None,
         org=None,
         vision=False,
-        reasoning=False,
+        reasoning=True,
         supports_tool_calling=True,
         base_url=None,
         litellm_model_name="mistral/mistral-large-latest",


### PR DESCRIPTION
## Problem
Turning off reasoning support on a completion model could still leave **Reasoning effort** visible in assistant settings. The UI was following the backend contract correctly, but the backend could still report `supported_model_kwargs.reasoning_effort.supported=true` when old or explicit `model_kwargs_capabilities` metadata said so.

## Solution
- Treat the model's `reasoning` flag as a core capability guard for `reasoning_effort`.
- Keep explicit model kwarg metadata as the source of truth for configurable parameters, but constrain it by core model flags before exposing it through `supported_model_kwargs`.
- Add a regression test for stored reasoning metadata with `reasoning=false`.

This keeps the fix in the backend capability contract, so assistants, apps, services, and templates all get the same behavior without frontend-specific checks.

## Testing
- `cd /workspace/backend && .venv/bin/pytest tests/unit/test_completion_model_kwargs_capabilities.py -q`
- `cd /workspace/backend && .venv/bin/ruff check src/intric/completion_models/domain/model_kwargs_capabilities.py tests/unit/test_completion_model_kwargs_capabilities.py`
- `cd /workspace/backend && .venv/bin/ruff format --check src/intric/completion_models/domain/model_kwargs_capabilities.py tests/unit/test_completion_model_kwargs_capabilities.py`
- `cd /workspace/backend && .venv/bin/pyright --pythonpath .venv/bin/python`
- Commit hooks: `ruff`, `ruff-format`, `pyright`, `uv-lock`, `i18n-no-duplicate-keys`