### PR TITLE
refactor(api-keys): drop central allowed-origins allowlist; trust per…

### DIFF
--- a/backend/src/intric/allowed_origins/origin_matching.py
+++ b/backend/src/intric/allowed_origins/origin_matching.py
@@ -1,4 +1,27 @@
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
+
+
+def _safe_port(parsed: ParseResult) -> int | None:
+    """Return ``parsed.port`` without raising on malformed values.
+
+    ``urlparse('http://h:*').port`` raises ValueError because the wildcard is
+    not an integer; treat that as "no fixed port" so the caller can interpret
+    it however it wants.
+    """
+    try:
+        return parsed.port
+    except ValueError:
+        return None
+
+
+def _has_port_wildcard(parsed: ParseResult) -> bool:
+    """A pattern like ``http://localhost:*`` indicates "any port matches".
+
+    We strip optional ``user:pass@`` userinfo before checking so credentials
+    embedded in a URL can't trigger a false positive.
+    """
+    host_and_port = parsed.netloc.rsplit("@", 1)[-1]
+    return host_and_port.endswith(":*")
 
 
 def origin_matches_pattern(origin: str, pattern: str) -> bool:
@@ -8,7 +31,11 @@ def origin_matches_pattern(origin: str, pattern: str) -> bool:
 
     origin_scheme = origin_parsed.scheme.lower()
     origin_host = origin_parsed.hostname.lower()
-    origin_port = origin_parsed.port or (443 if origin_scheme == "https" else 80)
+    origin_port_raw = _safe_port(origin_parsed)
+    if origin_port_raw is None and ":" in origin_parsed.netloc.rsplit("@", 1)[-1]:
+        # Inbound Origin had a malformed port — fail closed.
+        return False
+    origin_port = origin_port_raw or (443 if origin_scheme == "https" else 80)
 
     if "://" not in pattern:
         pattern_host = pattern.lower()
@@ -27,10 +54,18 @@ def origin_matches_pattern(origin: str, pattern: str) -> bool:
 
     pattern_scheme = pattern_parsed.scheme.lower()
     pattern_host = pattern_parsed.hostname.lower()
-    pattern_port = pattern_parsed.port or (443 if pattern_scheme == "https" else 80)
 
-    if pattern_scheme != origin_scheme or pattern_port != origin_port:
+    if pattern_scheme != origin_scheme:
         return False
+
+    # Port handling. ``:*`` means "any port"; otherwise pin to the parsed
+    # value (or the scheme default if absent).
+    if not _has_port_wildcard(pattern_parsed):
+        pattern_port = _safe_port(pattern_parsed) or (
+            443 if pattern_scheme == "https" else 80
+        )
+        if pattern_port != origin_port:
+            return False
 
     if pattern_host.startswith("*."):
         base = pattern_host[2:]

--- a/backend/src/intric/authentication/api_key_policy.py
+++ b/backend/src/intric/authentication/api_key_policy.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
 import ipaddress
-from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, cast
 from urllib.parse import urlparse
 from uuid import UUID
 
-from intric.allowed_origins.allowed_origin_repo import AllowedOriginRepository
 from intric.allowed_origins.origin_matching import origin_matches_pattern
 from intric.authentication.api_key_request_context import resolve_client_ip
 from intric.authentication.api_key_resolver import ApiKeyValidationError
@@ -34,30 +32,16 @@ if TYPE_CHECKING:
     from intric.users.user import UserInDB
 
 
-@dataclass(slots=True)
-class _TenantOriginCacheEntry:
-    patterns: list[str]
-    expires_at: datetime
-
-
 class ApiKeyPolicyService:
-    _shared_tenant_origin_cache: dict[UUID, _TenantOriginCacheEntry] = {}
-
     def __init__(
         self,
-        allowed_origin_repo: AllowedOriginRepository,
         space_service: "SpaceService | None" = None,
         user: "UserInDB | None" = None,
     ):
         super().__init__()
-        self.allowed_origin_repo = allowed_origin_repo
         self.space_service = space_service
         self.user = user
         self.settings = get_settings()
-        self._tenant_origin_cache = self._shared_tenant_origin_cache
-        self._tenant_origin_cache_ttl_seconds = max(
-            int(self.settings.api_key_origin_cache_ttl_seconds), 0
-        )
 
     def _require_space_service(self) -> "SpaceService":
         if self.space_service is None:
@@ -143,20 +127,8 @@ class ApiKeyPolicyService:
                     code="invalid_request",
                     message="pk_ keys do not allow IP restrictions.",
                 )
-            if request.allowed_origins:
-                for origin in request.allowed_origins:
-                    if not self._origin_has_scheme(
-                        origin
-                    ) and not self._is_localhost_origin(origin):
-                        raise ApiKeyValidationError(
-                            status_code=400,
-                            code="invalid_request",
-                            message="Origin entries must include scheme (https://...).",
-                        )
-                await self.validate_allowed_origins_subset(
-                    allowed_origins=request.allowed_origins,
-                    tenant_id=self._require_user().tenant_id,
-                )
+            for origin in request.allowed_origins:
+                self._validate_origin_format(origin)
 
         if request.key_type == ApiKeyType.SK and request.allowed_origins is not None:
             raise ApiKeyValidationError(
@@ -342,20 +314,8 @@ class ApiKeyPolicyService:
                         code="invalid_request",
                         message="pk_ keys require at least one allowed origin.",
                     )
-                if allowed_origins:
-                    for origin in allowed_origins:
-                        if not self._origin_has_scheme(
-                            origin
-                        ) and not self._is_localhost_origin(origin):
-                            raise ApiKeyValidationError(
-                                status_code=400,
-                                code="invalid_request",
-                                message="Origin entries must include scheme (https://...).",
-                            )
-                await self.validate_allowed_origins_subset(
-                    allowed_origins=allowed_origins,
-                    tenant_id=key.tenant_id,
-                )
+                for origin in allowed_origins:
+                    self._validate_origin_format(origin)
 
         if "allowed_ips" in updates:
             allowed_ips = cast(list[str] | None, updates.get("allowed_ips"))
@@ -445,50 +405,6 @@ class ApiKeyPolicyService:
         if ApiKeyType(key.key_type) == ApiKeyType.SK:
             self._validate_ip(key=key, client_ip=client_ip)
 
-    async def validate_allowed_origins_subset(
-        self, *, allowed_origins: list[str] | None, tenant_id: UUID
-    ):
-        if allowed_origins is None:
-            return
-
-        tenant_patterns = await self._get_tenant_origin_patterns(tenant_id)
-
-        if not tenant_patterns:
-            for origin in allowed_origins:
-                if not self._is_localhost_origin(origin):
-                    raise ApiKeyValidationError(
-                        status_code=400,
-                        code="invalid_request",
-                        message="Origin not allowed by tenant policy.",
-                    )
-            return
-
-        for origin in allowed_origins:
-            if self._is_localhost_origin(origin):
-                continue
-            if "*" in origin:
-                if origin in tenant_patterns:
-                    continue
-                if "://" in origin:
-                    host_only = origin.split("://", 1)[1]
-                    if host_only in tenant_patterns:
-                        continue
-                if origin not in tenant_patterns:
-                    raise ApiKeyValidationError(
-                        status_code=400,
-                        code="invalid_request",
-                        message=f"Origin '{origin}' is not allowed by tenant policy.",
-                    )
-                continue
-            if not any(
-                self._origin_matches(origin, pattern) for pattern in tenant_patterns
-            ):
-                raise ApiKeyValidationError(
-                    status_code=400,
-                    code="invalid_request",
-                    message=f"Origin '{origin}' is not allowed by tenant policy.",
-                )
-
     async def _validate_expiration(self, expires_at: datetime | None):
         user = self._require_user()
         policy = user.tenant.api_key_policy or {}
@@ -574,41 +490,22 @@ class ApiKeyPolicyService:
                 message="Origin header required for pk_ keys.",
             )
 
