### PR TITLE
fix(group-chat): prevent crash when selector returns out-of-range index

### DIFF
--- a/backend/src/intric/group_chat/application/group_chat_service.py
+++ b/backend/src/intric/group_chat/application/group_chat_service.py
@@ -35,6 +35,14 @@ if TYPE_CHECKING:
     from intric.users.user import UserInDB
 
 
+# Strict contract with the selector model: a routing decision is the whole
+# response and nothing else. Anything that isn't an exact `ASSISTANT=<n>` line
+# is treated as clarification prose and surfaced to the user — including
+# digits embedded in clarification text, which previously caused false-positive
+# routing or crashes.
+_ASSISTANT_SENTINEL = re.compile(r"\s*ASSISTANT\s*=\s*(\d+)\s*", re.IGNORECASE)
+
+
 @dataclass
 class GroupChatAssistantSelectionResult:
     assistant: Optional[GroupChatAssistant]
@@ -234,26 +242,22 @@ class GroupChatService:
         assistant_list = "\n".join(assistant_info)
 
         return f"""
-                Given a user question and a list of AI assistants, you need to determine the most
-                appropriate assistant to answer the question.
+                You are routing a user question to one of {len(assistants)} AI assistants.
+
                 User Question: {question}
+
                 Available Assistants:
                 {assistant_list}
 
-                Based only on the descriptions above, which assistant number (1-{len(assistants)})
-                would be most appropriate to answer this question?
+                Reply with EXACTLY ONE of:
+                - The literal line `ASSISTANT=<n>` where <n> is an integer in
+                  1-{len(assistants)}, when one assistant is the clear best match. Nothing
+                  else on the line. No commentary, no quotes, no punctuation.
+                - A friendly clarification in the language of the question when the
+                  question is ambiguous or spans multiple assistants. Never include the
+                  token `ASSISTANT=` anywhere in clarification text.
 
-                Follow these guidelines:
-                - Choose ONE assistant from the list. Return only a single number.
-                - Select the assistant whose expertise best matches the question.
-                - Always be decisive - do not suggest multiple assistants.
-
-                If and only if there is a clear answer respond ONLY with the assistant number
-                (e.g., "1"), otherwise you should tell the user to be more
-                specific in a friendly tone.
-                Answer in the language of the question.
-
-                Take earlier questions in the context into account.
+                Take earlier questions in the conversation into account.
                 """
 
     def _is_match(
@@ -261,12 +265,12 @@ class GroupChatService:
     ) -> int | None:
         """Parse the model's response to a 1-indexed assistant number, or None.
 
-        Bounds-checks the parsed digit so an out-of-range pick (e.g. a stray
-        year like "2024" or a hallucinated index) collapses to None and the
-        caller falls through to the clarification branch instead of crashing
-        on `selection_result.response_str`.
+        Routing requires the response to be exactly `ASSISTANT=<n>` (with
+        flexible whitespace and case). Anything else — including bare digits,
+        prose containing numbers, or out-of-range sentinels — returns None and
+        the caller surfaces the text as a clarification reply.
         """
-        match = re.search(r"(\d+)", response_text.strip().upper())
+        match = _ASSISTANT_SENTINEL.fullmatch(response_text)
         if match is None:
             return None
         n = int(match.group(1))

--- a/backend/src/intric/group_chat/application/group_chat_service.py
+++ b/backend/src/intric/group_chat/application/group_chat_service.py
@@ -259,16 +259,20 @@ class GroupChatService:
     def _is_match(
         self, response_text: str, assistants: list[GroupChatAssistant]
     ) -> int | None:
-        """Parse the model's response to determine which assistant to use"""
-        response_text = response_text.strip().upper()
+        """Parse the model's response to a 1-indexed assistant number, or None.
 
-        # Look for a number in the response
-        match = re.search(r"(\d+)", response_text)
-
-        if match:
-            return int(match.group(1))
-        else:
+        Bounds-checks the parsed digit so an out-of-range pick (e.g. a stray
+        year like "2024" or a hallucinated index) collapses to None and the
+        caller falls through to the clarification branch instead of crashing
+        on `selection_result.response_str`.
+        """
+        match = re.search(r"(\d+)", response_text.strip().upper())
+        if match is None:
             return None
+        n = int(match.group(1))
+        if 1 <= n <= len(assistants):
+            return n
+        return None
 
     async def _select_assistant_with_completion_model(
         self,
@@ -306,24 +310,21 @@ class GroupChatService:
             session=session,
             text_input=question,
         )
