### PR TITLE
fix(api-keys): unblock /ask for service keys + show service keys in s…

### DIFF
--- a/backend/alembic/versions/202605061100_sessions_nullable_user_id_add_api_key_id.py
+++ b/backend/alembic/versions/202605061100_sessions_nullable_user_id_add_api_key_id.py
@@ -1,0 +1,62 @@
+"""sessions: nullable user_id + add api_key_id
+
+Service API keys resolve to a synthetic UserInDB whose id is never inserted
+into ``users``. Writing that synthetic id into ``sessions.user_id`` (NOT NULL
+FK to ``users.id``) blew up /ask with a ForeignKeyViolationError, surfacing
+as a 500 on every question asked through a pk_ service key.
+
+This migration:
+1. Drops NOT NULL on ``sessions.user_id`` so service-key sessions can omit it.
+2. Adds ``sessions.api_key_id`` (FK to ``api_keys_v2.id``, ON DELETE SET NULL)
+   so service-key sessions still have an owning principal recorded for
+   ownership checks and audit.
+3. Indexes ``api_key_id`` for the ownership-check query path.
+
+Revision ID: 202605061100
+Revises: 202604291030
+Create Date: 2026-05-06
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision = "202605061100"
+down_revision = "202604291030"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "sessions",
+        "user_id",
+        existing_type=sa.dialects.postgresql.UUID(),
+        nullable=True,
+    )
+    op.add_column(
+        "sessions",
+        sa.Column(
+            "api_key_id",
+            sa.dialects.postgresql.UUID(),
+            sa.ForeignKey("api_keys_v2.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_sessions_api_key_id",
+        "sessions",
+        ["api_key_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sessions_api_key_id", table_name="sessions")
+    op.drop_column("sessions", "api_key_id")
+    # Fail-fast: if service-key sessions exist, the operator must purge them
+    # before reverting; we don't synthesize fake user rows on rollback.
+    op.execute(
+        "ALTER TABLE sessions ALTER COLUMN user_id SET NOT NULL"
+    )

--- a/backend/src/intric/assistants/api/assistant_router.py
+++ b/backend/src/intric/assistants/api/assistant_router.py
@@ -25,7 +25,11 @@ from intric.authentication.api_key_router_helpers import (
     error_responses as api_key_error_responses,
 )
 from intric.authentication.auth_dependencies import get_scope_filter
-from intric.authentication.auth_models import ApiKey, ApiKeyNotificationTargetType
+from intric.authentication.auth_models import (
+    ApiKey,
+    ApiKeyNotificationTargetType,
+    audit_actor_for,
+)
 from intric.database.database import AsyncSession
 from intric.main.config import get_settings
 from intric.main.container.container import Container
@@ -778,9 +782,11 @@ async def ask_assistant(
     }
 
     audit_service = container.audit_service()
+    actor_id, actor_type = audit_actor_for(user)
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        actor_id=actor_id,
+        actor_type=actor_type,
         action=ActionType.SESSION_STARTED,
         entity_type=EntityType.ASSISTANT,
         entity_id=id,
@@ -883,9 +889,11 @@ async def delete_assistant_session(
     }
 
     audit_service = container.audit_service()
+    actor_id, actor_type = audit_actor_for(user)
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        actor_id=actor_id,
+        actor_type=actor_type,
         action=ActionType.SESSION_ENDED,
         entity_type=EntityType.ASSISTANT,
         entity_id=id,

--- a/backend/src/intric/audit/application/audit_metadata.py
+++ b/backend/src/intric/audit/application/audit_metadata.py
@@ -35,6 +35,42 @@ Security considerations:
 from typing import Any, Mapping, Optional
 from uuid import UUID
 
+from intric.authentication.auth_models import is_service_api_key
+
+
+def _actor_snapshot(actor: Any) -> dict[str, Any]:
+    """Build the ``actor`` block for audit metadata.
+
+    Service keys resolve to a synthetic UserInDB whose id, email and
+    username are placeholders ("sk-xxxx@service.key", "Service Key (...)").
+    Surfacing those in the audit UI is misleading — there's no real user.
+    For service-key actors we emit a service-shaped block keyed by the
+    actual API key id and name, with no email field.
+
+    For real users we keep the existing shape (id, name, email).
+    """
+    if is_service_api_key(actor):
+        key = actor.active_api_key
+        return {
+            "type": "service_key",
+            "id": str(key.id),
+            "name": key.name,
+            "key_prefix": getattr(key, "key_prefix", None),
+        }
+
+    actor_name = (
+        getattr(actor, "username", None)
+        or getattr(actor, "name", None)
+        or (getattr(actor, "email", "") or "").split("@")[0]
+        or "unknown"
+    )
+    return {
+        "type": "user",
+        "id": str(actor.id),
+        "name": actor_name,
+        "email": getattr(actor, "email", None),
+    }
+
 
 class AuditMetadata:
     """Factory for standardized audit metadata structures."""
@@ -80,14 +116,6 @@ class AuditMetadata:
                 tenant=tenant,  # Includes tenant_id and tenant_name automatically
             )
         """
