### PR TITLE
feat(model-providers): live-list models, generalized across providers

### DIFF
--- a/backend/src/intric/model_providers/domain/model_provider_service.py
+++ b/backend/src/intric/model_providers/domain/model_provider_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional
 from uuid import UUID, uuid4
 
@@ -12,6 +13,104 @@ if TYPE_CHECKING:
     pass
 
 
+# Default base URLs for providers that don't ask the user for one.
+# Any provider configured with its own ``endpoint`` wins over the default.
+_DEFAULT_ENDPOINTS: dict[str, str] = {
+    "openai": "https://api.openai.com",
+    "anthropic": "https://api.anthropic.com",
+}
+
+
+def _auth_headers_for(provider_type: str, api_key: str) -> dict[str, str]:
+    """Auth header set per provider. Bearer for everyone except Anthropic,
+    which uses its own header pair."""
+    if provider_type == "anthropic":
+        return {"x-api-key": api_key, "anthropic-version": "2023-06-01"}
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def _normalize_endpoint_base(base: str) -> str:
+    """Strip a trailing slash and an optional ``/v1`` suffix so users can
+    paste either ``https://api.example.com`` or ``https://api.example.com/v1``
+    without us producing ``/v1/v1/models``."""
+    s = base.rstrip("/")
+    if s.endswith("/v1"):
+        s = s[:-3].rstrip("/")
+    return s
+
+
+def _coerce_to_epoch(value: Any) -> float:
+    """Best-effort parse of a created/release timestamp into epoch seconds.
+    Accepts an int/float (already epoch), an ISO 8601 string, or returns 0.0
+    for anything else so models without a timestamp sort last."""
+    if value is None or value == "":
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+    except (ValueError, AttributeError):
+        return 0.0
+
+
+def _extract_mode_hint(m: dict[str, Any]) -> str | None:
+    """Read mode classification from provider-supplied response metadata.
+
+    Some providers expose richer fields than just ``id`` — read them
+    opportunistically. When present, these are far more reliable than
+    name-based heuristics (``intfloat/multilingual-e5-large`` is an
+    embedding model whose name doesn't say so). Sources, in priority order:
+
+    1. ``model_type`` — coarse category. Values seen in the wild:
+       ``"embedding"``, ``"text"``, ``"audio"``/``"transcription"``.
+    2. ``capabilities.embeddings: true`` — fallback for providers that
+       use ``model_type: "text"`` for everything and rely on the flag.
+
+    Returns one of ``"completion"``, ``"embedding"``, ``"transcription"``,
+    or ``None`` when the response carries neither field and the caller
+    should fall back to name-based inference.
+    """
+    raw_capabilities: Any = m.get("capabilities")
+    embeddings_flag: bool = (
+        isinstance(raw_capabilities, dict)
+        and raw_capabilities.get("embeddings") is True  # type: ignore[reportUnknownMemberType]
+    )
+
+    model_type = m.get("model_type")
+    if model_type == "embedding":
+        return "embedding"
+    if model_type in ("audio", "transcription"):
+        return "transcription"
+    if model_type == "text":
+        # Could still be an embedding flagged via capabilities.
+        return "embedding" if embeddings_flag else "completion"
+
+    if embeddings_flag:
+        return "embedding"
+
+    return None
+
+
+def _normalize_live_model(m: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a single ``/v1/models`` entry across providers.
+
+    Pull each field with a fallback chain so any provider that follows the
+    same rough shape works without a code change. Field variants seen in
+    the wild: ``display_name``/``name`` for the friendly label;
+    ``created_at`` (ISO) / ``created`` (epoch) / ``release_date`` for
+    the timestamp; richer providers also include ``capabilities`` and
+    ``model_type`` which we read via ``_extract_mode_hint``.
+    """
+    return {
+        "id": m["id"],
+        "display_name": m.get("display_name") or m.get("name", ""),
+        "created_at": _coerce_to_epoch(
+            m.get("created_at") or m.get("created") or m.get("release_date")
+        ),
+        "mode_hint": _extract_mode_hint(m),
+    }
+
+
 # LiteLLM mode → our model_type. Anything else (image, tts, moderation) is filtered out.
 _LITELLM_MODE_TO_OUR_MODE: dict[str, str] = {
     "chat": "completion",
@@ -21,6 +120,11 @@ _LITELLM_MODE_TO_OUR_MODE: dict[str, str] = {
 }
 
 # Name substrings to drop — same set the static capabilities endpoint filters.
+# These run on every name regardless of whether it appears in litellm.model_cost,
+# i.e. they catch known-but-unwanted models (preview snapshots, audio variants).
+# This is intentionally kept separate from the keyword list inside
+# `_infer_mode_from_name`, which only runs on cache misses to *classify* an
+# unknown name's mode (e.g. "whisper-2" → transcription, "dall-e-99" → drop).
 _NAME_FILTER_SUBSTRINGS: tuple[str, ...] = (
     "realtime",
     "-audio-",
@@ -31,30 +135,28 @@ _NAME_FILTER_SUBSTRINGS: tuple[str, ...] = (
 )
 
 
-def _infer_mode_from_name(name: str, provider_type: str) -> str | None:
+def _infer_mode_from_name(name: str) -> str | None:
     """Best-effort mode inference for names not in litellm.model_cost.
 
-    Returns None when the name clearly maps to a non-text mode (image, tts,
-    moderation) so the entry is dropped. Returns "completion" by default for
-    Anthropic (their /v1/models only returns chat models). Returns None for
-    fully unknown names so we don't pollute mode-specific pickers.
+    This is only invoked for names that arrived via a live ``/v1/models``
+    response — i.e. the provider has already asserted they serve this
+    model. Image/audio/moderation names are still dropped from the picker;
+    everything else defaults to ``"completion"`` since the alternative
+    (returning None and dropping the entry) silently hides real models
+    from any provider whose names don't match a hardcoded prefix.
     """
     lower = name.lower()
-    if any(kw in lower for kw in ("dall-e", "image", "tts-", "moderation", "whisper")):
-        if "whisper" in lower:
-            return "transcription"
+    if any(kw in lower for kw in ("dall-e", "tts-", "moderation")):
         return None
+    if "whisper" in lower:
+        return "transcription"
     if "embedding" in lower:
         return "embedding"
-    if provider_type == "anthropic":
-        return "completion"
-    if lower.startswith(("gpt-", "o1", "o3", "o4", "chatgpt-")):
-        return "completion"
-    return None
+    return "completion"
 
 
 def _enrich_with_litellm_metadata(
-    name: str, provider_type: str
+    name: str, provider_type: str, mode_hint: str | None = None
 ) -> dict[str, Any] | None:
     """Look up `name` in litellm.model_cost (with prefix variants) and return
     an enriched capability dict, or None if the model should be hidden.
@@ -62,9 +164,10 @@ def _enrich_with_litellm_metadata(
     Returns None when the name matches a non-text filter substring or maps to
     a litellm mode we don't surface (image, tts, moderation, etc.).
 
-    For names not present in the cost map, falls back to mode inference from
-    the name so newly-released models still show up. Returns None if no mode
-    can be inferred (avoids polluting mode-specific pickers with unknowns).
+    When the name isn't in the cost map, ``mode_hint`` (read from the
+    provider's own response — see ``_extract_mode_hint``) wins over name
+    inference, so embedding models with non-obvious names like
+    ``intfloat/multilingual-e5-large`` get classified correctly.
     """
     import litellm
 
@@ -84,10 +187,10 @@ def _enrich_with_litellm_metadata(
             break
 
     if info is None:
-        inferred = _infer_mode_from_name(name, provider_type)
-        if inferred is None:
+        chosen = mode_hint or _infer_mode_from_name(name)
+        if chosen is None:
             return None
-        return {"name": name, "mode": inferred}
+        return {"name": name, "mode": chosen}
 
     litellm_mode = info.get("mode", "")
     mode = _LITELLM_MODE_TO_OUR_MODE.get(litellm_mode)
@@ -333,57 +436,57 @@ class ModelProviderService:
                 return {"success": False, "error": "Could not connect to API"}
             return {"success": False, "error": f"Validation failed: {str(e)}"}
 
-    async def _fetch_live_model_names(
+    async def _fetch_live_models(
         self, provider_type: str, api_key: str, endpoint: str
-    ) -> list[str]:
-        """Fetch the list of model names available on a provider via its own API."""
+    ) -> list[dict[str, Any]]:
+        """Fetch the live model list from a provider.
+
+        Most providers expose ``GET /v1/models`` returning
+        ``{"data": [{"id": ...}]}``. The two things that vary are the auth
+        header and the base URL — captured by ``_auth_headers_for`` and
+        ``_DEFAULT_ENDPOINTS``. Fields beyond ``id`` are pulled
+        opportunistically through fallback chains in ``_normalize_live_model``
+        so providers with richer responses get more metadata, while
+        minimal-shape providers still work.
+
+        Returns entries with ``id``, optional ``display_name``, a
+        ``created_at`` epoch-seconds value used to sort newest-first, and
+        an optional ``mode_hint`` from provider-supplied capability fields.
+        Azure is skipped — its ``/openai/models`` returns every model in
+        the region, not deployed ones.
+        """
         import httpx
 
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            if provider_type == "azure":
-                # Azure /openai/models returns all models in the region, not
-                # just deployed ones. Users enter their deployment name manually.
-                return []
-
-            if provider_type == "openai":
-                resp = await client.get(
-                    "https://api.openai.com/v1/models",
-                    headers={"Authorization": f"Bearer {api_key}"},
-                )
-                resp.raise_for_status()
-                return [m["id"] for m in resp.json().get("data", [])]
-
-            if provider_type == "anthropic":
-                resp = await client.get(
-                    "https://api.anthropic.com/v1/models",
-                    headers={
-                        "x-api-key": api_key,
-                        "anthropic-version": "2023-06-01",
-                    },
-                )
-                resp.raise_for_status()
-                return [m["id"] for m in resp.json().get("data", [])]
-
-            # OpenAI-compatible providers (vLLM, custom endpoints)
-            if endpoint:
-                resp = await client.get(
-                    f"{endpoint.rstrip('/')}/v1/models",
-                    headers={"Authorization": f"Bearer {api_key}"},
-                )
-                resp.raise_for_status()
-                return [m["id"] for m in resp.json().get("data", [])]
-
+        if provider_type == "azure":
             return []
 
-    async def list_available_models(self, provider_id: UUID) -> list[dict[str, Any]]:
+        base = endpoint or _DEFAULT_ENDPOINTS.get(provider_type)
+        if not base:
+            return []
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{_normalize_endpoint_base(base)}/v1/models",
+                headers=_auth_headers_for(provider_type, api_key),
+            )
+            resp.raise_for_status()
+            return [_normalize_live_model(m) for m in resp.json().get("data", [])]
+
+    async def list_available_models(
+        self, provider_id: UUID, mode: str | None = None
+    ) -> list[dict[str, Any]]:
         """List models available on a provider using its credentials, enriched
         with capability metadata from litellm.model_cost.
 
         Each entry has at least ``name`` and ``mode`` (one of "completion",
-        "embedding", "transcription", or None for unknown). Completion entries
-        include ``max_input_tokens``, ``max_output_tokens``, and ``supports_*``
+        "embedding", "transcription"). Completion entries include
+        ``max_input_tokens``, ``max_output_tokens``, and ``supports_*``
         flags; embedding entries include ``max_input_tokens`` and
         ``output_vector_size``.
+
+        Pass ``mode`` to filter the response to a single category — keeps
+        consumers (frontend pickers, external API clients) from having to
+        filter client-side.
         """
         provider = await self.repository.get_by_id(provider_id)
         decrypted_creds = self._decrypt_credentials(provider.credentials)
@@ -392,19 +495,34 @@ class ModelProviderService:
         endpoint = provider.config.get("endpoint", "")
 
         try:
-            names = await self._fetch_live_model_names(provider_type, api_key, endpoint)
+            items = await self._fetch_live_models(provider_type, api_key, endpoint)
         except Exception as e:
             return [{"error": f"Failed to list models: {str(e)}"}]
 
+        # Sort newest-first by provider-supplied created_at, with id as a
+        # stable tiebreaker so models without a timestamp keep alphabetical order.
+        sorted_items = sorted(
+            items, key=lambda x: (-float(x.get("created_at", 0) or 0), x["id"])
+        )
+
         enriched: list[dict[str, Any]] = []
         seen: set[str] = set()
-        for name in sorted(names):
+        for item in sorted_items:
+            name = item["id"]
             if name in seen:
                 continue
             seen.add(name)
-            entry = _enrich_with_litellm_metadata(name, provider_type)
-            if entry is not None:
-                enriched.append(entry)
+            entry = _enrich_with_litellm_metadata(
+                name, provider_type, mode_hint=item.get("mode_hint")
+            )
+            if entry is None:
+                continue
+            if mode is not None and entry.get("mode") != mode:
+                continue
+            display_name = item.get("display_name")
+            if display_name:
+                entry["display_name"] = display_name
+            enriched.append(entry)
         return enriched
 
     async def test_connection(self, provider_id: UUID) -> dict[str, Any]:

--- a/backend/src/intric/model_providers/domain/model_provider_service.py
+++ b/backend/src/intric/model_providers/domain/model_provider_service.py
@@ -12,6 +12,103 @@ if TYPE_CHECKING:
     pass
 
 
+# LiteLLM mode → our model_type. Anything else (image, tts, moderation) is filtered out.
+_LITELLM_MODE_TO_OUR_MODE: dict[str, str] = {
+    "chat": "completion",
+    "completion": "completion",
+    "embedding": "embedding",
+    "audio_transcription": "transcription",
+}
+
+# Name substrings to drop — same set the static capabilities endpoint filters.
+_NAME_FILTER_SUBSTRINGS: tuple[str, ...] = (
+    "realtime",
+    "-audio-",
+    "gpt-audio",
+    "search-preview",
+    "search-api",
+    "-diarize",
+)
+
+
+def _infer_mode_from_name(name: str, provider_type: str) -> str | None:
+    """Best-effort mode inference for names not in litellm.model_cost.
+
+    Returns None when the name clearly maps to a non-text mode (image, tts,
+    moderation) so the entry is dropped. Returns "completion" by default for
+    Anthropic (their /v1/models only returns chat models). Returns None for
+    fully unknown names so we don't pollute mode-specific pickers.
+    """
+    lower = name.lower()
+    if any(kw in lower for kw in ("dall-e", "image", "tts-", "moderation", "whisper")):
+        if "whisper" in lower:
+            return "transcription"
+        return None
+    if "embedding" in lower:
+        return "embedding"
+    if provider_type == "anthropic":
+        return "completion"
+    if lower.startswith(("gpt-", "o1", "o3", "o4", "chatgpt-")):
+        return "completion"
+    return None
+
+
+def _enrich_with_litellm_metadata(
+    name: str, provider_type: str
+) -> dict[str, Any] | None:
+    """Look up `name` in litellm.model_cost (with prefix variants) and return
+    an enriched capability dict, or None if the model should be hidden.
+
+    Returns None when the name matches a non-text filter substring or maps to
+    a litellm mode we don't surface (image, tts, moderation, etc.).
+
+    For names not present in the cost map, falls back to mode inference from
+    the name so newly-released models still show up. Returns None if no mode
+    can be inferred (avoids polluting mode-specific pickers with unknowns).
+    """
+    import litellm
+
+    lower = name.lower()
+    if any(kw in lower for kw in _NAME_FILTER_SUBSTRINGS):
+        return None
+    if name.endswith("-latest") or "/container" in lower:
+        return None
+
+    model_cost = getattr(litellm, "model_cost", {})
+
+    candidates = [name, f"{provider_type}/{name}"]
+    info: dict[str, Any] | None = None
+    for key in candidates:
+        if key in model_cost:
+            info = model_cost[key]
+            break
+
+    if info is None:
+        inferred = _infer_mode_from_name(name, provider_type)
+        if inferred is None:
+            return None
+        return {"name": name, "mode": inferred}
+
+    litellm_mode = info.get("mode", "")
+    mode = _LITELLM_MODE_TO_OUR_MODE.get(litellm_mode)
+    if mode is None:
+        return None
+
+    enriched: dict[str, Any] = {"name": name, "mode": mode}
+    if mode == "completion":
+        enriched["max_input_tokens"] = info.get("max_input_tokens")
+        enriched["max_output_tokens"] = info.get("max_output_tokens")
+        enriched["supports_vision"] = info.get("supports_vision", False)
+        enriched["supports_function_calling"] = info.get(
+            "supports_function_calling", False
+        )
+        enriched["supports_reasoning"] = info.get("supports_reasoning", False)
+    elif mode == "embedding":
+        enriched["max_input_tokens"] = info.get("max_input_tokens")
+        enriched["output_vector_size"] = info.get("output_vector_size")
+    return enriched
+
+
 class ModelProviderService:
     """Service for managing model providers with credential encryption."""
 
@@ -236,68 +333,79 @@ class ModelProviderService:
                 return {"success": False, "error": "Could not connect to API"}
             return {"success": False, "error": f"Validation failed: {str(e)}"}
 
-    async def list_available_models(self, provider_id: UUID) -> list[dict[str, Any]]:
-        """List models/deployments available on a provider using its credentials."""
+    async def _fetch_live_model_names(
+        self, provider_type: str, api_key: str, endpoint: str
+    ) -> list[str]:
+        """Fetch the list of model names available on a provider via its own API."""
         import httpx
 
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            if provider_type == "azure":
+                # Azure /openai/models returns all models in the region, not
+                # just deployed ones. Users enter their deployment name manually.
+                return []
+
+            if provider_type == "openai":
+                resp = await client.get(
+                    "https://api.openai.com/v1/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                return [m["id"] for m in resp.json().get("data", [])]
+
+            if provider_type == "anthropic":
+                resp = await client.get(
+                    "https://api.anthropic.com/v1/models",
+                    headers={
+                        "x-api-key": api_key,
+                        "anthropic-version": "2023-06-01",
+                    },
+                )
+                resp.raise_for_status()
+                return [m["id"] for m in resp.json().get("data", [])]
+
+            # OpenAI-compatible providers (vLLM, custom endpoints)
+            if endpoint:
+                resp = await client.get(
+                    f"{endpoint.rstrip('/')}/v1/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp.raise_for_status()
+                return [m["id"] for m in resp.json().get("data", [])]
+
+            return []
+
+    async def list_available_models(self, provider_id: UUID) -> list[dict[str, Any]]:
+        """List models available on a provider using its credentials, enriched
+        with capability metadata from litellm.model_cost.
+
+        Each entry has at least ``name`` and ``mode`` (one of "completion",
+        "embedding", "transcription", or None for unknown). Completion entries
+        include ``max_input_tokens``, ``max_output_tokens``, and ``supports_*``
+        flags; embedding entries include ``max_input_tokens`` and
+        ``output_vector_size``.
+        """
         provider = await self.repository.get_by_id(provider_id)
         decrypted_creds = self._decrypt_credentials(provider.credentials)
         api_key = decrypted_creds.get("api_key", "")
         provider_type = provider.provider_type.lower()
+        endpoint = provider.config.get("endpoint", "")
 
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
-                if provider_type == "azure":
-                    # Azure /openai/models returns all available models in the
-                    # region, not just deployed ones. Skip live listing — users
-                    # should enter their deployment name manually.
-                    return []
-
-                elif provider_type == "openai":
-                    resp = await client.get(
-                        "https://api.openai.com/v1/models",
-                        headers={"Authorization": f"Bearer {api_key}"},
-                    )
-                    resp.raise_for_status()
-                    data = resp.json()
-                    return [
-                        {"name": m["id"], "owned_by": m.get("owned_by", "")}
-                        for m in sorted(data.get("data", []), key=lambda m: m["id"])
-                    ]
-
-                elif provider_type == "anthropic":
-                    resp = await client.get(
-                        "https://api.anthropic.com/v1/models",
-                        headers={
-                            "x-api-key": api_key,
-                            "anthropic-version": "2023-06-01",
-                        },
-                    )
-                    resp.raise_for_status()
-                    data = resp.json()
-                    return [
-                        {"name": m["id"], "display_name": m.get("display_name", "")}
-                        for m in sorted(data.get("data", []), key=lambda m: m["id"])
-                    ]
-
-                else:
-                    # For other providers, try OpenAI-compatible /v1/models
-                    endpoint = provider.config.get("endpoint", "").rstrip("/")
-                    if endpoint:
-                        resp = await client.get(
-                            f"{endpoint}/v1/models",
-                            headers={"Authorization": f"Bearer {api_key}"},
-                        )
-                        resp.raise_for_status()
-                        data = resp.json()
-                        return [
-                            {"name": m["id"]}
-                            for m in sorted(data.get("data", []), key=lambda m: m["id"])
-                        ]
-                    return []
-
+            names = await self._fetch_live_model_names(provider_type, api_key, endpoint)
         except Exception as e:
             return [{"error": f"Failed to list models: {str(e)}"}]
+
+        enriched: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for name in sorted(names):
+            if name in seen:
+                continue
+            seen.add(name)
+            entry = _enrich_with_litellm_metadata(name, provider_type)
+            if entry is not None:
+                enriched.append(entry)
+        return enriched
 
     async def test_connection(self, provider_id: UUID) -> dict[str, Any]:
         """Test connectivity to a model provider by making a minimal LiteLLM call.

--- a/backend/src/intric/model_providers/presentation/model_provider_router.py
+++ b/backend/src/intric/model_providers/presentation/model_provider_router.py
@@ -1,10 +1,10 @@
 import re
 from collections import defaultdict
 from datetime import date
-from typing import Annotated, Any, cast
+from typing import Annotated, Any, Literal, cast
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from typing_extensions import TypedDict
 
 from intric.authentication.auth_dependencies import get_current_active_user
@@ -383,9 +383,20 @@ async def update_provider(
 async def list_provider_models(
     provider_id: UUID,
     service: ServiceDep,
+    mode: Annotated[
+        Literal["completion", "embedding", "transcription"] | None,
+        Query(description="Filter response to a single mode."),
+    ] = None,
 ) -> list[dict[str, Any]]:
-    """List available models/deployments from the provider's API using its credentials."""
-    return await service.list_available_models(provider_id)
+    """List available models from the provider's API using its credentials.
+
+    Each entry has at least ``name`` and ``mode``. Completion entries also
+    include ``max_input_tokens``, ``max_output_tokens`` and ``supports_*``
+    flags; embedding entries include ``max_input_tokens`` and
+    ``output_vector_size``. When ``mode`` is supplied the server returns
+    only matching entries — consumers don't need to filter client-side.
+    """
+    return await service.list_available_models(provider_id, mode=mode)
 
 
 @router.post(

--- a/backend/tests/unittests/model_providers/test_enrich_with_litellm_metadata.py
+++ b/backend/tests/unittests/model_providers/test_enrich_with_litellm_metadata.py
@@ -1,0 +1,176 @@
+"""Unit tests for the live-listing metadata enrichment helper."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from intric.model_providers.domain import model_provider_service
+
+
+def _patch_cost_map(fake: dict[str, dict[str, Any]]):
+    """Helper: patch litellm.model_cost for the duration of a test."""
+    return patch("litellm.model_cost", fake)
+
+
+def test_enriches_known_completion_model() -> None:
+    fake = {
+        "claude-opus-4-7": {
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+            "max_input_tokens": 200000,
+            "max_output_tokens": 8000,
+            "supports_vision": True,
+            "supports_function_calling": True,
+            "supports_reasoning": True,
+        }
+    }
+    with _patch_cost_map(fake):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "claude-opus-4-7", "anthropic"
+        )
+    assert result == {
+        "name": "claude-opus-4-7",
+        "mode": "completion",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 8000,
+        "supports_vision": True,
+        "supports_function_calling": True,
+        "supports_reasoning": True,
+    }
+
+
+def test_enriches_via_provider_prefix_lookup() -> None:
+    """OpenAI-style names sometimes only exist as `openai/<name>` in cost map."""
+    fake = {
+        "openai/gpt-4o": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "max_input_tokens": 128000,
+            "max_output_tokens": 16000,
+            "supports_vision": True,
+            "supports_function_calling": True,
+            "supports_reasoning": False,
+        }
+    }
+    with _patch_cost_map(fake):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "gpt-4o", "openai"
+        )
+    assert result is not None
+    assert result["mode"] == "completion"
+    assert result["max_input_tokens"] == 128000
+
+
+def test_enriches_embedding_model() -> None:
+    fake = {
+        "text-embedding-3-large": {
+            "litellm_provider": "openai",
+            "mode": "embedding",
+            "max_input_tokens": 8191,
+            "output_vector_size": 3072,
+        }
+    }
+    with _patch_cost_map(fake):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "text-embedding-3-large", "openai"
+        )
+    assert result == {
+        "name": "text-embedding-3-large",
+        "mode": "embedding",
+        "max_input_tokens": 8191,
+        "output_vector_size": 3072,
+    }
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "gpt-4o-realtime-preview",
+        "gpt-audio-mini",
+        "whisper-1-search-preview",
+        "claude-3-5-sonnet-diarize",
+    ],
+)
+def test_filters_realtime_audio_search_diarize(name: str) -> None:
+    fake = {name: {"litellm_provider": "openai", "mode": "chat"}}
+    with _patch_cost_map(fake):
+        assert (
+            model_provider_service._enrich_with_litellm_metadata(name, "openai") is None
+        )
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["gpt-4o-latest", "claude-3-5-sonnet-latest"],
+)
+def test_filters_latest_aliases(name: str) -> None:
+    fake = {name: {"litellm_provider": "openai", "mode": "chat"}}
+    with _patch_cost_map(fake):
+        assert (
+            model_provider_service._enrich_with_litellm_metadata(name, "openai") is None
+        )
+
+
+def test_filters_image_and_tts_modes() -> None:
+    fake = {
+        "dall-e-3": {"litellm_provider": "openai", "mode": "image_generation"},
+        "tts-1": {"litellm_provider": "openai", "mode": "audio_speech"},
+        "omni-moderation-latest": {
+            "litellm_provider": "openai",
+            "mode": "moderation",
+        },
+    }
+    with _patch_cost_map(fake):
+        assert (
+            model_provider_service._enrich_with_litellm_metadata("dall-e-3", "openai")
+            is None
+        )
+        assert (
+            model_provider_service._enrich_with_litellm_metadata("tts-1", "openai")
+            is None
+        )
+
+
+def test_unknown_anthropic_model_defaults_to_completion() -> None:
+    """Anthropic's /v1/models only ever returns chat models, so unknown names
+    fall through as completion. This keeps newly-released models reachable."""
+    with _patch_cost_map({}):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "claude-opus-4-99", "anthropic"
+        )
+    assert result == {"name": "claude-opus-4-99", "mode": "completion"}
+
+
+def test_unknown_openai_gpt_model_defaults_to_completion() -> None:
+    with _patch_cost_map({}):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "gpt-9-future", "openai"
+        )
+    assert result == {"name": "gpt-9-future", "mode": "completion"}
+
+
+def test_unknown_openai_whisper_defaults_to_transcription() -> None:
+    with _patch_cost_map({}):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "whisper-2", "openai"
+        )
+    assert result == {"name": "whisper-2", "mode": "transcription"}
+
+
+def test_unknown_openai_image_model_dropped() -> None:
+    with _patch_cost_map({}):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "dall-e-99", "openai"
+        )
+    assert result is None
+
+
+def test_unknown_arbitrary_model_dropped() -> None:
+    """For unknown providers and arbitrary names, we don't guess — better to
+    drop than to pollute the wrong mode picker."""
+    with _patch_cost_map({}):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "mystery-model-xyz", "vllm"
+        )
+    assert result is None

--- a/backend/tests/unittests/model_providers/test_enrich_with_litellm_metadata.py
+++ b/backend/tests/unittests/model_providers/test_enrich_with_litellm_metadata.py
@@ -132,25 +132,17 @@ def test_filters_image_and_tts_modes() -> None:
         )
 
 
-def test_unknown_anthropic_model_defaults_to_completion() -> None:
-    """Anthropic's /v1/models only ever returns chat models, so unknown names
-    fall through as completion. This keeps newly-released models reachable."""
+def test_unknown_name_defaults_to_completion() -> None:
+    """Live-listed names that aren't in the cost map default to completion —
+    if the provider served it on /v1/models we trust it's a real text model."""
     with _patch_cost_map({}):
         result = model_provider_service._enrich_with_litellm_metadata(
-            "claude-opus-4-99", "anthropic"
+            "future-model-1", "openai"
         )
-    assert result == {"name": "claude-opus-4-99", "mode": "completion"}
+    assert result == {"name": "future-model-1", "mode": "completion"}
 
 
-def test_unknown_openai_gpt_model_defaults_to_completion() -> None:
-    with _patch_cost_map({}):
-        result = model_provider_service._enrich_with_litellm_metadata(
-            "gpt-9-future", "openai"
-        )
-    assert result == {"name": "gpt-9-future", "mode": "completion"}
-
-
-def test_unknown_openai_whisper_defaults_to_transcription() -> None:
+def test_unknown_whisper_inferred_as_transcription() -> None:
     with _patch_cost_map({}):
         result = model_provider_service._enrich_with_litellm_metadata(
             "whisper-2", "openai"
@@ -158,19 +150,17 @@ def test_unknown_openai_whisper_defaults_to_transcription() -> None:
     assert result == {"name": "whisper-2", "mode": "transcription"}
 
 
-def test_unknown_openai_image_model_dropped() -> None:
+def test_unknown_embedding_inferred_as_embedding() -> None:
+    with _patch_cost_map({}):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "future-embedding-1", "openai"
+        )
+    assert result == {"name": "future-embedding-1", "mode": "embedding"}
+
+
+def test_unknown_image_model_dropped() -> None:
     with _patch_cost_map({}):
         result = model_provider_service._enrich_with_litellm_metadata(
             "dall-e-99", "openai"
-        )
-    assert result is None
-
-
-def test_unknown_arbitrary_model_dropped() -> None:
-    """For unknown providers and arbitrary names, we don't guess — better to
-    drop than to pollute the wrong mode picker."""
-    with _patch_cost_map({}):
-        result = model_provider_service._enrich_with_litellm_metadata(
-            "mystery-model-xyz", "vllm"
         )
     assert result is None

--- a/backend/tests/unittests/model_providers/test_list_available_models.py
+++ b/backend/tests/unittests/model_providers/test_list_available_models.py
@@ -1,0 +1,299 @@
+"""End-to-end tests for ``list_available_models``: fetch → normalize →
+enrich → sort newest-first. Covers the composition risk that's not exercised
+by the per-helper unit tests."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from intric.model_providers.domain.model_provider_service import ModelProviderService
+
+
+def _build_service_with_provider(
+    provider_type: str, endpoint: str = ""
+) -> tuple[ModelProviderService, Any]:
+    """Build a service whose repository returns a stub provider matching the
+    given type. Credentials decryption is bypassed so we don't need real keys."""
+    provider = MagicMock()
+    provider.id = uuid4()
+    provider.provider_type = provider_type
+    provider.credentials = {"api_key": "ciphertext"}
+    provider.config = {"endpoint": endpoint}
+
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=provider)
+
+    encryption = MagicMock()
+    service = ModelProviderService(repository=repository, encryption=encryption)
+    # Bypass real decryption — return the api_key field as-is.
+    service._decrypt_credentials = lambda creds: {"api_key": "test-key"}  # type: ignore[method-assign]
+    return service, provider
+
+
+def _mock_httpx_get(payload: dict[str, Any]):
+    """Patch httpx.AsyncClient.get to return a 200 response with the given JSON."""
+
+    async def fake_get(self, url, headers=None, **kwargs):  # noqa: ARG001
+        return httpx.Response(200, json=payload, request=httpx.Request("GET", url))
+
+    return patch("httpx.AsyncClient.get", new=fake_get)
+
+
+@pytest.mark.asyncio
+async def test_results_sorted_newest_first_with_display_names() -> None:
+    """A response with ISO-formatted ``created_at`` and ``display_name``
+    should be sorted newest-first and propagate the friendly name through."""
+    payload = {
+        "data": [
+            {
+                "id": "model-old",
+                "display_name": "Model (Old)",
+                "created_at": "2025-05-14T00:00:00Z",
+            },
+            {
+                "id": "model-newest",
+                "display_name": "Model (Newest)",
+                "created_at": "2025-11-01T00:00:00Z",
+            },
+            {
+                "id": "model-mid",
+                "display_name": "Model (Mid)",
+                "created_at": "2025-10-01T00:00:00Z",
+            },
+        ]
+    }
+    service, _ = _build_service_with_provider("openai")
+    with _mock_httpx_get(payload), patch("litellm.model_cost", {}):
+        result = await service.list_available_models(uuid4())
+
+    names = [r["name"] for r in result]
+    assert names == ["model-newest", "model-mid", "model-old"]
+    assert result[0]["display_name"] == "Model (Newest)"
+    # All entries get a mode (default "completion" for unknown live-listed names).
+    assert all(r["mode"] == "completion" for r in result)
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_endpoint_with_rich_response_shape() -> None:
+    """Validates the maintainability promise: any OpenAI-compatible provider
+    that follows the /v1/models shape works without code changes. Some
+    providers return additional fields (``name``, ``release_date``); the
+    normalizer pulls them in via fallback chains."""
+    payload = {
+        "data": [
+            {
+                "id": "model-a",
+                "name": "Model A",
+                "object": "model",
+                "created": 1730000000,
+                "release_date": "2025-09-15",
+            }
+        ]
+    }
+    service, _ = _build_service_with_provider(
+        "hosted_vllm", endpoint="https://api.example.com"
+    )
+    with _mock_httpx_get(payload), patch("litellm.model_cost", {}):
+        result = await service.list_available_models(uuid4())
+
+    assert len(result) == 1
+    assert result[0]["name"] == "model-a"
+    assert result[0]["display_name"] == "Model A"  # falls back from `name`
+    assert result[0]["mode"] == "completion"  # default for unknown live-listed names
+
+
+@pytest.mark.asyncio
+async def test_openai_filters_realtime_and_audio_variants() -> None:
+    """Live list calls into the same filter as the static endpoint, so noise
+    like realtime-preview and gpt-audio doesn't reach the picker."""
+    payload = {
+        "data": [
+            {"id": "gpt-4o", "created": 1715000000},
+            {"id": "gpt-4o-realtime-preview", "created": 1716000000},
+            {"id": "gpt-audio-mini", "created": 1717000000},
+        ]
+    }
+    fake_cost = {
+        "gpt-4o": {"litellm_provider": "openai", "mode": "chat"},
+        "gpt-4o-realtime-preview": {"litellm_provider": "openai", "mode": "chat"},
+        "gpt-audio-mini": {"litellm_provider": "openai", "mode": "chat"},
+    }
+    service, _ = _build_service_with_provider("openai")
+    with _mock_httpx_get(payload), patch("litellm.model_cost", fake_cost):
+        result = await service.list_available_models(uuid4())
+
+    assert [r["name"] for r in result] == ["gpt-4o"]
+
+
+@pytest.mark.asyncio
+async def test_azure_returns_empty_without_calling_out() -> None:
+    """Azure's /openai/models returns the wrong thing. We skip it entirely."""
+
+    async def fail(*_args, **_kwargs):
+        raise AssertionError("Azure should not perform an HTTP call")
+
+    service, _ = _build_service_with_provider("azure")
+    with patch("httpx.AsyncClient.get", new=fail):
+        result = await service.list_available_models(uuid4())
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_without_endpoint_returns_empty() -> None:
+    """A provider type without a default URL and without a configured
+    endpoint short-circuits to empty — frontend then falls back to static."""
+
+    async def fail(*_args, **_kwargs):
+        raise AssertionError("Should not perform an HTTP call")
+
+    service, _ = _build_service_with_provider("gemini")
+    with patch("httpx.AsyncClient.get", new=fail):
+        result = await service.list_available_models(uuid4())
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_http_error_returns_error_entry_for_frontend() -> None:
+    async def fake_get(self, url, headers=None, **kwargs):  # noqa: ARG001
+        return httpx.Response(
+            401, json={"error": "Unauthorized"}, request=httpx.Request("GET", url)
+        )
+
+    service, _ = _build_service_with_provider("anthropic")
+    with patch("httpx.AsyncClient.get", new=fake_get):
+        result = await service.list_available_models(uuid4())
+
+    assert len(result) == 1 and "error" in result[0]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_uses_x_api_key_header() -> None:
+    """Verify the auth-header dispatch reaches the wire."""
+    captured: dict[str, Any] = {}
+
+    async def fake_get(self, url, headers=None, **kwargs):  # noqa: ARG001
+        captured["url"] = url
+        captured["headers"] = headers
+        return httpx.Response(200, json={"data": []}, request=httpx.Request("GET", url))
+
+    service, _ = _build_service_with_provider("anthropic")
+    with patch("httpx.AsyncClient.get", new=fake_get):
+        await service.list_available_models(uuid4())
+
+    assert captured["url"] == "https://api.anthropic.com/v1/models"
+    assert captured["headers"]["x-api-key"] == "test-key"
+    assert captured["headers"]["anthropic-version"] == "2023-06-01"
+    assert "Authorization" not in captured["headers"]
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_endpoint_uses_bearer() -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_get(self, url, headers=None, **kwargs):  # noqa: ARG001
+        captured["url"] = url
+        captured["headers"] = headers
+        return httpx.Response(200, json={"data": []}, request=httpx.Request("GET", url))
+
+    service, _ = _build_service_with_provider(
+        "hosted_vllm", endpoint="https://api.example.com/"
+    )
+    with patch("httpx.AsyncClient.get", new=fake_get):
+        await service.list_available_models(uuid4())
+
+    # Trailing slash on endpoint should be stripped, no double slash in path.
+    assert captured["url"] == "https://api.example.com/v1/models"
+    assert captured["headers"]["Authorization"] == "Bearer test-key"
+
+
+@pytest.mark.asyncio
+async def test_endpoint_with_v1_suffix_does_not_double() -> None:
+    """Regression: users who paste the URL with ``/v1`` should not get
+    ``…/v1/v1/models``."""
+    captured: dict[str, Any] = {}
+
+    async def fake_get(self, url, headers=None, **kwargs):  # noqa: ARG001
+        captured["url"] = url
+        return httpx.Response(200, json={"data": []}, request=httpx.Request("GET", url))
+
+    service, _ = _build_service_with_provider(
+        "hosted_vllm", endpoint="https://api.example.com/v1"
+    )
+    with patch("httpx.AsyncClient.get", new=fake_get):
+        await service.list_available_models(uuid4())
+
+    assert captured["url"] == "https://api.example.com/v1/models"
+
+
+@pytest.mark.asyncio
+async def test_provider_metadata_classifies_embedding_with_obscure_name() -> None:
+    """Regression: embedding models whose names don't contain the word
+    "embedding" (e.g. ``intfloat/multilingual-e5-large-instruct``) used to
+    get bucketed as completion. When the provider's response includes
+    ``model_type``/``capabilities`` we use that instead of name inference."""
+    payload = {
+        "data": [
+            {
+                "id": "intfloat/multilingual-e5-large-instruct",
+                "name": "multilingual-e5-large-instruct",
+                "model_type": "embedding",
+                "capabilities": {"embeddings": True},
+            },
+            {
+                "id": "meta-llama/Llama-3.1-8B-Instruct",
+                "name": "Llama-3.1-8B-Instruct",
+                "model_type": "text",
+                "capabilities": {"embeddings": False},
+            },
+        ]
+    }
+    service, _ = _build_service_with_provider(
+        "hosted_vllm", endpoint="https://api.example.com"
+    )
+    with _mock_httpx_get(payload), patch("litellm.model_cost", {}):
+        result = await service.list_available_models(uuid4())
+
+    by_name = {r["name"]: r for r in result}
+    assert by_name["intfloat/multilingual-e5-large-instruct"]["mode"] == "embedding"
+    assert by_name["meta-llama/Llama-3.1-8B-Instruct"]["mode"] == "completion"
+
+
+@pytest.mark.asyncio
+async def test_mode_filter_returns_only_matching_entries() -> None:
+    """Service-level mode filter: callers asking for ``mode="embedding"``
+    must get only embedding entries; completion/transcription are dropped."""
+    payload = {
+        "data": [
+            {"id": "chat-model", "created": 1715000000},
+            {"id": "future-embedding-1", "created": 1716000000},
+            {"id": "whisper-1", "created": 1717000000},
+        ]
+    }
+    service, _ = _build_service_with_provider("openai")
+    with _mock_httpx_get(payload), patch("litellm.model_cost", {}):
+        result = await service.list_available_models(uuid4(), mode="embedding")
+
+    assert len(result) == 1
+    assert result[0]["name"] == "future-embedding-1"
+    assert result[0]["mode"] == "embedding"
+
+
+@pytest.mark.asyncio
+async def test_mode_none_returns_all_modes() -> None:
+    """Backwards compat: omitting ``mode`` returns everything (so existing
+    consumers and ad-hoc /v1/models inspection both still work)."""
+    payload = {
+        "data": [
+            {"id": "chat-model", "created": 1715000000},
+            {"id": "future-embedding-1", "created": 1716000000},
+            {"id": "whisper-1", "created": 1717000000},
+        ]
+    }
+    service, _ = _build_service_with_provider("openai")
+    with _mock_httpx_get(payload), patch("litellm.model_cost", {}):
+        result = await service.list_available_models(uuid4())
+
+    assert {r["mode"] for r in result} == {"completion", "embedding", "transcription"}

--- a/backend/tests/unittests/model_providers/test_normalize_live_model.py
+++ b/backend/tests/unittests/model_providers/test_normalize_live_model.py
@@ -1,0 +1,164 @@
+"""Unit tests for the cross-provider /v1/models normalization helpers."""
+
+from intric.model_providers.domain.model_provider_service import (
+    _auth_headers_for,
+    _coerce_to_epoch,
+    _extract_mode_hint,
+    _normalize_endpoint_base,
+    _normalize_live_model,
+)
+
+
+def test_normalizes_minimal_openai_compatible_shape() -> None:
+    """Minimal OpenAI-compatible shape: just ``id`` and ``created`` epoch."""
+    raw = {
+        "id": "model-1",
+        "object": "model",
+        "created": 1715367049,
+        "owned_by": "someone",
+    }
+    assert _normalize_live_model(raw) == {
+        "id": "model-1",
+        "display_name": "",
+        "created_at": 1715367049.0,
+        "mode_hint": None,
+    }
+
+
+def test_normalizes_shape_with_iso_created_and_display_name() -> None:
+    """Some providers send ``display_name`` and an ISO ``created_at`` instead
+    of an epoch ``created`` — the normalizer accepts both."""
+    raw = {
+        "type": "model",
+        "id": "model-2",
+        "display_name": "Model Two",
+        "created_at": "2025-11-01T00:00:00Z",
+    }
+    out = _normalize_live_model(raw)
+    assert out["id"] == "model-2"
+    assert out["display_name"] == "Model Two"
+    assert out["created_at"] > 0
+
+
+def test_normalizes_shape_with_extra_fields() -> None:
+    """Providers with richer responses (``name`` instead of ``display_name``,
+    ``release_date`` alongside ``created``) work via the normalizer's fallback
+    chains — no provider-specific code needed."""
+    raw = {
+        "id": "model-3",
+        "name": "Model Three",
+        "object": "model",
+        "created": 1730000000,
+        "release_date": "2025-09-15",
+    }
+    out = _normalize_live_model(raw)
+    assert out["id"] == "model-3"
+    assert out["display_name"] == "Model Three"  # falls back from `name`
+    assert out["created_at"] == 1730000000.0  # `created` wins over release_date
+
+
+def test_falls_back_to_release_date_when_no_created() -> None:
+    raw = {"id": "x", "release_date": "2025-09-15"}
+    assert _normalize_live_model(raw)["created_at"] > 0
+
+
+def test_unknown_shape_still_works_with_just_id() -> None:
+    raw = {"id": "mystery-model"}
+    assert _normalize_live_model(raw) == {
+        "id": "mystery-model",
+        "display_name": "",
+        "created_at": 0.0,
+        "mode_hint": None,
+    }
+
+
+def test_anthropic_uses_x_api_key() -> None:
+    headers = _auth_headers_for("anthropic", "sk-ant-test")
+    assert headers == {
+        "x-api-key": "sk-ant-test",
+        "anthropic-version": "2023-06-01",
+    }
+
+
+def test_other_providers_use_bearer() -> None:
+    assert _auth_headers_for("openai", "sk-test") == {"Authorization": "Bearer sk-test"}
+    assert _auth_headers_for("vllm", "tok") == {"Authorization": "Bearer tok"}
+    assert _auth_headers_for("berget", "tok") == {"Authorization": "Bearer tok"}
+
+
+def test_endpoint_normalization_handles_v1_suffix() -> None:
+    """Users may paste either ``https://api.example.com`` or ``…/v1`` and we
+    must avoid producing ``/v1/v1/models`` either way."""
+    assert (
+        _normalize_endpoint_base("https://api.example.com") == "https://api.example.com"
+    )
+    assert (
+        _normalize_endpoint_base("https://api.example.com/")
+        == "https://api.example.com"
+    )
+    assert (
+        _normalize_endpoint_base("https://api.example.com/v1")
+        == "https://api.example.com"
+    )
+    assert (
+        _normalize_endpoint_base("https://api.example.com/v1/")
+        == "https://api.example.com"
+    )
+    # ``v1beta`` should NOT be stripped — only the exact ``/v1`` segment.
+    assert (
+        _normalize_endpoint_base("https://api.example.com/v1beta")
+        == "https://api.example.com/v1beta"
+    )
+    # Path before /v1 is preserved.
+    assert (
+        _normalize_endpoint_base("https://gateway.example.com/proxy/v1")
+        == "https://gateway.example.com/proxy"
+    )
+
+
+def test_mode_hint_from_explicit_model_type_embedding() -> None:
+    raw = {"id": "x", "model_type": "embedding"}
+    assert _extract_mode_hint(raw) == "embedding"
+
+
+def test_mode_hint_from_text_with_embeddings_capability() -> None:
+    """Some providers set ``model_type: "text"`` but flag embeddings via
+    capabilities — we still classify as embedding."""
+    raw = {
+        "id": "x",
+        "model_type": "text",
+        "capabilities": {"embeddings": True},
+    }
+    assert _extract_mode_hint(raw) == "embedding"
+
+
+def test_mode_hint_from_text_without_embeddings_is_completion() -> None:
+    raw = {
+        "id": "x",
+        "model_type": "text",
+        "capabilities": {"embeddings": False},
+    }
+    assert _extract_mode_hint(raw) == "completion"
+
+
+def test_mode_hint_from_audio_model_type() -> None:
+    assert _extract_mode_hint({"id": "x", "model_type": "audio"}) == "transcription"
+    assert (
+        _extract_mode_hint({"id": "x", "model_type": "transcription"})
+        == "transcription"
+    )
+
+
+def test_mode_hint_returns_none_when_metadata_missing() -> None:
+    """OpenAI/Anthropic don't expose model_type or capabilities on /v1/models —
+    the hint extractor returns None and the caller falls back to name inference."""
+    assert _extract_mode_hint({"id": "gpt-4o", "created": 1715367049}) is None
+    assert _extract_mode_hint({"id": "claude", "display_name": "Claude"}) is None
+
+
+def test_coerce_handles_epoch_int_iso_and_garbage() -> None:
+    assert _coerce_to_epoch(1715367049) == 1715367049.0
+    assert _coerce_to_epoch("2025-11-01T00:00:00Z") > 0
+    assert _coerce_to_epoch(None) == 0.0
+    assert _coerce_to_epoch("") == 0.0
+    assert _coerce_to_epoch("not a date") == 0.0

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepModels.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepModels.svelte
@@ -101,6 +101,7 @@
   // Model info from capabilities API
   interface ModelInfo {
     name: string;
+    mode?: string;
     max_input_tokens?: number;
     max_output_tokens?: number;
     supports_vision?: boolean;
@@ -124,13 +125,16 @@
     return limit.toString();
   }
 
-  // Providers that need live model listing from their API (not LiteLLM static data)
-  const liveListProviders = new Set(["vllm"]);
+  // Providers that list models live via their own API rather than the static
+  // LiteLLM catalog. Live listing returns only models the user's API key can
+  // actually call, which avoids preview/deprecated names polluting the picker.
+  const liveListProviders = new Set(["vllm", "openai", "anthropic"]);
 
   // Providers where LiteLLM names don't match user input (e.g. Azure uses deployment names)
   const noSuggestionsProviders = new Set(["azure"]);
 
-  // Live models fetched from the provider's own API
+  // Live models fetched from the provider's own API, enriched server-side
+  // with capability metadata from litellm.model_cost.
   let liveModels: ModelInfo[] = [];
   let liveModelsLoaded = false;
   let liveModelsError = "";
@@ -150,11 +154,15 @@
         liveModelsError = (result[0] as Record<string, unknown>).error as string;
       } else if (result && Array.isArray(result)) {
         liveModels = result.map((item: Record<string, unknown>) => ({
-          name: item.model ? `${item.name} (${item.model})` : String(item.name),
-          max_input_tokens: undefined,
-          max_output_tokens: undefined,
-          supports_vision: false,
-          supports_reasoning: false
+          name: String(item.name),
+          mode: item.mode != null ? String(item.mode) : undefined,
+          max_input_tokens: item.max_input_tokens as number | undefined,
+          max_output_tokens: item.max_output_tokens as number | undefined,
+          supports_vision: (item.supports_vision as boolean | undefined) ?? false,
+          supports_function_calling:
+            (item.supports_function_calling as boolean | undefined) ?? false,
+          supports_reasoning: (item.supports_reasoning as boolean | undefined) ?? false,
+          output_vector_size: item.output_vector_size as number | undefined
         }));
       }
     } catch {
@@ -164,11 +172,12 @@
   }
   $: if (liveListProviders.has(providerType) && providerId) loadLiveModels();
 
