### PR TITLE
Normalize SharePoint scope paths before comparison

### DIFF
--- a/backend/src/intric/integration/infrastructure/content_service/sharepoint_content_service.py
+++ b/backend/src/intric/integration/infrastructure/content_service/sharepoint_content_service.py
@@ -1,5 +1,7 @@
+import unicodedata
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Optional, cast
+from urllib.parse import unquote
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -1518,9 +1520,13 @@ class SharePointContentService:
                 parent_ref.get("path", "")
             )
 
-            # Item is in scope if its parent path starts with or equals the folder path
-            normalized_scope = scope_folder_path.rstrip("/")
-            normalized_parent = relative_path.rstrip("/")
+            # Item is in scope if its parent path starts with or equals the folder
+            # path. SharePoint paths are case-insensitive and may arrive
+            # percent-encoded (e.g. "%20", encoded å/ä/ö), so normalize both sides
+            # before comparing — otherwise folders with spaces or non-ASCII names
+            # silently fail the scope check and never get indexed.
+            normalized_scope = self._normalize_path(scope_folder_path)
+            normalized_parent = self._normalize_path(relative_path)
             if normalized_scope and (
                 normalized_parent == normalized_scope
                 or normalized_parent.startswith(normalized_scope + "/")
@@ -1528,6 +1534,19 @@ class SharePointContentService:
                 return True
 
         return False
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        """Normalize a SharePoint path for case- and encoding-insensitive comparison.
+
+        URL-decodes percent-encoding, normalizes Unicode to NFC (so å/ä/ö in NFC
+        vs NFD forms compare equal), strips a trailing slash, and casefolds.
+        """
+        if not path:
+            return ""
+        decoded = unquote(path)
+        nfc = unicodedata.normalize("NFC", decoded)
+        return nfc.rstrip("/").casefold()
 
     @staticmethod
     def _extract_relative_graph_path(parent_path: str) -> str:

--- a/backend/tests/unittests/integration/test_sharepoint_content_service.py
+++ b/backend/tests/unittests/integration/test_sharepoint_content_service.py
@@ -4,6 +4,7 @@ Tests the content pulling, delta change processing, and token handling
 for SharePoint integrations.
 """
 
+import unicodedata
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -617,6 +618,142 @@ class TestIsItemInFolderScope:
         )
 
         assert result is False
+
+    def test_matches_path_with_encoded_spaces(self, service):
+        """Percent-encoded spaces in the Graph path match a decoded scope path."""
+        item = {
+            "id": "child-1",
+            "parentReference": {
+                "id": "subfolder-x",
+                "path": "/drives/d/root:/Documents/My%20Files",
+            },
+        }
+
+        result = service._is_item_in_folder_scope(
+            item,
+            scope_folder_id="folder-123",
+            scope_folder_path="/Documents/My Files",
+            selected_item_type="folder",
+        )
+
+        assert result is True
+
+    def test_matches_path_with_encoded_non_ascii(self, service):
+        """Percent-encoded å/ä/ö in the Graph path match a decoded scope path."""
+        item = {
+            "id": "child-1",
+            "parentReference": {
+                "id": "subfolder-x",
+                # UTF-8 percent-encoding of "Åäö"
+                "path": "/drives/d/root:/Dokument/%C3%85%C3%A4%C3%B6",
+            },
+        }
+
+        result = service._is_item_in_folder_scope(
+            item,
+            scope_folder_id="folder-123",
+            scope_folder_path="/Dokument/Åäö",
+            selected_item_type="folder",
+        )
+
+        assert result is True
+
+    def test_matches_path_with_nfd_unicode(self, service):
+        """NFD-form Unicode in the Graph path matches an NFC-form scope path."""
+        nfd_path = unicodedata.normalize("NFD", "/Dokument/Åäö")
+        item = {
+            "id": "child-1",
+            "parentReference": {
+                "id": "subfolder-x",
+                "path": f"/drives/d/root:{nfd_path}",
+            },
+        }
+
+        result = service._is_item_in_folder_scope(
+            item,
+            scope_folder_id="folder-123",
+            # scope stored in NFC form
+            scope_folder_path=unicodedata.normalize("NFC", "/Dokument/Åäö"),
+            selected_item_type="folder",
+        )
+
+        assert result is True
+
+    def test_matches_path_case_insensitively(self, service):
+        """Mixed-case Graph path matches a differently-cased scope path."""
+        item = {
+            "id": "child-1",
+            "parentReference": {
+                "id": "subfolder-x",
+                "path": "/drives/d/root:/documents/REPORTS",
+            },
+        }
+
+        result = service._is_item_in_folder_scope(
+            item,
+            scope_folder_id="folder-123",
+            scope_folder_path="/Documents/Reports",
+            selected_item_type="folder",
+        )
+
+        assert result is True
+
+    def test_matches_nested_descendant_path(self, service):
+        """An item nested below the scope folder is in scope."""
+        item = {
+            "id": "child-1",
+            "parentReference": {
+                "id": "subfolder-x",
+                "path": "/drives/d/root:/Documents/Reports/2024/Q1",
+            },
+        }
+
+        result = service._is_item_in_folder_scope(
+            item,
+            scope_folder_id="folder-123",
+            scope_folder_path="/Documents/Reports",
+            selected_item_type="folder",
+        )
+
+        assert result is True
+
+    def test_does_not_match_sibling_prefix_path(self, service):
+        """A sibling whose name merely starts with the scope name is out of scope."""
+        item = {
+            "id": "child-1",
+            "parentReference": {
+                "id": "subfolder-x",
+                "path": "/drives/d/root:/Documents/ReportsArchive",
+            },
+        }
+
+        result = service._is_item_in_folder_scope(
+            item,
+            scope_folder_id="folder-123",
+            scope_folder_path="/Documents/Reports",
+            selected_item_type="folder",
+        )
+
+        assert result is False
+
+    def test_matches_path_with_trailing_slash_in_scope(self, service):
+        """A trailing slash on the scope path does not break matching."""
+        item = {
+            "id": "child-1",
+            "parentReference": {
+                "id": "subfolder-x",
+                "path": "/drives/d/root:/Documents/Reports",
+            },
+        }
+
+        result = service._is_item_in_folder_scope(
+            item,
+            scope_folder_id="folder-123",
+            scope_folder_path="/Documents/Reports/",
+            selected_item_type="folder",
+        )
+
+        assert result is True
 
 
 class TestGetItemType:


### PR DESCRIPTION
## Summary

Fixes #429.

`_is_item_in_folder_scope` compared the configured integration scope path against `parentReference.path` from Microsoft Graph using only `rstrip("/")` and a case-sensitive string match. SharePoint paths are case-insensitive and may arrive percent-encoded (`%20`, encoded å/ä/ö). As a result, files in folders with spaces or non-ASCII names silently failed the scope check and were never indexed — a guaranteed issue for Swedish/municipality content.

## Change

- Add a `_normalize_path` helper: URL-decode (`unquote`), Unicode-normalize to NFC, `rstrip("/")`, `casefold()`.
- Apply it to both sides at the only path-comparison site in the integration code. The legacy folder-path resolution stores the raw path; normalization happens at comparison time only, so stored `folder_path` values stay human-readable.

## Tests

New unit tests in `TestIsItemInFolderScope` cover:
- Encoded spaces (`/Documents/My%20Files` vs `/Documents/My Files`)
- Encoded non-ASCII (`%C3%85%C3%A4%C3%B6` vs `Åäö`)
- NFC vs NFD Unicode mismatch
- Mixed case (`/documents/REPORTS` vs `/Documents/Reports`)
- Nested descendants in scope
- Sibling-prefix exclusion (`ReportsArchive` not in scope of `Reports`)
- Trailing-slash scope path

All 52 tests in the file pass; `ruff check` clean.

## Acceptance criteria

- [x] `_is_item_in_folder_scope` URL-decodes both inputs before comparison
- [x] Comparison is case-insensitive (casefold)
- [x] Unicode normalized to NFC before comparison
- [x] Same normalization applied at all SharePoint path comparison sites
- [x] Unit tests cover spaces, non-ASCII, mixed case, encoded/decoded forms
- [x] No regressions in existing tests