### PR TITLE
feat(model-providers): live-list models for OpenAI and Anthropic

### DIFF
--- a/backend/src/intric/model_providers/domain/model_provider_service.py
+++ b/backend/src/intric/model_providers/domain/model_provider_service.py
@@ -12,6 +12,103 @@ if TYPE_CHECKING:
     pass
 
 
+# LiteLLM mode → our model_type. Anything else (image, tts, moderation) is filtered out.
+_LITELLM_MODE_TO_OUR_MODE: dict[str, str] = {
+    "chat": "completion",
+    "completion": "completion",
+    "embedding": "embedding",
+    "audio_transcription": "transcription",
+}
+
+# Name substrings to drop — same set the static capabilities endpoint filters.
+_NAME_FILTER_SUBSTRINGS: tuple[str, ...] = (
+    "realtime",
+    "-audio-",
+    "gpt-audio",
+    "search-preview",
+    "search-api",
+    "-diarize",
+)
+
+
+def _infer_mode_from_name(name: str, provider_type: str) -> str | None:
+    """Best-effort mode inference for names not in litellm.model_cost.
+
+    Returns None when the name clearly maps to a non-text mode (image, tts,
+    moderation) so the entry is dropped. Returns "completion" by default for
+    Anthropic (their /v1/models only returns chat models). Returns None for
+    fully unknown names so we don't pollute mode-specific pickers.
+    """
+    lower = name.lower()
+    if any(kw in lower for kw in ("dall-e", "image", "tts-", "moderation", "whisper")):
+        if "whisper" in lower:
+            return "transcription"
+        return None
+    if "embedding" in lower:
+        return "embedding"
+    if provider_type == "anthropic":
+        return "completion"
+    if lower.startswith(("gpt-", "o1", "o3", "o4", "chatgpt-")):
+        return "completion"
+    return None
+
+
+def _enrich_with_litellm_metadata(
+    name: str, provider_type: str
+) -> dict[str, Any] | None:
+    """Look up `name` in litellm.model_cost (with prefix variants) and return
+    an enriched capability dict, or None if the model should be hidden.
+
+    Returns None when the name matches a non-text filter substring or maps to
+    a litellm mode we don't surface (image, tts, moderation, etc.).
+
+    For names not present in the cost map, falls back to mode inference from
+    the name so newly-released models still show up. Returns None if no mode
+    can be inferred (avoids polluting mode-specific pickers with unknowns).
+    """
+    import litellm
+
+    lower = name.lower()
+    if any(kw in lower for kw in _NAME_FILTER_SUBSTRINGS):
+        return None
+    if name.endswith("-latest") or "/container" in lower:
+        return None
+
+    model_cost = getattr(litellm, "model_cost", {})
+
+    candidates = [name, f"{provider_type}/{name}"]
+    info: dict[str, Any] | None = None
+    for key in candidates:
+        if key in model_cost:
+            info = model_cost[key]
+            break
+
+    if info is None:
+        inferred = _infer_mode_from_name(name, provider_type)
+        if inferred is None:
+            return None
+        return {"name": name, "mode": inferred}
+
+    litellm_mode = info.get("mode", "")
+    mode = _LITELLM_MODE_TO_OUR_MODE.get(litellm_mode)
+    if mode is None:
+        return None
+
+    enriched: dict[str, Any] = {"name": name, "mode": mode}
+    if mode == "completion":
+        enriched["max_input_tokens"] = info.get("max_input_tokens")
+        enriched["max_output_tokens"] = info.get("max_output_tokens")
+        enriched["supports_vision"] = info.get("supports_vision", False)
+        enriched["supports_function_calling"] = info.get(
+            "supports_function_calling", False
+        )
+        enriched["supports_reasoning"] = info.get("supports_reasoning", False)
+    elif mode == "embedding":
+        enriched["max_input_tokens"] = info.get("max_input_tokens")
+        enriched["output_vector_size"] = info.get("output_vector_size")
+    return enriched
+
+
 class ModelProviderService:
     """Service for managing model providers with credential encryption."""
 
@@ -236,68 +333,79 @@ class ModelProviderService:
                 return {"success": False, "error": "Could not connect to API"}
             return {"success": False, "error": f"Validation failed: {str(e)}"}
 