-        if (
-            self._is_localhost_origin(origin)
-            and self.settings.api_key_allow_localhost_origin
-        ):
-            return
-        # When allow_localhost_origin is off, localhost falls through to
-        # normal tenant/key pattern matching — no free pass.
-
-        tenant_patterns = await self._get_tenant_origin_patterns(key.tenant_id)
-
-        if not tenant_patterns:
-            raise ApiKeyValidationError(
-                status_code=403,
-                code="origin_not_allowed",
-                message="Origin not allowed by tenant policy.",
-            )
-
+        # Per-key allowed_origins is the only authority. The central tenant
+        # allowlist was dropped: trust the key creator to list exactly the
+        # origins their integration needs.
         key_patterns = key.allowed_origins
         if key_patterns is None:
-            key_patterns = tenant_patterns
-        elif len(key_patterns) == 0:
+            # Legacy keys minted before allowed_origins became required.
+            # New pk_ keys always carry a non-empty list.
+            return
+        if len(key_patterns) == 0:
             raise ApiKeyValidationError(
                 status_code=403,
                 code="origin_not_allowed",
                 message="Origin not allowed by API key policy.",
             )
 
-        matches_tenant = any(
-            self._origin_matches(origin, pattern) for pattern in tenant_patterns
-        )
-        matches_key = any(
-            self._origin_matches(origin, pattern) for pattern in key_patterns
-        )
-
-        if not matches_tenant or not matches_key:
+        if not any(self._origin_matches(origin, pattern) for pattern in key_patterns):
             raise ApiKeyValidationError(
                 status_code=403,
                 code="origin_not_allowed",
@@ -654,15 +551,24 @@ class ApiKeyPolicyService:
                 return True
         return False
 
-    def _origin_has_scheme(self, origin: str) -> bool:
-        parsed = urlparse(origin)
-        return bool(parsed.scheme and parsed.hostname)
+    def _validate_origin_format(self, origin: str) -> None:
+        """Sanity-check a per-key origin entry. Trust the key creator on the
+        value, but reject typos that would silently break their integration.
 
-    def _is_localhost_origin(self, origin: str) -> bool:
+        Required shape: ``<scheme>://<host>[:port]`` with scheme http(s) and
+        a non-empty host. Wildcards in the host are fine (matching is the
+        request-time concern of ``origin_matches_pattern``).
+        """
         parsed = urlparse(origin)
-        if parsed.hostname in ("localhost", "127.0.0.1", "::1"):
-            return True
-        return False
+        if parsed.scheme not in ("http", "https") or not parsed.hostname:
+            raise ApiKeyValidationError(
+                status_code=400,
+                code="invalid_request",
+                message=(
+                    f"Invalid origin '{origin}': "
+                    "must include scheme (http:// or https://) and host."
+                ),
+            )
 
     def _origin_matches(self, origin: str, pattern: str) -> bool:
         return origin_matches_pattern(origin, pattern)
@@ -675,26 +581,3 @@ class ApiKeyPolicyService:
                 message="User context required.",
             )
         return self.user
-
-    async def _get_tenant_origin_patterns(self, tenant_id: UUID) -> list[str]:
-        now = datetime.now(timezone.utc)
-        if self._tenant_origin_cache_ttl_seconds > 0:
-            cached = self._tenant_origin_cache.get(tenant_id)
-            if cached is not None and cached.expires_at > now:
-                return cached.patterns
-
-        tenant_origins = await self.allowed_origin_repo.get_by_tenant(tenant_id)
-        patterns = [origin.url for origin in tenant_origins]
-        if self._tenant_origin_cache_ttl_seconds > 0:
-            self._tenant_origin_cache[tenant_id] = _TenantOriginCacheEntry(
-                patterns=patterns,
-                expires_at=now
-                + timedelta(seconds=self._tenant_origin_cache_ttl_seconds),
-            )
-        return patterns
-
-    def invalidate_tenant_origin_cache(self, tenant_id: UUID | None = None) -> None:
-        if tenant_id is None:
-            self._tenant_origin_cache.clear()
-            return
-        self._tenant_origin_cache.pop(tenant_id, None)

--- a/backend/src/intric/main/config.py
+++ b/backend/src/intric/main/config.py
@@ -398,8 +398,6 @@ class Settings(BaseSettings):
     api_key_rate_limit_assistant_default: int = 1000
     api_key_rate_limit_app_default: int = 1000
     api_key_enforce_resource_permissions: bool = True
-    api_key_origin_cache_ttl_seconds: int = 30
-    api_key_allow_localhost_origin: bool = False
     trusted_proxy_count: int = 0
     trusted_proxy_headers: list[str] = ["x-forwarded-for", "x-real-ip"]
     jwt_audience: str

--- a/backend/src/intric/main/container/container.py
+++ b/backend/src/intric/main/container/container.py
@@ -883,7 +883,6 @@ class Container(containers.DeclarativeContainer):
     )
     api_key_policy_service = providers.Factory(
         ApiKeyPolicyService,
-        allowed_origin_repo=allowed_origin_repo,
         space_service=space_service,
         user=user,
     )
@@ -1107,7 +1106,6 @@ class Container(containers.DeclarativeContainer):
         auth_service=auth_service,
         api_key_auth_resolver=api_key_auth_resolver,
         api_key_v2_repo=api_key_v2_repo,
-        allowed_origin_repo=allowed_origin_repo,
         audit_service=audit_service,
         settings_repo=settings_repo,
         tenant_repo=tenant_repo,

--- a/backend/src/intric/sysadmin/sysadmin_router.py
+++ b/backend/src/intric/sysadmin/sysadmin_router.py
@@ -39,7 +39,6 @@ from intric.audit.domain.action_types import ActionType
 from intric.audit.domain.actor_types import ActorType
 from intric.audit.domain.entity_types import EntityType
 from intric.authentication import auth