-  // All models: live from provider API, static from LiteLLM, or none for Azure
+  // All models: live from provider API (filtered to current modelType),
+  // static from LiteLLM, or none for Azure.
   $: allModels = noSuggestionsProviders.has(providerType)
     ? []
     : liveListProviders.has(providerType)
-      ? liveModels
+      ? liveModels.filter((m) => m.mode === modeMap[modelType])
       : ((capabilityProviders[providerType]?.models?.[modeMap[modelType]] ?? []) as ModelInfo[]);
 
   // Top 4 as quick suggestions (leaving room for "Browse all" chip)

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepModels.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepModels.svelte
@@ -101,6 +101,7 @@
   // Model info from capabilities API
   interface ModelInfo {
     name: string;
+    display_name?: string;
     mode?: string;
     max_input_tokens?: number;
     max_output_tokens?: number;
@@ -125,36 +126,61 @@
     return limit.toString();
   }
 
-  // Providers that list models live via their own API rather than the static
-  // LiteLLM catalog. Live listing returns only models the user's API key can
-  // actually call, which avoids preview/deprecated names polluting the picker.
-  const liveListProviders = new Set(["vllm", "openai", "anthropic"]);
-
-  // Providers where LiteLLM names don't match user input (e.g. Azure uses deployment names)
+  // Providers where neither live listing nor the static catalog can produce
+  // useful suggestions — Azure uses deployment names that vary per tenant.
   const noSuggestionsProviders = new Set(["azure"]);
 
   // Live models fetched from the provider's own API, enriched server-side