-    async def list_available_models(self, provider_id: UUID) -> list[dict[str, Any]]:
-        """List models/deployments available on a provider using its credentials."""
+    async def _fetch_live_model_names(
+        self, provider_type: str, api_key: str, endpoint: str
+    ) -> list[str]:
+        """Fetch the list of model names available on a provider via its own API."""
         import httpx
 
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            if provider_type == "azure":
+                # Azure /openai/models returns all models in the region, not
+                # just deployed ones. Users enter their deployment name manually.
+                return []
+
+            if provider_type == "openai":
+                resp = await client.get(
+                    "https://api.openai.com/v1/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                return [m["id"] for m in resp.json().get("data", [])]
+
+            if provider_type == "anthropic":
+                resp = await client.get(
+                    "https://api.anthropic.com/v1/models",
+                    headers={
+                        "x-api-key": api_key,
+                        "anthropic-version": "2023-06-01",
+                    },
+                )
+                resp.raise_for_status()
+                return [m["id"] for m in resp.json().get("data", [])]
+
+            # OpenAI-compatible providers (vLLM, custom endpoints)
+            if endpoint:
+                resp = await client.get(
+                    f"{endpoint.rstrip('/')}/v1/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                return [m["id"] for m in resp.json().get("data", [])]
+
+            return []
+
+    async def list_available_models(self, provider_id: UUID) -> list[dict[str, Any]]:
+        """List models available on a provider using its credentials, enriched
+        with capability metadata from litellm.model_cost.
+
+        Each entry has at least ``name`` and ``mode`` (one of "completion",
+        "embedding", "transcription", or None for unknown). Completion entries
+        include ``max_input_tokens``, ``max_output_tokens``, and ``supports_*``
+        flags; embedding entries include ``max_input_tokens`` and
+        ``output_vector_size``.
+        """
         provider = await self.repository.get_by_id(provider_id)
         decrypted_creds = self._decrypt_credentials(provider.credentials)
         api_key = decrypted_creds.get("api_key", "")
         provider_type = provider.provider_type.lower()
+        endpoint = provider.config.get("endpoint", "")
 
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                if provider_type == "azure":
-                    # Azure /openai/models returns all available models in the
-                    # region, not just deployed ones. Skip live listing — users
-                    # should enter their deployment name manually.
-                    return []
-
-                elif provider_type == "openai":
-                    resp = await client.get(
-                        "https://api.openai.com/v1/models",
-                        headers={"Authorization": f"Bearer {api_key}"},
-                    )
-                    resp.raise_for_status()
-                    data = resp.json()
-                    return [
-                        {"name": m["id"], "owned_by": m.get("owned_by", "")}
-                        for m in sorted(data.get("data", []), key=lambda m: m["id"])
-                    ]
-
-                elif provider_type == "anthropic":
-                    resp = await client.get(
-                        "https://api.anthropic.com/v1/models",
-                        headers={
-                            "x-api-key": api_key,
-                            "anthropic-version": "2023-06-01",
-                        },
-                    )
-                    resp.raise_for_status()
-                    data = resp.json()
-                    return [
-                        {"name": m["id"], "display_name": m.get("display_name", "")}
-                        for m in sorted(data.get("data", []), key=lambda m: m["id"])
-                    ]
-
-                else:
-                    # For other providers, try OpenAI-compatible /v1/models
-                    endpoint = provider.config.get("endpoint", "").rstrip("/")
-                    if endpoint:
-                        resp = await client.get(
-                            f"{endpoint}/v1/models",
-                            headers={"Authorization": f"Bearer {api_key}"},
-                        )
-                        resp.raise_for_status()
-                        data = resp.json()
-                        return [
-                            {"name": m["id"]}
-                            for m in sorted(data.get("data", []), key=lambda m: m["id"])
-                        ]
-                    return []
-
+            names = await self._fetch_live_model_names(provider_type, api_key, endpoint)
         except Exception as e:
             return [{"error": f"Failed to list models: {str(e)}"}]
+
+        enriched: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for name in sorted(names):
+            if name in seen:
+                continue
+            seen.add(name)
+            entry = _enrich_with_litellm_metadata(name, provider_type)
+            if entry is not None:
+                enriched.append(entry)
+        return enriched
 
     async def test_connection(self, provider_id: UUID) -> dict[str, Any]:
         """Test connectivity to a model provider by making a minimal LiteLLM call.

--- a/backend/tests/unittests/model_providers/test_enrich_with_litellm_metadata.py
+++ b/backend/tests/unittests/model_providers/test_enrich_with_litellm_metadata.py
@@ -1,0 +1,176 @@
+"""Unit tests for the live-listing metadata enrichment helper."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from intric.model_providers.domain import model_provider_service
+
+
+def _patch_cost_map(fake: dict[str, dict[str, Any]]):
+    """Helper: patch litellm.model_cost for the duration of a test."""
+    return patch("litellm.model_cost", fake)
+
+
+def test_enriches_known_completion_model() -> None:
+    fake = {
+        "claude-opus-4-7": {
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+            "max_input_tokens": 200000,
+            "max_output_tokens": 8000,
+            "supports_vision": True,
+            "supports_function_calling": True,
+            "supports_reasoning": True,
+        }
+    }
+    with _patch_cost_map(fake):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "claude-opus-4-7", "anthropic"
+        )
+    assert result == {
+        "name": "claude-opus-4-7",
+        "mode": "completion",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8000,
+        "supports_vision": True,
+        "supports_function_calling": True,
+        "supports_reasoning": True,
+    }
+
+
+def test_enriches_via_provider_prefix_lookup() -> None:
+    """OpenAI-style names sometimes only exist as `openai/<name>` in cost map."""
+    fake = {
+        "openai/gpt-4o": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "max_input_tokens": 128000,
+            "max_output_tokens": 16000,
+            "supports_vision": True,
+            "supports_function_calling": True,
+            "supports_reasoning": False,
+        }
+    }
+    with _patch_cost_map(fake):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "gpt-4o", "openai"
+        )
+    assert result is not None
+    assert result["mode"] == "completion"
+    assert result["max_input_tokens"] == 128000
+
+
+def test_enriches_embedding_model() -> None:
+    fake = {
+        "text-embedding-3-large": {
+            "litellm_provider": "openai",
+            "mode": "embedding",
+            "max_input_tokens": 8191,
+            "output_vector_size": 3072,
+        }
+    }
+    with _patch_cost_map(fake):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "text-embedding-3-large", "openai"
+        )
+    assert result == {
+        "name": "text-embedding-3-large",
+        "mode": "embedding",
+        "max_input_tokens": 8191,
+        "output_vector_size": 3072,
+    }
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "gpt-4o-realtime-preview",
+        "gpt-audio-mini",
+        "whisper-1-search-preview",
+        "claude-3-5-sonnet-diarize",
+    ],
+)
+def test_filters_realtime_audio_search_diarize(name: str) -> None:
+    fake = {name: {"litellm_provider": "openai", "mode": "chat"}}
+    with _patch_cost_map(fake):
+        assert (
+            model_provider_service._enrich_with_litellm_metadata(name, "openai") is None
+        )
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["gpt-4o-latest", "claude-3-5-sonnet-latest"],
+)
+def test_filters_latest_aliases(name: str) -> None:
+    fake = {name: {"litellm_provider": "openai", "mode": "chat"}}
+    with _patch_cost_map(fake):
+        assert (
+            model_provider_service._enrich_with_litellm_metadata(name, "openai") is None
+        )
+
+
+def test_filters_image_and_tts_modes() -> None:
+    fake = {
+        "dall-e-3": {"litellm_provider": "openai", "mode": "image_generation"},
+        "tts-1": {"litellm_provider": "openai", "mode": "audio_speech"},
+        "omni-moderation-latest": {
+            "litellm_provider": "openai",
+            "mode": "moderation",
+        },
+    }
+    with _patch_cost_map(fake):
+        assert (
+            model_provider_service._enrich_with_litellm_metadata("dall-e-3", "openai")
+            is None
+        )
+        assert (
+            model_provider_service._enrich_with_litellm_metadata("tts-1", "openai")
+            is None
+        )
+
+
+def test_unknown_anthropic_model_defaults_to_completion() -> None:
+    """Anthropic's /v1/models only ever returns chat models, so unknown names
+    fall through as completion. This keeps newly-released models reachable."""
+    with _patch_cost_map({}):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "claude-opus-4-99", "anthropic"
+        )
+    assert result == {"name": "claude-opus-4-99", "mode": "completion"}
+
+
+def test_unknown_openai_gpt_model_defaults_to_completion() -> None:
+    with _patch_cost_map({}):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "gpt-9-future", "openai"
+        )
+    assert result == {"name": "gpt-9-future", "mode": "completion"}
+
+
+def test_unknown_openai_whisper_defaults_to_transcription() -> None:
+    with _patch_cost_map({}):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "whisper-2", "openai"
+        )
+    assert result == {"name": "whisper-2", "mode": "transcription"}
+
+
+def test_unknown_openai_image_model_dropped() -> None:
+    with _patch_cost_map({}):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "dall-e-99", "openai"
+        )
+    assert result is None
+
+
+def test_unknown_arbitrary_model_dropped() -> None:
+    """For unknown providers and arbitrary names, we don't guess — better to
+    drop than to pollute the wrong mode picker."""
+    with _patch_cost_map({}):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "mystery-model-xyz", "vllm"
+        )
+    assert result is None

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepModels.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepModels.svelte
@@ -101,6 +101,7 @@
   // Model info from capabilities API
   interface ModelInfo {
     name: string;
+    mode?: string;
     max_input_tokens?: number;
     max_output_tokens?: number;
     supports_vision?: boolean;
@@ -124,13 +125,16 @@
     return limit.toString();
   }
 