-from intric.authentication.api_key_policy import ApiKeyPolicyService
 from intric.completion_models.presentation.completion_model_models import (
     MigrationResult,
     ModelMigrationRequest,
@@ -73,15 +72,6 @@ from intric.worker.usage_stats_tasks import recalculate_tenant_usage_stats_direc
 logger = get_logger(__name__)
 
 router = APIRouter(dependencies=[Security(auth.authenticate_super_api_key)])
-
-
-def _invalidate_api_key_origin_cache(container: Container, tenant_id: UUID) -> None:
-    policy_service = ApiKeyPolicyService(
-        allowed_origin_repo=container.allowed_origin_repo(),
-        space_service=None,
-        user=None,
-    )
-    policy_service.invalidate_tenant_origin_cache(tenant_id)
 
 
 class OIDCDebugToggleRequest(BaseModel):
@@ -690,7 +680,6 @@ async def add_origin(
     created = await allowed_origin_repo.add_origin(
         origin=origin.url, tenant_id=origin.tenant_id
     )
-    _invalidate_api_key_origin_cache(container, origin.tenant_id)
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=origin.tenant_id,
@@ -734,7 +723,6 @@ async def delete_origin(
     await allowed_origin_repo.delete(id)
     if origin is None:
         return
-    _invalidate_api_key_origin_cache(container, origin.tenant_id)
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=origin.tenant_id,

--- a/backend/src/intric/users/user_service.py
+++ b/backend/src/intric/users/user_service.py
@@ -8,7 +8,6 @@ import jwt
 import sqlalchemy as sa
 from starlette.requests import Request
 
-from intric.allowed_origins.allowed_origin_repo import AllowedOriginRepository
 from intric.audit.application.audit_metadata import AuditMetadata
 from intric.audit.application.audit_service import AuditService
 from intric.audit.domain.action_types import ActionType
@@ -205,7 +204,6 @@ class UserService:
         auth_service: AuthService,
         api_key_auth_resolver: ApiKeyAuthResolver,
         api_key_v2_repo: ApiKeysV2Repository,
-        allowed_origin_repo: AllowedOriginRepository,
         audit_service: Optional[AuditService],
         settings_repo: SettingsRepository,
         tenant_repo: TenantRepository,
@@ -220,7 +218,6 @@ class UserService:
         self.auth_service = auth_service
         self.api_key_auth_resolver = api_key_auth_resolver
         self.api_key_v2_repo = api_key_v2_repo
-        self.allowed_origin_repo = allowed_origin_repo
         self.space_service = space_service
         self.audit_service = audit_service
         self.settings_repo = settings_repo
@@ -857,7 +854,6 @@ class UserService:
         user.active_api_key = resolved.key
 
         policy_service = ApiKeyPolicyService(
-            allowed_origin_repo=self.allowed_origin_repo,
             space_service=self.space_service,
             user=None,
         )

--- a/backend/tests/integration/test_api_key_endpoints.py
+++ b/backend/tests/integration/test_api_key_endpoints.py
@@ -250,81 +250,68 @@ async def test_pk_origin_guardrail(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_pk_localhost_origin_denied_when_allow_localhost_origin_false(
-    client, db_container, default_user, default_user_token
+async def test_pk_localhost_origin_rejected_when_not_listed_on_key(
+    client, default_user_token
 ):
-    """When localhost bypass is disabled, localhost must follow normal pattern matching."""
-    settings = get_settings()
-    patched = settings.model_copy(update={"api_key_allow_localhost_origin": False})
-    set_settings(patched)
-    try:
-        allowed_origin = f"https://app-{uuid4().hex[:8]}.example.com"
-        await _add_allowed_origin(db_container, default_user.tenant_id, allowed_origin)
+    """A pk_ key whose allowed_origins doesn't include localhost rejects localhost requests.
 
-        create_response = await client.post(
-            "/api/v1/api-keys",
-            json={
-                "name": "PK Localhost Disabled",
-                "key_type": "pk_",
-                "permission": "read",
-                "scope_type": "tenant",
-                "allowed_origins": [allowed_origin],
-            },
-            headers={"Authorization": f"Bearer {default_user_token}"},
-        )
-        assert create_response.status_code == 201, create_response.text
-        secret = create_response.json()["secret"]
+    Localhost is no longer magic — it must be explicitly listed on the key.
+    """
+    allowed_origin = f"https://app-{uuid4().hex[:8]}.example.com"
 
-        localhost_response = await client.get(
-            _AUTH_ENDPOINT,
-            headers={
-                "X-API-Key": secret,
-                "Origin": "http://localhost:3000",
-            },
-        )
-        assert localhost_response.status_code == 403
-        assert localhost_response.json()["code"] == "origin_not_allowed"
-    finally:
-        set_settings(settings)
+    create_response = await client.post(
+        "/api/v1/api-keys",
+        json={
+            "name": "PK No Localhost",
+            "key_type": "pk_",
+            "permission": "read",
+            "scope_type": "tenant",
+            "allowed_origins": [allowed_origin],
+        },
+        headers={"Authorization": f"Bearer {default_user_token}"},
+    )
+    assert create_response.status_code == 201, create_response.text
+    secret = create_response.json()["secret"]
+
+    localhost_response = await client.get(
+        _AUTH_ENDPOINT,
+        headers={
+            "X-API-Key": secret,
+            "Origin": "http://localhost:3000",
+        },
+    )
+    assert localhost_response.status_code == 403
+    assert localhost_response.json()["code"] == "origin_not_allowed"
 
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_pk_localhost_origin_allowed_when_allow_localhost_origin_true(
-    client, db_container, default_user, default_user_token
+async def test_pk_localhost_origin_allowed_when_listed_on_key(
+    client, default_user_token
 ):
-    """When localhost bypass is enabled, localhost should pass even without matching patterns."""
-    settings = get_settings()
-    patched = settings.model_copy(update={"api_key_allow_localhost_origin": True})
-    set_settings(patched)
-    try:
-        allowed_origin = f"https://app-{uuid4().hex[:8]}.example.com"
-        await _add_allowed_origin(db_container, default_user.tenant_id, allowed_origin)
+    """Localhost works iff the key creator put it on the per-key allowed_origins list."""
+    create_response = await client.post(
+        "/api/v1/api-keys",
+        json={
+            "name": "PK With Localhost",
+            "key_type": "pk_",
+            "permission": "read",
+            "scope_type": "tenant",
+            "allowed_origins": ["http://localhost:3000"],
+        },
+        headers={"Authorization": f"Bearer {default_user_token}"},
+    )
+    assert create_response.status_code == 201, create_response.text
+    secret = create_response.json()["secret"]
 
-        create_response = await client.post(
-            "/api/v1/api-keys",
-            json={
-                "name": "PK Localhost Enabled",
-                "key_type": "pk_",
-                "permission": "read",
-                "scope_type": "tenant",
-                "allowed_origins": [allowed_origin],
-            },
-            headers={"Authorization": f"Bearer {default_user_token}"},
-        )
-        assert create_response.status_code == 201, create_response.text
-        secret = create_response.json()["secret"]
-
-        localhost_response = await client.get(
-            _AUTH_ENDPOINT,
-            headers={
-                "X-API-Key": secret,
-                "Origin": "http://localhost:3000",
-            },
-        )
-        assert localhost_response.status_code == 200, localhost_response.text
-    finally:
-        set_settings(settings)
+    localhost_response = await client.get(
+        _AUTH_ENDPOINT,
+        headers={
+            "X-API-Key": secret,
+            "Origin": "http://localhost:3000",
+        },
+    )
+    assert localhost_response.status_code == 200, localhost_response.text
 
 
 @pytest.mark.integration

--- a/backend/tests/unit/test_api_key_auth_guards.py
+++ b/backend/tests/unit/test_api_key_auth_guards.py
@@ -354,7 +354,6 @@ class TestPolicyMaxRateLimit:
         tenant = SimpleNamespace(api_key_policy={"max_rate_limit_override": 100})
         user = SimpleNamespace(tenant=tenant, permissions=[])
         service = ApiKeyPolicyService(
-            allowed_origin_repo=SimpleNamespace(),
             space_service=SimpleNamespace(),
             user=user,
         )
@@ -620,7 +619,6 @@ class TestAuthFailureAuditEnrichment:
             auth_service=AsyncMock(),
             api_key_auth_resolver=AsyncMock(),
             api_key_v2_repo=AsyncMock(),
-            allowed_origin_repo=AsyncMock(),
             audit_service=audit,
             settings_repo=AsyncMock(),
             tenant_repo=AsyncMock(),

--- a/backend/tests/unit/test_api_key_policy_service.py
+++ b/backend/tests/unit/test_api_key_policy_service.py
@@ -15,42 +15,51 @@ from intric.authentication.auth_models import (
 from intric.roles.permissions import Permission
 
 
-class DummyOrigin:
-    def __init__(self, url: str):
-        self.url = url
-
-
-class DummyOriginRepo:
-    def __init__(self, patterns: list[str]):
-        self.patterns = patterns
-        self.calls = 0
-
-    async def get_by_tenant(self, tenant_id):
-        self.calls += 1
-        return [DummyOrigin(url) for url in self.patterns]
-
-
 class DummySpaceService:
     pass
 
 
-def _service_with_user(patterns: list[str], *, permissions: list[object] | None = None):
-    tenant = SimpleNamespace(api_key_policy={})
-    user = SimpleNamespace(tenant=tenant, permissions=permissions or [])
+def _service(*, user: object | None = None) -> ApiKeyPolicyService:
     return ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo(patterns),
         space_service=DummySpaceService(),
         user=user,
     )
 
 
+def _service_with_user(
+    *, permissions: list[object] | None = None
+) -> ApiKeyPolicyService:
+    tenant = SimpleNamespace(api_key_policy={})
+    user = SimpleNamespace(tenant=tenant, permissions=permissions or [])
+    return _service(user=user)
+
+
+_UNSET = object()
+
+
+def _make_pk_key(*, tenant_id=None, allowed_origins=_UNSET):
+    """Build a minimal pk_ key-like object for _validate_origin tests."""
+    if allowed_origins is _UNSET:
+        allowed_origins = ["http://localhost:3000"]
+    return SimpleNamespace(
+        key_type=ApiKeyType.PK.value,
+        allowed_origins=allowed_origins,
+        allowed_ips=None,
+        revoked_at=None,
+        suspended_at=None,
+        expires_at=None,
+        tenant_id=tenant_id or uuid4(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _origin_matches: pattern matching (host, wildcard, scheme, port)
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_origin_matches_single_label_wildcard():
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
+    service = _service()
 
     assert service._origin_matches("https://app.example.com", "https://*.example.com")
     assert not service._origin_matches(
@@ -60,11 +69,7 @@ async def test_origin_matches_single_label_wildcard():
 
 @pytest.mark.asyncio
 async def test_origin_matches_host_only_patterns():
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
+    service = _service()
 
     assert service._origin_matches("https://example.com", "example.com")
     assert service._origin_matches("http://example.com:80", "example.com")
@@ -73,11 +78,7 @@ async def test_origin_matches_host_only_patterns():
 
 @pytest.mark.asyncio
 async def test_origin_matches_host_only_wildcard():
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
+    service = _service()
 
     assert service._origin_matches("https://app.example.com", "*.example.com")
     assert service._origin_matches("http://app.example.com", "*.example.com")
@@ -86,90 +87,27 @@ async def test_origin_matches_host_only_wildcard():
 
 @pytest.mark.asyncio
 async def test_origin_matches_default_ports():
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
+    service = _service()
 
     assert service._origin_matches("https://example.com:443", "https://example.com")
     assert service._origin_matches("http://example.com:80", "http://example.com")
 
 
 @pytest.mark.asyncio
-async def test_allowed_origins_subset_with_tenant_wildcard():
-    tenant_id = uuid4()
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo(["https://*.example.com"]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
+async def test_origin_matches_case_insensitive_scheme():
+    service = _service()
 
-    await service.validate_allowed_origins_subset(
-        allowed_origins=["https://app.example.com"], tenant_id=tenant_id
-    )
+    assert service._origin_matches("HTTPS://Example.Com", "https://example.com")
 
 
-@pytest.mark.asyncio
-async def test_allowed_origins_subset_rejects_unlisted_wildcard():
-    tenant_id = uuid4()
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo(["https://app.example.com"]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-
-    with pytest.raises(ApiKeyValidationError):
-        await service.validate_allowed_origins_subset(
-            allowed_origins=["https://*.example.com"], tenant_id=tenant_id
-        )
-
-
-@pytest.mark.asyncio
-async def test_allowed_origins_subset_with_host_only_tenant_entry():
-    tenant_id = uuid4()
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo(["example.com"]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-
-    await service.validate_allowed_origins_subset(
-        allowed_origins=["https://example.com"], tenant_id=tenant_id
-    )
-
-
-@pytest.mark.asyncio
-async def test_allowed_origins_subset_accepts_host_only_wildcard():
-    tenant_id = uuid4()
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo(["*.example.com"]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-
-    await service.validate_allowed_origins_subset(
-        allowed_origins=["https://*.example.com"], tenant_id=tenant_id
-    )
-
-
-@pytest.mark.asyncio
-async def test_allowed_origins_subset_allows_empty_list():
-    tenant_id = uuid4()
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo(["https://example.com"]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-
-    await service.validate_allowed_origins_subset(
-        allowed_origins=[], tenant_id=tenant_id
-    )
+# ---------------------------------------------------------------------------
+# Per-key allowed_origins: create + update validation
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_create_request_rejects_empty_allowed_origins_for_pk():
-    service = _service_with_user([], permissions=[Permission.ADMIN])
+    service = _service_with_user(permissions=[Permission.ADMIN])
 
     request = ApiKeyCreateRequest(
         name="Public key",
@@ -190,15 +128,10 @@ async def test_create_request_rejects_empty_allowed_origins_for_pk():
 
 @pytest.mark.asyncio
 async def test_update_request_rejects_empty_allowed_origins_for_pk():
-    tenant_id = uuid4()
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo(["https://example.com"]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
+    service = _service()
     key = SimpleNamespace(
         key_type=ApiKeyType.PK.value,
-        tenant_id=tenant_id,
+        tenant_id=uuid4(),
         permission=ApiKeyPermission.READ.value,
         resource_permissions=None,
     )
@@ -216,11 +149,7 @@ async def test_update_request_rejects_empty_allowed_origins_for_pk():
 
 @pytest.mark.asyncio
 async def test_update_request_rejects_non_read_permission_for_pk():
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
+    service = _service()
     key = SimpleNamespace(
         key_type=ApiKeyType.PK.value,
         tenant_id=uuid4(),
@@ -240,13 +169,215 @@ async def test_update_request_rejects_non_read_permission_for_pk():
         assert "can only have read permission" in exc.value.message
 
 
+# ---------------------------------------------------------------------------
+# Origin format validation (sanity check on per-key entries)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_origin_without_scheme():
+    """Bare hostnames (no scheme) are rejected with a clear 400."""
+    service = _service_with_user(permissions=[Permission.ADMIN])
+
+    request = ApiKeyCreateRequest(
+        name="Public key",
+        key_type=ApiKeyType.PK,
+        permission=ApiKeyPermission.READ,
+        scope_type=ApiKeyScopeType.TENANT,
+        scope_id=None,
+        allowed_origins=["example.com"],
+    )
+
+    with pytest.raises(ApiKeyValidationError) as exc:
+        await service.validate_create_request(request=request)
+
+    assert exc.value.status_code == 400
+    assert exc.value.code == "invalid_request"
+    assert "scheme" in exc.value.message
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_origin_with_non_http_scheme():
+    """Schemes other than http/https are rejected."""
+    service = _service_with_user(permissions=[Permission.ADMIN])
+
+    request = ApiKeyCreateRequest(
+        name="Public key",
+        key_type=ApiKeyType.PK,
+        permission=ApiKeyPermission.READ,
+        scope_type=ApiKeyScopeType.TENANT,
+        scope_id=None,
+        allowed_origins=["ftp://example.com"],
+    )
+
+    with pytest.raises(ApiKeyValidationError) as exc:
+        await service.validate_create_request(request=request)
+
+    assert exc.value.status_code == 400
+    assert exc.value.code == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_create_accepts_https_origin_without_consulting_tenant_allowlist():
+    """No central allowlist gate — any well-formed origin the user lists is accepted."""
+    service = _service_with_user(permissions=[Permission.ADMIN])
+
+    request = ApiKeyCreateRequest(
+        name="Public key",
+        key_type=ApiKeyType.PK,
+        permission=ApiKeyPermission.READ,
+        scope_type=ApiKeyScopeType.TENANT,
+        scope_id=None,
+        allowed_origins=["https://mrp.sundsvall.dev", "http://localhost:5173"],
+    )
+
+    # Should NOT raise — well-formed origins, no tenant allowlist consulted.
+    await service.validate_create_request(request=request)
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_origin_without_scheme():
+    service = _service()
+    key = SimpleNamespace(
+        key_type=ApiKeyType.PK.value,
+        tenant_id=uuid4(),
+        permission=ApiKeyPermission.READ.value,
+        resource_permissions=None,
+    )
+
+    with pytest.raises(ApiKeyValidationError) as exc:
+        await service.validate_update_request(
+            key=key,
+            updates={"allowed_origins": ["bare-hostname"]},
+        )
+    assert exc.value.status_code == 400
+    assert exc.value.code == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_create_accepts_port_wildcard():
+    """``http://localhost:*`` is a valid pattern for dev iteration."""
+    service = _service_with_user(permissions=[Permission.ADMIN])
+
+    request = ApiKeyCreateRequest(
+        name="Public key",
+        key_type=ApiKeyType.PK,
+        permission=ApiKeyPermission.READ,
+        scope_type=ApiKeyScopeType.TENANT,
+        scope_id=None,
+        allowed_origins=["http://localhost:*", "https://*.example.com:*"],
+    )
+
+    # Should NOT raise — wildcards in port and subdomain are accepted.
+    await service.validate_create_request(request=request)
+
+
+@pytest.mark.asyncio
+async def test_pk_port_wildcard_matches_any_port_at_request_time():
+    """Pattern ``http://localhost:*`` permits any port on localhost."""
+    service = _service()
+    key = _make_pk_key(allowed_origins=["http://localhost:*"])
+
+    await service._validate_origin(key=key, origin="http://localhost:5173")
+    await service._validate_origin(key=key, origin="http://localhost:6006")
+
+    # Different host → still rejected.
+    with pytest.raises(ApiKeyValidationError):
+        await service._validate_origin(key=key, origin="http://evil.local:5173")
+
+
+# ---------------------------------------------------------------------------
+# _validate_origin: request-time check against per-key allowed_origins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pk_key_missing_origin_header_rejected():
+    """pk_ key with NO Origin header → 403 origin_not_allowed."""
+    service = _service()
+    key = _make_pk_key(allowed_origins=["https://example.com"])
+
+    with pytest.raises(ApiKeyValidationError) as exc:
+        await service._validate_origin(key=key, origin=None)
+
+    assert exc.value.status_code == 403
+    assert exc.value.code == "origin_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_pk_origin_matched_against_per_key_list():
+    """Origin in the key's allowed_origins → permitted."""
+    service = _service()
+    key = _make_pk_key(allowed_origins=["https://app.example.com"])
+
+    await service._validate_origin(key=key, origin="https://app.example.com")
+
+
+@pytest.mark.asyncio
+async def test_pk_origin_not_in_per_key_list_rejected():
+    """Origin not in the key's allowed_origins → 403."""
+    service = _service()
+    key = _make_pk_key(allowed_origins=["https://app.example.com"])
+
+    with pytest.raises(ApiKeyValidationError) as exc:
+        await service._validate_origin(key=key, origin="https://evil.example")
+
+    assert exc.value.status_code == 403
+    assert exc.value.code == "origin_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_pk_localhost_permitted_when_listed_on_key():
+    """No env-flag bypass — localhost works iff the key explicitly lists it."""
+    service = _service()
+    key = _make_pk_key(allowed_origins=["http://localhost:5173"])
+
+    await service._validate_origin(key=key, origin="http://localhost:5173")
+
+
+@pytest.mark.asyncio
+async def test_pk_localhost_rejected_when_not_listed_on_key():
+    """localhost is not magic — if the key didn't list it, it's denied."""
+    service = _service()
+    key = _make_pk_key(allowed_origins=["https://app.example.com"])
+
+    with pytest.raises(ApiKeyValidationError) as exc:
+        await service._validate_origin(key=key, origin="http://localhost:5173")
+    assert exc.value.code == "origin_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_pk_empty_allowed_origins_blocks_all():
+    """An empty list is treated as 'block everything'."""
+    service = _service()
+    key = _make_pk_key(allowed_origins=[])
+
+    with pytest.raises(ApiKeyValidationError) as exc:
+        await service._validate_origin(key=key, origin="https://app.example.com")
+    assert exc.value.code == "origin_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_pk_none_allowed_origins_permits_legacy_keys():
+    """Legacy pk_ rows whose allowed_origins is NULL are permitted (no constraint).
+
+    New pk_ keys minted after the allowlist requirement always carry a non-empty
+    list; this branch only exists for pre-existing data.
+    """
+    service = _service()
+    key = _make_pk_key(allowed_origins=None)
+
+    await service._validate_origin(key=key, origin="https://anything.example")
+
+
+# ---------------------------------------------------------------------------
+# IP allowlist (sk_ keys)
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
 async def test_ip_allowlist_allows_matching_ip():
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
+    service = _service()
     key = SimpleNamespace(allowed_ips=["10.0.0.0/24"])
 
     service._validate_ip(key=key, client_ip="10.0.0.5")
@@ -254,11 +385,7 @@ async def test_ip_allowlist_allows_matching_ip():
 
 @pytest.mark.asyncio
 async def test_ip_allowlist_rejects_non_matching_ip():
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
+    service = _service()
     key = SimpleNamespace(allowed_ips=["10.0.0.0/24"])
 
     with pytest.raises(ApiKeyValidationError):
@@ -267,11 +394,7 @@ async def test_ip_allowlist_rejects_non_matching_ip():
 
 @pytest.mark.asyncio
 async def test_ip_allowlist_requires_client_ip():
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
+    service = _service()
     key = SimpleNamespace(allowed_ips=["10.0.0.0/24"])
 
     with pytest.raises(ApiKeyValidationError):
@@ -280,11 +403,7 @@ async def test_ip_allowlist_requires_client_ip():
 
 @pytest.mark.asyncio
 async def test_ip_allowlist_rejects_malformed_client_ip():
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
+    service = _service()
     key = SimpleNamespace(allowed_ips=["10.0.0.0/24"])
 
     with pytest.raises(ApiKeyValidationError) as exc:
@@ -293,19 +412,32 @@ async def test_ip_allowlist_rejects_malformed_client_ip():
 
 
 @pytest.mark.asyncio
-async def test_localhost_origin_supports_ipv6_loopback():
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
+async def test_ip_allowlist_none_skips_check():
+    """Key with allowed_ips=None → IP check is skipped entirely."""
+    service = _service()
+    key = SimpleNamespace(allowed_ips=None)
+    # Should NOT raise — no IP restriction
+    service._validate_ip(key=key, client_ip="anything")
 
-    assert service._is_localhost_origin("http://[::1]:5173")
+
+@pytest.mark.asyncio
+async def test_ip_allowlist_empty_list_rejects_all():
+    """Key with allowed_ips=[] → rejects all IPs (no entries match)."""
+    service = _service()
+    key = SimpleNamespace(allowed_ips=[])
+    with pytest.raises(ApiKeyValidationError) as exc:
+        service._validate_ip(key=key, client_ip="10.0.0.1")
+    assert exc.value.code == "ip_not_allowed"
+
+
+# ---------------------------------------------------------------------------
+# Rate limits
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_rate_limit_zero_rejected():
-    service = _service_with_user([])
+    service = _service_with_user()
 
     with pytest.raises(ApiKeyValidationError) as exc:
         await service._validate_rate_limit(0)
@@ -315,71 +447,66 @@ async def test_rate_limit_zero_rejected():
 
 
 @pytest.mark.asyncio
-async def test_tenant_origin_cache_reuses_patterns_within_ttl():
-    tenant_id = uuid4()
-    repo = DummyOriginRepo(["https://example.com"])
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=repo,
-        space_service=DummySpaceService(),
-        user=None,
-    )
-    service._tenant_origin_cache_ttl_seconds = 60
-
-    await service.validate_allowed_origins_subset(
-        allowed_origins=["https://example.com"], tenant_id=tenant_id
-    )
-    await service.validate_allowed_origins_subset(
-        allowed_origins=["https://example.com"], tenant_id=tenant_id
-    )
-
-    assert repo.calls == 1
-
-
-@pytest.mark.asyncio
-async def test_tenant_origin_cache_invalidate_forces_reload():
-    tenant_id = uuid4()
-    repo = DummyOriginRepo(["https://example.com"])
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=repo,
-        space_service=DummySpaceService(),
-        user=None,
-    )
-    service._tenant_origin_cache_ttl_seconds = 60
-
-    await service.validate_allowed_origins_subset(
-        allowed_origins=["https://example.com"], tenant_id=tenant_id
-    )
-    service.invalidate_tenant_origin_cache(tenant_id)
-    await service.validate_allowed_origins_subset(
-        allowed_origins=["https://example.com"], tenant_id=tenant_id
-    )
-
-    assert repo.calls == 2
-
-
-@pytest.mark.asyncio
-async def test_pk_key_missing_origin_header_rejected():
-    """pk_ key with NO Origin header → 403 origin_not_allowed."""
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo(["https://example.com"]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-    key = SimpleNamespace(
-        key_type=ApiKeyType.PK.value,
-        allowed_origins=["https://example.com"],
-        allowed_ips=None,
-        revoked_at=None,
-        suspended_at=None,
-        expires_at=None,
-        tenant_id=uuid4(),
-    )
+async def test_max_rate_limit_override_blocks_unlimited_rate_limit():
+    """max_rate_limit_override blocks rate_limit=-1 on create/update."""
+    service = _service_with_user()
+    service.user.tenant.api_key_policy = {"max_rate_limit_override": 100}
 
     with pytest.raises(ApiKeyValidationError) as exc:
-        await service.enforce_guardrails(key=key, origin=None, client_ip=None)
+        await service._validate_rate_limit(-1)
 
-    assert exc.value.status_code == 403
-    assert exc.value.code == "origin_not_allowed"
+    assert exc.value.status_code == 400
+    assert "not allowed" in exc.value.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_max_rate_limit_override_blocks_exceeding_value():
+    """max_rate_limit_override blocks rate_limit exceeding the cap."""
+    service = _service_with_user()
+    service.user.tenant.api_key_policy = {"max_rate_limit_override": 100}
+
+    with pytest.raises(ApiKeyValidationError) as exc:
+        await service._validate_rate_limit(200)
+
+    assert exc.value.status_code == 400
+    assert "exceeds" in exc.value.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_negative_one_is_unlimited_without_cap_requires_admin():
+    """rate_limit=-1 (unlimited) without cap → requires admin permission."""
+    # Non-admin user → rejected
+    service = _service_with_user(permissions=[])
+    service.user.tenant.api_key_policy = {}
+    with pytest.raises(ApiKeyValidationError) as exc:
+        await service._validate_rate_limit(-1)
+    assert exc.value.code == "insufficient_permission"
+
+    # Admin user → allowed
+    admin_service = _service_with_user(permissions=[Permission.ADMIN])
+    admin_service.user.tenant.api_key_policy = {}
+    await admin_service._validate_rate_limit(-1)
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_positive_value_always_valid():
+    """Positive rate_limit is always valid regardless of cap."""
+    service = _service_with_user()
+    service.user.tenant.api_key_policy = {"max_rate_limit_override": 1000}
+    await service._validate_rate_limit(500)
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_at_cap_boundary_valid():
+    """rate_limit exactly at the cap boundary → valid."""
+    service = _service_with_user()
+    service.user.tenant.api_key_policy = {"max_rate_limit_override": 100}
+    await service._validate_rate_limit(100)
+
+
+# ---------------------------------------------------------------------------
+# Reverse-proxy IP resolution
+# ---------------------------------------------------------------------------
 
 
 def test_reverse_proxy_ip_resolution_extracts_leftmost_untrusted():
@@ -416,32 +543,6 @@ def test_reverse_proxy_ip_resolution_with_multiple_proxies():
     assert ip == "203.0.113.50"
 
 
-@pytest.mark.asyncio
-async def test_max_rate_limit_override_blocks_unlimited_rate_limit():
-    """max_rate_limit_override blocks rate_limit=-1 on create/update."""
-    service = _service_with_user([])
-    service.user.tenant.api_key_policy = {"max_rate_limit_override": 100}
-
-    with pytest.raises(ApiKeyValidationError) as exc:
-        await service._validate_rate_limit(-1)
-
-    assert exc.value.status_code == 400
-    assert "not allowed" in exc.value.message.lower()
-
-
-@pytest.mark.asyncio
-async def test_max_rate_limit_override_blocks_exceeding_value():
-    """max_rate_limit_override blocks rate_limit exceeding the cap."""
-    service = _service_with_user([])
-    service.user.tenant.api_key_policy = {"max_rate_limit_override": 100}
-
-    with pytest.raises(ApiKeyValidationError) as exc:
-        await service._validate_rate_limit(200)
-
-    assert exc.value.status_code == 400
-    assert "exceeds" in exc.value.message.lower()
-
-
 def test_reverse_proxy_ip_resolution_falls_back_to_client_host():
     """No X-Forwarded-For + trusted_proxy_count=0 → uses request.client.host."""
     request = SimpleNamespace(
@@ -455,269 +556,3 @@ def test_reverse_proxy_ip_resolution_falls_back_to_client_host():
         trusted_proxy_headers=[],
     )
     assert ip == "192.168.1.1"
-
-
-# ---------------------------------------------------------------------------
-# Guardrail edge cases (Phase 7L)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_ip_allowlist_none_skips_check():
-    """Key with allowed_ips=None → IP check is skipped entirely."""
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-    key = SimpleNamespace(allowed_ips=None)
-    # Should NOT raise — no IP restriction
-    service._validate_ip(key=key, client_ip="anything")
-
-
-@pytest.mark.asyncio
-async def test_ip_allowlist_empty_list_rejects_all():
-    """Key with allowed_ips=[] → rejects all IPs (no entries match)."""
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-    key = SimpleNamespace(allowed_ips=[])
-    with pytest.raises(ApiKeyValidationError) as exc:
-        service._validate_ip(key=key, client_ip="10.0.0.1")
-    assert exc.value.code == "ip_not_allowed"
-
-
-@pytest.mark.asyncio
-async def test_origin_matches_case_insensitive_scheme():
-    """Origin matching is case-insensitive for scheme and host."""
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-    assert service._origin_matches("HTTPS://Example.Com", "https://example.com")
-
-
-@pytest.mark.asyncio
-async def test_localhost_origin_detection():
-    """Localhost detection covers common patterns."""
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-    assert service._is_localhost_origin("http://localhost:3000")
-    assert service._is_localhost_origin("http://127.0.0.1:8080")
-    assert not service._is_localhost_origin("https://app.example.com")
-
-
-@pytest.mark.asyncio
-async def test_rate_limit_negative_one_is_unlimited_without_cap_requires_admin():
-    """rate_limit=-1 (unlimited) without cap → requires admin permission."""
-    from intric.roles.permissions import Permission
-
-    # Non-admin user → rejected
-    service = _service_with_user([], permissions=[])
-    service.user.tenant.api_key_policy = {}
-    with pytest.raises(ApiKeyValidationError) as exc:
-        await service._validate_rate_limit(-1)
-    assert exc.value.code == "insufficient_permission"
-
-    # Admin user → allowed
-    admin_service = _service_with_user([], permissions=[Permission.ADMIN])
-    admin_service.user.tenant.api_key_policy = {}
-    await admin_service._validate_rate_limit(-1)
-
-
-@pytest.mark.asyncio
-async def test_rate_limit_positive_value_always_valid():
-    """Positive rate_limit is always valid regardless of cap."""
-    service = _service_with_user([])
-    service.user.tenant.api_key_policy = {"max_rate_limit_override": 1000}
-    await service._validate_rate_limit(500)
-
-
-@pytest.mark.asyncio
-async def test_rate_limit_at_cap_boundary_valid():
-    """rate_limit exactly at the cap boundary → valid."""
-    service = _service_with_user([])
-    service.user.tenant.api_key_policy = {"max_rate_limit_override": 100}
-    await service._validate_rate_limit(100)
-
-
-# ---------------------------------------------------------------------------
-# Localhost origin configurable bypass (Plan 1F)
-# ---------------------------------------------------------------------------
-
-
-def _make_pk_key(*, tenant_id=None, allowed_origins=None):
-    """Build a minimal pk_ key-like object for _validate_origin tests."""
-    return SimpleNamespace(
-        key_type=ApiKeyType.PK.value,
-        allowed_origins=allowed_origins or ["http://localhost:3000"],
-        allowed_ips=None,
-        revoked_at=None,
-        suspended_at=None,
-        expires_at=None,
-        tenant_id=tenant_id or uuid4(),
-    )
-
-
-@pytest.mark.asyncio
-async def test_pk_localhost_origin_denied_when_allow_localhost_origin_false(
-    monkeypatch,
-):
-    """When api_key_allow_localhost_origin=False, localhost origin falls through
-    to normal tenant pattern matching. If no patterns match, it's rejected.
-
-    This is the core security fix: localhost no longer gets a free pass.
-    """
-
-    tenant_id = uuid4()
-    # Tenant has only https://example.com — no localhost pattern
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo(["https://example.com"]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-    # Override the setting to False
-    service.settings = SimpleNamespace(
-        **{
-            **vars(service.settings),
-            "api_key_allow_localhost_origin": False,
-            "api_key_origin_cache_ttl_seconds": 0,
-        }
-    )
-    key = _make_pk_key(tenant_id=tenant_id)
-
-    with pytest.raises(ApiKeyValidationError) as exc:
-        await service._validate_origin(key=key, origin="http://localhost:3000")
-
-    assert exc.value.status_code == 403
-    assert exc.value.code == "origin_not_allowed"
-
-
-@pytest.mark.asyncio
-async def test_pk_localhost_origin_allowed_when_allow_localhost_origin_true(
-    monkeypatch,
-):
-    """When api_key_allow_localhost_origin=True, localhost origin bypasses all
-    origin checks and returns immediately.
-    """
-    tenant_id = uuid4()
-    # Tenant has NO matching patterns — but bypass should kick in
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-    service.settings = SimpleNamespace(
-        **{
-            **vars(service.settings),
-            "api_key_allow_localhost_origin": True,
-            "api_key_origin_cache_ttl_seconds": 0,
-        }
-    )
-    key = _make_pk_key(tenant_id=tenant_id)
-
-    # Should NOT raise — localhost bypass active
-    await service._validate_origin(key=key, origin="http://localhost:3000")
-
-
-@pytest.mark.asyncio
-async def test_pk_localhost_127_0_0_1_respects_setting(monkeypatch):
-    """127.0.0.1 is recognized as localhost and respects the config setting."""
-    tenant_id = uuid4()
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo(["https://example.com"]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-    # Setting OFF → 127.0.0.1 must be denied (no matching tenant pattern)
-    service.settings = SimpleNamespace(
-        **{
-            **vars(service.settings),
-            "api_key_allow_localhost_origin": False,
-            "api_key_origin_cache_ttl_seconds": 0,
-        }
-    )
-    key = _make_pk_key(tenant_id=tenant_id)
-
-    with pytest.raises(ApiKeyValidationError) as exc:
-        await service._validate_origin(key=key, origin="http://127.0.0.1:8080")
-    assert exc.value.code == "origin_not_allowed"
-
-
-@pytest.mark.asyncio
-async def test_pk_localhost_ipv6_respects_setting(monkeypatch):
-    """IPv6 loopback [::1] is recognized as localhost and respects the config setting."""
-    tenant_id = uuid4()
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo(["https://example.com"]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-    service.settings = SimpleNamespace(
-        **{
-            **vars(service.settings),
-            "api_key_allow_localhost_origin": False,
-            "api_key_origin_cache_ttl_seconds": 0,
-        }
-    )
-    key = _make_pk_key(tenant_id=tenant_id)
-
-    with pytest.raises(ApiKeyValidationError) as exc:
-        await service._validate_origin(key=key, origin="http://[::1]:5173")
-    assert exc.value.code == "origin_not_allowed"
-
-
-@pytest.mark.asyncio
-async def test_pk_non_localhost_not_affected_by_setting(monkeypatch):
-    """Non-localhost origins are unaffected by api_key_allow_localhost_origin setting.
-
-    Ensures the setting only controls localhost behavior, not general origin matching.
-    """
-    tenant_id = uuid4()
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo(["https://app.example.com"]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-    service.settings = SimpleNamespace(
-        **{
-            **vars(service.settings),
-            "api_key_allow_localhost_origin": True,  # Even with bypass ON
-            "api_key_origin_cache_ttl_seconds": 0,
-        }
-    )
-    key = _make_pk_key(
-        tenant_id=tenant_id,
-        allowed_origins=["https://app.example.com"],
-    )
-
-    # Non-localhost with matching pattern → should pass
-    await service._validate_origin(key=key, origin="https://app.example.com")
-
-    # Non-localhost with non-matching pattern → should fail
-    with pytest.raises(ApiKeyValidationError) as exc:
-        await service._validate_origin(key=key, origin="https://evil.com")
-    assert exc.value.code == "origin_not_allowed"
-
-
-@pytest.mark.asyncio
-async def test_localhost_subdomain_trick_not_bypassed():
-    """Subdomain tricks like 'localhost.evil.com' must NOT be treated as localhost.
-
-    Security test: only exact localhost/127.0.0.1/::1 hostnames should match.
-    """
-    service = ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo([]),
-        space_service=DummySpaceService(),
-        user=None,
-    )
-
-    assert not service._is_localhost_origin("https://localhost.evil.com")
-    assert not service._is_localhost_origin("https://foo.localhost")
-    assert not service._is_localhost_origin("https://127.0.0.1.evil.com")

--- a/backend/tests/unit/test_api_key_policy_service_ownership.py
+++ b/backend/tests/unit/test_api_key_policy_service_ownership.py
@@ -32,12 +32,14 @@ class DummySpaceService:
 
 
 def _service_with_user(patterns: list[str], *, permissions: list[object] | None = None):
+    """patterns is unused after the central allowlist gate was dropped — kept
+    in the signature for back-compat with existing call sites."""
+    del patterns  # noqa: keep signature stable
     tenant = SimpleNamespace(api_key_policy={})
     user = SimpleNamespace(
         tenant=tenant, permissions=permissions or [], tenant_id=uuid4()
     )
     return ApiKeyPolicyService(
-        allowed_origin_repo=DummyOriginRepo(patterns),
         space_service=DummySpaceService(),
         user=user,
     )

--- a/backend/tests/unit/test_api_key_scope_enforcement.py
+++ b/backend/tests/unit/test_api_key_scope_enforcement.py
@@ -654,7 +654,6 @@ class TestResolveApiKeyScopeWiring:
                 )
             )
         )
-        svc.allowed_origin_repo = AsyncMock()
         svc.space_service = AsyncMock()
         svc.api_key_rate_limiter = None
         svc._session = None
@@ -1640,7 +1639,6 @@ class TestTenantScopeForDeleteEnforcement:
                 )
             )
         )
-        svc.allowed_origin_repo = AsyncMock()
         svc.space_service = AsyncMock()
         svc.api_key_rate_limiter = None
         svc._session = None

--- a/backend/tests/unit/test_origin_matching.py
+++ b/backend/tests/unit/test_origin_matching.py
@@ -32,3 +32,38 @@ def test_origin_matches_host_only_pattern_and_wildcard():
 def test_invalid_origin_or_pattern_returns_false():
     assert not origin_matches_pattern("not-a-url", "https://example.com")
     assert not origin_matches_pattern("https://example.com", "not-a-url")
+
+
+def test_port_wildcard_matches_any_port_on_same_scheme_host():
+    """``http://localhost:*`` matches the host on any port — useful for dev."""
+    assert origin_matches_pattern("http://localhost:5173", "http://localhost:*")
+    assert origin_matches_pattern("http://localhost:6006", "http://localhost:*")
+    assert origin_matches_pattern("http://localhost:80", "http://localhost:*")
+    assert origin_matches_pattern("http://localhost", "http://localhost:*")
+
+
+def test_port_wildcard_still_pins_scheme_and_host():
+    """Port wildcard does not relax scheme or host."""
+    # Different scheme → no match even though port wildcard would match.
+    assert not origin_matches_pattern("https://localhost:5173", "http://localhost:*")
+    # Different host → no match.
+    assert not origin_matches_pattern("http://other.local:5173", "http://localhost:*")
+
+
+def test_port_wildcard_combines_with_subdomain_wildcard():
+    """``https://*.example.com:*`` matches any subdomain on any port."""
+    assert origin_matches_pattern(
+        "https://app.example.com:8443", "https://*.example.com:*"
+    )
+    assert origin_matches_pattern(
+        "https://admin.example.com", "https://*.example.com:*"
+    )
+    # But still only one subdomain level.
+    assert not origin_matches_pattern(
+        "https://a.b.example.com:8443", "https://*.example.com:*"
+    )
+
+
+def test_malformed_port_in_origin_fails_closed():
+    """If the inbound Origin somehow has a malformed port, deny rather than 500."""
+    assert not origin_matches_pattern("http://localhost:abc", "http://localhost:*")

--- a/backend/tests/unittests/sysadmin/test_sysadmin_router.py
+++ b/backend/tests/unittests/sysadmin/test_sysadmin_router.py
@@ -14,13 +14,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from intric.allowed_origins.allowed_origin_models import AllowedOriginCreate
 from intric.main.exceptions import NotFoundException
 from intric.sysadmin.sysadmin_router import (
-    add_origin,
-    delete_origin as delete_allowed_origin,
-    get_access_token,
     delete_user,
+    get_access_token,
     get_user,
     update_user,
 )
@@ -184,121 +181,3 @@ class TestUpdateUser:
 
         assert "No such user exists" in str(exc_info.value)
         user_service.update_user.assert_not_called()
-
-
-class TestAllowedOriginCacheInvalidation:
-    """Allowed-origin mutations should invalidate API-key origin cache immediately."""
-
-    async def test_add_origin_builds_policy_service_without_user_dependency(
-        self, monkeypatch
-    ):
-        tenant_id = uuid.uuid4()
-        origin = AllowedOriginCreate(
-            url="https://app.example.com",
-            tenant_id=tenant_id,
-        )
-
-        container = MagicMock()
-        allowed_origin_repo = AsyncMock()
-        allowed_origin_repo.add_origin = AsyncMock(
-            return_value=MagicMock(url=origin.url, tenant_id=tenant_id)
-        )
-        container.allowed_origin_repo.return_value = allowed_origin_repo
-        container.audit_service.return_value = AsyncMock(log_async=AsyncMock())
-
-        captured_kwargs = {}
-        policy_service = MagicMock()
-
-        class _PolicyService:
-            def __init__(self, **kwargs):
-                nonlocal captured_kwargs
-                captured_kwargs = kwargs
-
-            def invalidate_tenant_origin_cache(self, tenant_id: uuid.UUID):
-                policy_service.invalidate_tenant_origin_cache(tenant_id)
-
-        monkeypatch.setattr(
-            "intric.sysadmin.sysadmin_router.ApiKeyPolicyService",
-            _PolicyService,
-        )
-
-        await add_origin(origin=origin, container=container)
-
-        assert (
-            captured_kwargs["allowed_origin_repo"]
-            is container.allowed_origin_repo.return_value
-        )
-        assert captured_kwargs["space_service"] is None
-        assert captured_kwargs["user"] is None
-        policy_service.invalidate_tenant_origin_cache.assert_called_once_with(tenant_id)
-
-    async def test_add_origin_invalidates_api_key_origin_cache(self, monkeypatch):
-        tenant_id = uuid.uuid4()
-        origin = AllowedOriginCreate(
-            url="https://app.example.com",
-            tenant_id=tenant_id,
-        )
-
-        container = MagicMock()
-        allowed_origin_repo = AsyncMock()
-        allowed_origin_repo.add_origin = AsyncMock(
-            return_value=MagicMock(url=origin.url, tenant_id=tenant_id)
-        )
-        container.allowed_origin_repo.return_value = allowed_origin_repo
-        container.audit_service.return_value = AsyncMock(log_async=AsyncMock())
-        policy_service = MagicMock()
-        monkeypatch.setattr(
-            "intric.sysadmin.sysadmin_router.ApiKeyPolicyService",
-            MagicMock(return_value=policy_service),
-        )
-
-        await add_origin(origin=origin, container=container)
-
-        policy_service.invalidate_tenant_origin_cache.assert_called_once_with(tenant_id)
-
-    async def test_delete_origin_invalidates_api_key_origin_cache(self, monkeypatch):
-        tenant_id = uuid.uuid4()
-        origin_id = uuid.uuid4()
-
-        container = MagicMock()
-        allowed_origin_repo = AsyncMock()
-        allowed_origin_repo.get_by_id = AsyncMock(
-            return_value=MagicMock(
-                id=origin_id,
-                url="https://app.example.com",
-                tenant_id=tenant_id,
-            )
-        )
-        allowed_origin_repo.delete = AsyncMock(return_value=None)
-        container.allowed_origin_repo.return_value = allowed_origin_repo
-        container.audit_service.return_value = AsyncMock(log_async=AsyncMock())
-        policy_service = MagicMock()
-        monkeypatch.setattr(
-            "intric.sysadmin.sysadmin_router.ApiKeyPolicyService",
-            MagicMock(return_value=policy_service),
-        )
-
-        await delete_allowed_origin(id=origin_id, container=container)
-
-        policy_service.invalidate_tenant_origin_cache.assert_called_once_with(tenant_id)
-
-    async def test_delete_origin_missing_record_does_not_invalidate_cache(
-        self, monkeypatch
-    ):
-        origin_id = uuid.uuid4()
-
-        container = MagicMock()
-        allowed_origin_repo = AsyncMock()
-        allowed_origin_repo.get_by_id = AsyncMock(return_value=None)
-        allowed_origin_repo.delete = AsyncMock(return_value=None)
-        container.allowed_origin_repo.return_value = allowed_origin_repo
-        container.audit_service.return_value = AsyncMock(log_async=AsyncMock())
-        policy_service = MagicMock()
-        monkeypatch.setattr(
-            "intric.sysadmin.sysadmin_router.ApiKeyPolicyService",
-            MagicMock(return_value=policy_service),
-        )
-
-        await delete_allowed_origin(id=origin_id, container=container)
-
-        policy_service.invalidate_tenant_origin_cache.assert_not_called()

--- a/backend/tests/unittests/users/test_admin_safety.py
+++ b/backend/tests/unittests/users/test_admin_safety.py
@@ -30,7 +30,6 @@ def _make_service():
         auth_service=AsyncMock(),
         api_key_auth_resolver=AsyncMock(),
         api_key_v2_repo=AsyncMock(),
-        allowed_origin_repo=AsyncMock(),
         audit_service=AsyncMock(),
         settings_repo=AsyncMock(),
         tenant_repo=AsyncMock(),

--- a/backend/tests/unittests/users/test_user_service.py
+++ b/backend/tests/unittests/users/test_user_service.py
@@ -26,7 +26,6 @@ def service_with_mocks():
         auth_service=AsyncMock(),
         api_key_auth_resolver=AsyncMock(),
         api_key_v2_repo=AsyncMock(),
-        allowed_origin_repo=AsyncMock(),
         audit_service=AsyncMock(),
         settings_repo=AsyncMock(),
         tenant_repo=AsyncMock(),


### PR DESCRIPTION
Sysadmins no longer have to pre-register every origin a tenant might use via /sysadmin/allowed-origins/. Per-key allowed_origins is now the sole authority at request time.

  What changes

  - Drop the central gate. validate_allowed_origins_subset and its callers in create/update flows are gone.
  - Format check. Each entry must urlparse as http(s)://<host> — catches typos without imposing a policy.
  - Port wildcards. Matcher now supports :* (e.g. http://localhost:* matches any local port). Malformed inbound ports fail closed instead of 500-ing.
  - Settings removed: API_KEY_ALLOW_LOCALHOST_ORIGIN and api_key_origin_cache_ttl_seconds — both redundant once the per-key list is the only authority.

  What stays

  - The allowed_origins table, the 3 /sysadmin/allowed-origins/ endpoints, and CORSMiddleware wiring — still used for browser CORS on the main Eneo web app.
  - Per-key allowed_origins enforcement at request time.