-        # Safe actor name: prefer username, fallback to email prefix, then "unknown"
-        actor_name = (
-            getattr(actor, "username", None)
-            or getattr(actor, "name", None)
-            or (getattr(actor, "email", "") or "").split("@")[0]
-            or "unknown"
-        )
-
         # Build target snapshot with all available context
         target_snapshot = {
             "id": str(target.id),
@@ -110,11 +138,7 @@ class AuditMetadata:
             target_snapshot["tenant_name"] = getattr(tenant, "name", None)
 
         metadata: dict[str, Any] = {
-            "actor": {
-                "id": str(actor.id),
-                "name": actor_name,
-                "email": getattr(actor, "email", None),
-            },
+            "actor": _actor_snapshot(actor),
             "target": target_snapshot,
         }
 
@@ -159,20 +183,8 @@ class AuditMetadata:
                 extra={"space_id": str(space.id), "space_name": space.name}
             )
         """
-        # Safe actor name: prefer username, fallback to email prefix, then "unknown"
-        actor_name = (
-            getattr(actor, "username", None)
-            or getattr(actor, "name", None)
-            or (getattr(actor, "email", "") or "").split("@")[0]
-            or "unknown"
-        )
-
         metadata: dict[str, Any] = {
-            "actor": {
-                "id": str(actor.id),
-                "name": actor_name,
-                "email": getattr(actor, "email", None),
-            },
+            "actor": _actor_snapshot(actor),
             "operation": operation,
             "targets": [
                 {
@@ -277,20 +289,8 @@ class AuditMetadata:
                 extra={"ip_address": request.client.host, "attempts": 3}
             )
         """
-        # Safe actor name: prefer username, fallback to email prefix, then "unknown"
-        actor_name = (
-            getattr(actor, "username", None)
-            or getattr(actor, "name", None)
-            or (getattr(actor, "email", "") or "").split("@")[0]
-            or "unknown"
-        )
-
         metadata: dict[str, Any] = {
-            "actor": {
-                "id": str(actor.id),
-                "name": actor_name,
-                "email": getattr(actor, "email", None),
-            },
+            "actor": _actor_snapshot(actor),
             "authentication_method": method,
             "success": success,
         }