-  // Providers that need live model listing from their API (not LiteLLM static data)
-  const liveListProviders = new Set(["vllm"]);
+  // Providers that list models live via their own API rather than the static
+  // LiteLLM catalog. Live listing returns only models the user's API key can
+  // actually call, which avoids preview/deprecated names polluting the picker.
+  const liveListProviders = new Set(["vllm", "openai", "anthropic"]);
 
   // Providers where LiteLLM names don't match user input (e.g. Azure uses deployment names)
   const noSuggestionsProviders = new Set(["azure"]);
 
-  // Live models fetched from the provider's own API
+  // Live models fetched from the provider's own API, enriched server-side
+  // with capability metadata from litellm.model_cost.
   let liveModels: ModelInfo[] = [];
   let liveModelsLoaded = false;
   let liveModelsError = "";
@@ -150,11 +154,15 @@
         liveModelsError = (result[0] as Record<string, unknown>).error as string;
       } else if (result && Array.isArray(result)) {
         liveModels = result.map((item: Record<string, unknown>) => ({
-          name: item.model ? `${item.name} (${item.model})` : String(item.name),
-          max_input_tokens: undefined,
-          max_output_tokens: undefined,
-          supports_vision: false,
-          supports_reasoning: false
+          name: String(item.name),
+          mode: item.mode != null ? String(item.mode) : undefined,
+          max_input_tokens: item.max_input_tokens as number | undefined,
+          max_output_tokens: item.max_output_tokens as number | undefined,
+          supports_vision: (item.supports_vision as boolean | undefined) ?? false,
+          supports_function_calling:
+            (item.supports_function_calling as boolean | undefined) ?? false,
+          supports_reasoning: (item.supports_reasoning as boolean | undefined) ?? false,
+          output_vector_size: item.output_vector_size as number | undefined
         }));
       }
     } catch {
@@ -164,11 +172,12 @@
   }
   $: if (liveListProviders.has(providerType) && providerId) loadLiveModels();
 