-  // with capability metadata from litellm.model_cost.
+  // with capability metadata from litellm.model_cost. The backend short-
+  // circuits to an empty list for providers that don't expose /v1/models, so
+  // we always try live first and fall back to the static LiteLLM catalog
+  // when the response is empty. The backend also filters by mode, so the
+  // payload we receive contains only models for the current tab — adding a
+  // new live-list provider is a backend-only change (extend
+  // `_DEFAULT_ENDPOINTS` or `_auth_headers_for`).
+  type ApiMode = "completion" | "embedding" | "transcription";
   let liveModels: ModelInfo[] = [];
-  let liveModelsLoaded = false;
   let liveModelsError = "";
-  async function loadLiveModels() {
-    if (!providerId || liveModelsLoaded) return;
+  // Cache key includes mode so switching wizard tabs refetches only the
+  // first time the user lands on that tab.
+  let liveLoadedFor: { providerId: string; mode: ApiMode } | null = null;
+
+  async function loadLiveModels(forProviderId: string, forMode: ApiMode) {
+    if (
+      liveLoadedFor &&
+      liveLoadedFor.providerId === forProviderId &&
+      liveLoadedFor.mode === forMode
+    )
+      return;
+    // Reset state so a previous provider/mode's models don't bleed through.
+    liveModels = [];
     liveModelsError = "";
+    liveLoadedFor = { providerId: forProviderId, mode: forMode };
+
     try {
       const result = (await intric.modelProviders.listModels({
-        id: providerId
+        id: forProviderId,
+        mode: forMode
       })) as unknown as Record<string, unknown>[];
+      // The user may have switched provider/mode while we were waiting;
+      // a newer fetch has already taken over — drop this stale response.
       if (
-        result &&
+        !liveLoadedFor ||
+        liveLoadedFor.providerId !== forProviderId ||
+        liveLoadedFor.mode !== forMode
+      )
+        return;
+
+      if (
         Array.isArray(result) &&
         result.length > 0 &&
         (result[0] as Record<string, unknown>)?.error
       ) {
         liveModelsError = (result[0] as Record<string, unknown>).error as string;
-      } else if (result && Array.isArray(result)) {
+      } else if (Array.isArray(result)) {
         liveModels = result.map((item: Record<string, unknown>) => ({
           name: String(item.name),
+          display_name: item.display_name != null ? String(item.display_name) : undefined,
           mode: item.mode != null ? String(item.mode) : undefined,
           max_input_tokens: item.max_input_tokens as number | undefined,
           max_output_tokens: item.max_output_tokens as number | undefined,
@@ -166,18 +192,28 @@
         }));
       }
     } catch {
-      liveModelsError = "Could not fetch models from provider";
+      if (
+        liveLoadedFor &&
+        liveLoadedFor.providerId === forProviderId &&
+        liveLoadedFor.mode === forMode
+      ) {
+        liveModelsError = "Could not fetch models from provider";
+      }
     }
-    liveModelsLoaded = true;
   }
-  $: if (liveListProviders.has(providerType) && providerId) loadLiveModels();
+  $: if (providerId && !noSuggestionsProviders.has(providerType))
+    loadLiveModels(providerId, modeMap[modelType] as ApiMode);
 
-  // All models: live from provider API (filtered to current modelType),
-  // static from LiteLLM, or none for Azure.
+  // Treat the provider as "live-listing capable" iff the backend actually
+  // returned models. Empty live result → fall back to static catalog.
+  $: hasLiveModels = liveModels.length > 0;
+
+  // The backend already filters by mode so we don't filter again here.
+  // Azure stays empty; otherwise live (when supported) or static catalog.
   $: allModels = noSuggestionsProviders.has(providerType)
     ? []
-    : liveListProviders.has(providerType)
-      ? liveModels.filter((m) => m.mode === modeMap[modelType])
+    : hasLiveModels
+      ? liveModels
       : ((capabilityProviders[providerType]?.models?.[modeMap[modelType]] ?? []) as ModelInfo[]);
 
   // Top 4 as quick suggestions (leaving room for "Browse all" chip)
@@ -201,12 +237,17 @@
   let showAllModels = false;
   let modelSearch = "";
   $: filteredModels = modelSearch
-    ? allModels.filter((m) => m.name.toLowerCase().includes(modelSearch.toLowerCase()))
+    ? allModels.filter((m) => {
+        const q = modelSearch.toLowerCase();
+        return (
+          m.name.toLowerCase().includes(q) || (m.display_name?.toLowerCase().includes(q) ?? false)
+        );
+      })
     : allModels;
 
   function selectModelInfo(info: ModelInfo) {
     currentModel.name = info.name;
-    currentModel.displayName = info.name;
+    currentModel.displayName = info.display_name ?? info.name;
     if (modelType === "completion") {
       currentModel.maxInputTokensStr =
         info.max_input_tokens != null ? String(info.max_input_tokens) : "";
@@ -438,8 +479,9 @@
               : 'border-dimmer hover:border-accent-default hover:bg-accent-dimmer'}
               focus-visible:ring-accent-default/60 focus-visible:ring-offset-surface focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
             on:click={() => selectModelInfo(suggestion)}
+            title={suggestion.display_name ? suggestion.name : undefined}
           >
-            {suggestion.name}
+            {suggestion.display_name ?? suggestion.name}
           </button>
         {/each}
         {#if allModels.length > 4}
@@ -483,7 +525,10 @@
                   showAllModels = false;
                 }}
               >
-                <span class="font-medium">{model.name}</span>
+                <span class="font-medium">{model.display_name ?? model.name}</span>
+                {#if model.display_name && model.display_name !== model.name}
+                  <span class="text-muted mt-0.5 block font-mono text-xs">{model.name}</span>
+                {/if}
                 <span class="text-muted mt-0.5 flex gap-3 text-xs">
                   {#if model.max_input_tokens}
                     <span>{formatTokens(model.max_input_tokens)} context</span>

--- a/frontend/packages/intric-js/src/endpoints/model-providers.js
+++ b/frontend/packages/intric-js/src/endpoints/model-providers.js
@@ -100,15 +100,26 @@ export function initModelProviders(client) {
     },
 
     /**
-     * List available models/deployments from the provider's own API.
-     * @param {{id: string}} provider
+     * List available models from the provider's own API.
+     *
+     * Pass ``mode`` to have the server filter the response — preferred over
+     * filtering client-side so consumers (frontend pickers, external API
+     * clients) get only what they need.
+     *
+     * @param {{id: string, mode?: "completion" | "embedding" | "transcription"}} args
      * @returns {Promise<any>}
      * @throws {IntricError}
      * */
-    listModels: async ({ id }) => {
+    listModels: async ({ id, mode }) => {
       const res = await client.fetch("/api/v1/admin/model-providers/{provider_id}/models/", {
         method: "get",
-        params: { path: { provider_id: id } }
+        params: {
+          path: { provider_id: id },
+          // @ts-expect-error — `mode` is a new optional query param; this
+          // typing relaxation can be removed once schema.d.ts is regenerated
+          // from the backend's openapi.json (run `node update.js`).
+          query: mode ? { mode } : undefined
+        }
       });
 
       return res;


### PR DESCRIPTION
## Summary

In the admin "Add model" wizard, the suggestion list and Browse-all catalogue come from `litellm.model_cost` — a static catalogue bundled with the LiteLLM package. That catalogue contains every model name LiteLLM has heard of, including preview snapshots, deprecated old-style names, and minor-version siblings, none of which can be reliably filtered out by heuristics.

This PR switches to live-listing via the provider's own `/v1/models` endpoint once a provider has been created. The provider's API only returns models the user's API key can actually call, eliminating preview/limited-rollout names and old superseded snapshots.

The implementation generalizes the live-listing path so adding a new OpenAI-compatible provider (Berget, Cohere, Mistral, Together, Groq, etc.) requires **zero code changes** — the admin configures it through the UI with an endpoint and an API key. Provider-specific knowledge is reduced to two small lookups:

- `_DEFAULT_ENDPOINTS` — base URLs for `openai` and `anthropic` (any provider with `endpoint` set wins)
- `_auth_headers_for` — Bearer for everyone except Anthropic's `x-api-key` + `anthropic-version` (genuine protocol difference)

Field extraction (display name, timestamp, mode hint) goes through fallback chains in `_normalize_live_model` so providers with richer responses (e.g. `model_type`, `capabilities.embeddings`) get accurate classification while minimal-shape providers still work.

## Key changes

- **Backend `_fetch_live_models`** — single HTTP code path, dispatched on auth + base URL via the two small lookups above. Azure stays skipped (`/openai/models` returns wrong data).
- **Mode classification** — first `litellm.model_cost`, then provider-supplied `model_type`/`capabilities`, then name-based inference defaulting to completion. Embedding models with non-obvious names like `intfloat/multilingual-e5-large-instruct` get classified correctly via the provider's own metadata.
- **Server-side mode filter** — new `?mode=` query param on `GET /{provider_id}/models/`. Consumers (frontend pickers, external API clients) get filtered payloads without client-side work.
- **Sorting** — newest-first using provider-supplied `created_at`/`created`/`release_date`, with id as a stable tiebreaker.
- **Display names** — `display_name` (Anthropic) or `name` (richer providers) shown as primary in the picker; canonical id as secondary detail.
- **Endpoint URL handling** — strip trailing `/v1` so users can paste either `https://api.example.com` or `…/v1` without producing `/v1/v1/models`.
- **Frontend** — removes hardcoded `liveListProviders` set; live vs static catalog is driven by whether the backend returned any models. Cache keyed on `(providerId, mode)` so tab-switching only fetches once per mode. Race protection so a stale fetch doesn't overwrite a newer one.

## Tests

40 unit tests covering normalization, mode-hint extraction, endpoint-URL handling, auth-header dispatch, sorting, mode filtering, and end-to-end fetch → enrich → sort flow with mocked httpx.

```
======================== 40 passed, 1 warning in 0.92s =========================
```

Frontend `bun run check` clean (0 errors).

## Test plan

- [x] Backend unit tests pass (40 new tests)
- [x] Frontend type check clean
- [ ] Restart backend in devcontainer, regenerate `schema.d.ts` via `node update.js` (the SDK has one `@ts-expect-error` that goes away after regen)
- [ ] Smoke test: create OpenAI provider in wizard → completion tab shows GPT models with correct metadata
- [ ] Smoke test: create Anthropic provider → completion tab shows Claude models sorted newest-first with friendly names
- [ ] Smoke test: create vLLM/self-hosted provider with a Berget-style endpoint → embedding/completion tabs filter correctly
- [ ] Smoke test: switching tabs in wizard refetches per mode (verify in network tab)

## Note on the previously closed PR #364

This branch was opened earlier as #364 and closed without merge while the design was in flux. The commits on this branch include the original work plus a substantial generalization iteration that addresses the maintainability concerns discussed during review. Re-opening as a fresh PR for clarity.