### PR TITLE
fix(api-keys): scope /account/api-keys list to caller-owned keys + au…

### DIFF
--- a/backend/src/intric/authentication/api_key_router.py
+++ b/backend/src/intric/authentication/api_key_router.py
@@ -386,6 +386,7 @@ async def _collect_manageable_keys_for_page(
     state: ApiKeyState | None,
     key_type: ApiKeyType | None,
     ownership: str | None = None,
+    owner_user_id: UUID | None = None,
 ) -> list[ApiKeyV2InDB]:
     """Collect enough manageable keys to produce one filtered page.
 
@@ -409,6 +410,7 @@ async def _collect_manageable_keys_for_page(
             state=state,
             key_type=key_type.value if key_type else None,
             ownership=ownership,
+            owner_user_id=owner_user_id,
         )
         if not raw_keys:
             break
@@ -958,6 +960,10 @@ async def list_api_keys(
     policy: ApiKeyPolicyService = container.api_key_policy_service()
 
     ownership_value = ownership.value if ownership else None
+    # /account/api-keys is a personal listing — only show keys the caller owns,
+    # regardless of tenant-admin manageability. Tenant-wide listing is the
+    # responsibility of /admin/api-keys.
+    owner_filter = user.id
     if limit is not None and not previous:
         filtered_keys = await _collect_manageable_keys_for_page(
             repo=repo,
@@ -970,6 +976,7 @@ async def list_api_keys(
             state=state,
             key_type=key_type,
             ownership=ownership_value,
+            owner_user_id=owner_filter,
         )
     else:
         raw_keys = await repo.list_paginated(
@@ -982,6 +989,7 @@ async def list_api_keys(
             state=state,
             key_type=key_type.value if key_type else None,
             ownership=ownership_value,
+            owner_user_id=owner_filter,
         )
 
         filtered_keys, _auth_cache = await _filter_manageable_keys(
@@ -998,6 +1006,7 @@ async def list_api_keys(
             state=state,
             key_type=key_type.value if key_type else None,
             ownership=ownership_value,
+            owner_user_id=owner_filter,
         )
 
     return ApiKeyListResponse.model_validate(

--- a/backend/src/intric/authentication/auth_service.py
+++ b/backend/src/intric/authentication/auth_service.py
@@ -162,6 +162,33 @@ class AuthService:
 
         return api_key
 
+    async def create_user_api_key_v2(
+        self, *, user_id: UUID, tenant_id: UUID
+    ) -> ApiKeyCreated:
+        """Mint a v2 personal API key for a user, no v1 row, no Legacy mirror."""
+        if self.api_key_v2_repo is None:
+            raise RuntimeError("api_key_v2_repo is required to mint v2 keys")
+
+        api_key = self._create_and_hash_api_key(prefix="sk")
+        await self.api_key_v2_repo.create(
+            tenant_id=tenant_id,
+            owner_user_id=user_id,
+            created_by_user_id=user_id,
+            scope_type=ApiKeyScopeType.TENANT.value,
+            scope_id=None,
+            permission=ApiKeyPermission.ADMIN.value,
+            key_type=ApiKeyType.SK.value,
+            key_hash=api_key.hashed_key,
+            hash_version=ApiKeyHashVersion.SHA256.value,
+            key_prefix=self._normalize_prefix(api_key.key, fallback="sk"),
+            key_suffix=api_key.truncated_key,
+            name="Personal API key",
+            description=None,
+            state=ApiKeyState.ACTIVE.value,
+        )
+
+        return api_key
+
     async def create_assistant_api_key(
         self,
         prefix: str,

--- a/backend/src/intric/users/user_service.py
+++ b/backend/src/intric/users/user_service.py
@@ -686,7 +686,9 @@ class UserService:
         settings_upsert = SettingsUpsert(user_id=user_in_db.id)
         await self.settings_repo.add(settings_upsert)
 
-        api_key = await self.generate_api_key(user_id=user_in_db.id)
+        api_key = await self.auth_service.create_user_api_key_v2(
+            user_id=user_in_db.id, tenant_id=user_in_db.tenant_id
+        )
 
         access_token = AccessToken(
             access_token=self.auth_service.create_access_token_for_user(


### PR DESCRIPTION
…to-provision v2 personal key on user creation, not v1 legacy
