### PR TITLE
fix(api-keys): allow users to edit their own keys from personal listing

### DIFF
--- a/frontend/apps/web/src/lib/features/api-keys/ApiKeyActionMenu.svelte
+++ b/frontend/apps/web/src/lib/features/api-keys/ApiKeyActionMenu.svelte
@@ -206,8 +206,8 @@
         </DropdownMenu.Item>
       {/if}
 
-      {#if isAdmin && onEditRequested}
-        <DropdownMenu.Item onclick={onEditRequested}>
+      {#if onEditRequested}
+        <DropdownMenu.Item onclick={onEditRequested} disabled={!canManage}>
           <Pencil />
           {m.api_keys_admin_action_edit()}
         </DropdownMenu.Item>

--- a/frontend/apps/web/src/lib/features/api-keys/ApiKeyDialog.svelte
+++ b/frontend/apps/web/src/lib/features/api-keys/ApiKeyDialog.svelte
@@ -6,6 +6,7 @@
 
   let {
     mode = "create",
+    scope = "user",
     apiKey,
     open = $bindable(false),
     onCreated,
@@ -16,6 +17,7 @@
     triggerVariant = "primary"
   } = $props<{
     mode?: DialogMode;
+    scope?: "user" | "admin";
     apiKey?: ApiKeyV2;
     open?: boolean;
     onCreated?: () => void;
@@ -29,6 +31,7 @@
 
 <CreateApiKeyDialog
   {mode}
+  {scope}
   {apiKey}
   bind:open
   {onCreated}

--- a/frontend/apps/web/src/lib/features/api-keys/CreateApiKeyDialog.svelte
+++ b/frontend/apps/web/src/lib/features/api-keys/CreateApiKeyDialog.svelte
@@ -60,6 +60,7 @@
 
   let {
     mode = "create",
+    scope = "user",
     apiKey,
     open = $bindable(false),
     onCreated,
@@ -70,6 +71,7 @@
     triggerVariant = "primary"
   }: {
     mode?: DialogMode;
+    scope?: "user" | "admin";
     apiKey?: ApiKeyV2;
     open?: boolean;
     onCreated?: () => void;
@@ -772,7 +774,11 @@
     isSubmitting = true;
 
     try {
-      await intric.apiKeys.admin.update({ id: apiKey.id, update: updates });
+      if (scope === "admin") {
+        await intric.apiKeys.admin.update({ id: apiKey.id, update: updates });
+      } else {
+        await intric.apiKeys.update({ id: apiKey.id, update: updates });
+      }
       onChanged?.();
       showDialog = false;
     } catch (error: unknown) {

--- a/frontend/apps/web/src/routes/(app)/account/api-keys/ApiKeyActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/account/api-keys/ApiKeyActions.svelte
@@ -22,6 +22,7 @@
   }>();
 
   let showViewDialog = $state(false);
+  let showEditDialog = $state(false);
 </script>
 
 <ApiKeyActionMenu
@@ -33,9 +34,13 @@
   {isFollowedViaScope}
   {onFollowChanged}
   {currentUserId}
+  onEditRequested={() => {
+    showEditDialog = true;
+  }}
   onViewRequested={() => {
     showViewDialog = true;
   }}
 />
 
+<ApiKeyDialog mode="edit" {apiKey} bind:open={showEditDialog} {onChanged} />
 <ApiKeyDialog mode="view" {apiKey} bind:open={showViewDialog} />

--- a/frontend/apps/web/src/routes/(app)/admin/api-keys/AdminApiKeyActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/api-keys/AdminApiKeyActions.svelte
@@ -26,5 +26,5 @@
   }}
 />
 
-<ApiKeyDialog mode="edit" {apiKey} bind:open={showEditDialog} {onChanged} />
+<ApiKeyDialog mode="edit" scope="admin" {apiKey} bind:open={showEditDialog} {onChanged} />
 <ApiKeyDialog mode="view" {apiKey} bind:open={showViewDialog} />


### PR DESCRIPTION
Personal users couldn't edit their own keys because the dropdown's Edit item was gated by admin mode and CreateApiKeyDialog hard-coded the admin PATCH endpoint. Backend already permits owner edits via the user endpoint.

- Add scope prop ("user" | "admin") on ApiKeyDialog/CreateApiKeyDialog; route updateKey to the user PATCH when scope="user".
- Show Edit in ApiKeyActionMenu whenever onEditRequested is provided, disabled when !canManage (covers non-owners viewing service keys).
- Wire onEditRequested + edit ApiKeyDialog in account/api-keys ApiKeyActions; pass scope="admin" from admin/api-keys actions to preserve admin routing.
