### PR TITLE
fix(audit): sweep actor resolution through audit_actor_for to unblock service keys

### DIFF
--- a/backend/src/intric/admin/admin_router.py
+++ b/backend/src/intric/admin/admin_router.py
@@ -378,7 +378,7 @@ async def register_user(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.USER_CREATED,
         entity_type=EntityType.USER,
         entity_id=user.id,
@@ -573,7 +573,7 @@ async def update_user(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.USER_UPDATED,
         entity_type=EntityType.USER,
         entity_id=user_updated.id,
@@ -657,7 +657,7 @@ async def delete_user(username: str, container: AdminContainer):
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.USER_DELETED,
         entity_type=EntityType.USER,
         entity_id=user_to_delete.id,
@@ -723,7 +723,7 @@ async def deactivate_user(username: str, container: AdminContainer):
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.USER_UPDATED,  # Deactivation is a state update
         entity_type=EntityType.USER,
         entity_id=user.id,
@@ -789,7 +789,7 @@ async def reactivate_user(username: str, container: AdminContainer):
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.USER_UPDATED,  # Reactivation is a state update
         entity_type=EntityType.USER,
         entity_id=user.id,
@@ -916,7 +916,7 @@ async def update_privacy_policy(url: PrivacyPolicy, container: AdminContainer):
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.TENANT_SETTINGS_UPDATED,
         entity_type=EntityType.TENANT_SETTINGS,
         entity_id=user.tenant_id,
@@ -1174,7 +1174,7 @@ async def update_api_key_policy(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.TENANT_POLICY_UPDATED,
         entity_type=EntityType.TENANT_SETTINGS,
         entity_id=user.tenant_id,
@@ -1278,7 +1278,7 @@ async def update_api_key_notification_policy(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.TENANT_POLICY_UPDATED,
         entity_type=EntityType.TENANT_SETTINGS,
         entity_id=user.tenant_id,

--- a/backend/src/intric/api/audit/config_routes.py
+++ b/backend/src/intric/api/audit/config_routes.py
@@ -104,7 +104,7 @@ async def update_audit_config(
     if changes:
         await audit_service.log_async(
             tenant_id=user.tenant_id,
-            actor_id=user.id,
+            user=user,
             action=ActionType.TENANT_SETTINGS_UPDATED,
             entity_type=EntityType.TENANT_SETTINGS,
             entity_id=user.tenant_id,
@@ -192,7 +192,7 @@ async def update_action_config(
     if request.updates:
         await audit_service.log_async(
             tenant_id=user.tenant_id,
-            actor_id=user.id,
+            user=user,
             action=ActionType.TENANT_SETTINGS_UPDATED,
             entity_type=EntityType.TENANT_SETTINGS,
             entity_id=user.tenant_id,

--- a/backend/src/intric/api/audit/routes.py
+++ b/backend/src/intric/api/audit/routes.py
@@ -277,7 +277,7 @@ async def create_access_session(
     try:
         await audit_service.log(
             tenant_id=current_user.tenant_id,
-            actor_id=current_user.id,
+            user=current_user,
             action=ActionType.AUDIT_SESSION_CREATED,
             entity_type=EntityType.AUDIT_LOG,
             entity_id=current_user.tenant_id,
@@ -506,7 +506,7 @@ async def list_audit_logs(
     # Log the audit access with comprehensive metadata
     await audit_service.log(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.AUDIT_LOG_VIEWED,
         entity_type=EntityType.AUDIT_LOG,
         entity_id=current_user.tenant_id,  # Use tenant_id as entity_id for audit logs
@@ -628,7 +628,7 @@ async def get_user_logs(
     # Log the GDPR export access
     await audit_service.log(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.AUDIT_LOG_VIEWED,
         entity_type=EntityType.USER,
         entity_id=user_id,
@@ -834,7 +834,7 @@ async def export_audit_logs(
     except ExportTooLargeError as exc:
         await audit_service.log(
             tenant_id=current_user.tenant_id,
-            actor_id=current_user.id,
+            user=current_user,
             action=ActionType.AUDIT_LOG_EXPORTED,
             entity_type=EntityType.AUDIT_LOG,
             entity_id=current_user.tenant_id,
@@ -847,7 +847,7 @@ async def export_audit_logs(
     except Exception as exc:
         await audit_service.log(
             tenant_id=current_user.tenant_id,
-            actor_id=current_user.id,
+            user=current_user,
             action=ActionType.AUDIT_LOG_EXPORTED,
             entity_type=EntityType.AUDIT_LOG,
             entity_id=current_user.tenant_id,
@@ -861,7 +861,7 @@ async def export_audit_logs(
     # Log the export after successful generation
     await audit_service.log(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.AUDIT_LOG_EXPORTED,
         entity_type=EntityType.AUDIT_LOG,
         entity_id=current_user.tenant_id,
@@ -976,7 +976,7 @@ async def request_async_export(
 
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.AUDIT_LOG_EXPORTED,
         entity_type=EntityType.AUDIT_LOG,
         entity_id=job_id,
@@ -1252,7 +1252,7 @@ async def update_retention_policy(
 
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.TENANT_SETTINGS_UPDATED,
         entity_type=EntityType.TENANT_SETTINGS,
         entity_id=current_user.tenant_id,

--- a/backend/src/intric/apps/app_runs/api/app_run_router.py
+++ b/backend/src/intric/apps/app_runs/api/app_run_router.py
@@ -55,7 +55,7 @@ async def delete_app_run(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.APP_RUN_DELETED,
         entity_type=EntityType.APP_RUN,
         entity_id=id,

--- a/backend/src/intric/apps/apps/api/app_router.py
+++ b/backend/src/intric/apps/apps/api/app_router.py
@@ -322,7 +322,7 @@ async def update_app(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.APP_UPDATED,
         entity_type=EntityType.APP,
         entity_id=id,
@@ -378,7 +378,7 @@ async def delete_app(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.APP_DELETED,
         entity_type=EntityType.APP,
         entity_id=id,
@@ -432,7 +432,7 @@ async def run_app(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.APP_EXECUTED,
         entity_type=EntityType.APP,
         entity_id=id,
@@ -524,7 +524,7 @@ async def publish_app(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.APP_PUBLISHED,
         entity_type=EntityType.APP,
         entity_id=id,

--- a/backend/src/intric/assistants/api/assistant_router.py
+++ b/backend/src/intric/assistants/api/assistant_router.py
@@ -138,7 +138,7 @@ async def create_assistant(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.ASSISTANT_CREATED,
         entity_type=EntityType.ASSISTANT,
         entity_id=created_assistant_id,
@@ -639,7 +639,7 @@ async def update_assistant(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.ASSISTANT_UPDATED,
         entity_type=EntityType.ASSISTANT,
         entity_id=id,
@@ -718,7 +718,7 @@ async def delete_assistant(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.ASSISTANT_DELETED,
         entity_type=EntityType.ASSISTANT,
         entity_id=id,
@@ -1050,7 +1050,7 @@ async def generate_read_only_assistant_key(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.API_KEY_GENERATED,
         entity_type=EntityType.API_KEY,
         entity_id=id,  # Use assistant ID as entity ID for assistant API keys
@@ -1118,7 +1118,7 @@ async def transfer_assistant_to_space(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.ASSISTANT_TRANSFERRED,
         entity_type=EntityType.ASSISTANT,
         entity_id=id,
@@ -1186,7 +1186,7 @@ async def publish_assistant(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.ASSISTANT_PUBLISHED,
         entity_type=EntityType.ASSISTANT,
         entity_id=id,
@@ -1269,7 +1269,7 @@ async def add_mcp_to_assistant(
     mcp_server = await mcp_server_service.get_mcp_server(mcp_server_id)
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.ASSISTANT_UPDATED,
         entity_type=EntityType.ASSISTANT,
         entity_id=id,
@@ -1316,7 +1316,7 @@ async def remove_mcp_from_assistant(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.ASSISTANT_UPDATED,
         entity_type=EntityType.ASSISTANT,
         entity_id=id,

--- a/backend/src/intric/audit/application/audit_metadata.py
+++ b/backend/src/intric/audit/application/audit_metadata.py
@@ -325,7 +325,7 @@ class AuditMetadata:
 
         Example:
             metadata = AuditMetadata.minimal(
-                actor_id=user.id,
+                user=user,
                 target_id=file.id,
                 extra={"size_bytes": file.size}
             )

--- a/backend/src/intric/audit/application/audit_service.py
+++ b/backend/src/intric/audit/application/audit_service.py
@@ -27,6 +27,7 @@ from intric.main.request_context import get_request_context
 
 if TYPE_CHECKING:
     from intric.feature_flag.feature_flag_service import FeatureFlagService
+    from intric.users.user import UserInDB
 
 logger = logging.getLogger(__name__)
 
@@ -110,15 +111,21 @@ class AuditService:
 
     async def log(
         self,
+        *,
         tenant_id: UUID,
-        actor_id: Optional[UUID],
         action: ActionType,
         entity_type: EntityType,
         entity_id: UUID,
         description: str,
         metadata: dict[str, Any],
-        outcome: Outcome = Outcome.SUCCESS,
+        # Pass `user` to derive actor_id/actor_type via audit_actor_for so
+        # service-key callers don't FK-violate audit_log.actor_id (their
+        # synthetic UUID has no users row). Sysadmin paths that act without
+        # a user keep using the explicit form with actor_type=SYSTEM.
+        user: Optional["UserInDB"] = None,
+        actor_id: Optional[UUID] = None,
         actor_type: ActorType = ActorType.USER,
+        outcome: Outcome = Outcome.SUCCESS,
         ip_address: Optional[str] = None,
         user_agent: Optional[str] = None,
         request_id: Optional[UUID] = None,
@@ -152,6 +159,11 @@ class AuditService:
         should_log = await self._should_log_action(tenant_id, action)
         if not should_log:
             return None
+
+        if user is not None:
+            from intric.authentication.auth_models import audit_actor_for
+
+            actor_id, actor_type = audit_actor_for(user)
 
         if actor_type != ActorType.SYSTEM and actor_id is None:
             raise ValueError("actor_id required for non-system actions")
@@ -255,15 +267,19 @@ class AuditService:
 
     async def log_async(
         self,
+        *,
         tenant_id: UUID,
-        actor_id: Optional[UUID],
         action: ActionType,
         entity_type: EntityType,
         entity_id: UUID,
         description: str,
         metadata: dict[str, Any],
-        outcome: Outcome = Outcome.SUCCESS,
+        # See `log()` for `user` semantics — derives actor_id/actor_type via
+        # audit_actor_for so service-key callers don't FK-violate.
+        user: Optional["UserInDB"] = None,
+        actor_id: Optional[UUID] = None,
         actor_type: ActorType = ActorType.USER,
+        outcome: Outcome = Outcome.SUCCESS,
         ip_address: Optional[str] = None,
         user_agent: Optional[str] = None,
         request_id: Optional[UUID] = None,
@@ -304,6 +320,11 @@ class AuditService:
         should_log = await self._should_log_action(tenant_id, action)
         if not should_log:
             return None
+
+        if user is not None:
+            from intric.authentication.auth_models import audit_actor_for
+
+            actor_id, actor_type = audit_actor_for(user)
 
         if actor_type != ActorType.SYSTEM and actor_id is None:
             raise ValueError("actor_id required for non-system actions")

--- a/backend/src/intric/authentication/api_key_lifecycle.py
+++ b/backend/src/intric/authentication/api_key_lifecycle.py
@@ -144,7 +144,7 @@ class ApiKeyLifecycleService:
         if self.audit_service is not None:
             await self.audit_service.log_async(
                 tenant_id=user.tenant_id,
-                actor_id=user.id,
+                user=user,
                 action=ActionType.API_KEY_CREATED,
                 entity_type=EntityType.API_KEY,
                 entity_id=record.id,
@@ -274,7 +274,7 @@ class ApiKeyLifecycleService:
         if self.audit_service is not None:
             await self.audit_service.log_async(
                 tenant_id=user.tenant_id,
-                actor_id=user.id,
+                user=user,
                 action=ActionType.API_KEY_ROTATED,
                 entity_type=EntityType.API_KEY,
                 entity_id=record.id,
@@ -448,7 +448,7 @@ class ApiKeyLifecycleService:
 
             await self.audit_service.log_async(
                 tenant_id=user.tenant_id,
-                actor_id=user.id,
+                user=user,
                 action=ActionType.API_KEY_UPDATED,
                 entity_type=EntityType.API_KEY,
                 entity_id=updated_key.id,
@@ -620,7 +620,7 @@ class ApiKeyLifecycleService:
         if self.audit_service is not None:
             await self.audit_service.log_async(
                 tenant_id=user.tenant_id,
-                actor_id=user.id,
+                user=user,
                 action=ActionType.API_KEY_SUSPENDED,
                 entity_type=EntityType.API_KEY,
                 entity_id=updated_key.id,
@@ -730,7 +730,7 @@ class ApiKeyLifecycleService:
         if self.audit_service is not None:
             await self.audit_service.log_async(
                 tenant_id=user.tenant_id,
-                actor_id=user.id,
+                user=user,
                 action=ActionType.API_KEY_REACTIVATED,
                 entity_type=EntityType.API_KEY,
                 entity_id=updated_key.id,
@@ -809,7 +809,7 @@ class ApiKeyLifecycleService:
         if self.audit_service is not None:
             await self.audit_service.log_async(
                 tenant_id=user.tenant_id,
-                actor_id=user.id,
+                user=user,
                 action=ActionType.API_KEY_REVOKED,
                 entity_type=EntityType.API_KEY,
                 entity_id=updated_key.id,
@@ -890,7 +890,7 @@ class ApiKeyLifecycleService:
         if self.audit_service is not None:
             await self.audit_service.log_async(
                 tenant_id=user.tenant_id,
-                actor_id=user.id,
+                user=user,
                 action=ActionType.API_KEY_PURGED,
                 entity_type=EntityType.API_KEY,
                 entity_id=key.id,
@@ -1118,7 +1118,7 @@ class ApiKeyLifecycleService:
 
         await self.audit_service.log_async(
             tenant_id=user.tenant_id,
-            actor_id=user.id,
+            user=user,
             action=ActionType.API_KEY_EXPIRATION_EXTENDED,
             entity_type=EntityType.API_KEY,
             entity_id=key.id,
@@ -1191,7 +1191,7 @@ class ApiKeyLifecycleService:
         }
         await self.audit_service.log_async(
             tenant_id=user.tenant_id,
-            actor_id=user.id,
+            user=user,
             action=action,
             entity_type=EntityType.API_KEY,
             entity_id=key.id if key is not None else key_id,

--- a/backend/src/intric/authentication/api_key_scope_revoker.py
+++ b/backend/src/intric/authentication/api_key_scope_revoker.py
@@ -78,7 +78,7 @@ class ApiKeyScopeRevoker:
             if self.audit_service is not None:
                 await self.audit_service.log_async(
                     tenant_id=self.user.tenant_id,
-                    actor_id=self.user.id,
+                    user=self.user,
                     action=ActionType.API_KEY_REVOKED,
                     entity_type=EntityType.API_KEY,
                     entity_id=updated_key.id,

--- a/backend/src/intric/completion_models/presentation/completion_models_router.py
+++ b/backend/src/intric/completion_models/presentation/completion_models_router.py
@@ -152,7 +152,7 @@ async def update_completion_model(
         audit_service = container.audit_service()
         await audit_service.log_async(
             tenant_id=user.tenant_id,
-            actor_id=user.id,
+            user=user,
             action=ActionType.COMPLETION_MODEL_UPDATED,
             entity_type=EntityType.COMPLETION_MODEL,
             entity_id=id,

--- a/backend/src/intric/conversations/conversations_router.py
+++ b/backend/src/intric/conversations/conversations_router.py
@@ -652,7 +652,7 @@ async def approve_tools(
         audit_service = container.audit_service()
         await audit_service.log_async(
             tenant_id=current_user.tenant_id,
-            actor_id=current_user.id,
+            user=current_user,
             action=ActionType.TOOL_APPROVAL_SUBMITTED,
             entity_type=entity_type,
             entity_id=entity_id,

--- a/backend/src/intric/embedding_models/presentation/embedding_model_router.py
+++ b/backend/src/intric/embedding_models/presentation/embedding_model_router.py
@@ -116,7 +116,7 @@ async def update_embedding_model(
         audit_service = container.audit_service()
         await audit_service.log_async(
             tenant_id=user.tenant_id,
-            actor_id=user.id,
+            user=user,
             action=ActionType.EMBEDDING_MODEL_UPDATED,
             entity_type=EntityType.EMBEDDING_MODEL,
             entity_id=id,

--- a/backend/src/intric/files/file_router.py
+++ b/backend/src/intric/files/file_router.py
@@ -60,7 +60,7 @@ async def upload_file(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.FILE_UPLOADED,
         entity_type=EntityType.FILE,
         entity_id=file.id,
@@ -134,7 +134,7 @@ async def delete_file(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.FILE_DELETED,
         entity_type=EntityType.FILE,
         entity_id=id,

--- a/backend/src/intric/groups_legacy/api/group_router.py
+++ b/backend/src/intric/groups_legacy/api/group_router.py
@@ -135,7 +135,7 @@ async def update_group(
 
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.COLLECTION_UPDATED,
         entity_type=EntityType.COLLECTION,
         entity_id=collection_updated.id,
@@ -195,7 +195,7 @@ async def delete_group_by_id(
 
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.COLLECTION_DELETED,
         entity_type=EntityType.COLLECTION,
         entity_id=id,
@@ -285,7 +285,7 @@ async def add_info_blobs(
 
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.FILE_UPLOADED,
         entity_type=EntityType.FILE,
         entity_id=id,  # Group ID
@@ -376,7 +376,7 @@ async def upload_file(
 
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.FILE_UPLOADED,
         entity_type=EntityType.FILE,
         entity_id=id,  # Use group ID as entity

--- a/backend/src/intric/integration/presentation/integration_auth_router.py
+++ b/backend/src/intric/integration/presentation/integration_auth_router.py
@@ -54,7 +54,7 @@ async def on_auth_callback(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.INTEGRATION_CONNECTED,
         entity_type=EntityType.INTEGRATION,
         entity_id=integration.id,

--- a/backend/src/intric/integration/presentation/integration_router.py
+++ b/backend/src/intric/integration/presentation/integration_router.py
@@ -82,7 +82,7 @@ async def add_tenant_integration(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.INTEGRATION_ADDED,
         entity_type=EntityType.INTEGRATION,
         entity_id=tenant_integration.id,
@@ -123,7 +123,7 @@ async def remove_tenant_integration(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.INTEGRATION_REMOVED,
         entity_type=EntityType.INTEGRATION,
         entity_id=tenant_integration_id,
@@ -228,7 +228,7 @@ async def disconnect_user_integration(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.INTEGRATION_DISCONNECTED,
         entity_type=EntityType.INTEGRATION,
         entity_id=user_integration_id,

--- a/backend/src/intric/mcp_servers/presentation/mcp_server_router.py
+++ b/backend/src/intric/mcp_servers/presentation/mcp_server_router.py
@@ -111,7 +111,7 @@ async def enable_mcp_for_tenant(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.MCP_SERVER_ENABLED,
         entity_type=EntityType.MCP_SERVER,
         entity_id=settings.id,
@@ -170,7 +170,7 @@ async def disable_mcp_for_tenant(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.MCP_SERVER_DISABLED,
         entity_type=EntityType.MCP_SERVER,
         entity_id=mcp_server_id,
@@ -210,7 +210,7 @@ async def update_tenant_tool_enabled(
     )
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=action,
         entity_type=EntityType.MCP_SERVER_TOOL,
         entity_id=tool.id,
@@ -299,7 +299,7 @@ async def create_mcp_server(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.MCP_SERVER_CREATED,
         entity_type=EntityType.MCP_SERVER,
         entity_id=result.server.id,
@@ -398,7 +398,7 @@ async def update_mcp_server(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.MCP_SERVER_UPDATED,
         entity_type=EntityType.MCP_SERVER,
         entity_id=mcp_server.id,
@@ -431,7 +431,7 @@ async def delete_mcp_server(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.MCP_SERVER_DELETED,
         entity_type=EntityType.MCP_SERVER,
         entity_id=id,
@@ -540,7 +540,7 @@ async def approve_tool_changes(
     mcp_server = await service.get_mcp_server(id)
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.MCP_SERVER_UPDATED,
         entity_type=EntityType.MCP_SERVER,
         entity_id=id,
@@ -585,7 +585,7 @@ async def reject_tool_changes(
     mcp_server = await service.get_mcp_server(id)
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.MCP_SERVER_UPDATED,
         entity_type=EntityType.MCP_SERVER,
         entity_id=id,
@@ -624,7 +624,7 @@ async def approve_all_tool_changes(
     mcp_server = await service.get_mcp_server(id)
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.MCP_SERVER_UPDATED,
         entity_type=EntityType.MCP_SERVER,
         entity_id=id,
@@ -668,7 +668,7 @@ async def update_tool_default_enabled(
     )
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=action,
         entity_type=EntityType.MCP_SERVER_TOOL,
         entity_id=tool.id,

--- a/backend/src/intric/roles/roles_router.py
+++ b/backend/src/intric/roles/roles_router.py
@@ -93,7 +93,7 @@ async def create_role(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.ROLE_CREATED,
         entity_type=EntityType.ROLE,
         entity_id=created_role.id,
@@ -142,7 +142,7 @@ async def update_role(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.ROLE_MODIFIED,
         entity_type=EntityType.ROLE,
         entity_id=role_id,
@@ -180,7 +180,7 @@ async def delete_role_by_id(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.ROLE_DELETED,
         entity_type=EntityType.ROLE,
         entity_id=role_id,
@@ -217,7 +217,7 @@ async def reset_role_to_default(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.ROLE_MODIFIED,
         entity_type=EntityType.ROLE,
         entity_id=role_id,
@@ -264,7 +264,7 @@ async def set_default_role(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.TENANT_SETTINGS_UPDATED,
         entity_type=EntityType.TENANT_SETTINGS,
         entity_id=user.tenant_id,

--- a/backend/src/intric/security_classifications/presentation/security_classification_router.py
+++ b/backend/src/intric/security_classifications/presentation/security_classification_router.py
@@ -62,7 +62,7 @@ async def create_security_classification(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.SECURITY_CLASSIFICATION_CREATED,
         entity_type=EntityType.SECURITY_CLASSIFICATION,
         entity_id=security_classification.id,
@@ -174,7 +174,7 @@ async def update_security_classification_levels(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.SECURITY_CLASSIFICATION_LEVELS_UPDATED,
         entity_type=EntityType.SECURITY_CLASSIFICATION,
         entity_id=user.tenant_id,  # Use tenant as entity since multiple classifications affected
@@ -240,7 +240,7 @@ async def delete_security_classification(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.SECURITY_CLASSIFICATION_DELETED,
         entity_type=EntityType.SECURITY_CLASSIFICATION,
         entity_id=id,
@@ -305,7 +305,7 @@ async def update_security_classification(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.SECURITY_CLASSIFICATION_UPDATED,
         entity_type=EntityType.SECURITY_CLASSIFICATION,
         entity_id=id,
@@ -360,7 +360,7 @@ async def toggle_security_classifications(
 
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=action,
         entity_type=EntityType.TENANT_SETTINGS,
         entity_id=user.tenant_id,

--- a/backend/src/intric/settings/setting_service.py
+++ b/backend/src/intric/settings/setting_service.py
@@ -176,7 +176,7 @@ class SettingService:
 
         await self.audit_service.log_async(
             tenant_id=self.user.tenant_id,
-            actor_id=self.user.id,
+            user=self.user,
             action=ActionType.TENANT_SETTINGS_UPDATED,
             entity_type=EntityType.TENANT_SETTINGS,
             entity_id=self.user.tenant_id,
@@ -225,7 +225,7 @@ class SettingService:
 
         await self.audit_service.log_async(
             tenant_id=self.user.tenant_id,
-            actor_id=self.user.id,
+            user=self.user,
             action=ActionType.TENANT_SETTINGS_UPDATED,
             entity_type=EntityType.TENANT_SETTINGS,
             entity_id=self.user.tenant_id,
@@ -264,7 +264,7 @@ class SettingService:
 
         await self.audit_service.log_async(
             tenant_id=self.user.tenant_id,
-            actor_id=self.user.id,
+            user=self.user,
             action=ActionType.TENANT_SETTINGS_UPDATED,
             entity_type=EntityType.TENANT_SETTINGS,
             entity_id=self.user.tenant_id,
@@ -306,7 +306,7 @@ class SettingService:
 
         await self.audit_service.log_async(
             tenant_id=self.user.tenant_id,
-            actor_id=self.user.id,
+            user=self.user,
             action=ActionType.TENANT_SETTINGS_UPDATED,
             entity_type=EntityType.TENANT_SETTINGS,
             entity_id=self.user.tenant_id,

--- a/backend/src/intric/spaces/api/space_router.py
+++ b/backend/src/intric/spaces/api/space_router.py
@@ -118,7 +118,7 @@ async def create_space(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.SPACE_CREATED,
         entity_type=EntityType.SPACE,
         entity_id=space_id,
@@ -291,7 +291,7 @@ async def update_space(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.SPACE_UPDATED,
         entity_type=EntityType.SPACE,
         entity_id=id,
@@ -348,7 +348,7 @@ async def delete_space(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.SPACE_DELETED,
         entity_type=EntityType.SPACE,
         entity_id=id,
@@ -444,7 +444,7 @@ async def create_space_assistant(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.ASSISTANT_CREATED,
         entity_type=EntityType.ASSISTANT,
         entity_id=assistant.id,
@@ -490,7 +490,7 @@ async def create_group_chat(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.GROUP_CHAT_CREATED,
         entity_type=EntityType.GROUP_CHAT,
         entity_id=group_chat.id,
@@ -530,7 +530,7 @@ async def create_app(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.APP_CREATED,
         entity_type=EntityType.APP,
         entity_id=app.id,
@@ -630,7 +630,7 @@ async def create_space_groups(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.COLLECTION_CREATED,
         entity_type=EntityType.COLLECTION,
         entity_id=created_collection.id,
@@ -721,7 +721,7 @@ async def create_space_websites(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.WEBSITE_CREATED,
         entity_type=EntityType.WEBSITE,
         entity_id=created_website.id,
@@ -783,7 +783,7 @@ async def create_space_integration_knowledge(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.INTEGRATION_KNOWLEDGE_CREATED,
         entity_type=EntityType.INTEGRATION_KNOWLEDGE,
         entity_id=knowledge.id,
@@ -876,7 +876,7 @@ async def create_space_integration_knowledge_batch(
 
             await audit_service.log_async(
                 tenant_id=user.tenant_id,
-                actor_id=user.id,
+                user=user,
                 action=ActionType.INTEGRATION_KNOWLEDGE_CREATED,
                 entity_type=EntityType.INTEGRATION_KNOWLEDGE,
                 entity_id=knowledge.id,
@@ -942,7 +942,7 @@ async def delete_space_integration_knowledge(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.INTEGRATION_KNOWLEDGE_DELETED,
         entity_type=EntityType.INTEGRATION_KNOWLEDGE,
         entity_id=integration_knowledge_id,
@@ -1038,7 +1038,7 @@ async def trigger_integration_full_sync(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.INTEGRATION_KNOWLEDGE_SYNCED,
         entity_type=EntityType.INTEGRATION_KNOWLEDGE,
         entity_id=integration_knowledge_id,
@@ -1100,7 +1100,7 @@ async def add_space_member(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.SPACE_MEMBER_ADDED,
         entity_type=EntityType.SPACE,
         entity_id=id,
@@ -1179,7 +1179,7 @@ async def change_role_of_member(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.ROLE_MODIFIED,
         entity_type=EntityType.SPACE,
         entity_id=id,
@@ -1246,7 +1246,7 @@ async def remove_space_member(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.SPACE_MEMBER_REMOVED,
         entity_type=EntityType.SPACE,
         entity_id=id,
@@ -1324,7 +1324,7 @@ async def add_space_group_member(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.SPACE_MEMBER_ADDED,
         entity_type=EntityType.SPACE,
         entity_id=id,
@@ -1390,7 +1390,7 @@ async def change_group_member_role(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.ROLE_MODIFIED,
         entity_type=EntityType.SPACE,
         entity_id=id,
@@ -1452,7 +1452,7 @@ async def remove_space_group_member(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.SPACE_MEMBER_REMOVED,
         entity_type=EntityType.SPACE,
         entity_id=id,

--- a/backend/src/intric/templates/app_template/api/admin_router.py
+++ b/backend/src/intric/templates/app_template/api/admin_router.py
@@ -153,7 +153,7 @@ async def create_template(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.TEMPLATE_CREATED,
         entity_type=EntityType.TEMPLATE,
         entity_id=template.id,
@@ -240,7 +240,7 @@ async def update_template(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.TEMPLATE_UPDATED,
         entity_type=EntityType.TEMPLATE,
         entity_id=template_id,
@@ -383,7 +383,7 @@ async def delete_template(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.TEMPLATE_DELETED,
         entity_type=EntityType.TEMPLATE,
         entity_id=template_id,

--- a/backend/src/intric/templates/assistant_template/api/admin_router.py
+++ b/backend/src/intric/templates/assistant_template/api/admin_router.py
@@ -160,7 +160,7 @@ async def create_template(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.TEMPLATE_CREATED,
         entity_type=EntityType.TEMPLATE,
         entity_id=template.id,
@@ -246,7 +246,7 @@ async def update_template(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.TEMPLATE_UPDATED,
         entity_type=EntityType.TEMPLATE,
         entity_id=template_id,
@@ -408,7 +408,7 @@ async def delete_template(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.TEMPLATE_DELETED,
         entity_type=EntityType.TEMPLATE,
         entity_id=template_id,

--- a/backend/src/intric/transcription_models/presentation/transcription_models_router.py
+++ b/backend/src/intric/transcription_models/presentation/transcription_models_router.py
@@ -113,7 +113,7 @@ async def update_transcription_model(
         audit_service = container.audit_service()
         await audit_service.log_async(
             tenant_id=user.tenant_id,
-            actor_id=user.id,
+            user=user,
             action=ActionType.TRANSCRIPTION_MODEL_UPDATED,
             entity_type=EntityType.TRANSCRIPTION_MODEL,
             entity_id=id,

--- a/backend/src/intric/users/user_router.py
+++ b/backend/src/intric/users/user_router.py
@@ -838,7 +838,7 @@ async def generate_api_key(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.API_KEY_GENERATED,
         entity_type=EntityType.API_KEY,
         entity_id=current_user.id,  # Use user ID as entity ID for user API keys
@@ -880,7 +880,7 @@ async def revoke_legacy_api_key(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.API_KEY_REVOKED,
         entity_type=EntityType.API_KEY,
         entity_id=current_user.id,
@@ -972,7 +972,7 @@ async def invite_user(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.USER_CREATED,
         entity_type=EntityType.USER,
         entity_id=new_user.id,
@@ -1090,7 +1090,7 @@ async def update_user(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.USER_UPDATED,
         entity_type=EntityType.USER,
         entity_id=id,
@@ -1163,7 +1163,7 @@ async def delete_user(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=current_user.tenant_id,
-        actor_id=current_user.id,
+        user=current_user,
         action=ActionType.USER_DELETED,
         entity_type=EntityType.USER,
         entity_id=id,

--- a/backend/src/intric/websites/presentation/website_router.py
+++ b/backend/src/intric/websites/presentation/website_router.py
@@ -201,7 +201,7 @@ async def update_website(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.WEBSITE_UPDATED,
         entity_type=EntityType.WEBSITE,
         entity_id=id,
@@ -234,7 +234,7 @@ async def delete_website(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.WEBSITE_DELETED,
         entity_type=EntityType.WEBSITE,
         entity_id=id,
@@ -319,7 +319,7 @@ async def transfer_website_to_space(
     audit_service = container.audit_service()
     await audit_service.log_async(
         tenant_id=user.tenant_id,
-        actor_id=user.id,
+        user=user,
         action=ActionType.WEBSITE_TRANSFERRED,
         entity_type=EntityType.WEBSITE,
         entity_id=id,

--- a/backend/tests/unit/test_setting_service_audit.py
+++ b/backend/tests/unit/test_setting_service_audit.py
@@ -142,7 +142,7 @@ class TestSettingToggleAuditLogging:
         assert call_kwargs["metadata"]["changes"]["provisioning"]["old"] is False
 
     @pytest.mark.asyncio
-    async def test_audit_log_includes_actor_id(self):
+    async def test_audit_log_includes_actor(self):
         """Audit entry must include who made the change."""
         user = _make_user()
         service, audit_mock = _make_service(user=user)
@@ -153,7 +153,7 @@ class TestSettingToggleAuditLogging:
         await service.update_template_setting(enabled=True)
 
         call_kwargs = audit_mock.log_async.call_args[1]
-        assert call_kwargs["actor_id"] == user.id
+        assert call_kwargs["user"] is user
         assert call_kwargs["tenant_id"] == user.tenant_id
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Finishes the audit-actor sweep started in `7caa940d` (which only covered the two `/ask` paths) so service-key callers no longer FK-violate `audit_log.actor_id` when their request triggers an audit log.

## Background

Service API keys resolve to a synthetic `UserInDB` whose `id` is never inserted into the `users` table — passing that synthetic UUID into `audit_log.actor_id` (FK to `users.id`) would `IntegrityError` every audited service-key mutation. `audit_actor_for(user)` returns `(None, SYSTEM)` for service keys and `(user.id, USER)` for real users; `7caa940d` applied that helper on the two paths that motivated the original incident.

This PR finishes the sweep across the remaining 112 call sites.

## Changes

### `AuditService.log` / `AuditService.log_async` (audit_service.py)

- Added a `user: Optional[UserInDB]` kwarg. When set, the helper internally resolves `actor_id`/`actor_type` via `audit_actor_for(user)` and ignores the explicit kwargs.
- Sysadmin paths that act without a real user keep using `actor_id=None, actor_type=ActorType.SYSTEM` and are untouched.
- Both signatures are now keyword-only (`*,`). Every call site in the repository already used kwargs, so this is API-tightening, not breaking.

### Call-site sweep (26 files, 112 call sites)

| Area | Files | Sites |
|---|---|---|
| Spaces | `spaces/api/space_router.py` | 18 |
| MCP servers | `mcp_servers/presentation/mcp_server_router.py` | 10 |
| API key lifecycle | `authentication/api_key_lifecycle.py` | 9 |
| Admin + users | `admin/admin_router.py`, `users/user_router.py` | 13 |
| Assistants | `assistants/api/assistant_router.py` | 8 |
| Audit routes | `api/audit/routes.py`, `api/audit/config_routes.py` | 10 |
| Security classifications | `security_classifications/presentation/security_classification_router.py` | 5 |
| Roles | `roles/roles_router.py` | 5 |
| Settings | `settings/setting_service.py` | 4 |
| Apps + app runs | `apps/apps/api/app_router.py`, `apps/app_runs/api/app_run_router.py` | 5 |
| Templates | `templates/{app_template,assistant_template}/api/admin_router.py` | 6 |
| Groups + integrations + others | misc | 18 |

The transformation is purely mechanical:

```diff
 await audit_service.log_async(
     tenant_id=user.tenant_id,
-    actor_id=user.id,
+    user=user,
     action=ActionType.X,
     ...
 )
```

No business logic changes. No call site had an explicit `actor_type=ActorType.USER` to drop — they all relied on the default.

## Why a separate PR

`feature/flag-deprecated-models` (PR #315) flagged this sweep as a follow-up item — the review of that branch noted that the audit-actor sweep was incomplete but out of scope. This PR is purely the sweep, so reviewers can read the 112 call-site delta without it being buried inside the deprecated-models redesign.

## Testing

- 1055 backend unit tests pass.
- Pyright clean on `audit_service.py` and the most-touched routers (`assistant_router.py`, `space_router.py`, `admin_router.py`, `user_router.py`, `security_classification_router.py`).
- Audit service tests (`tests/unittests/audit/`) — 9 passed; the existing `test_log_async_swallows_redis_enqueue_failure` keeps working with the new signature.

## Test plan

- [ ] CI passes on this branch.
- [ ] Smoke test: hit a service-key-authorized endpoint that audits (e.g. `POST /api/v1/spaces/<id>/assistants` with a service key) and verify no `audit_log.actor_id` FK violation.