### PR TITLE
fix(mcp): disconnect clients in reverse-connect order to honour anyio LIFO

### DIFF
--- a/backend/src/intric/mcp_servers/infrastructure/proxy/mcp_proxy_session.py
+++ b/backend/src/intric/mcp_servers/infrastructure/proxy/mcp_proxy_session.py
@@ -519,7 +519,15 @@ class MCPProxySession:
                 current,
             )
 
-        for server_id, client in self._clients.items():
+        # Disconnect in reverse-connect order. Each streamablehttp_client
+        # __aenter__ pushes an anyio cancel scope onto this task's scope
+        # stack; anyio enforces strict LIFO on __aexit__. Iterating in
+        # insertion order would try to exit the first-connected client
+        # while later clients' scopes are still on top, which anyio rejects
+        # with "Attempted to exit a cancel scope that isn't the current
+        # task's current cancel scope" and silently leaks the underlying
+        # HTTP read/write TaskGroup children.
+        for server_id, client in reversed(self._clients.items()):
             try:
                 await client.disconnect()
             except Exception as e:


### PR DESCRIPTION
## Summary

Each `streamablehttp_client.__aenter__` pushes an anyio cancel scope onto the iterating task's scope stack. Anyio enforces strict LIFO on `__aexit__`: you can only exit the scope currently on top.

`MCPProxySession.close()` iterated `self._clients.items()` in insertion order, so with two or more servers it tried to disconnect the first-connected one while later clients' scopes were still on top. That raised "Attempted to exit a cancel scope that isn't the current task's current cancel scope" — surfaced as the existing task-boundary error log — and silently leaked the `streamablehttp_client` TaskGroup (persistent HTTP read/write loops), exactly the leak the pre-existing comment in `close()` warned about. Only the last-connected client closed cleanly; everything earlier in the stack rotted.

Iterate in reverse-connect order so the top of the scope stack is always the one being exited. `dict.items()` preserves insertion order (3.7+) and `reversed()` works on dict views (3.8+).

Single-server case is unaffected — there is only one scope to exit.

## Test plan

- [ ] Multi-server MCP chat session ends without the "Attempted to exit a cancel scope..." error in logs