-  // All models: live from provider API, static from LiteLLM, or none for Azure
+  // All models: live from provider API (filtered to current modelType),
+  // static from LiteLLM, or none for Azure.
   $: allModels = noSuggestionsProviders.has(providerType)
     ? []
     : liveListProviders.has(providerType)
-      ? liveModels
+      ? liveModels.filter((m) => m.mode === modeMap[modelType])
       : ((capabilityProviders[providerType]?.models?.[modeMap[modelType]] ?? []) as ModelInfo[]);
 
   // Top 4 as quick suggestions (leaving room for "Browse all" chip)


### PR DESCRIPTION
## Summary

The "Add model" wizard's suggestions and Browse-all list come from `litellm.model_cost` — a static catalogue bundled with the litellm package. It contains every model name LiteLLM has ever heard of, including preview snapshots (`claude-opus-4-7-20260416`), deprecated old-style names (`claude-4-opus-20250514`), and superseded minor versions. None of those can be reliably filtered out by heuristics — many entries have no `deprecation_date`, and no entry has a `release_date`.

This PR switches OpenAI and Anthropic to **live-list** via their own `/v1/models` endpoint once a provider has been created. The provider's API only returns models the user's API key can actually call, eliminating preview/limited-rollout names and old superseded snapshots in one shot.