--- a/backend/src/intric/authentication/api_key_router.py
+++ b/backend/src/intric/authentication/api_key_router.py
@@ -953,10 +953,27 @@ async def list_api_keys(
     policy: ApiKeyPolicyService = container.api_key_policy_service()
 
     ownership_value = ownership.value if ownership else None
-    # /account/api-keys is a personal listing — only show keys the caller owns,
-    # regardless of tenant-admin manageability. Tenant-wide listing is the
-    # responsibility of /admin/api-keys.
-    owner_filter = user.id
+    # Default: personal listing — only show keys the caller owns. Tenant-wide
+    # listing is the responsibility of /admin/api-keys.
+    # Exception: when the caller can administer the requested scope (space /
+    # assistant / app), drop the owner filter so service keys (owner_user_id
+    # is NULL by design) and other members' keys are visible to admins of
+    # that scope. Falls back to the personal filter when the caller is not
+    # a scope admin.
+    owner_filter: UUID | None = user.id
+    if (
+        scope_type is not None
+        and scope_type != ApiKeyScopeType.TENANT
+        and scope_id is not None
+    ):
+        try:
+            await policy.ensure_creator_authorized(
+                scope_type=scope_type, scope_id=scope_id
+            )
+            owner_filter = None
+        except ApiKeyValidationError:
+            pass
+
     if limit is not None and not previous:
         filtered_keys = await _collect_manageable_keys_for_page(
             repo=repo,

--- a/backend/src/intric/authentication/api_key_router.py
+++ b/backend/src/intric/authentication/api_key_router.py
@@ -972,6 +972,10 @@ async def list_api_keys(
             )
             owner_filter = None
         except ApiKeyValidationError:
+            # Caller is not an admin of this scope — keep the personal
+            # owner_filter so they only see their own keys, never raise.
+            # The 403 from ensure_creator_authorized is intentional inside
+            # mutating endpoints; here it is just a permission probe.
             pass
 
     if limit is not None and not previous:

--- a/backend/src/intric/authentication/auth_models.py
+++ b/backend/src/intric/authentication/auth_models.py
@@ -12,6 +12,7 @@ from pydantic import (
     field_validator,
 )
 
+from intric.audit.domain.actor_types import ActorType
 from intric.main.config import get_settings
 
 if TYPE_CHECKING:
@@ -68,6 +69,19 @@ def is_service_api_key(user: "UserInDB") -> bool:
     if key is None:
         return False
     return key.ownership == ApiKeyOwnership.SERVICE
+
+
+def audit_actor_for(user: "UserInDB") -> tuple[UUID | None, ActorType]:
+    """Resolve (actor_id, actor_type) for an audit_log entry on this request.
+
+    Service keys have no real user row — passing the synthetic user.id into
+    audit_log.actor_id (FK to users.id) would FK-violate. Mirror the gating
+    pattern used by user_service._log_api_key_used: emit (None, SYSTEM) for
+    service keys, (user.id, USER) for real users.
+    """
+    if is_service_api_key(user):
+        return None, ActorType.SYSTEM
+    return user.id, ActorType.USER
 
 
 class ApiKeyType(str, Enum):

--- a/backend/src/intric/database/tables/sessions_table.py
+++ b/backend/src/intric/database/tables/sessions_table.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from sqlalchemy import ForeignKey, Index
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from intric.database.tables.api_keys_v2_table import ApiKeysV2
 from intric.database.tables.assistant_table import Assistants
 from intric.database.tables.base_class import BasePublic
 from intric.database.tables.group_chats_table import GroupChatsTable
@@ -15,7 +16,15 @@ if TYPE_CHECKING:
 
 
 class Sessions(BasePublic):
-    user_id: Mapped[UUID] = mapped_column(ForeignKey(Users.id, ondelete="CASCADE"))
+    # user_id is nullable so service-key sessions (which authenticate via an
+    # API key, not a real user) can be persisted. api_key_id carries the
+    # owning principal in that case. Exactly one of the two is set per row.
+    user_id: Mapped[Optional[UUID]] = mapped_column(
+        ForeignKey(Users.id, ondelete="CASCADE"), nullable=True
+    )
+    api_key_id: Mapped[Optional[UUID]] = mapped_column(
+        ForeignKey(ApiKeysV2.id, ondelete="SET NULL"), nullable=True
+    )
     name: Mapped[str] = mapped_column()
     feedback_value: Mapped[Optional[int]] = mapped_column()
     feedback_text: Mapped[Optional[str]] = mapped_column()

--- a/backend/src/intric/sessions/session.py
+++ b/backend/src/intric/sessions/session.py
@@ -30,7 +30,10 @@ class SessionBase(BaseModel):
 
 
 class SessionAdd(SessionBase):
-    user_id: UUID
+    # Exactly one of user_id (real user) or api_key_id (service-key principal)
+    # is set per session. The session_service write paths enforce this invariant.
+    user_id: Optional[UUID] = None
+    api_key_id: Optional[UUID] = None
     assistant_id: Optional[UUID] = None
     group_chat_id: Optional[UUID] = None
 
@@ -40,7 +43,8 @@ class SessionUpdate(SessionBase):
 
 
 class SessionInDB(SessionBase, InDB):
-    user_id: UUID
+    user_id: Optional[UUID] = None
+    api_key_id: Optional[UUID] = None
     feedback_value: Optional[Literal[-1, 1]] = None
     feedback_text: Optional[str] = None
 

--- a/backend/src/intric/sessions/session_service.py
+++ b/backend/src/intric/sessions/session_service.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from intric.ai_models.completion_models.completion_model import CompletionModel
 from intric.assistants.assistant_service import AssistantService
+from intric.authentication.auth_models import is_service_api_key
 from intric.files.file_models import File
 from intric.group_chat.application.group_chat_service import GroupChatService
 from intric.info_blobs.info_blob import InfoBlobChunkInDBWithScore
@@ -57,6 +58,36 @@ class SessionService:
         async with session.begin():
             yield
 
+    def _principal_columns(self) -> tuple[UUID | None, UUID | None]:
+        """Return (user_id, api_key_id) for the current authenticated principal.
+
+        Service keys resolve to a synthetic UserInDB whose id is not in the
+        users table, so we cannot persist self.user.id as sessions.user_id.
+        Instead we record the API key id; the resolver-supplied UserInDB
+        carries it on .active_api_key.
+
+        Exactly one of the returned values is non-None.
+        """
+        if is_service_api_key(self.user):
+            key = self.user.active_api_key
+            assert key is not None  # guaranteed by is_service_api_key
+            return None, key.id
+        return self.user.id, None
+
+    def _is_owner(self, session: SessionInDB) -> bool:
+        """Match the session's principal against the current request's principal.
+
+        Both branches require a non-None match; we never treat NULL == NULL
+        as a match (defends against the synthetic-user/no-user trap where two
+        unrelated NULL fields would otherwise compare equal).
+        """
+        user_id, api_key_id = self._principal_columns()
+        if user_id is not None:
+            return session.user_id == user_id
+        if api_key_id is not None:
+            return session.api_key_id == api_key_id
+        return False
+
     def _check_exists_and_belongs_to_user(
         self,
         session: SessionInDB | None,
@@ -66,8 +97,8 @@ class SessionService:
         if session is None:
             raise NotFoundException("Session not found")
 
-        if session.user_id != self.user.id:
-            raise UnauthorizedException("Session belongs to other user")
+        if not self._is_owner(session):
+            raise UnauthorizedException("Session belongs to other principal")
 
         # Handle cross-endpoint access attempt
         if assistant_id is not None and session.group_chat_id is not None:
@@ -108,9 +139,11 @@ class SessionService:
         previous: bool = False,
         name_filter: str | None = None,
     ) -> tuple[list[SessionInDB], int]:
+        user_id, api_key_id = self._principal_columns()
         return await self.session_repo.get_by_assistant(
             assistant_id=assistant_id,
-            user_id=self.user.id,
+            user_id=user_id,
+            api_key_id=api_key_id,
             limit=limit,
             cursor=cursor,
             previous=previous,
@@ -139,9 +172,11 @@ class SessionService:
         assistant_id: UUID | None = None,
         group_chat_id: UUID | None = None,
     ) -> SessionInDB:
+        user_id, api_key_id = self._principal_columns()
         session_add = SessionAdd(
             name=name,
-            user_id=self.user.id,
+            user_id=user_id,
+            api_key_id=api_key_id,
             assistant_id=assistant_id,
             group_chat_id=group_chat_id,
         )
@@ -211,9 +246,11 @@ class SessionService:
         previous: bool = False,
         name_filter: str | None = None,
     ) -> tuple[list[SessionInDB], int]:
+        user_id, api_key_id = self._principal_columns()
         return await self.session_repo.get_by_group_chat(
             group_chat_id=group_chat_id,
-            user_id=self.user.id,
+            user_id=user_id,
+            api_key_id=api_key_id,
             limit=limit,
             cursor=cursor,
             previous=previous,

--- a/backend/src/intric/sessions/sessions_repo.py
+++ b/backend/src/intric/sessions/sessions_repo.py
@@ -90,6 +90,7 @@ class SessionRepository:
         self,
         assistant_id: UUID | None = None,
         user_id: UUID | None = None,
+        api_key_id: UUID | None = None,
         group_chat_id: UUID | None = None,
         name_filter: str | None = None,
         start_date: datetime | None = None,
@@ -108,8 +109,12 @@ class SessionRepository:
         if group_chat_id is not None:
             query = query.where(Sessions.group_chat_id == group_chat_id)
 
+        # Principal scoping: user_id and api_key_id are mutually exclusive in
+        # session_service callers (exactly one is non-None per request).
         if user_id is not None:
             query = query.where(Sessions.user_id == user_id)
+        if api_key_id is not None:
+            query = query.where(Sessions.api_key_id == api_key_id)
 
         if name_filter is not None:
             query = query.where(Sessions.name.ilike(f"%{name_filter}%"))
@@ -127,6 +132,7 @@ class SessionRepository:
         self,
         assistant_id: UUID,
         user_id: UUID | None = None,
+        api_key_id: UUID | None = None,
         limit: int | None = None,
         cursor: datetime | None = None,
         previous: bool = False,
@@ -145,6 +151,8 @@ class SessionRepository:
 
         if user_id is not None:
             query = query.where(Sessions.user_id == user_id)
+        if api_key_id is not None:
+            query = query.where(Sessions.api_key_id == api_key_id)
 
         if normalized_name_filter is not None:
             query = query.where(Sessions.name.ilike(f"%{normalized_name_filter}%"))
@@ -158,6 +166,7 @@ class SessionRepository:
         total_count = await self._get_total_count(
             assistant_id=assistant_id,
             user_id=user_id,
+            api_key_id=api_key_id,
             name_filter=normalized_name_filter,
             start_date=start_date,
             end_date=end_date,
@@ -207,6 +216,7 @@ class SessionRepository:
         self,
         assistant_id: UUID,
         user_id: UUID | None = None,
+        api_key_id: UUID | None = None,
         limit: int | None = None,
         cursor: datetime | None = None,
         previous: bool = False,
@@ -227,6 +237,8 @@ class SessionRepository:
 
         if user_id is not None:
             query = query.where(Sessions.user_id == user_id)
+        if api_key_id is not None:
+            query = query.where(Sessions.api_key_id == api_key_id)
 
         if normalized_name_filter is not None:
             query = query.where(Sessions.name.ilike(f"%{normalized_name_filter}%"))
@@ -240,6 +252,7 @@ class SessionRepository:
         total_count = await self._get_total_count(
             assistant_id=assistant_id,
             user_id=user_id,
+            api_key_id=api_key_id,
             name_filter=normalized_name_filter,
             start_date=start_date,
             end_date=end_date,
@@ -277,6 +290,7 @@ class SessionRepository:
         self,
         group_chat_id: UUID,
         user_id: UUID | None = None,
+        api_key_id: UUID | None = None,
         limit: int | None = None,
         cursor: datetime | None = None,
         previous: bool = False,
@@ -295,6 +309,8 @@ class SessionRepository:
 
         if user_id is not None:
             query = query.where(Sessions.user_id == user_id)
+        if api_key_id is not None:
+            query = query.where(Sessions.api_key_id == api_key_id)
 
         if normalized_name_filter is not None:
             query = query.where(Sessions.name.ilike(f"%{normalized_name_filter}%"))
@@ -308,6 +324,7 @@ class SessionRepository:
         total_count = await self._get_total_count(
             group_chat_id=group_chat_id,
             user_id=user_id,
+            api_key_id=api_key_id,
             name_filter=normalized_name_filter,
             start_date=start_date,
             end_date=end_date,
@@ -343,6 +360,7 @@ class SessionRepository:
         self,
         group_chat_id: UUID,
         user_id: UUID | None = None,
+        api_key_id: UUID | None = None,
         limit: int | None = None,
         cursor: datetime | None = None,
         previous: bool = False,
@@ -363,6 +381,8 @@ class SessionRepository:
 
         if user_id is not None:
             query = query.where(Sessions.user_id == user_id)
+        if api_key_id is not None:
+            query = query.where(Sessions.api_key_id == api_key_id)
 
         if normalized_name_filter is not None:
             query = query.where(Sessions.name.ilike(f"%{normalized_name_filter}%"))
@@ -376,6 +396,7 @@ class SessionRepository:
         total_count = await self._get_total_count(
             group_chat_id=group_chat_id,
             user_id=user_id,
+            api_key_id=api_key_id,
             name_filter=normalized_name_filter,
             start_date=start_date,
             end_date=end_date,

--- a/backend/tests/unittests/sessions/test_sessions_service.py
+++ b/backend/tests/unittests/sessions/test_sessions_service.py
@@ -45,7 +45,7 @@ async def test_get_error_when_user_not_owner_of_session(service: SessionService)
         id=TEST_UUID,
     )
 
-    with pytest.raises(UnauthorizedException, match="belongs to other user"):
+    with pytest.raises(UnauthorizedException, match="belongs to other principal"):
         await service.get_session_by_uuid(1)
 
 
@@ -95,7 +95,7 @@ async def test_update_error_when_user_is_not_owner_of_session(service: SessionSe
     )
     session_upsert = SessionUpdate(name="new_test_name", id=TEST_UUID)
 
-    with pytest.raises(UnauthorizedException, match="belongs to other user"):
+    with pytest.raises(UnauthorizedException, match="belongs to other principal"):
         await service.update_session(session_upsert)
 
 
@@ -113,5 +113,5 @@ async def test_delete_error_when_user_not_owner_of_session(service: SessionServi
         id=TEST_UUID,
     )
 
-    with pytest.raises(UnauthorizedException, match="belongs to other user"):
+    with pytest.raises(UnauthorizedException, match="belongs to other principal"):
         await service.delete(1)


### PR DESCRIPTION
## Summary

  Two bugs reported on `test.eneo.ai`, sharing the same root cause: the
  synthetic `UserInDB` constructed for service-key authentication carries
  a `user.id` that does not exist in the `users` table, and any path that
  propagates that id into an FK column blows up.

  ### Bug 1 — Service keys invisible in space settings
  - **Symptom:** Reporter creates a `pk_` service key on a space, sees it under the admin tab, but the space-settings panel shows zero keys.
  - **Cause:** `#368` added an unconditional `owner_user_id = caller.id` filter to `GET /api/v1/api-keys`. Service keys are created with `owner_user_id = NULL`, so the filter excludes
   every service key — even from the user who created it.
  - **Fix:** drop the filter when the caller can administer the requested scope (space / assistant / app). Reuses `policy.ensure_creator_authorized`, which is the same gate every
  other "manage this key" path uses, so the "admin of the scope" definition is consistent.

  ### Bug 2 — `/ask` crashes with 500 on every service-key question (P0)
  - **Symptom:** Reporter integrates `mrp.sundsvall.dev` with a `pk_` service key. Auth and permissions check out, but every question returns 500 with a rolling `error_id`, and "Eneo
  doesn't even snap up that calls are being made" (no useful logs because the audit writes never run).
  - **Cause:** `_build_service_user` in `user_service.py` returns a synthetic `UserInDB` whose `id` is never in `users`. `session_service.create_session` writes that synthetic id into
   `sessions.user_id` (NOT NULL FK → `users.id`). Postgres returns `ForeignKeyViolationError` → 500. The audit-log calls below it (`actor_id=user.id`) are latent FK violations of the
  same kind.
  - **Fix:**
    - Alembic migration: `sessions.user_id` becomes nullable, new `sessions.api_key_id` FK to `api_keys_v2(id)` `ON DELETE SET NULL`, plus index.
    - Service-key sessions persist as `(user_id=NULL, api_key_id=key.id)`. Session ownership check accepts either branch and explicitly rejects `None == None` to defend against the
  synthetic-user trap.
    - All five `sessions_repo` list methods + `_get_total_count` accept an `api_key_id` filter.
    - New `audit_actor_for(user) -> (actor_id, ActorType)` helper in `auth_models.py` mirrors the existing pattern in `user_service._log_api_key_used`. Applied to
  `assistant_router.ask_assistant` (`SESSION_STARTED`) and `delete_assistant_session` (`SESSION_ENDED`).
    - `AuditMetadata.standard` / `multi_target` / `authentication` now route through a single `_actor_snapshot` helper. For service keys it emits `{type: "service_key", id:
  <api_key.id>, name: <api_key.name>, key_prefix}` — no fake email, no synthetic uuid in the audit-log UI. Real users keep the existing shape. Frontend already conditionally renders
  the email row, no UI change required.

  ## Architectural note

  The synthetic-user pattern itself is fine: it correctly carries `tenant_id` and `active_api_key` for `SpaceActor`, and reads work. The leaks happen only at FK *write* boundaries.
  There are ~66 `user_id=*.id` write sites in the backend; most aren't reachable by service-key auth today, but every new endpoint that opens up to API keys is a potential 500. A
  typed `Principal = User | ServiceKey` abstraction would close that with typechecker support, but it's a larger refactor — out of scope here. The audit-actor helper plus
  `sessions.api_key_id` covers the actual leak the reporter hit.

  ## Out of scope (tracked as follow-ups)

  - **Cross-principal session denials are not separately audited.** When Key B asks a question on a session created by Key A, the API correctly returns 403 but the audit log only
  shows "Service API key used / outcome=success" from the auth layer. No `outcome=failure` entry is written for the denial. Filed as draft on the Eneo Findings board.
  - **Service-key conformance smoke test.** The reason this bug shipped is that no integration test pairs (service key) × (chat write). The `test_api_key_*` suite covers lifecycle and
   access-matrix GETs but never POSTs `/conversations/` with a service key. A single conformance test that fires every API-key-eligible endpoint with a service key and asserts no 500
  would catch the next FK leak at CI. Did not add it in this branch to keep scope tight.
  - **Analytics / token-usage attribution.** `analysis_repo.py` and `user_token_usage_analyzer.py` join `Sessions` to `Users` with INNER JOINs, so service-key sessions are silently
  invisible there. Not a correctness break, but if billing/attribution becomes a need, those query paths need an `api_key_id` branch.

  ## Test plan

  - [x] Alembic migration up/down round-trip in devcontainer
  - [x] `pyright --strict` clean on changed files
  - [x] `ruff check` clean on changed files
  - [ ] **Manual smoke** (driven by reporter):
    - [ ] Service key visible under space settings for a space admin
    - [ ] `POST /api/v1/conversations/` with a `pk_` service key returns 200, not 500
    - [ ] Resulting `sessions` row has `user_id IS NULL` and `api_key_id` populated
    - [ ] Resulting `audit_log` row has `actor_id IS NULL`, `actor_type = 'system'`, and `metadata.actor` shows the new `{type: "service_key", …}` shape
    - [ ] Follow-up question on the same `session_id` with the same key succeeds
    - [ ] Follow-up question on the same `session_id` with a *different* service key in the same space returns 403