-        # parse the response to determine which assistant to use
         assistant_match = self._is_match(
             response.completion.text,  # type: ignore[union-attr]
             assistants,
         )
-        if assistant_match:
-            if 1 <= assistant_match <= len(assistants):
-                return GroupChatAssistantSelectionResult(
-                    assistant=assistants[assistant_match - 1],
-                    response_str=response.completion.text,  # type: ignore[union-attr]
-                    assistant_selector_tokens=assistant_selector_tokens,
-                )
-        else:
+        if assistant_match is not None:
             return GroupChatAssistantSelectionResult(
-                assistant=None,
+                assistant=assistants[assistant_match - 1],
                 response_str=response.completion.text,  # type: ignore[union-attr]
                 assistant_selector_tokens=assistant_selector_tokens,
             )
+        return GroupChatAssistantSelectionResult(
+            assistant=None,
+            response_str=response.completion.text,  # type: ignore[union-attr]
+            assistant_selector_tokens=assistant_selector_tokens,
+        )
 
     async def _handle_response(
         self,

--- a/backend/tests/unit/test_group_chat_selector_repro.py
+++ b/backend/tests/unit/test_group_chat_selector_repro.py
@@ -1,0 +1,150 @@
+"""Reproduction for the group-chat selector NoneType crash.
+
+Production traceback (see incident notes):
+
+    File ".../group_chat/application/group_chat_service.py", line 399, in ask_group_chat
+        response_from_selector = selection_result.response_str
+    AttributeError: 'NoneType' object has no attribute 'response_str'
+
+Root cause is in `_select_assistant_with_completion_model`:
+
+    if assistant_match:
+        if 1 <= assistant_match <= len(assistants):
+            return GroupChatAssistantSelectionResult(...)
+        # ← no else: falls through to implicit None
+    else:
+        return GroupChatAssistantSelectionResult(assistant=None, ...)
+
+`_is_match` does no bounds-check — it returns the first digit run found in
+the selector model's response. When that run is outside `1..len(assistants)`
+the function silently returns None and the caller crashes.
+
+These tests cover the cases that can hit it in prod:
+- model picks an index strictly greater than len(assistants)
+- model embeds a stray year / large number in clarification prose
+- happy paths must keep working (sanity)
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from intric.ai_models.completion_models.completion_model import Completion
+from intric.group_chat.application.group_chat_service import GroupChatService
+from intric.group_chat.domain.entities.group_chat import GroupChatAssistant
+
+
+def _make_assistant(name: str, description: str) -> GroupChatAssistant:
+    completion_model = SimpleNamespace(name="gpt-test")
+    assistant = SimpleNamespace(
+        id=f"assistant-{name}",
+        name=name,
+        description=description,
+        completion_model=completion_model,
+    )
+    return GroupChatAssistant(assistant=assistant, user_description=None)
+
+
+def _make_service(selector_text: str) -> GroupChatService:
+    completion_response = SimpleNamespace(
+        completion=Completion(text=selector_text),
+    )
+    completion_service = MagicMock()
+    completion_service.get_response = AsyncMock(return_value=completion_response)
+
+    return GroupChatService(
+        user=MagicMock(),
+        space_service=MagicMock(),
+        space_repo=MagicMock(),
+        actor_manager=MagicMock(),
+        assistant_service=MagicMock(),
+        session_service=MagicMock(),
+        completion_service=completion_service,
+        icon_repo=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_selector_returns_index_greater_than_assistant_count():
+    """Selector picks '3' with only 2 assistants — current code returns None."""
+    service = _make_service(selector_text="3")
+    assistants = [
+        _make_assistant("Knowledge", "Looks up policy docs"),
+        _make_assistant("Reasoning", "Performs multi-step reasoning"),
+    ]
+
+    result = await service._select_assistant_with_completion_model(
+        question="Who should answer this?",
+        assistants=assistants,
+    )
+
+    # FAILS today (returns None) — proves the missing-else fall-through.
+    # Expected after fix: a result with assistant=None so the clarification
+    # branch in ask_group_chat runs instead of crashing.
+    assert result is not None, (
+        "Out-of-range selector index returned None — caller will crash on "
+        ".response_str at group_chat_service.py:449"
+    )
+    assert result.assistant is None
+
+
+@pytest.mark.asyncio
+async def test_selector_response_contains_stray_year():
+    """Selector emits prose like 'Regarding your 2024 budget question' — `\\d+`
+    picks up 2024, which is out of range and crashes."""
+    service = _make_service(
+        selector_text="Regarding your 2024 budget question, please clarify."
+    )
+    assistants = [
+        _make_assistant("Knowledge", "Looks up policy docs"),
+        _make_assistant("Reasoning", "Performs multi-step reasoning"),
+    ]
+
+    result = await service._select_assistant_with_completion_model(
+        question="Tell me about taxes",
+        assistants=assistants,
+    )
+
+    assert result is not None
+    assert result.assistant is None
+    # The full prose should still be available so the clarification branch
+    # can surface it back to the user.
+    assert "clarify" in result.response_str
+
+
+@pytest.mark.asyncio
+async def test_selector_picks_valid_index():
+    """Sanity: '2' with 2 assistants must keep working."""
+    service = _make_service(selector_text="2")
+    a1 = _make_assistant("Knowledge", "Looks up policy docs")
+    a2 = _make_assistant("Reasoning", "Performs multi-step reasoning")
+
+    result = await service._select_assistant_with_completion_model(
+        question="Walk me through this proof",
+        assistants=[a1, a2],
+    )
+
+    assert result is not None
+    assert result.assistant is a2
+
+
+@pytest.mark.asyncio
+async def test_selector_returns_no_digit_goes_to_clarification():
+    """Sanity: pure clarification text (no digits) must keep working."""
+    service = _make_service(
+        selector_text="Could you be more specific about what you need?"
+    )
+    assistants = [
+        _make_assistant("Knowledge", "Looks up policy docs"),
+        _make_assistant("Reasoning", "Performs multi-step reasoning"),
+    ]
+
+    result = await service._select_assistant_with_completion_model(
+        question="help",
+        assistants=assistants,
+    )
+
+    assert result is not None
+    assert result.assistant is None
+    assert "specific" in result.response_str

--- a/backend/tests/unit/test_group_chat_selector_repro.py
+++ b/backend/tests/unit/test_group_chat_selector_repro.py
@@ -1,28 +1,21 @@
-"""Reproduction for the group-chat selector NoneType crash.
+"""Tests for the group-chat selector contract.
 
-Production traceback (see incident notes):
+Background — the original production crash:
 
     File ".../group_chat/application/group_chat_service.py", line 399, in ask_group_chat
         response_from_selector = selection_result.response_str
     AttributeError: 'NoneType' object has no attribute 'response_str'
 
-Root cause is in `_select_assistant_with_completion_model`:
+`_is_match` did `re.search(r"(\\d+)", text)` with no bounds-check and accepted
+any digit anywhere in the selector model's response. Out-of-range digits (a
+year like "2024", a hallucinated index, a list marker) fell through a nested
+if/else and returned None implicitly, crashing the caller.
 
-    if assistant_match:
-        if 1 <= assistant_match <= len(assistants):
-            return GroupChatAssistantSelectionResult(...)
-        # ← no else: falls through to implicit None
-    else:
-        return GroupChatAssistantSelectionResult(assistant=None, ...)
-
-`_is_match` does no bounds-check — it returns the first digit run found in
-the selector model's response. When that run is outside `1..len(assistants)`
-the function silently returns None and the caller crashes.
-
-These tests cover the cases that can hit it in prod:
-- model picks an index strictly greater than len(assistants)
-- model embeds a stray year / large number in clarification prose
-- happy paths must keep working (sanity)
+The fix moves the selector to a strict sentinel contract: the model must
+reply with exactly `ASSISTANT=<n>` to route. Anything else — bare digits,
+prose containing numbers, out-of-range sentinels — is treated as
+clarification text and surfaced to the user. This eliminates both the crash
+class and the silent false-positive routing class.
 """
 
 from types import SimpleNamespace
@@ -65,41 +58,87 @@ def _make_service(selector_text: str) -> GroupChatService:
     )
 
 
