### PR TITLE
chore(deps): pause dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "Europe/Stockholm"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "backend"
@@ -32,7 +32,7 @@ updates:
       day: "monday"
       time: "06:30"
       timezone: "Europe/Stockholm"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "frontend"
@@ -54,7 +54,7 @@ updates:
       day: "monday"
       time: "07:00"
       timezone: "Europe/Stockholm"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "github-actions"
@@ -73,7 +73,7 @@ updates:
       day: "monday"
       time: "07:30"
       timezone: "Europe/Stockholm"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "docker"
@@ -96,7 +96,7 @@ updates:
       day: "monday"
       time: "07:45"
       timezone: "Europe/Stockholm"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "docker"
@@ -119,7 +119,7 @@ updates:
       day: "monday"
       time: "08:00"
       timezone: "Europe/Stockholm"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "docker"
@@ -142,7 +142,7 @@ updates:
       day: "monday"
       time: "08:15"
       timezone: "Europe/Stockholm"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
       - "devcontainer"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 version: 2
 
+# Dependabot version updates are intentionally paused while we stabilize the
+# initial security rollout and close the noisy first batch of generated PRs.
+#
+# Re-enable one ecosystem at a time by raising its open-pull-requests-limit
+# from 0 to 1. Do not raise all ecosystems together.
 updates:
   - package-ecosystem: "uv"
     directory: "/backend"
@@ -10,6 +15,7 @@ updates:
       time: "06:00"
       timezone: "Europe/Stockholm"
     open-pull-requests-limit: 0
+    rebase-strategy: "disabled"
     labels:
       - "dependencies"
       - "backend"
@@ -33,6 +39,7 @@ updates:
       time: "06:30"
       timezone: "Europe/Stockholm"
     open-pull-requests-limit: 0
+    rebase-strategy: "disabled"
     labels:
       - "dependencies"
       - "frontend"
@@ -55,6 +62,7 @@ updates:
       time: "07:00"
       timezone: "Europe/Stockholm"
     open-pull-requests-limit: 0
+    rebase-strategy: "disabled"
     labels:
       - "dependencies"
       - "github-actions"
@@ -74,6 +82,7 @@ updates:
       time: "07:30"
       timezone: "Europe/Stockholm"
     open-pull-requests-limit: 0
+    rebase-strategy: "disabled"
     labels:
       - "dependencies"
       - "docker"
@@ -87,6 +96,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Eneo currently runs Python 3.11 in CI, Docker, devcontainer, and pyright.
+      # Runtime upgrades should be deliberate PRs, not automatic dependency noise.
+      - dependency-name: "python"
+        versions:
+          - ">=3.12"
 
   - package-ecosystem: "docker"
     directory: "/frontend"
@@ -97,6 +112,7 @@ updates:
       time: "07:45"
       timezone: "Europe/Stockholm"
     open-pull-requests-limit: 0
+    rebase-strategy: "disabled"
     labels:
       - "dependencies"
       - "docker"
@@ -110,6 +126,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Keep Node runtime upgrades explicit until the frontend runtime is reviewed.
+      - dependency-name: "node"
+        versions:
+          - ">=21"
 
   - package-ecosystem: "docker"
     directory: "/.devcontainer"
@@ -120,6 +141,7 @@ updates:
       time: "08:00"
       timezone: "Europe/Stockholm"
     open-pull-requests-limit: 0
+    rebase-strategy: "disabled"
     labels:
       - "dependencies"
       - "docker"
@@ -133,6 +155,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Match the backend runtime until the team intentionally upgrades Python.
+      - dependency-name: "devcontainers/python"
+        versions:
+          - ">=3.12"
 
   - package-ecosystem: "devcontainers"
     directory: "/"
@@ -143,6 +170,7 @@ updates:
       time: "08:15"
       timezone: "Europe/Stockholm"
     open-pull-requests-limit: 0
+    rebase-strategy: "disabled"
     labels:
       - "dependencies"
       - "devcontainer"


### PR DESCRIPTION
## Summary

Pauses Dependabot version-update PRs while we stabilize the first security rollout and close the noisy initial batch.

This keeps the Dependabot config in place, but sets every ecosystem to `open-pull-requests-limit: 0` and disables automatic rebasing so existing Dependabot branches stop creating more CI churn. It also keeps guardrails for future re-enablement so Python 3.12+/3.14 and Node 21+/25 runtime bumps are deliberate PRs instead of automatic noise.

## Developer impact

- New normal Dependabot version-update PRs should stop after this lands on `develop`.
- Existing open Dependabot PRs still need to be closed manually.
- Existing queued/running Dependabot workflow runs may need to be cancelled manually.
- Security signals from GitHub alerts are separate from this config and can still be reviewed manually.

## Re-enable later

Re-enable one ecosystem at a time by changing its `open-pull-requests-limit` from `0` to `1`. Do not re-enable all ecosystems together.

## Validation

- Parsed `.github/dependabot.yml` as YAML locally.
- Ran `git diff --check`.