The live name list is enriched server-side with capability metadata from `litellm.model_cost` (`max_input_tokens`, `supports_vision`, etc.) so the wizard form pre-fills correctly when the user clicks a chip. Names not in the cost map fall back to mode inference from the name pattern so newly-released models still appear without losing the picker filter.

## What changes for the user

| Provider | Before | After |
|---|---|---|
| OpenAI | Static catalogue (197 entries, includes dated snapshots, deprecated names) | Live `/v1/models`, filtered to current model type, enriched with metadata |
| Anthropic | Static catalogue (20 entries, including `claude-4-opus-20250514`, `claude-opus-4-7-20260416`) | Live `/v1/models`, only models the API key has access to |
| vLLM | Live (unchanged) | Live (unchanged) |
| Azure | No suggestions (manual deployment name) | No suggestions (unchanged) |
| Gemini, Mistral, Cohere, others | Static catalogue | Static catalogue (unchanged) |

## Implementation notes

**Backend** (`model_provider_service.py`)
- Split fetching from enrichment: `_fetch_live_model_names` returns plain `list[str]`, `_enrich_with_litellm_metadata` enriches each name and applies all filters
- Same name-pattern filter as the static endpoint: drops `realtime`, `-audio-`, `gpt-audio`, `search-preview`, `search-api`, `-diarize`, `-latest`, `/container`
- Drops models whose litellm mode isn't text (image, tts, moderation)
- Mode inference fallback for models not in the cost map:
  - Anthropic: any name → `completion` (their API only ever returns chat models)
  - OpenAI: `gpt-`/`o1`/`o3`/`o4`/`chatgpt-` → completion, `whisper` → transcription, `embedding` in name → embedding, `dall-e`/`tts-`/`moderation`/`image` → dropped
  - Other providers: dropped (no inference, to avoid polluting wrong mode pickers)

**Frontend** (`StepModels.svelte`)
- Add `openai` and `anthropic` to `liveListProviders`
- Map enriched response into existing `ModelInfo` shape with new optional `mode` field
- Filter live models by `mode === modeMap[modelType]` so each picker only shows matching models

## Test plan

- [x] 15 new unit tests for `_enrich_with_litellm_metadata` (known/unknown models, prefix lookup, mode inference, name filters, mode filters)
- [x] Full backend unit suite: **1311 passed**
- [x] `pyright` on backend changes: 0 errors, 0 warnings
- [x] Frontend `svelte-check`: 0 errors (pre-existing warnings unrelated)
- [ ] Manual E2E:
  - Add OpenAI provider with valid API key → verify only models the key has access to are listed (no `gpt-4o-realtime-preview-2024-12-17`, no `omni-moderation-2024-09-26` in completion picker, no `dall-e-3`)
  - Add Anthropic provider with valid API key → verify clean list (no `claude-opus-4-7-20260416`, no `claude-4-opus-20250514`)
  - Switch model type to embedding/transcription → verify picker filters correctly
  - Live API failure (revoked key) → verify error UI appears with manual-entry hint

## Notes

- vLLM behaviour is preserved (no `liveModelsLoaded` reset between toggles needed since `providerId` is stable through the wizard step)
- This PR is independent of #360 (dated-alias collapse) — they layer cleanly: live-listing is the primary path, the static-catalogue collapse remains for non-live providers