### PR TITLE
fix(chat): persist user message and partial reply when stream is aborted (#349)

### DIFF
--- a/backend/src/intric/assistants/assistant_service.py
+++ b/backend/src/intric/assistants/assistant_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 from collections.abc import AsyncGenerator, Callable, Sequence
 from datetime import datetime
@@ -658,10 +659,14 @@ class AssistantService:
         session: "SessionInDB",
         stream: bool,
         assistant_id: UUID,
+        question_id: UUID,
         version: int = 1,
         web_search_results: Sequence["WebSearchResult"] | None = None,
         assistant_selector_tokens: int = 0,
     ) -> str | AsyncGenerator[Completion, None]:
+        # Capture tenant_id outside the generator so the abort-path background save
+        # doesn't depend on self.user being safely accessible during teardown.
+        tenant_id = self.user.tenant_id
         if stream:
 
             async def response_stream() -> AsyncGenerator[Completion, None]:
@@ -670,193 +675,225 @@ class AssistantService:
                 generated_files: list[File] = []
                 tool_calls: list[ToolCallInfo] = []
                 stream_usage: TokenUsage | None = None
+                completed = False
 
-                completion = response.completion
-                if isinstance(completion, str):
-                    raise TypeError("Expected streaming completion response")
+                try:
+                    completion = response.completion
+                    if isinstance(completion, str):
+                        raise TypeError("Expected streaming completion response")
 
-                async for chunk in completion:
-                    reasoning_token_count = chunk.reasoning_token_count
-                    if chunk.usage:
-                        stream_usage = chunk.usage
+                    async for chunk in completion:
+                        reasoning_token_count = chunk.reasoning_token_count
+                        if chunk.usage:
+                            stream_usage = chunk.usage
 
-                    if chunk.response_type == ResponseType.TEXT:
-                        response_string = f"{response_string}{chunk.text}"
-                        chunk.reference_chunks = get_references(
-                            response_string=response_string,
-                            info_blobs=datastore_result.info_blobs,
-                            version=version,
-                        )
-                        yield chunk
+                        if chunk.response_type == ResponseType.TEXT:
+                            response_string = f"{response_string}{chunk.text}"
+                            chunk.reference_chunks = get_references(
+                                response_string=response_string,
+                                info_blobs=datastore_result.info_blobs,
+                                version=version,
+                            )
+                            yield chunk
 
-                    if chunk.response_type == ResponseType.FILES:
-                        image_file = await self.file_service.save_image_from_bytes(
-                            chunk.image_data
-                        )
+                        if chunk.response_type == ResponseType.FILES:
+                            image_file = await self.file_service.save_image_from_bytes(
+                                chunk.image_data
+                            )
 
-                        generated_files.append(image_file)
-                        chunk.generated_file = image_file
-                        yield chunk
+                            generated_files.append(image_file)
+                            chunk.generated_file = image_file
+                            yield chunk
 
-                    if chunk.response_type == ResponseType.INTRIC_EVENT:
-                        yield chunk
+                        if chunk.response_type == ResponseType.INTRIC_EVENT:
+                            yield chunk
 