-@pytest.mark.asyncio
-async def test_selector_returns_index_greater_than_assistant_count():
-    """Selector picks '3' with only 2 assistants — current code returns None."""
-    service = _make_service(selector_text="3")
-    assistants = [
+def _two_assistants() -> list[GroupChatAssistant]:
+    return [
         _make_assistant("Knowledge", "Looks up policy docs"),
         _make_assistant("Reasoning", "Performs multi-step reasoning"),
     ]
+
+
+# --- routing happy path ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sentinel_routes_to_named_assistant():
+    service = _make_service(selector_text="ASSISTANT=2")
+    assistants = _two_assistants()
+
+    result = await service._select_assistant_with_completion_model(
+        question="Walk me through this proof",
+        assistants=assistants,
+    )
+
+    assert result is not None
+    assert result.assistant is assistants[1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "selector_text",
+    [
+        "ASSISTANT=2",
+        "assistant=2",
+        "Assistant = 2",
+        "  ASSISTANT=2  ",
+        "ASSISTANT = 2\n",
+    ],
+)
+async def test_sentinel_tolerates_whitespace_and_case(selector_text: str):
+    service = _make_service(selector_text=selector_text)
+    assistants = _two_assistants()
+
+    result = await service._select_assistant_with_completion_model(
+        question="…",
+        assistants=assistants,
+    )
+
+    assert result is not None
+    assert result.assistant is assistants[1]
+
+
+# --- regressions for the original crash class -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_bare_out_of_range_digit_does_not_crash():
+    """Original crash repro: model emits '3' with 2 assistants.
+
+    Pre-fix: implicit None return → AttributeError in caller.
+    Post-fix: no sentinel match → clarification, no crash.
+    """
+    service = _make_service(selector_text="3")
+    assistants = _two_assistants()
 
     result = await service._select_assistant_with_completion_model(
         question="Who should answer this?",
         assistants=assistants,
     )
 
-    # FAILS today (returns None) — proves the missing-else fall-through.
-    # Expected after fix: a result with assistant=None so the clarification
-    # branch in ask_group_chat runs instead of crashing.
-    assert result is not None, (
-        "Out-of-range selector index returned None — caller will crash on "
-        ".response_str at group_chat_service.py:449"
-    )
+    assert result is not None
     assert result.assistant is None
 
 
 @pytest.mark.asyncio
-async def test_selector_response_contains_stray_year():
-    """Selector emits prose like 'Regarding your 2024 budget question' — `\\d+`
-    picks up 2024, which is out of range and crashes."""
+async def test_stray_year_in_prose_does_not_crash():
+    """`\\d+` used to grab '2024' from any clarification text.
+
+    Pre-fix: out of range → implicit None → caller crash.
+    Post-fix: no sentinel → clarification surfaced as-is.
+    """
     service = _make_service(
         selector_text="Regarding your 2024 budget question, please clarify."
     )
-    assistants = [
-        _make_assistant("Knowledge", "Looks up policy docs"),
-        _make_assistant("Reasoning", "Performs multi-step reasoning"),
-    ]
+    assistants = _two_assistants()
 
     result = await service._select_assistant_with_completion_model(
         question="Tell me about taxes",
@@ -108,37 +147,73 @@ async def test_selector_response_contains_stray_year():
 
     assert result is not None
     assert result.assistant is None
-    # The full prose should still be available so the clarification branch
-    # can surface it back to the user.
     assert "clarify" in result.response_str
 
 
 @pytest.mark.asyncio
-async def test_selector_picks_valid_index():
-    """Sanity: '2' with 2 assistants must keep working."""
-    service = _make_service(selector_text="2")
-    a1 = _make_assistant("Knowledge", "Looks up policy docs")
-    a2 = _make_assistant("Reasoning", "Performs multi-step reasoning")
+async def test_out_of_range_sentinel_falls_through_to_clarification():
+    """Even with the right token, an out-of-range index must not route."""
+    service = _make_service(selector_text="ASSISTANT=5")
+    assistants = _two_assistants()
 
     result = await service._select_assistant_with_completion_model(
-        question="Walk me through this proof",
-        assistants=[a1, a2],
+        question="…",
+        assistants=assistants,
     )
 
     assert result is not None
-    assert result.assistant is a2
+    assert result.assistant is None
+
+
+# --- new in-range false-positive class (the sentinel's main win) ---------
 
 
 @pytest.mark.asyncio
-async def test_selector_returns_no_digit_goes_to_clarification():
-    """Sanity: pure clarification text (no digits) must keep working."""
+async def test_numbered_list_in_clarification_does_not_route():
+    """Pre-sentinel, this routed to assistant 1 because `\\d+` matched '1)'.
+
+    The user was being asked to clarify, but the parser silently picked an
+    assistant and answered as if the question were unambiguous.
+    """
+    service = _make_service(
+        selector_text="Could you specify if you mean 1) tax questions or 2) HR questions?"
+    )
+    assistants = _two_assistants()
+
+    result = await service._select_assistant_with_completion_model(
+        question="help",
+        assistants=assistants,
+    )
+
+    assert result is not None
+    assert result.assistant is None
+    assert "specify" in result.response_str
+
+
+@pytest.mark.asyncio
+async def test_bare_digit_without_sentinel_does_not_route():
+    """Strict contract: a number alone is not a routing decision."""
+    service = _make_service(selector_text="2")
+    assistants = _two_assistants()
+
+    result = await service._select_assistant_with_completion_model(
+        question="…",
+        assistants=assistants,
+    )
+
+    assert result is not None
+    assert result.assistant is None
+
+
+# --- pure clarification path -----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clarification_text_with_no_digits():
     service = _make_service(
         selector_text="Could you be more specific about what you need?"
     )
-    assistants = [
-        _make_assistant("Knowledge", "Looks up policy docs"),
-        _make_assistant("Reasoning", "Performs multi-step reasoning"),
-    ]
+    assistants = _two_assistants()
 
     result = await service._select_assistant_with_completion_model(
         question="help",
@@ -148,3 +223,21 @@ async def test_selector_returns_no_digit_goes_to_clarification():
     assert result is not None
     assert result.assistant is None
     assert "specific" in result.response_str
+
+
+# --- single-assistant shortcut (no model call) ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_assistant_shortcut_bypasses_selector():
+    service = _make_service(selector_text="<should not be read>")
+    only = _make_assistant("Solo", "Handles everything")
+
+    result = await service._select_assistant_with_completion_model(
+        question="anything",
+        assistants=[only],
+    )
+
+    assert result is not None
+    assert result.assistant is only
+    service.completion_service.get_response.assert_not_called()


### PR DESCRIPTION
## Summary
  - Latent crash surfaced in prod: `AttributeError: 'NoneType' object has no attribute 'response_str'` at `group_chat_service.py:399`, on a 2-assistant group chat using Azure GPT-5.2 (`reasoning=low`).
  - `_is_match` greedily ran `re.search(r"\d+", text)` on the selector model's response with no bounds check. Out-of-range digits fell through a nested if/else in `_select_assistant_with_completion_model` and
  silently returned `None`, crashing the caller.
  - Same parser also caused **silent false-positive routing** whenever the model wrote numbered clarification prose (e.g. `"Could you mean 1) X or 2) Y?"` → routed to assistant 1 instead of clarifying). Latent
  since the May 2025 release; never had a test.

  ## Approach
  Tighten the model↔parser contract instead of band-aiding the parser. The selector must now reply with exactly `ASSISTANT=<n>` (case- and whitespace-tolerant) to route; anything else is treated as clarification
  text and surfaced to the user as-is.

  ## Changes
  - **`_is_match`** — replaced loose `\d+` search with `re.fullmatch` against a compiled `ASSISTANT=<n>` sentinel, plus existing bounds check. Out-of-range sentinels still fall through to clarification.
  - **`_create_assistant_selection_prompt`** — rewritten to specify the sentinel contract explicitly and to forbid the `ASSISTANT=` token inside clarification text. Removed example digits that previously leaked
  into model output.
  - **`_select_assistant_with_completion_model`** — collapsed the nested `if/if/else` (which had the implicit-None fall-through) into a single non-falling-through branch. Function now always returns a result.
  - **`tests/unit/test_group_chat_selector_repro.py`** — 13 cases covering: happy-path routing, sentinel whitespace/case tolerance, the original out-of-range crash, stray-year prose, out-of-range sentinel, in-range
   false-positive elimination (numbered clarification), bare-digit rejection, pure clarification, and single-assistant shortcut.

  ## Test plan
  - [x] `uv run pytest tests/unit/test_group_chat_selector_repro.py` — 13/13 pass.
  - [x] `uv run ruff check` + `ruff format --check` clean on edited files.
  - [ ] Manual smoke: 2-assistant group chat, ambiguous question — expect a clarification reply (not a 500, and not silent mis-routing).
  - [ ] Manual smoke: 2-assistant group chat, clearly knowledge-only question — expect the knowledge assistant to answer.

  ## Behavior change to flag for review
  Tenants previously relying on the loose parser will see slightly more clarification responses instead of guessed routing — this is the intended effect. Provider compatibility (OpenAI, Anthropic, Mistral, Azure,
  vLLM via litellm) was not exhaustively re-tested live; the sentinel is plain ASCII and easy for any reasonable model to emit.