### PR TITLE
refactor(users): stop auto-provisioning personal API keys at user creation

### DIFF
--- a/backend/src/intric/admin/admin_router.py
+++ b/backend/src/intric/admin/admin_router.py
@@ -302,7 +302,7 @@ async def get_users(
     response_model=UserCreatedAdminView,
     status_code=201,
     summary="Create new user in tenant",
-    description="Creates a new user account within your tenant. The user will be created with the provided credentials and automatically associated with your organization. Returns user details including a new API key for the user.",
+    description="Creates a new user account within your tenant. The user will be created with the provided credentials and automatically associated with your organization. Personal API keys are no longer auto-provisioned; the user can create one via POST /api/v1/api-keys when needed.",
     responses={
         201: {"description": "User successfully created"},
         400: {"description": "Invalid input data or validation errors"},
@@ -339,7 +339,7 @@ async def register_user(
     current_user = container.user()
 
     # Create user
-    user, _, api_key = await admin_service.register_tenant_user(new_user)
+    user, _ = await admin_service.register_tenant_user(new_user)
 
     # Build extra context for user creation
     extra: dict[str, object] = {
@@ -390,9 +390,7 @@ async def register_user(
         ),
     )
 
-    user_admin_view = UserCreatedAdminView(
-        **user.model_dump(exclude={"api_key"}), api_key=api_key
-    )
+    user_admin_view = UserCreatedAdminView(**user.model_dump(exclude={"api_key"}))
 
     return user_admin_view
 

--- a/backend/src/intric/admin/admin_router.py
+++ b/backend/src/intric/admin/admin_router.py
@@ -390,7 +390,7 @@ async def register_user(
         ),
     )
 
-    user_admin_view = UserCreatedAdminView(**user.model_dump(exclude={"api_key"}))
+    user_admin_view = UserCreatedAdminView(**user.model_dump())
 
     return user_admin_view
 

--- a/backend/src/intric/admin/admin_router.py
+++ b/backend/src/intric/admin/admin_router.py
@@ -66,7 +66,6 @@ from intric.tenants.tenant import TenantPublic
 from intric.users.user import (
     UserAddAdmin,
     UserAdminView,
-    UserCreatedAdminView,
     UserUpdatePublic,
 )
 
@@ -299,7 +298,7 @@ async def get_users(
 
 @router.post(
     "/users/",
-    response_model=UserCreatedAdminView,
+    response_model=UserAdminView,
     status_code=201,
     summary="Create new user in tenant",
     description="Creates a new user account within your tenant. The user will be created with the provided credentials and automatically associated with your organization. Personal API keys are no longer auto-provisioned; the user can create one via POST /api/v1/api-keys when needed.",
@@ -390,7 +389,7 @@ async def register_user(
         ),
     )
 
-    user_admin_view = UserCreatedAdminView(**user.model_dump())
+    user_admin_view = UserAdminView(**user.model_dump())
 
     return user_admin_view
 

--- a/backend/src/intric/authentication/auth_service.py
+++ b/backend/src/intric/authentication/auth_service.py
@@ -162,33 +162,6 @@ class AuthService:
 
         return api_key
 
-    async def create_user_api_key_v2(
-        self, *, user_id: UUID, tenant_id: UUID
-    ) -> ApiKeyCreated:
-        """Mint a v2 personal API key for a user, no v1 row, no Legacy mirror."""
-        if self.api_key_v2_repo is None:
-            raise RuntimeError("api_key_v2_repo is required to mint v2 keys")
-
-        api_key = self._create_and_hash_api_key(prefix="sk")
-        await self.api_key_v2_repo.create(
-            tenant_id=tenant_id,
-            owner_user_id=user_id,
-            created_by_user_id=user_id,
-            scope_type=ApiKeyScopeType.TENANT.value,
-            scope_id=None,
-            permission=ApiKeyPermission.ADMIN.value,
-            key_type=ApiKeyType.SK.value,
-            key_hash=api_key.hashed_key,
-            hash_version=ApiKeyHashVersion.SHA256.value,
-            key_prefix=self._normalize_prefix(api_key.key, fallback="sk"),
-            key_suffix=api_key.truncated_key,
-            name="Personal API key",
-            description=None,
-            state=ApiKeyState.ACTIVE.value,
-        )
-
-        return api_key
-
     async def create_assistant_api_key(
         self,
         prefix: str,

--- a/backend/src/intric/sysadmin/sysadmin_router.py
+++ b/backend/src/intric/sysadmin/sysadmin_router.py
@@ -121,7 +121,7 @@ async def register_new_user(
     user_service = container.user_service()
 
     # Create user
-    created_user, access_token, api_key = await user_service.register(new_user)
+    created_user, access_token = await user_service.register(new_user)
 
     # Audit logging (system action since no authenticated user for sysadmin)
     audit_service = container.audit_service()
@@ -148,7 +148,6 @@ async def register_new_user(
     return UserCreated(
         **created_user.model_dump(exclude={"api_key"}),
         access_token=access_token,
-        api_key=api_key,
     )
 
 

--- a/backend/src/intric/users/user.py
+++ b/backend/src/intric/users/user.py
@@ -367,7 +367,7 @@ class UserAdminView(UserPublicBase):
 
 
 class UserCreatedAdminView(UserAdminView):
-    api_key: ApiKey
+    pass
 
 
 class UserUpdatePublic(BaseModel):

--- a/backend/src/intric/users/user.py
+++ b/backend/src/intric/users/user.py
@@ -366,10 +366,6 @@ class UserAdminView(UserPublicBase):
     user_groups: list[UserGroupRead]
 
 
-class UserCreatedAdminView(UserAdminView):
-    pass
-
-
 class UserUpdatePublic(BaseModel):
     email: Optional[EmailStr] = Field(
         default=None,

--- a/backend/src/intric/users/user_service.py
+++ b/backend/src/intric/users/user_service.py
@@ -729,10 +729,6 @@ class UserService:
         settings_upsert = SettingsUpsert(user_id=user_in_db.id)
         await self.settings_repo.add(settings_upsert)
 
-        api_key = await self.auth_service.create_user_api_key_v2(
-            user_id=user_in_db.id, tenant_id=user_in_db.tenant_id
-        )
-
         access_token = AccessToken(
             access_token=self.auth_service.create_access_token_for_user(
                 user=user_in_db
@@ -740,7 +736,7 @@ class UserService:
             token_type="bearer",
         )
 
-        return user_in_db, access_token, api_key
+        return user_in_db, access_token
 
     async def _get_user_from_token(self, token: str):
         username = self.auth_service.get_username_from_token(

--- a/backend/tests/unittests/users/test_user_service.py
+++ b/backend/tests/unittests/users/test_user_service.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 import pytest
 
-from intric.authentication.auth_models import AccessToken, ApiKeyCreated
+from intric.authentication.auth_models import AccessToken
 from intric.main.exceptions import AuthenticationException, UniqueUserException
 from intric.main.models import ModelId
 from intric.settings.settings import SettingsUpsert
@@ -130,9 +130,6 @@ async def test_register_user_creates_a_user_and_settings(service: UserService):
         test_salt,
         hashed_password,
     )
-    service.auth_service._create_and_hash_api_key.return_value = ApiKeyCreated(
-        key="api_key", truncated_key="ey", hashed_key="4p1 k3y"
-    )
     service.auth_service.create_access_token_for_user = MagicMock()
     service.auth_service.create_access_token_for_user.return_value = (
         "bingobongo you have access"
@@ -146,12 +143,15 @@ async def test_register_user_creates_a_user_and_settings(service: UserService):
         tenant_id=TEST_TENANT.id,
     )
 
-    user, access_token, api_key = await service.register(new_user)
+    user, access_token = await service.register(new_user)
 
     assert user == expected_user_in_db
 
     service.repo.add.assert_awaited_with(expected_user_upsert)
     service.settings_repo.add.assert_awaited_with(expected_settings)
+    # Personal API keys are no longer auto-provisioned at user creation —
+    # users mint their own via POST /api/v1/api-keys when they need one.
+    service.auth_service.create_user_api_key_v2.assert_not_called()
 
 
 async def test_update_used_tokens(service: UserService):

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -1892,7 +1892,7 @@ export interface paths {
     put?: never;
     /**
      * Create new user in tenant
-     * @description Creates a new user account within your tenant. The user will be created with the provided credentials and automatically associated with your organization. Returns user details including a new API key for the user.
+     * @description Creates a new user account within your tenant. The user will be created with the provided credentials and automatically associated with your organization. Personal API keys are no longer auto-provisioned; the user can create one via POST /api/v1/api-keys when needed.
      */
     post: operations["register_user_api_v1_admin_users__post"];
     delete?: never;
@@ -15664,7 +15664,6 @@ export interface components {
       roles: components["schemas"]["RolePublic"][];
       /** User Groups */
       user_groups: components["schemas"]["UserGroupRead"][];
-      api_key: components["schemas"]["ApiKey"];
     };
     /**
      * UserDeletedListItem

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -15622,49 +15622,6 @@ export interface components {
       /** Permissions */
       readonly permissions: components["schemas"]["Permission"][];
     };
-    /** UserCreatedAdminView */
-    UserCreatedAdminView: {
-      /**
-       * Email
-       * Format: email
-       * @description Valid email address
-       * @example john.doe@municipality.se
-       */
-      email: string;
-      /**
-       * Username
-       * @description Unique username (optional, will use email prefix if not provided)
-       * @example john.doe
-       */
-      username?: string | null;
-      /** Created At */
-      created_at?: string | null;
-      /** Updated At */
-      updated_at?: string | null;
-      /**
-       * Id
-       * Format: uuid
-       */
-      id: string;
-      /**
-       * Quota Used
-       * @default 0
-       */
-      quota_used?: number;
-      /** Used Tokens */
-      used_tokens: number;
-      /** Email Verified */
-      email_verified: boolean;
-      /** Quota Limit */
-      quota_limit: number | null;
-      /** Is Active */
-      is_active: boolean;
-      state: components["schemas"]["UserState"];
-      /** Roles */
-      roles: components["schemas"]["RolePublic"][];
-      /** User Groups */
-      user_groups: components["schemas"]["UserGroupRead"][];
-    };
     /**
      * UserDeletedListItem
      * @description User information for deleted users list operations
@@ -23192,7 +23149,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "application/json": components["schemas"]["UserCreatedAdminView"];
+          "application/json": components["schemas"]["UserAdminView"];
         };
       };
       /** @description Invalid input data or validation errors */


### PR DESCRIPTION
## Summary

Every user created via `/admin/users` or `/sysadmin/users/` silently received an ACTIVE admin-permission `sk_` key in `api_keys_v2`. The plaintext was returned in the HTTP response but **no frontend client read it** (`UserEditor.svelte` ignored the `api_key` field), so the keys were minted, persisted, and forgotten — an unused admin-scope credential per created user with no way for the user themselves to ever see the value.

## Why

The auto-provisioning is dead-on-arrival:

| Aspect | Status today |
|---|---|
| DB row in `api_keys_v2` (hash + ACTIVE + ADMIN) | Created on every `register()` |
| Plaintext returned in HTTP response | Yes — but no frontend client reads it |
| Backend code that depends on the row existing | None found (no ownership check, lifecycle hook, audit snapshot) |
| Functional usage by the actual user | Zero (plaintext is invisible → can't be used for auth) |

Net effect: one unused ACTIVE admin-permission credential per created user, with no operator workflow to surface it. Anyone who could later extract the plaintext from the DB would have admin access — the kind of "lying credential" that shouldn't exist by default.

## Changes

- Remove `create_user_api_key_v2()` from `auth_service` (no remaining callers).
- Remove the `api_key` field from `UserCreatedAdminView`.
- Drop the `api_key` slot from `user_service.register()`'s return tuple — now `(user, access_token)`.
- Update `sysadmin/users/` and `admin/users/` responses to stop trying to set `api_key=`.
- Update the unit test to assert `create_user_api_key_v2` is **not** called.
- Document the new flow in the admin route description: users create their own keys via `POST /api/v1/api-keys` when they need one.

## Breaking change (release-relevant)

The `api_key` field is gone from:
- `POST /api/v1/admin/users/` (`UserCreatedAdminView`) — was always required, now removed.
- `POST /api/v1/sysadmin/users/` (`UserCreated`) — was already `Optional` on `UserInDB`, now always `null`.

The known consumer (`intric-js` → `frontend/apps/web` UserEditor) never read the field, so no UI breakage. External integrations that read `response.api_key` from these endpoints will need to switch to calling `POST /api/v1/api-keys` after user creation to mint a key explicitly.

## Why a separate PR

Originally bundled into `feature/flag-deprecated-models` (PR #315) — that branch's review explicitly flagged scope drift as a problem, so this change was extracted to its own PR. It's been reverted there (`000498ec Revert "refactor(users): ..."`) and re-applied here on a clean branch off develop.

## Test plan

- [ ] CI passes.
- [ ] Smoke test: `POST /api/v1/admin/users/` returns a `UserCreatedAdminView` without an `api_key` field.
- [ ] Smoke test: a freshly-created user can mint a personal key via `POST /api/v1/api-keys`.
- [ ] Verify `api_keys_v2` table no longer accumulates orphan `name="Personal API key"` rows for new users.