-                    if chunk.response_type == ResponseType.TOOL_CALL:
-                        if chunk.tool_calls_metadata:
-                            for tc in chunk.tool_calls_metadata:
-                                # Check if this tool_call already exists (from TOOL_APPROVAL_REQUIRED)
-                                existing = next(
-                                    (
-                                        t
-                                        for t in tool_calls
-                                        if t.tool_call_id
-                                        and t.tool_call_id == tc.tool_call_id
-                                    ),
-                                    None,
-                                )
-                                if existing:
-                                    # Update existing entry with approval status
-                                    existing.approved = tc.approved
-                                    existing.result_status = tc.result_status
-                                    # The TOOL_CALL chunk after execution carries the
-                                    # tool output; keep it so later turns can replay.
-                                    if tc.result is not None:
-                                        existing.result = tc.result
-                                else:
-                                    # Add new tool call
-                                    tool_calls.append(
-                                        ToolCallInfo(
-                                            server_name=tc.server_name,
-                                            tool_name=tc.tool_name,
-                                            arguments=cast(
-                                                dict[str, object] | None,
-                                                tc.arguments,
-                                            ),
-                                            tool_call_id=tc.tool_call_id or "",
-                                            approved=tc.approved,
-                                            result_status=tc.result_status,
-                                            result=tc.result,
-                                            mcp_tool_name=tc.mcp_tool_name,
-                                        )
-                                    )
-                        yield chunk
-
-                    if chunk.response_type == ResponseType.TOOL_APPROVAL_REQUIRED:
-                        # Collect tool calls for approval flow (approval status will be updated later)
-                        if chunk.tool_calls_metadata:
-                            for tc in chunk.tool_calls_metadata:
-                                tool_calls.append(
-                                    ToolCallInfo(
-                                        server_name=tc.server_name,
-                                        tool_name=tc.tool_name,
-                                        arguments=cast(
-                                            dict[str, object] | None, tc.arguments
+                        if chunk.response_type == ResponseType.TOOL_CALL:
+                            if chunk.tool_calls_metadata:
+                                for tc in chunk.tool_calls_metadata:
+                                    # Check if this tool_call already exists (from TOOL_APPROVAL_REQUIRED)
+                                    existing = next(
+                                        (
+                                            t
+                                            for t in tool_calls
+                                            if t.tool_call_id
+                                            and t.tool_call_id == tc.tool_call_id
                                         ),
-                                        tool_call_id=tc.tool_call_id or "",
-                                        approved=None,
-                                        result_status=tc.result_status,
-                                        mcp_tool_name=tc.mcp_tool_name,
+                                        None,
                                     )
-                                )
-                        yield chunk
+                                    if existing:
+                                        # Update existing entry with approval status
+                                        existing.approved = tc.approved
+                                        existing.result_status = tc.result_status
+                                        # The TOOL_CALL chunk after execution carries the
+                                        # tool output; keep it so later turns can replay.
+                                        if tc.result is not None:
+                                            existing.result = tc.result
+                                    else:
+                                        # Add new tool call
+                                        tool_calls.append(
+                                            ToolCallInfo(
+                                                server_name=tc.server_name,
+                                                tool_name=tc.tool_name,
+                                                arguments=cast(
+                                                    dict[str, object] | None,
+                                                    tc.arguments,
+                                                ),
+                                                tool_call_id=tc.tool_call_id or "",
+                                                approved=tc.approved,
+                                                result_status=tc.result_status,
+                                                result=tc.result,
+                                                mcp_tool_name=tc.mcp_tool_name,
+                                            )
+                                        )
+                            yield chunk
 
-                    if chunk.response_type == ResponseType.TOOL_APPROVAL_TIMEOUT:
-                        if chunk.tool_calls_metadata:
-                            for tc in chunk.tool_calls_metadata:
-                                existing = next(
-                                    (
-                                        t
-                                        for t in tool_calls
-                                        if t.tool_call_id
-                                        and t.tool_call_id == tc.tool_call_id
-                                    ),
-                                    None,
-                                )
-                                if existing:
-                                    existing.approved = False
-                                    existing.result_status = (
-                                        tc.result_status or "timeout_denied"
-                                    )
-                                else:
+                        if chunk.response_type == ResponseType.TOOL_APPROVAL_REQUIRED:
+                            # Collect tool calls for approval flow (approval status will be updated later)
+                            if chunk.tool_calls_metadata:
+                                for tc in chunk.tool_calls_metadata:
                                     tool_calls.append(
                                         ToolCallInfo(
                                             server_name=tc.server_name,
                                             tool_name=tc.tool_name,
                                             arguments=cast(
-                                                dict[str, object] | None,
-                                                tc.arguments,
+                                                dict[str, object] | None, tc.arguments
                                             ),
                                             tool_call_id=tc.tool_call_id or "",
-                                            approved=False,
-                                            result_status=tc.result_status
-                                            or "timeout_denied",
+                                            approved=None,
+                                            result_status=tc.result_status,
                                             mcp_tool_name=tc.mcp_tool_name,
                                         )
                                     )
-                        yield chunk
+                            yield chunk
 
-                # Get the references for the whole response
-                reference_chunks = get_references(
-                    response_string=response_string,
-                    info_blobs=datastore_result.no_duplicate_chunks,
-                    version=version,
-                    get_id_func=lambda chunk: chunk.info_blob_id,
-                )
-                # Prefer actual provider token counts, fall back to litellm estimates
-                if stream_usage and stream_usage.prompt_tokens is not None:
-                    num_tokens_question = (
-                        stream_usage.prompt_tokens + assistant_selector_tokens
+                        if chunk.response_type == ResponseType.TOOL_APPROVAL_TIMEOUT:
+                            if chunk.tool_calls_metadata:
+                                for tc in chunk.tool_calls_metadata:
+                                    existing = next(
+                                        (
+                                            t
+                                            for t in tool_calls
+                                            if t.tool_call_id
+                                            and t.tool_call_id == tc.tool_call_id
+                                        ),
+                                        None,
+                                    )
+                                    if existing:
+                                        existing.approved = False
+                                        existing.result_status = (
+                                            tc.result_status or "timeout_denied"
+                                        )
+                                    else:
+                                        tool_calls.append(
+                                            ToolCallInfo(
+                                                server_name=tc.server_name,
+                                                tool_name=tc.tool_name,
+                                                arguments=cast(
+                                                    dict[str, object] | None,
+                                                    tc.arguments,
+                                                ),
+                                                tool_call_id=tc.tool_call_id or "",
+                                                approved=False,
+                                                result_status=tc.result_status
+                                                or "timeout_denied",
+                                                mcp_tool_name=tc.mcp_tool_name,
+                                            )
+                                        )
+                            yield chunk
+
+                    # Get the references for the whole response
+                    reference_chunks = get_references(
+                        response_string=response_string,
+                        info_blobs=datastore_result.no_duplicate_chunks,
+                        version=version,
+                        get_id_func=lambda chunk: chunk.info_blob_id,
                     )
-                    input_source = "provider"
-                else:
-                    num_tokens_question = (
-                        response.total_token_count + assistant_selector_tokens
+                    # Prefer actual provider token counts, fall back to litellm estimates
+                    if stream_usage and stream_usage.prompt_tokens is not None:
+                        num_tokens_question = (
+                            stream_usage.prompt_tokens + assistant_selector_tokens
+                        )
+                        input_source = "provider"
+                    else:
+                        num_tokens_question = (
+                            response.total_token_count + assistant_selector_tokens
+                        )
+                        input_source = "litellm"
+
+                    if stream_usage and stream_usage.completion_tokens is not None:
+                        num_tokens_answer = stream_usage.completion_tokens
+                        output_source = "provider"
+                    else:
+                        assert completion_model is not None
+                        num_tokens_answer = (
+                            count_tokens(response_string, completion_model.name)
+                            + reasoning_token_count
+                        )
+                        output_source = "litellm"
+
+                    logger.info(
+                        f"[TokenUsage] assistant={assistant_id} streaming — "
+                        f"input={num_tokens_question} ({input_source}), "
+                        f"output={num_tokens_answer} ({output_source})"
                     )
-                    input_source = "litellm"
 
-                if stream_usage and stream_usage.completion_tokens is not None:
-                    num_tokens_answer = stream_usage.completion_tokens
-                    output_source = "provider"
-                else:
-                    assert completion_model is not None
-                    num_tokens_answer = (
-                        count_tokens(response_string, completion_model.name)
-                        + reasoning_token_count
+                    await self.session_service.complete_question_with_answer(
+                        question_id=question_id,
+                        answer=response_string,
+                        num_tokens_question=num_tokens_question,
+                        num_tokens_answer=num_tokens_answer,
+                        completion_model=cast("AICompletionModel", completion_model),
+                        info_blob_chunks=reference_chunks,
+                        generated_files=generated_files,
+                        logging_details=response.extended_logging
+                        or LoggingDetails(model_kwargs={}),
+                        web_search_results=list(web_search_results or []),
+                        tool_calls=tool_calls if tool_calls else None,
                     )
-                    output_source = "litellm"
+                    completed = True
 
-                logger.info(
-                    f"[TokenUsage] assistant={assistant_id} streaming — "
-                    f"input={num_tokens_question} ({input_source}), "
-                    f"output={num_tokens_answer} ({output_source})"
-                )
+                    # Send token usage event to frontend
+                    yield Completion(
+                        text="",
+                        response_type=ResponseType.TOKEN_USAGE,
+                        usage=TokenUsage(
+                            prompt_tokens=num_tokens_question,
+                            completion_tokens=num_tokens_answer,
+                        ),
+                    )
+                finally:
+                    if not completed:
+                        # Stream was aborted before the answer could be saved. Persist
+                        # whatever was streamed so far via a fresh DB session so the
+                        # user's question + partial answer aren't lost. No await here —
+                        # the request-scoped AsyncSession may already be torn down and
+                        # `await` across GeneratorExit is fragile; fire-and-forget on
+                        # the event loop.
+                        if completion_model is not None:
+                            partial_tokens_answer = (
+                                count_tokens(response_string, completion_model.name)
+                                + reasoning_token_count
+                            )
+                        else:
+                            partial_tokens_answer = 0
+                        from intric.sessions.session_service import (
+                            persist_partial_question_answer,
+                        )
 
-                await self.session_service.add_question_to_session(
-                    question=question,
-                    answer=response_string,
-                    num_tokens_question=num_tokens_question,
-                    num_tokens_answer=num_tokens_answer,
-                    session=session,
-                    completion_model=cast("AICompletionModel", completion_model),
-                    info_blob_chunks=reference_chunks,
-                    files=list(files),
-                    generated_files=generated_files,
-                    logging_details=response.extended_logging
-                    or LoggingDetails(model_kwargs={}),
-                    assistant_id=assistant_id,
-                    web_search_results=list(web_search_results or []),
-                    tool_calls=tool_calls if tool_calls else None,
-                )
-
-                # Send token usage event to frontend
-                yield Completion(
-                    text="",
-                    response_type=ResponseType.TOKEN_USAGE,
-                    usage=TokenUsage(
-                        prompt_tokens=num_tokens_question,
-                        completion_tokens=num_tokens_answer,
-                    ),
-                )
+                        asyncio.create_task(
+                            persist_partial_question_answer(
+                                tenant_id=tenant_id,
+                                question_id=question_id,
+                                answer=response_string,
+                                num_tokens_answer=partial_tokens_answer,
+                            )
+                        )
+                        logger.info(
+                            "Scheduled partial chat answer save on stream abort: "
+                            f"assistant={assistant_id} question_id={question_id} "
+                            f"answer_chars={len(response_string)}"
+                        )
 
             return response_stream()
         else:
@@ -907,19 +944,16 @@ class AssistantService:
                 f"output={num_tokens_answer} ({output_source})"
             )
 
-            await self.session_service.add_question_to_session(
-                question=question,
+            await self.session_service.complete_question_with_answer(
+                question_id=question_id,
                 answer=final_answer,
                 num_tokens_question=num_tokens_question,
                 num_tokens_answer=num_tokens_answer,
-                files=list(files),
                 generated_files=generated_files,
                 completion_model=cast("AICompletionModel", completion_model),
                 info_blob_chunks=reference_chunks,
-                session=session,
                 logging_details=response.extended_logging
                 or LoggingDetails(model_kwargs={}),
-                assistant_id=assistant_id,
                 web_search_results=list(web_search_results or []),
             )
 
@@ -1016,6 +1050,19 @@ class AssistantService:
         for _question in session.questions:
             _question.question = clean_intric_tag(_question.question)
 
+        # Persist a placeholder Question row BEFORE the LLM stream begins. This commits
+        # with the router's setup transaction (conversations_router.py line 300/328), so
+        # the user's message is durable even if the stream is aborted mid-flight.
+        question_id = await self.session_service.create_question_placeholder(
+            question=question,
+            session=session,
+            files=files,
+            assistant_id=assistant_to_ask.id,
+            completion_model=cast(
+                "AICompletionModel | None", assistant_to_ask.completion_model
+            ),
+        )
+
         if use_web_search and version == 2:
             web_search = await self.web_search
             web_search_results = await web_search.search(search_query=question)
@@ -1046,6 +1093,7 @@ class AssistantService:
             session=session,
             stream=stream,
             assistant_id=assistant_to_ask.id,
+            question_id=question_id,
             version=version,
             web_search_results=web_search_results,
             assistant_selector_tokens=assistant_selector_tokens,
@@ -1071,6 +1119,7 @@ class AssistantService:
             ),
             description=assistant_to_ask.description,
             web_search_results=web_search_results,
+            question_id=question_id,
         )
 
         return final_response

--- a/backend/src/intric/assistants/assistant_service.py
+++ b/backend/src/intric/assistants/assistant_service.py
@@ -1,4 +1,3 @@
-import asyncio
 import re
 from collections.abc import AsyncGenerator, Callable, Sequence
 from datetime import datetime
@@ -863,25 +862,31 @@ class AssistantService:
                         ),
                     )
                 finally:
-                    if not completed:
-                        # Stream was aborted before the answer could be saved. Persist
-                        # whatever was streamed so far via a fresh DB session so the
-                        # user's question + partial answer aren't lost. No await here —
-                        # the request-scoped AsyncSession may already be torn down and
-                        # `await` across GeneratorExit is fragile; fire-and-forget on
-                        # the event loop.
-                        if completion_model is not None:
-                            partial_tokens_answer = (
-                                count_tokens(response_string, completion_model.name)
-                                + reasoning_token_count
-                            )
-                        else:
-                            partial_tokens_answer = 0
+                    # Stream did not reach normal completion: client abort, LLM
+                    # error, network drop, etc. The placeholder row already captures
+                    # the user's question, so an empty `response_string` means there
+                    # is nothing further to persist — skip the redundant UPDATE.
+                    # Anything else (partial answer streamed before abort) must be
+                    # saved via a fresh DB session because the request-scoped
+                    # AsyncSession may already be torn down and `await` across
+                    # GeneratorExit is fragile.
+                    if not completed and response_string:
                         from intric.sessions.session_service import (
                             persist_partial_question_answer,
+                            safe_count_tokens,
+                            schedule_background_save,
                         )
 
-                        asyncio.create_task(
+                        model_name = (
+                            completion_model.name
+                            if completion_model is not None
+                            else None
+                        )
+                        partial_tokens_answer = (
+                            safe_count_tokens(response_string, model_name)
+                            + reasoning_token_count
+                        )
+                        schedule_background_save(
                             persist_partial_question_answer(
                                 tenant_id=tenant_id,
                                 question_id=question_id,

--- a/backend/src/intric/group_chat/application/group_chat_service.py
+++ b/backend/src/intric/group_chat/application/group_chat_service.py
@@ -337,62 +337,83 @@ class GroupChatService:
         completion_model: "CompletionModel",
         session: "SessionInDB",
         stream: bool,
+        question_id: "UUID",
         assistant_selector_tokens: int = 0,
     ):
         """Handle response for group chat selector, matching assistant_service"""
 
+        # Capture tenant_id outside the generator so the abort-path background save
+        # doesn't depend on self.user being safely accessible during teardown.
+        tenant_id = self.user.tenant_id
+
         if stream:
 
             async def response_stream():
-                chunk_response = response.split()
                 response_string = ""
-                for i, chunk in enumerate(chunk_response):
-                    if i < len(chunk_response):
-                        chunk_text = chunk + " "
-                    else:
-                        chunk_text = chunk
+                completed = False
 
-                    response_string += chunk_text
-                    # yield empty references and chunk text, matching assistant_service format
-                    yield Completion(
-                        text=chunk_text,
-                        response_type=ResponseType.TEXT,
-                        reference_chunks=[],
+                try:
+                    chunk_response = response.split()
+                    for i, chunk in enumerate(chunk_response):
+                        if i < len(chunk_response):
+                            chunk_text = chunk + " "
+                        else:
+                            chunk_text = chunk
+
+                        response_string += chunk_text
+                        # yield empty references and chunk text, matching assistant_service format
+                        yield Completion(
+                            text=chunk_text,
+                            response_type=ResponseType.TEXT,
+                            reference_chunks=[],
+                        )
+                        await asyncio.sleep(0.05)
+
+                    # NOTE: refactor question_token_count to include the whole contructed prompt.
+                    question_token_count = count_tokens(question, completion_model.name)
+                    token_count = count_tokens(response, completion_model.name)
+                    await self.session_service.complete_question_with_answer(
+                        question_id=question_id,
+                        answer=response,
+                        num_tokens_question=question_token_count
+                        + assistant_selector_tokens,
+                        num_tokens_answer=token_count,
+                        completion_model=completion_model,  # pyright: ignore[reportArgumentType]  # domain.CompletionModel vs ai_models.CompletionModel; structurally compatible at runtime
+                        info_blob_chunks=[],
+                        logging_details=None,
                     )
-                    await asyncio.sleep(0.05)
+                    completed = True
+                finally:
+                    if not completed:
+                        partial_tokens_answer = count_tokens(
+                            response_string, completion_model.name
+                        )
+                        from intric.sessions.session_service import (
+                            persist_partial_question_answer,
+                        )
 
-                # NOTE: refactor question_token_count to include the whole contructed prompt.
-                question_token_count = count_tokens(question, completion_model.name)
-                token_count = count_tokens(response, completion_model.name)
-                await self.session_service.add_question_to_session(
-                    question=question,
-                    answer=response,
-                    num_tokens_question=question_token_count
-                    + assistant_selector_tokens,
-                    num_tokens_answer=token_count,
-                    session=session,
-                    completion_model=completion_model,  # pyright: ignore[reportArgumentType]  # domain.CompletionModel vs ai_models.CompletionModel; structurally compatible at runtime
-                    info_blob_chunks=[],
-                    files=[],
-                    logging_details=None,
-                )
+                        asyncio.create_task(
+                            persist_partial_question_answer(
+                                tenant_id=tenant_id,
+                                question_id=question_id,
+                                answer=response_string,
+                                num_tokens_answer=partial_tokens_answer,
+                            )
+                        )
 
             return response_stream()
         else:
             # NOTE: refactor question_token_count to include the whole contructed prompt.
             question_token_count = count_tokens(question, completion_model.name)
             token_count = count_tokens(response, completion_model.name)
-            await self.session_service.add_question_to_session(
-                question=question,
+            await self.session_service.complete_question_with_answer(
+                question_id=question_id,
                 answer=response,
                 num_tokens_question=question_token_count + assistant_selector_tokens,
                 num_tokens_answer=token_count,
-                session=session,
                 completion_model=completion_model,  # pyright: ignore[reportArgumentType]  # domain.CompletionModel vs ai_models.CompletionModel; structurally compatible at runtime
                 info_blob_chunks=[],
-                files=[],
                 logging_details=None,
-                assistant_id=None,
             )
             return response
 
@@ -466,12 +487,22 @@ class GroupChatService:
             assert (
                 first_completion_model is not None
             )  # assistant must have a model to be usable
+            # Persist a placeholder Question row before the selector echo streams out, so
+            # the user's question survives even if the stream is aborted.
+            question_id = await self.session_service.create_question_placeholder(
+                question=question,
+                session=session,
+                files=[],
+                assistant_id=None,
+                completion_model=first_completion_model,  # pyright: ignore[reportArgumentType]  # domain.CompletionModel vs ai_models.CompletionModel; structurally compatible at runtime
+            )
             final_response = await self._handle_response(
                 response=response_from_selector,
                 question=question,
                 completion_model=first_completion_model,  # pyright: ignore[reportArgumentType]  # domain.CompletionModel vs ai_models.CompletionModel; structurally compatible at runtime
                 session=session,
                 stream=stream,
+                question_id=question_id,
                 assistant_selector_tokens=selection_result.assistant_selector_tokens,
             )
             response = AssistantResponse(
@@ -484,6 +515,7 @@ class GroupChatService:
                 tools=UseTools(assistants=[]),
                 description=None,
                 web_search_results=[],
+                question_id=question_id,
             )
         else:
             response = await self.assistant_service.ask(

--- a/backend/src/intric/group_chat/application/group_chat_service.py
+++ b/backend/src/intric/group_chat/application/group_chat_service.py
@@ -384,15 +384,20 @@ class GroupChatService:
                     )
                     completed = True
                 finally:
-                    if not completed:
-                        partial_tokens_answer = count_tokens(
-                            response_string, completion_model.name
-                        )
+                    # Selector-echo stream did not reach normal completion. The
+                    # placeholder already captures the question; only schedule a
+                    # background UPDATE when there's actual content to persist.
+                    if not completed and response_string:
                         from intric.sessions.session_service import (
                             persist_partial_question_answer,
+                            safe_count_tokens,
+                            schedule_background_save,
                         )
 
-                        asyncio.create_task(
+                        partial_tokens_answer = safe_count_tokens(
+                            response_string, completion_model.name
+                        )
+                        schedule_background_save(
                             persist_partial_question_answer(
                                 tenant_id=tenant_id,
                                 question_id=question_id,

--- a/backend/src/intric/questions/questions_repo.py
+++ b/backend/src/intric/questions/questions_repo.py
@@ -25,6 +25,8 @@ from intric.questions.question import Question, QuestionAdd
 
 if TYPE_CHECKING:
     from intric.completion_models.infrastructure.web_search import WebSearchResult
+    from intric.logging.logging import LoggingDetails
+    from intric.questions.question import ToolCallInfo
 
 
 class QuestionRepository:
@@ -128,6 +130,77 @@ class QuestionRepository:
 
     async def get(self, id: UUID):
         return await self.delegate.get(id)
+
+    async def update_with_answer(
+        self,
+        *,
+        question_id: UUID,
+        tenant_id: UUID,
+        answer: str,
+        num_tokens_question: int | None = None,
+        num_tokens_answer: int | None = None,
+        completion_model_id: UUID | None = None,
+        tool_calls: list["ToolCallInfo"] | None = None,
+        info_blob_chunks: list[InfoBlobChunkInDBWithScore] | None = None,
+        generated_files: list[File] | None = None,
+        web_search_results: list["WebSearchResult"] | None = None,
+        logging_details: "LoggingDetails | None" = None,
+    ) -> None:
+        """Update an existing placeholder Question row with the final or partial answer.
+
+        Used both for normal stream completion (full answer + token counts + late-bound rows)
+        and for partial persistence on abort (just the answer text + estimated token counts).
+
+        tenant_id is required in the WHERE clause to defend against cross-tenant writes if a
+        caller ever supplies a stale question_id.
+        """
+        logging_details_id: object = None
+        if logging_details is not None:
+            log_stmt = (  # pyright: ignore[reportUnknownVariableType]  # logging_table is imperatively mapped
+                sa.insert(logging_table)
+                .values(**logging_details.model_dump())
+                .returning(logging_table)
+            )
+            log_result = await self.session.execute(log_stmt)  # pyright: ignore[reportUnknownArgumentType, reportUnknownVariableType]
+            logging_row = log_result.scalar_one()  # pyright: ignore[reportUnknownVariableType]
+            logging_details_id = logging_row.id  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+
+        update_values: dict[str, Any] = {"answer": answer}
+        if num_tokens_question is not None:
+            update_values["num_tokens_question"] = num_tokens_question
+        if num_tokens_answer is not None:
+            update_values["num_tokens_answer"] = num_tokens_answer
+        if completion_model_id is not None:
+            update_values["completion_model_id"] = completion_model_id
+        if tool_calls is not None:
+            update_values["tool_calls"] = [tc.model_dump() for tc in tool_calls]
+        if logging_details_id is not None:
+            update_values["logging_details_id"] = logging_details_id
+
+        update_stmt = (
+            sa.update(Questions)
+            .where(Questions.id == question_id)
+            .where(Questions.tenant_id == tenant_id)
+            .values(**update_values)
+        )
+        await self.session.execute(update_stmt)
+
+        if info_blob_chunks:
+            await self._add_references(
+                question_id=question_id,  # type: ignore[arg-type]  # helper annotated as int but ID is UUID
+                chunks=info_blob_chunks,
+            )
+        if generated_files:
+            await self._add_files(
+                question_id=question_id,  # type: ignore[arg-type]  # helper annotated as int but ID is UUID
+                files=list(generated_files),
+                file_type="assistant",
+            )
+        if web_search_results:
+            await self._add_web_search_results(
+                web_search_results=list(web_search_results),
+                question_id=question_id,
+            )
 
     async def add(
         self,

--- a/backend/src/intric/sessions/session_service.py
+++ b/backend/src/intric/sessions/session_service.py
@@ -297,7 +297,9 @@ class SessionService:
                 tool_calls=tool_calls,
                 info_blob_chunks=info_blob_chunks,
                 generated_files=list(generated_files) if generated_files else None,
-                web_search_results=list(web_search_results) if web_search_results else None,
+                web_search_results=list(web_search_results)
+                if web_search_results
+                else None,
                 logging_details=logging_details,
             )
 

--- a/backend/src/intric/sessions/session_service.py
+++ b/backend/src/intric/sessions/session_service.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from intric.ai_models.completion_models.completion_model import CompletionModel
 from intric.assistants.assistant_service import AssistantService
 from intric.authentication.auth_models import is_service_api_key
+from intric.database.database import sessionmanager
 from intric.files.file_models import File
 from intric.group_chat.application.group_chat_service import GroupChatService
 from intric.info_blobs.info_blob import InfoBlobChunkInDBWithScore
@@ -16,6 +17,7 @@ from intric.main.exceptions import (
     NotFoundException,
     UnauthorizedException,
 )
+from intric.main.logging import get_logger
 from intric.questions.question import QuestionAdd, ToolCallInfo
 from intric.questions.questions_repo import QuestionRepository
 from intric.sessions.session import (
@@ -29,6 +31,48 @@ from intric.users.user import UserInDB
 
 if TYPE_CHECKING:
     from intric.completion_models.infrastructure.web_search import WebSearchResult
+
+logger = get_logger(__name__)
+
+
+async def persist_partial_question_answer(
+    *,
+    tenant_id: UUID,
+    question_id: UUID,
+    answer: str,
+    num_tokens_answer: int,
+    completion_model_id: UUID | None = None,
+) -> None:
+    """Persist the answer text on a previously-created placeholder question using a fresh
+    DB session.
+
+    Called from the streaming generator's `finally` on abort. Decoupled from request scope
+    so the write survives even when FastAPI tears down the request-scoped AsyncSession.
+    Exceptions are logged and swallowed (except cancellation) — this is best-effort
+    cleanup, not a path that should fail the parent task.
+    """
+    try:
+        async with sessionmanager.session() as session, session.begin():
+            repo = QuestionRepository(session)
+            await repo.update_with_answer(
+                question_id=question_id,
+                tenant_id=tenant_id,
+                answer=answer,
+                num_tokens_answer=num_tokens_answer,
+                completion_model_id=completion_model_id,
+            )
+        logger.info(
+            "Persisted partial chat answer on stream abort",
+            extra={
+                "question_id": str(question_id),
+                "answer_chars": len(answer),
+            },
+        )
+    except Exception:
+        logger.exception(
+            "Failed to persist partial chat answer on stream abort",
+            extra={"question_id": str(question_id)},
+        )
 
 
 class SessionService:
@@ -183,44 +227,78 @@ class SessionService:
         async with self._write_transaction():
             return await self.session_repo.add(session_add)
 
-    async def add_question_to_session(
+    async def create_question_placeholder(
         self,
         *,
         question: str,
-        answer: str,
-        num_tokens_question: int,
-        num_tokens_answer: int,
         session: SessionInDB,
-        completion_model: CompletionModel | None = None,
-        info_blob_chunks: list[InfoBlobChunkInDBWithScore],
         files: Sequence[File] | None = None,
-        generated_files: Sequence[File] | None = None,
-        logging_details: LoggingDetails | None = None,
         assistant_id: UUID | None = None,
-        web_search_results: Sequence["WebSearchResult"] | None = None,
-        tool_calls: list[ToolCallInfo] | None = None,
-    ) -> object:
+        completion_model: CompletionModel | None = None,
+    ) -> UUID:
+        """Persist a placeholder Question row with the user's message and an empty answer.
+
+        Returns the new question's id so the caller can complete the row when the LLM
+        stream finishes (normally or via abort). This guarantees the user's message is
+        durably stored before any LLM token streams out.
+        """
         completion_model_id = completion_model.id if completion_model else None
         question_add = QuestionAdd(
             tenant_id=self.user.tenant_id,
             question=question,
-            answer=answer,
-            num_tokens_question=num_tokens_question,
-            num_tokens_answer=num_tokens_answer,
+            answer="",
+            num_tokens_question=0,
+            num_tokens_answer=0,
             completion_model_id=completion_model_id,
             session_id=session.id,
-            logging_details=logging_details,
+            logging_details=None,
             assistant_id=assistant_id,
-            tool_calls=tool_calls,
+            tool_calls=None,
         )
 
         async with self._write_transaction():
-            return await self.question_repo.add(
+            question_record = await self.question_repo.add(
                 question_add,
-                info_blob_chunks=info_blob_chunks,
+                info_blob_chunks=[],
                 files=list(files or []),
-                generated_files=list(generated_files or []),
-                web_search_results=list(web_search_results or []),
+                generated_files=[],
+                web_search_results=[],
+            )
+
+        assert question_record is not None, (
+            "question_repo.add must return the newly inserted row"
+        )
+        return question_record.id
+
+    async def complete_question_with_answer(
+        self,
+        *,
+        question_id: UUID,
+        answer: str,
+        num_tokens_question: int,
+        num_tokens_answer: int,
+        completion_model: CompletionModel | None = None,
+        info_blob_chunks: list[InfoBlobChunkInDBWithScore],
+        generated_files: Sequence[File] | None = None,
+        logging_details: LoggingDetails | None = None,
+        web_search_results: Sequence["WebSearchResult"] | None = None,
+        tool_calls: list[ToolCallInfo] | None = None,
+    ) -> None:
+        """Update a placeholder Question row with the final assistant answer."""
+        completion_model_id = completion_model.id if completion_model else None
+        async with self._write_transaction():
+            await self.question_repo.update_with_answer(
+                question_id=question_id,
+                tenant_id=self.user.tenant_id,
+                answer=answer,
+                num_tokens_question=num_tokens_question,
+                num_tokens_answer=num_tokens_answer,
+                completion_model_id=completion_model_id,
+                tool_calls=tool_calls,
+                info_blob_chunks=info_blob_chunks,
+                generated_files=list(generated_files) if generated_files else None,
+                web_search_results=list(web_search_results) if web_search_results else None,
+                logging_details=logging_details,
             )
 
     async def leave_feedback(

--- a/backend/src/intric/sessions/session_service.py
+++ b/backend/src/intric/sessions/session_service.py
@@ -1,12 +1,14 @@
-from collections.abc import Sequence
+import asyncio
+from collections.abc import Coroutine, Sequence
 from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import TYPE_CHECKING, AsyncIterator
+from typing import TYPE_CHECKING, Any, AsyncIterator
 from uuid import UUID
 
 from intric.ai_models.completion_models.completion_model import CompletionModel
 from intric.assistants.assistant_service import AssistantService
 from intric.authentication.auth_models import is_service_api_key
+from intric.completion_models.infrastructure.context_builder import count_tokens
 from intric.database.database import sessionmanager
 from intric.files.file_models import File
 from intric.group_chat.application.group_chat_service import GroupChatService
@@ -33,6 +35,43 @@ if TYPE_CHECKING:
     from intric.completion_models.infrastructure.web_search import WebSearchResult
 
 logger = get_logger(__name__)
+
+
+def safe_count_tokens(text: str, model_name: str | None) -> int:
+    """Best-effort token count. tiktoken can raise on unknown model names — falling back
+    to 0 keeps the surrounding persistence path alive when an exotic model is in use."""
+    if not model_name:
+        return 0
+    try:
+        return count_tokens(text, model_name)
+    except Exception:
+        logger.warning(
+            "count_tokens failed; falling back to 0",
+            extra={"model": model_name},
+            exc_info=True,
+        )
+        return 0
+
+
+# Keep strong references to background save tasks so the GC can't collect them
+# mid-flight. asyncio.create_task returns a weak reference internally; without a
+# strong ref a "lucky" GC pass can cancel the task silently — which on this code
+# path would be silent data loss on exactly the scenario the PR exists to protect.
+_background_save_tasks: set[asyncio.Task[None]] = set()
+
+
+def schedule_background_save(coro: Coroutine[Any, Any, None]) -> asyncio.Task[None]:
+    """Schedule a fire-and-forget background save with GC protection.
+
+    asyncio.create_task internally holds only a weak reference; without the
+    module-level set keeping a strong one, the GC can collect the task mid-flight
+    and silently drop the persistence write. The add_done_callback hook discards
+    the task from the set once it completes.
+    """
+    task = asyncio.create_task(coro)
+    _background_save_tasks.add(task)
+    task.add_done_callback(_background_save_tasks.discard)
+    return task
 
 
 async def persist_partial_question_answer(
@@ -241,13 +280,25 @@ class SessionService:
         Returns the new question's id so the caller can complete the row when the LLM
         stream finishes (normally or via abort). This guarantees the user's message is
         durably stored before any LLM token streams out.
+
+        Note: a placeholder row commits with the router's request transaction, so it
+        remains in the DB even if the LLM call later raises (rate limit, model
+        unavailable, network drop). The conversation lists endpoint will surface those
+        rows with `answer=""` — that is intentional, the row reflects what the user
+        asked.
+
+        `num_tokens_question` is seeded with `count_tokens(question, model_name)` so
+        analytics don't undercount aborted requests. The normal-completion path later
+        overwrites it with the provider-reported prompt token count.
         """
         completion_model_id = completion_model.id if completion_model else None
+        completion_model_name = completion_model.name if completion_model else None
+        initial_question_tokens = safe_count_tokens(question, completion_model_name)
         question_add = QuestionAdd(
             tenant_id=self.user.tenant_id,
             question=question,
             answer="",
-            num_tokens_question=0,
+            num_tokens_question=initial_question_tokens,
             num_tokens_answer=0,
             completion_model_id=completion_model_id,
             session_id=session.id,

--- a/backend/tests/integration/services/test_conversation_stream_abort.py
+++ b/backend/tests/integration/services/test_conversation_stream_abort.py
@@ -1,0 +1,263 @@
+"""Integration tests for the chat-stream-abort persistence flow (issue #349).
+
+These tests exercise the new placeholder + update persistence path against a real
+PostgreSQL database. The streaming generator and SSE infrastructure are exercised
+end-to-end at the unit level (tests/unit/test_chat_stream_abort_persistence.py); this
+file focuses on the DB-level behavior that those unit tests can't validate with mocks:
+
+1. The placeholder Question row is durably persisted before any stream begins.
+2. The late update_with_answer call correctly updates the same row.
+3. The abort-path `persist_partial_question_answer` works through a fresh sessionmanager
+   session and refuses to write across tenants (defense-in-depth on the WHERE clause).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+
+from intric.database.database import sessionmanager
+from intric.database.tables.questions_table import Questions
+from intric.sessions.session_service import persist_partial_question_answer
+
+
+@dataclass
+class QuestionSnapshot:
+    id: UUID
+    question: str
+    answer: str
+    num_tokens_question: int
+    num_tokens_answer: int
+    tenant_id: UUID
+    session_id: UUID | None
+
+
+async def _create_space(client, bearer_token: str) -> str:
+    response = await client.post(
+        "/api/v1/spaces/",
+        json={"name": f"abort-space-{uuid4().hex[:8]}"},
+        headers={"Authorization": f"Bearer {bearer_token}"},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+async def _create_assistant(client, bearer_token: str, space_id: str) -> str:
+    response = await client.post(
+        "/api/v1/assistants/",
+        json={"name": f"abort-assistant-{uuid4().hex[:8]}", "space_id": space_id},
+        headers={"Authorization": f"Bearer {bearer_token}"},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+@pytest.fixture
+async def default_user(db_container):
+    async with db_container() as container:
+        user_repo = container.user_repo()
+        user = await user_repo.get_user_by_email("test@example.com")
+    return user
+
+
+@pytest.fixture
+async def default_user_token(db_container, patch_auth_service_jwt, default_user):
+    async with db_container() as container:
+        auth_service = container.auth_service()
+        token = auth_service.create_access_token_for_user(default_user)
+    return token
+
+
+async def _get_question_row(question_id: UUID) -> QuestionSnapshot | None:
+    async with sessionmanager.session() as session, session.begin():
+        result = await session.execute(
+            sa.select(Questions).where(Questions.id == question_id)
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        # Snapshot the fields while the session is still open — otherwise the ORM
+        # object becomes detached and attribute access raises.
+        return QuestionSnapshot(
+            id=row.id,
+            question=row.question,
+            answer=row.answer,
+            num_tokens_question=row.num_tokens_question,
+            num_tokens_answer=row.num_tokens_answer,
+            tenant_id=row.tenant_id,
+            session_id=row.session_id,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_placeholder_persists_user_question_before_stream(
+    client, db_container, default_user, default_user_token
+):
+    """Phase 1: a placeholder row with the user's question and empty answer must be
+    durably written to the DB by `create_question_placeholder`. This is the linchpin
+    of the fix — if the stream is aborted before the assistant replies, the user's
+    message must still be queryable on the next refresh."""
+
+    space_id = await _create_space(client, default_user_token)
+    assistant_id = await _create_assistant(client, default_user_token, space_id)
+
+    async with db_container() as container:
+        session_service = container.session_service()
+        chat_session = await session_service.create_session(
+            name="abort-test", assistant_id=UUID(assistant_id)
+        )
+        question_id = await session_service.create_question_placeholder(
+            question="What happens if I press ESC?",
+            session=chat_session,
+            files=None,
+            assistant_id=UUID(assistant_id),
+            completion_model=None,
+        )
+
+    row = await _get_question_row(question_id)
+    assert row is not None
+    assert row.question == "What happens if I press ESC?"
+    assert row.answer == ""
+    assert row.num_tokens_question == 0
+    assert row.num_tokens_answer == 0
+    assert row.tenant_id == default_user.tenant_id
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_complete_question_with_answer_updates_existing_row(
+    client, db_container, default_user, default_user_token
+):
+    """Phase 2 (normal completion): the placeholder row is updated in-place, not
+    duplicated."""
+
+    space_id = await _create_space(client, default_user_token)
+    assistant_id = await _create_assistant(client, default_user_token, space_id)
+
+    async with db_container() as container:
+        session_service = container.session_service()
+        chat_session = await session_service.create_session(
+            name="abort-test", assistant_id=UUID(assistant_id)
+        )
+        question_id = await session_service.create_question_placeholder(
+            question="hi",
+            session=chat_session,
+            files=None,
+            assistant_id=UUID(assistant_id),
+            completion_model=None,
+        )
+
+        await session_service.complete_question_with_answer(
+            question_id=question_id,
+            answer="hello back",
+            num_tokens_question=5,
+            num_tokens_answer=3,
+            completion_model=None,
+            info_blob_chunks=[],
+            generated_files=None,
+            logging_details=None,
+            web_search_results=None,
+            tool_calls=None,
+        )
+
+    row = await _get_question_row(question_id)
+    assert row is not None
+    assert row.question == "hi"
+    assert row.answer == "hello back"
+    assert row.num_tokens_question == 5
+    assert row.num_tokens_answer == 3
+
+    # Confirm we have ONE row, not a duplicate from a stale INSERT path.
+    async with sessionmanager.session() as session, session.begin():
+        result = await session.execute(
+            sa.select(sa.func.count())
+            .select_from(Questions)
+            .where(Questions.session_id == chat_session.id)
+        )
+        assert result.scalar_one() == 1
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_persist_partial_question_answer_writes_via_fresh_session(
+    client, db_container, default_user, default_user_token
+):
+    """Phase 2 (abort path): the fire-and-forget helper uses a fresh DB session and
+    correctly updates the answer text + token count on the existing placeholder."""
+
+    space_id = await _create_space(client, default_user_token)
+    assistant_id = await _create_assistant(client, default_user_token, space_id)
+
+    async with db_container() as container:
+        session_service = container.session_service()
+        chat_session = await session_service.create_session(
+            name="abort-test", assistant_id=UUID(assistant_id)
+        )
+        question_id = await session_service.create_question_placeholder(
+            question="why did it stop?",
+            session=chat_session,
+            files=None,
+            assistant_id=UUID(assistant_id),
+            completion_model=None,
+        )
+
+    # Simulate the streaming generator's `finally`: open a fresh session
+    # (sessionmanager.session()) and update with the partial answer.
+    await persist_partial_question_answer(
+        tenant_id=default_user.tenant_id,
+        question_id=question_id,
+        answer="partial reply before the user pressed ESC",
+        num_tokens_answer=9,
+        completion_model_id=None,
+    )
+
+    row = await _get_question_row(question_id)
+    assert row is not None
+    assert row.question == "why did it stop?"
+    assert row.answer == "partial reply before the user pressed ESC"
+    assert row.num_tokens_answer == 9
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_persist_partial_question_answer_refuses_cross_tenant_write(
+    client, db_container, default_user, default_user_token
+):
+    """Tenancy guard: even if a caller fabricates a question_id, the WHERE-clause
+    tenant filter must prevent any update under another tenant's id."""
+
+    space_id = await _create_space(client, default_user_token)
+    assistant_id = await _create_assistant(client, default_user_token, space_id)
+
+    async with db_container() as container:
+        session_service = container.session_service()
+        chat_session = await session_service.create_session(
+            name="abort-test", assistant_id=UUID(assistant_id)
+        )
+        question_id = await session_service.create_question_placeholder(
+            question="real tenant's question",
+            session=chat_session,
+            files=None,
+            assistant_id=UUID(assistant_id),
+            completion_model=None,
+        )
+
+    # A different tenant tries to overwrite the real tenant's row via the helper.
+    # Must NOT raise (it's best-effort), but must NOT update either.
+    foreign_tenant_id = uuid4()
+    assert foreign_tenant_id != default_user.tenant_id
+    await persist_partial_question_answer(
+        tenant_id=foreign_tenant_id,
+        question_id=question_id,
+        answer="cross-tenant attempt",
+        num_tokens_answer=99,
+    )
+
+    row = await _get_question_row(question_id)
+    assert row is not None
+    assert row.answer == "", "cross-tenant write must be filtered out by WHERE clause"
+    assert row.num_tokens_answer == 0

--- a/backend/tests/unit/test_chat_stream_abort_persistence.py
+++ b/backend/tests/unit/test_chat_stream_abort_persistence.py
@@ -33,7 +33,6 @@ from intric.sessions.session_service import (
     persist_partial_question_answer,
 )
 
-
 # ----- Helpers --------------------------------------------------------------
 
 
@@ -70,32 +69,82 @@ def _make_session_in_db() -> SimpleNamespace:
 
 
 @pytest.mark.asyncio
-async def test_create_question_placeholder_inserts_row_with_empty_answer():
+async def test_create_question_placeholder_inserts_row_with_seeded_question_tokens():
+    """Placeholder commits with the user's question, empty answer, and a best-effort
+    `count_tokens(question, model)` so abort-only requests don't undercount in
+    analytics."""
     new_question_id = uuid4()
     service = _make_session_service(question_id=new_question_id)
 
-    returned = await service.create_question_placeholder(
-        question="how do I cancel a stream?",
-        session=_make_session_in_db(),
-        files=None,
-        assistant_id=uuid4(),
-        completion_model=SimpleNamespace(id=uuid4(), name="gpt-4"),
-    )
+    with patch.object(
+        session_service_module, "count_tokens", return_value=42
+    ) as count_mock:
+        returned = await service.create_question_placeholder(
+            question="how do I cancel a stream?",
+            session=_make_session_in_db(),
+            files=None,
+            assistant_id=uuid4(),
+            completion_model=SimpleNamespace(id=uuid4(), name="gpt-4"),
+        )
 
     assert returned == new_question_id
+    count_mock.assert_called_once_with("how do I cancel a stream?", "gpt-4")
     service.question_repo.add.assert_awaited_once()
 
     args, kwargs = service.question_repo.add.call_args
     question_add = args[0]
     assert question_add.question == "how do I cancel a stream?"
     assert question_add.answer == ""
-    assert question_add.num_tokens_question == 0
+    assert question_add.num_tokens_question == 42
     assert question_add.num_tokens_answer == 0
     assert question_add.tenant_id == service.user.tenant_id
     # No info_blob_chunks / generated_files / web_search on a placeholder
     assert kwargs.get("info_blob_chunks") == []
     assert kwargs.get("generated_files") == []
     assert kwargs.get("web_search_results") == []
+
+
+@pytest.mark.asyncio
+async def test_create_question_placeholder_falls_back_to_zero_when_count_tokens_raises():
+    """tiktoken can raise on unknown model names — the placeholder write must still
+    succeed with num_tokens_question=0 instead of crashing the request."""
+    service = _make_session_service()
+
+    def boom(*_: object, **__: object) -> int:
+        raise KeyError("unknown model")
+
+    with patch.object(session_service_module, "count_tokens", side_effect=boom):
+        await service.create_question_placeholder(
+            question="test",
+            session=_make_session_in_db(),
+            files=None,
+            assistant_id=uuid4(),
+            completion_model=SimpleNamespace(id=uuid4(), name="exotic-model-9000"),
+        )
+
+    service.question_repo.add.assert_awaited_once()
+    args, _ = service.question_repo.add.call_args
+    assert args[0].num_tokens_question == 0
+
+
+@pytest.mark.asyncio
+async def test_create_question_placeholder_without_model_records_zero_tokens():
+    """If no completion model is configured (e.g. some sysadmin/test paths), don't
+    even try to count — store 0 and move on."""
+    service = _make_session_service()
+
+    with patch.object(session_service_module, "count_tokens") as count_mock:
+        await service.create_question_placeholder(
+            question="test",
+            session=_make_session_in_db(),
+            files=None,
+            assistant_id=None,
+            completion_model=None,
+        )
+
+    count_mock.assert_not_called()
+    args, _ = service.question_repo.add.call_args
+    assert args[0].num_tokens_question == 0
 
 
 # ----- SessionService.complete_question_with_answer -------------------------
@@ -172,7 +221,9 @@ async def test_persist_partial_question_answer_uses_fresh_session():
 
     with (
         patch.object(
-            session_service_module, "sessionmanager", SimpleNamespace(session=fake_session)
+            session_service_module,
+            "sessionmanager",
+            SimpleNamespace(session=fake_session),
         ),
         patch.object(session_service_module, "QuestionRepository", FakeRepo),
     ):
@@ -389,3 +440,176 @@ async def test_streaming_handle_response_no_partial_save_on_normal_completion():
 
     # Crucially: no partial-save task was scheduled on a clean finish.
     assert persist_calls == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_handle_response_skips_partial_save_when_no_content():
+    """When the stream is aborted *before* any TEXT chunk arrives — or the LLM
+    raises before producing output — `response_string` is empty and an UPDATE
+    setting answer='' would be a no-op against the placeholder. The finally must
+    skip the redundant background save in that case."""
+
+    async def empty_then_error_stream():
+        # Mimic an LLM that errors before the first chunk is yielded.
+        if False:  # pragma: no cover - keeps it an async generator
+            yield None
+        raise RuntimeError("upstream LLM unreachable")
+
+    response = SimpleNamespace(
+        completion=empty_then_error_stream(),
+        total_token_count=0,
+        usage=None,
+        extended_logging=None,
+    )
+    datastore_result = SimpleNamespace(info_blobs=[], no_duplicate_chunks=[])
+
+    session_service_mock = AsyncMock()
+    svc = _make_assistant_service_for_streaming(session_service_mock)
+
+    persist_calls: list[dict[str, object]] = []
+
+    async def tracking_persist(**kwargs: object) -> None:
+        persist_calls.append(kwargs)
+
+    with patch.object(
+        session_service_module,
+        "persist_partial_question_answer",
+        tracking_persist,
+    ):
+        from intric.assistants.assistant_service import AssistantService
+
+        gen = await AssistantService._handle_response(  # pyright: ignore[reportPrivateUsage]
+            svc,  # pyright: ignore[reportArgumentType]
+            response=response,
+            datastore_result=datastore_result,
+            question="hello?",
+            files=[],
+            completion_model=SimpleNamespace(id=uuid4(), name="gpt-4"),
+            session=_make_session_in_db(),
+            stream=True,
+            assistant_id=uuid4(),
+            question_id=uuid4(),
+        )
+
+        with pytest.raises(RuntimeError, match="upstream LLM unreachable"):
+            async for _ in gen:
+                pass
+
+        await asyncio.sleep(0)
+
+    assert persist_calls == [], (
+        "no partial-save should be scheduled when no content was streamed; "
+        "the placeholder row already captures the user's question"
+    )
+
+
+@pytest.mark.asyncio
+async def test_streaming_handle_response_count_tokens_failure_still_persists_partial():
+    """The pre-fix code computed count_tokens inline inside `finally` — if tiktoken
+    raised on an exotic model name, the asyncio.create_task call was never reached
+    and the partial save collapsed silently. Verify the safe wrapper now lets the
+    save through with num_tokens_answer=0."""
+
+    async def fake_completion_stream():
+        yield SimpleNamespace(
+            reasoning_token_count=0,
+            usage=None,
+            response_type=ResponseType.TEXT,
+            text="partial",
+            reference_chunks=[],
+        )
+        # Hang on the next chunk — the consumer will aclose() in between.
+        await asyncio.sleep(10)
+        yield SimpleNamespace(
+            reasoning_token_count=0,
+            usage=None,
+            response_type=ResponseType.TEXT,
+            text="lost",
+            reference_chunks=[],
+        )
+
+    response = SimpleNamespace(
+        completion=fake_completion_stream(),
+        total_token_count=2,
+        usage=None,
+        extended_logging=None,
+    )
+    datastore_result = SimpleNamespace(info_blobs=[], no_duplicate_chunks=[])
+
+    session_service_mock = AsyncMock()
+    svc = _make_assistant_service_for_streaming(session_service_mock)
+
+    persist_calls: list[dict[str, object]] = []
+
+    async def tracking_persist(**kwargs: object) -> None:
+        persist_calls.append(kwargs)
+
+    def boom(*_: object, **__: object) -> int:
+        raise KeyError("unknown model")
+
+    with (
+        patch.object(
+            session_service_module,
+            "persist_partial_question_answer",
+            tracking_persist,
+        ),
+        patch.object(session_service_module, "count_tokens", side_effect=boom),
+    ):
+        from intric.assistants.assistant_service import AssistantService
+
+        gen = await AssistantService._handle_response(  # pyright: ignore[reportPrivateUsage]
+            svc,  # pyright: ignore[reportArgumentType]
+            response=response,
+            datastore_result=datastore_result,
+            question="hi",
+            files=[],
+            completion_model=SimpleNamespace(id=uuid4(), name="exotic-model"),
+            session=_make_session_in_db(),
+            stream=True,
+            assistant_id=uuid4(),
+            question_id=uuid4(),
+        )
+
+        first = await _drain_until(gen, 1)
+        assert [c.text for c in first] == ["partial"]
+
+        await gen.aclose()
+        await asyncio.sleep(0)
+
+    assert len(persist_calls) == 1, (
+        "partial save must still fire even when count_tokens raises"
+    )
+    assert persist_calls[0]["answer"] == "partial"
+    assert persist_calls[0]["num_tokens_answer"] == 0
+
+
+# ----- _schedule_background_save strong-ref invariant -----------------------
+
+
+@pytest.mark.asyncio
+async def test_schedule_background_save_holds_strong_reference_until_done():
+    """asyncio.create_task internally holds only a weak reference — without
+    `_background_save_tasks` keeping a strong one, the GC can collect the task
+    mid-flight and silently drop the persistence write."""
+    started = asyncio.Event()
+    finish = asyncio.Event()
+    ran_to_completion = False
+
+    async def slow_coro() -> None:
+        nonlocal ran_to_completion
+        started.set()
+        await finish.wait()
+        ran_to_completion = True
+
+    task = session_service_module.schedule_background_save(slow_coro())
+
+    await started.wait()
+    # The task should be tracked while in-flight.
+    assert task in session_service_module._background_save_tasks
+
+    finish.set()
+    await task
+
+    # And removed after completion via the add_done_callback.
+    assert task not in session_service_module._background_save_tasks
+    assert ran_to_completion is True

--- a/backend/tests/unit/test_chat_stream_abort_persistence.py
+++ b/backend/tests/unit/test_chat_stream_abort_persistence.py
@@ -1,0 +1,391 @@
+"""Tests for chat-stream-abort persistence (issue #349).
+
+The bug: when an SSE chat stream is aborted (client disconnect), the user's question
+and the partially-streamed assistant reply are not persisted. The fix splits chat
+persistence into two phases:
+
+1. A placeholder row is inserted before the LLM stream begins.
+2. The row is updated when the stream completes — or, on abort, a fire-and-forget
+   background task uses a fresh DB session to update with the partial answer.
+
+These tests cover the unit-level building blocks. The end-to-end abort flow is
+exercised in tests/integration/services/test_conversation_stream_abort.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from typing import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from intric.ai_models.completion_models.completion_model import (
+    Completion,
+    ResponseType,
+)
+from intric.sessions import session_service as session_service_module
+from intric.sessions.session_service import (
+    SessionService,
+    persist_partial_question_answer,
+)
+
+
+# ----- Helpers --------------------------------------------------------------
+
+
+def _make_user() -> SimpleNamespace:
+    return SimpleNamespace(id=uuid4(), tenant_id=uuid4(), active_api_key=None)
+
+
+def _make_session_service(*, question_id: UUID | None = None) -> SessionService:
+    """Build a SessionService with mocked repos and a no-op _write_transaction context."""
+
+    session = MagicMock()
+    session.in_transaction.return_value = True  # skip session.begin() entirely
+    session.begin = MagicMock()
+
+    session_repo = SimpleNamespace(session=session, add=AsyncMock())
+    return_value = SimpleNamespace(id=question_id or uuid4())
+    question_repo = AsyncMock()
+    question_repo.session = session
+    question_repo.add = AsyncMock(return_value=return_value)
+    question_repo.update_with_answer = AsyncMock(return_value=None)
+
+    return SessionService(
+        session_repo=session_repo,
+        question_repo=question_repo,
+        user=_make_user(),
+    )
+
+
+def _make_session_in_db() -> SimpleNamespace:
+    return SimpleNamespace(id=uuid4(), questions=[])
+
+
+# ----- SessionService.create_question_placeholder ---------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_question_placeholder_inserts_row_with_empty_answer():
+    new_question_id = uuid4()
+    service = _make_session_service(question_id=new_question_id)
+
+    returned = await service.create_question_placeholder(
+        question="how do I cancel a stream?",
+        session=_make_session_in_db(),
+        files=None,
+        assistant_id=uuid4(),
+        completion_model=SimpleNamespace(id=uuid4(), name="gpt-4"),
+    )
+
+    assert returned == new_question_id
+    service.question_repo.add.assert_awaited_once()
+
+    args, kwargs = service.question_repo.add.call_args
+    question_add = args[0]
+    assert question_add.question == "how do I cancel a stream?"
+    assert question_add.answer == ""
+    assert question_add.num_tokens_question == 0
+    assert question_add.num_tokens_answer == 0
+    assert question_add.tenant_id == service.user.tenant_id
+    # No info_blob_chunks / generated_files / web_search on a placeholder
+    assert kwargs.get("info_blob_chunks") == []
+    assert kwargs.get("generated_files") == []
+    assert kwargs.get("web_search_results") == []
+
+
+# ----- SessionService.complete_question_with_answer -------------------------
+
+
+@pytest.mark.asyncio
+async def test_complete_question_with_answer_calls_repo_update():
+    service = _make_session_service()
+    question_id = uuid4()
+    completion_model = SimpleNamespace(id=uuid4(), name="gpt-4")
+
+    await service.complete_question_with_answer(
+        question_id=question_id,
+        answer="Aborting an SSE stream is done by calling abort() on the AbortController.",
+        num_tokens_question=42,
+        num_tokens_answer=7,
+        completion_model=completion_model,
+        info_blob_chunks=[],
+        generated_files=None,
+        logging_details=None,
+        web_search_results=None,
+        tool_calls=None,
+    )
+
+    service.question_repo.update_with_answer.assert_awaited_once()
+    kwargs = service.question_repo.update_with_answer.call_args.kwargs
+    assert kwargs["question_id"] == question_id
+    assert kwargs["tenant_id"] == service.user.tenant_id
+    assert kwargs["answer"].startswith("Aborting an SSE stream")
+    assert kwargs["num_tokens_question"] == 42
+    assert kwargs["num_tokens_answer"] == 7
+    assert kwargs["completion_model_id"] == completion_model.id
+
+
+# ----- persist_partial_question_answer --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_persist_partial_question_answer_uses_fresh_session():
+    """The abort helper must NOT depend on the request-scoped AsyncSession — it has
+    to open its own via sessionmanager.session(), since by the time we hit `finally`
+    on aclose() the request session may have been torn down by FastAPI."""
+
+    captured: dict[str, object] = {}
+
+    fresh_session = MagicMock()
+
+    @asynccontextmanager
+    async def fake_session() -> AsyncIterator[object]:
+        captured["entered"] = True
+        yield fresh_session
+
+    @asynccontextmanager
+    async def fake_begin() -> AsyncIterator[None]:
+        captured["txn_opened"] = True
+        yield
+
+    fresh_session.begin = MagicMock(return_value=fake_begin())
+
+    update_called: dict[str, object] = {}
+
+    async def fake_update(**kwargs: object) -> None:
+        update_called.update(kwargs)
+
+    class FakeRepo:
+        def __init__(self, _session: object) -> None:
+            captured["repo_session"] = _session
+
+        async def update_with_answer(self, **kwargs: object) -> None:
+            await fake_update(**kwargs)
+
+    tenant_id = uuid4()
+    question_id = uuid4()
+
+    with (
+        patch.object(
+            session_service_module, "sessionmanager", SimpleNamespace(session=fake_session)
+        ),
+        patch.object(session_service_module, "QuestionRepository", FakeRepo),
+    ):
+        await persist_partial_question_answer(
+            tenant_id=tenant_id,
+            question_id=question_id,
+            answer="part",
+            num_tokens_answer=2,
+            completion_model_id=None,
+        )
+
+    assert captured.get("entered") is True
+    assert captured.get("txn_opened") is True
+    assert captured.get("repo_session") is fresh_session
+    assert update_called["question_id"] == question_id
+    assert update_called["tenant_id"] == tenant_id
+    assert update_called["answer"] == "part"
+    assert update_called["num_tokens_answer"] == 2
+
+
+@pytest.mark.asyncio
+async def test_persist_partial_question_answer_swallows_db_errors():
+    """Best-effort cleanup — must not raise even if the DB is unreachable."""
+
+    @asynccontextmanager
+    async def broken_session() -> AsyncIterator[object]:
+        raise RuntimeError("db down")
+        yield None  # pragma: no cover  (unreachable, keeps generator a generator)
+
+    with patch.object(
+        session_service_module,
+        "sessionmanager",
+        SimpleNamespace(session=broken_session),
+    ):
+        # Must not raise — broken DB is logged, not propagated
+        await persist_partial_question_answer(
+            tenant_id=uuid4(),
+            question_id=uuid4(),
+            answer="x",
+            num_tokens_answer=1,
+        )
+
+
+# ----- _handle_response streaming abort path --------------------------------
+
+
+def _make_assistant_service_for_streaming(
+    session_service: AsyncMock,
+) -> SimpleNamespace:
+    """Build the bare minimum object on which AssistantService._handle_response can be
+    invoked. The method only uses self.user.tenant_id, self.session_service, and
+    (for FILES chunks) self.file_service.save_image_from_bytes."""
+
+    return SimpleNamespace(
+        user=_make_user(),
+        session_service=session_service,
+        file_service=SimpleNamespace(save_image_from_bytes=AsyncMock()),
+    )
+
+
+async def _drain_until(gen, n: int) -> list[Completion]:
+    """Pull the first n chunks from an async generator."""
+    out: list[Completion] = []
+    async for chunk in gen:
+        out.append(chunk)
+        if len(out) >= n:
+            break
+    return out
+
+
+@pytest.mark.asyncio
+async def test_streaming_handle_response_schedules_partial_save_on_abort():
+    """When the SSE consumer aborts after some TEXT chunks have arrived, the streaming
+    generator's `finally` must fire-and-forget a background save of the partial answer."""
+
+    async def fake_completion_stream():
+        for text in ["hello ", "wor", "ld"]:
+            yield SimpleNamespace(
+                reasoning_token_count=0,
+                usage=None,
+                response_type=ResponseType.TEXT,
+                text=text,
+                reference_chunks=[],
+            )
+
+    response = SimpleNamespace(
+        completion=fake_completion_stream(),
+        total_token_count=5,
+        usage=None,
+        extended_logging=None,
+    )
+    datastore_result = SimpleNamespace(info_blobs=[], no_duplicate_chunks=[])
+
+    session_service_mock = AsyncMock()
+    session_service_mock.complete_question_with_answer = AsyncMock()
+    svc = _make_assistant_service_for_streaming(session_service_mock)
+
+    question_id = uuid4()
+    completion_model = SimpleNamespace(id=uuid4(), name="gpt-4")
+
+    persist_calls: list[dict[str, object]] = []
+
+    async def tracking_persist(**kwargs: object) -> None:
+        persist_calls.append(kwargs)
+
+    # Patch BOTH places: assistant_service does a deferred `from intric.sessions...
+    # import persist_partial_question_answer` inside finally, so patch the source
+    # module attribute.
+    with patch.object(
+        session_service_module,
+        "persist_partial_question_answer",
+        tracking_persist,
+    ):
+        from intric.assistants.assistant_service import AssistantService
+
+        gen = await AssistantService._handle_response(  # pyright: ignore[reportPrivateUsage]
+            svc,  # pyright: ignore[reportArgumentType]
+            response=response,
+            datastore_result=datastore_result,
+            question="hello?",
+            files=[],
+            completion_model=completion_model,
+            session=_make_session_in_db(),
+            stream=True,
+            assistant_id=uuid4(),
+            question_id=question_id,
+        )
+
+        # Pull 2 chunks then close — simulates the SSE client disconnecting after
+        # receiving the first two tokens.
+        chunks = await _drain_until(gen, 2)
+        assert [c.text for c in chunks] == ["hello ", "wor"]
+
+        await gen.aclose()
+
+        # Let the scheduled background task run.
+        await asyncio.sleep(0)
+
+    assert len(persist_calls) == 1, "expected exactly one partial-save scheduled"
+    call = persist_calls[0]
+    assert call["question_id"] == question_id
+    assert call["tenant_id"] == svc.user.tenant_id
+    assert call["answer"] == "hello wor"  # only what was streamed before close
+
+    # The normal-completion path must NOT have run.
+    session_service_mock.complete_question_with_answer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_streaming_handle_response_no_partial_save_on_normal_completion():
+    """When the stream completes naturally, complete_question_with_answer must be
+    called (once) and no partial-save task should be scheduled."""
+
+    async def fake_completion_stream():
+        yield SimpleNamespace(
+            reasoning_token_count=0,
+            usage=None,
+            response_type=ResponseType.TEXT,
+            text="ok",
+            reference_chunks=[],
+        )
+
+    response = SimpleNamespace(
+        completion=fake_completion_stream(),
+        total_token_count=3,
+        usage=None,
+        extended_logging=None,
+    )
+    datastore_result = SimpleNamespace(info_blobs=[], no_duplicate_chunks=[])
+
+    session_service_mock = AsyncMock()
+    session_service_mock.complete_question_with_answer = AsyncMock()
+    svc = _make_assistant_service_for_streaming(session_service_mock)
+
+    question_id = uuid4()
+    completion_model = SimpleNamespace(id=uuid4(), name="gpt-4")
+
+    persist_calls: list[dict[str, object]] = []
+
+    async def tracking_persist(**kwargs: object) -> None:
+        persist_calls.append(kwargs)
+
+    with patch.object(
+        session_service_module,
+        "persist_partial_question_answer",
+        tracking_persist,
+    ):
+        from intric.assistants.assistant_service import AssistantService
+
+        gen = await AssistantService._handle_response(  # pyright: ignore[reportPrivateUsage]
+            svc,  # pyright: ignore[reportArgumentType]
+            response=response,
+            datastore_result=datastore_result,
+            question="hello?",
+            files=[],
+            completion_model=completion_model,
+            session=_make_session_in_db(),
+            stream=True,
+            assistant_id=uuid4(),
+            question_id=question_id,
+        )
+
+        # Drain the generator fully — this is the "normal completion" path.
+        collected: list[Completion] = [c async for c in gen]
+
+    # The TEXT chunk + the trailing TOKEN_USAGE chunk are both expected.
+    assert any(c.response_type == ResponseType.TEXT for c in collected)
+    assert any(c.response_type == ResponseType.TOKEN_USAGE for c in collected)
+
+    session_service_mock.complete_question_with_answer.assert_awaited_once()
+    update_kwargs = session_service_mock.complete_question_with_answer.call_args.kwargs
+    assert update_kwargs["question_id"] == question_id
+    assert update_kwargs["answer"] == "ok"
+
+    # Crucially: no partial-save task was scheduled on a clean finish.
+    assert persist_calls == []

--- a/frontend/apps/web/src/lib/features/chat/ChatService.svelte.ts
+++ b/frontend/apps/web/src/lib/features/chat/ChatService.svelte.ts
@@ -406,36 +406,35 @@ export class ChatService {
 
         const streamAborted = error instanceof Error && error.message.includes("aborted");
         if (streamAborted) {
-          // In that case nothing more to do, just return
-          return;
-        }
-
-        // If the error happened before streaming started (ref is undefined),
-        // no message was added to the conversation — just propagate the error
-        // so ConversationInput can restore the user's input.
-        if (!ref) {
+          // Backend persists the user's message before stream start and best-effort
+          // saves a partial assistant reply on abort, so the conversation survives a
+          // refresh. Falling through to reloadHistory() (below) syncs the sidebar with
+          // the now-persisted state instead of leaving the new session invisible until
+          // a manual reload.
+        } else if (!ref) {
+          // If the error happened before streaming started (ref is undefined),
+          // no message was added to the conversation — just propagate the error
+          // so ConversationInput can restore the user's input.
           console.error(error);
           throw error;
-        }
-
-        // If streaming started but no content arrived yet, remove the empty message
-        if (error instanceof IntricError && !ref.answer) {
+        } else if (error instanceof IntricError && !ref.answer) {
+          // If streaming started but no content arrived yet, remove the empty message
           this.currentConversation.messages.pop();
           console.error(error);
           throw error;
-        }
+        } else {
+          // Error during streaming — show inline in the conversation
+          let message = "We encountered an error processing your request.";
+          if (error instanceof IntricError) {
+            message += `\n\`\`\`\n${error.code}: "${error.getReadableMessage()}"\n\`\`\``;
+          } else if (error instanceof Object && "message" in error && "name" in error) {
+            message += `\n\`\`\`\n${error.name}: "${error.message}"\n\`\`\``;
+          }
 
-        // Error during streaming — show inline in the conversation
-        let message = "We encountered an error processing your request.";
-        if (error instanceof IntricError) {
-          message += `\n\`\`\`\n${error.code}: "${error.getReadableMessage()}"\n\`\`\``;
-        } else if (error instanceof Object && "message" in error && "name" in error) {
-          message += `\n\`\`\`\n${error.name}: "${error.message}"\n\`\`\``;
+          this.currentConversation.messages[this.currentConversation.messages?.length - 1].answer =
+            message;
+          console.error(error);
         }
-
-        this.currentConversation.messages[this.currentConversation.messages?.length - 1].answer =
-          message;
-        console.error(error);
       } finally {
         if (this.#streamGen === streamGen) {
           if (ref && inrefBuffer) {


### PR DESCRIPTION
## Changes

Two-phase persistence for chat questions so a stream abort no longer loses the user's
message or the partially-streamed assistant reply.

Closes #349.

### Backend

- **`backend/src/intric/questions/questions_repo.py`**
  Added `update_with_answer(question_id, tenant_id, answer, ...)` — tenant-scoped UPDATE
  that mirrors the existing `add()` field set but updates an existing placeholder row
  instead of inserting a new one. The `tenant_id` is in the WHERE clause as a
  defense-in-depth guard against cross-tenant writes.

- **`backend/src/intric/sessions/session_service.py`**
  - `SessionService.create_question_placeholder(...)` — inserts a `Questions` row with
    the user's question and an empty answer **before the LLM stream begins**. Returns
    the new `question_id` so the caller can update it when the stream finishes.
    Committed by the router's setup transaction (`conversations_router.py:300/328`), so
    the user's message is durable before any byte streams out.
  - `SessionService.complete_question_with_answer(...)` — UPDATE-path counterpart to the
    old `add_question_to_session(...)`. Called when the stream completes normally and
    by the non-streaming branch.
  - Module-level `persist_partial_question_answer(...)` — abort-path helper. Opens a
    **fresh** `sessionmanager.session()` (intentionally not the request-scoped one,
    which FastAPI tears down concurrently with the SSE close) and writes the partial
    answer + estimated token count. Best-effort: exceptions are logged and swallowed.
  - **Removed `SessionService.add_question_to_session(...)`** — it had zero callers
    after the swap to `complete_question_with_answer`. Verified across src, tests,
    frontend, and docs before deletion. Full 2523-test unit suite still green.

- **`backend/src/intric/assistants/assistant_service.py`**
  - `ask()` now calls `create_question_placeholder(...)` between session creation and
    the LLM call, capturing `question_id` and threading it through `_handle_response()`
    and onto the returned `AssistantResponse` (so the existing `SSEFirstChunk` carries
    the real id instead of `None`).
  - `_handle_response()` streaming branch wraps the LLM iterator + token counting in
    `try / finally` with a local `completed = False` flag. On normal completion it
    calls `complete_question_with_answer(...)` and sets `completed = True`. In the
    `finally`, if `not completed`, it fires
    `asyncio.create_task(persist_partial_question_answer(...))` with the accumulated
    `response_string`. No `await` inside `finally` — `await` across `GeneratorExit` is
    fragile, and the request-scoped `AsyncSession` may already be closed;
    fire-and-forget on the event loop.
  - Non-streaming branch swapped to `complete_question_with_answer(...)` so the
    placeholder-then-update flow is consistent across both paths.

- **`backend/src/intric/group_chat/application/group_chat_service.py`**
  Same placeholder + abort-finally pattern applied to the selector-echo path
  (`_handle_response()` at line 333, plus the placeholder insert in
  `ask_group_chat()`'s no-assistant branch). The main group-chat happy path delegates
  to `assistant_service.ask()` and is automatically covered by the assistant_service
  change.

### Frontend

- **`frontend/apps/web/src/lib/features/chat/ChatService.svelte.ts`**
  Restructured the `catch (error)` block in `askQuestion()` as an `if/else if` chain.
  The `streamAborted` branch no longer `return`s early, so execution falls through to
  the existing `reloadHistory()` call below the `finally`. Result: the sidebar
  refreshes immediately after abort and the now-persisted conversation shows up
  without a manual reload.

### Tests

- **`backend/tests/unit/test_chat_stream_abort_persistence.py`** (new, 6 tests)
  - `create_question_placeholder` inserts a row with empty answer + 0 token counts +
    the right tenant_id.
  - `complete_question_with_answer` calls `question_repo.update_with_answer` with the
    expected fields.
  - `persist_partial_question_answer` opens a fresh `sessionmanager.session()` and
    writes via that session (not the request session).
  - `persist_partial_question_answer` swallows DB errors (best-effort cleanup must
    not crash the parent task).
  - `_handle_response` streaming generator schedules **exactly one** background
    partial-save task when the consumer closes the generator after 2 chunks, with
    `answer == "<chunk_1><chunk_2>"`.
  - `_handle_response` streaming generator **does not** schedule a partial-save task
    on normal completion (just the regular `complete_question_with_answer` call).

- **`backend/tests/integration/services/test_conversation_stream_abort.py`**
  (new, 4 tests; `@pytest.mark.integration` — runs against testcontainers Postgres)
  - Placeholder is durably persisted with the user's question and an empty answer.
  - Normal-completion update modifies the placeholder in-place — one row, not two.
  - `persist_partial_question_answer` successfully updates the placeholder via a
    fresh session.
  - Cross-tenant write attempt is filtered out by the WHERE clause — the row is
    not modified.

## Why

When a user sends a chat message and the SSE stream is aborted (Stop button, ESC,
tab close, network drop), the user's question and the partially-streamed assistant
reply are both lost from the database. After a page refresh, the conversation
appears empty in the sidebar and a follow-up question reaches the LLM without the
first exchange in context.

Root cause: in `assistant_service._handle_response()` the only DB write
(`add_question_to_session(...)`) lived inside the streaming generator, **after** the
LLM stream finishes. When the client closes the SSE connection, `sse-starlette`
calls `aclose()` on the generator → `GeneratorExit` at the suspended yield → the
`async for chunk in completion:` loop exits → the write never happens. The
`Sessions` row is committed earlier (in `create_session()`), which is why the bug
appears as "empty conversation in sidebar."

The fix follows the issue's expected behavior literally: *"Save the user's message
before stream start."* Persist a placeholder under the router's already-active
transaction (durable before any SSE byte leaves), then either update normally on
clean completion or background-update on abort using a fresh DB session decoupled
from the dying request.

## Testing

### Automated
- [x] **Unit:** `uv run pytest tests/unit/test_chat_stream_abort_persistence.py` — 6/6 pass.
- [x] **Integration:** `uv run pytest -m integration tests/integration/services/test_conversation_stream_abort.py` — 4/4 pass against testcontainers Postgres.
- [x] **Regression:** `uv run pytest -m "not integration" tests/` — 2523/2523 existing unit tests pass.
- [x] **Type check:** `uv run pyright` — 0 errors across the full codebase.
- [x] **Lint:** `svelte-check` clean on `ChatService.svelte.ts` (other repo-wide check errors are pre-existing `@intric/ui` workspace build issues, unrelated).

### Caller audit
Verified every caller of every function touched:
- `assistant_service.ask()` callers (3): `conversation_service.ask_conversation()` × 2, `group_chat_service.ask_group_chat()` × 1. All paths now create a placeholder.
- `group_chat_service.ask_group_chat()` callers (2): both via `conversation_service.ask_conversation()`. Both branches (no-assistant inline / with-assistant delegating to `assistant_service.ask()`) covered.
- `AssistantResponse(...)` constructor (2 sites): both updated to pass `question_id`.
- `question_repo.add()` callers: `service_runner.py:118` (legacy "Service" feature, unchanged code path, not chat-related) plus the new `create_question_placeholder`. No regression.
- `add_question_to_session()` callers: zero after my swap; removed as dead code.

### Manual (recommended for reviewer)
- [ ] Start a new chat with an assistant. Send a question. Click Stop (or press ESC) mid-reply. Refresh the page. **Expected:** the question + whatever was streamed before abort persist in the conversation.
- [ ] Send a follow-up question that references the first one. **Expected:** the LLM has the prior exchange in context (no longer treats it as a fresh conversation).
- [ ] Same test in a **group chat** session.
- [ ] Same test where the abort happens **before the first token arrives** — the user's question should still persist (empty answer is fine).

## Behavior changes to flag for review

1. **Two writes per chat message instead of one.** Normal flow now does an INSERT (placeholder) followed by an UPDATE (answer + late-bound rows). This is by design — the INSERT is what survives an abort. Same transaction scope.

2. **`AssistantResponse.question_id` is now populated.** The field existed but always carried `None`; the `SSEFirstChunk` SSE event therefore now carries a real UUID where it previously sent `null`. No frontend code reads this field today, so no observable behavior change — but worth knowing if any downstream consumer of the API does.

3. **Sidebar refreshes on abort.** The Svelte `ChatService` previously short-circuited the abort path before `reloadHistory()` ran, so the new (partially-saved) conversation only appeared in the sidebar after a manual reload. It now refreshes immediately.

4. **`SessionService.add_question_to_session()` removed.** Was internal to the class; only callers were the two `_handle_response()` sites that this PR migrates. Verified zero callers in src, tests, frontend, or docs before removing. 2523 unit tests still pass.

5. **Pre-existing audit-log gap not addressed.** `/api/v1/conversations/` POST still lacks `audit_log.create()` / `audit_service.log_async()`. This predates this PR and belongs to a separate change (the design of *when* to audit a chat — at request start? on save? both? on abort separately? — deserves its own discussion). Suggested follow-up.

6. **No DB migration.** No schema changes — the fix uses the existing `Questions` table as-is.