### PR TITLE
chore(releases): publish release SBOM assets

### DIFF
--- a/.github/workflows/release_sbom.yml
+++ b/.github/workflows/release_sbom.yml
@@ -1,0 +1,190 @@
+name: Release SBOM
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to scan, for example v2.0.0-rc.2
+        required: true
+        type: string
+      upload_release_assets:
+        description: Attach generated SBOMs to the GitHub release
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  packages: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  BACKEND_IMAGE: ghcr.io/eneo-ai/eneo-backend
+  FRONTEND_IMAGE: ghcr.io/eneo-ai/eneo-frontend
+  PLATFORM: linux/amd64
+  PLATFORM_OS: linux
+  PLATFORM_ARCH: amd64
+  SYFT_VERSION: v1.44.0
+
+jobs:
+  release-sbom:
+    name: Release SBOM
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Resolve release inputs
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          WORKFLOW_UPLOAD_RELEASE_ASSETS: ${{ inputs.upload_release_assets || false }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$RELEASE_TAG" ]]; then
+            echo "::error::Release tag is required."
+            exit 1
+          fi
+
+          if [[ "$RELEASE_TAG" != v* ]]; then
+            echo "::error::Release tag '$RELEASE_TAG' must start with v."
+            exit 1
+          fi
+
+          upload_release_assets="false"
+          if [[ "$EVENT_NAME" == "release" || "$WORKFLOW_UPLOAD_RELEASE_ASSETS" == "true" ]]; then
+            upload_release_assets="true"
+          fi
+
+          {
+            echo "tag=$RELEASE_TAG"
+            echo "image-tag=${RELEASE_TAG#v}"
+            echo "upload-release-assets=$upload_release_assets"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Syft
+        id: syft
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: ${{ env.SYFT_VERSION }}
+
+      - name: Generate image SBOMs
+        env:
+          SYFT_CMD: ${{ steps.syft.outputs.cmd }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          IMAGE_TAG: ${{ steps.release.outputs.image-tag }}
+        run: |
+          set -euo pipefail
+
+          out_dir="release-sbom"
+          mkdir -p "$out_dir"
+          : > "$out_dir/IMAGE-DIGESTS.txt"
+
+          resolve_platform_digest() {
+            local image_ref="$1"
+            local raw_manifest
+            local digest
+
+            for attempt in {1..60}; do
+              if raw_manifest="$(docker buildx imagetools inspect "$image_ref" --raw 2>/tmp/image-inspect-error.log)"; then
+                digest="$(jq -r --arg os "$PLATFORM_OS" --arg arch "$PLATFORM_ARCH" '
+                  [.manifests[]?
+                    | select(.platform.os == $os and .platform.architecture == $arch)
+                    | .digest][0] // empty
+                ' <<< "$raw_manifest")"
+
+                if [[ -n "$digest" ]]; then
+                  echo "$digest"
+                  return 0
+                fi
+
+                echo "::error::Image $image_ref does not expose a $PLATFORM platform manifest." >&2
+                return 1
+              fi
+
+              if [[ "$attempt" -eq 60 ]]; then
+                echo "::error::Image $image_ref was not available for $PLATFORM after waiting." >&2
+                cat /tmp/image-inspect-error.log >&2 || true
+                return 1
+              fi
+
+              sleep 30
+            done
+          }
+
+          generate_component_sbom() {
+            local component="$1"
+            local image="$2"
+            local image_ref="$image:$IMAGE_TAG"
+            local digest
+            local digest_ref
+            local asset_prefix
+
+            digest="$(resolve_platform_digest "$image_ref")"
+            digest_ref="$image@$digest"
+            asset_prefix="eneo-${component}-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}"
+
+            printf '%s %s %s\n' "$component" "$image_ref" "$digest_ref" >> "$out_dir/IMAGE-DIGESTS.txt"
+
+            "$SYFT_CMD" "registry:$digest_ref" \
+              --platform "$PLATFORM" \
+              -q \
+              -o "cyclonedx-json=$out_dir/${asset_prefix}.cyclonedx.json" \
+              -o "spdx-json=$out_dir/${asset_prefix}.spdx.json" \
+              -o "syft-table=$out_dir/${asset_prefix}.table.txt"
+          }
+
+          generate_component_sbom "backend" "$BACKEND_IMAGE"
+          generate_component_sbom "frontend" "$FRONTEND_IMAGE"
+
+          (
+            cd "$out_dir"
+            sha256sum -- IMAGE-DIGESTS.txt *.cyclonedx.json *.spdx.json *.table.txt > SBOM-SHA256SUMS.txt
+          )
+
+          {
+            echo "## Release SBOMs"
+            echo ""
+            echo "Generated SBOMs for \`$RELEASE_TAG\` from \`$PLATFORM\` image digests."
+            echo ""
+            echo "| Component | Image tag | Image digest |"
+            echo "| --- | --- | --- |"
+            while read -r component image_ref digest_ref; do
+              echo "| $component | \`$image_ref\` | \`$digest_ref\` |"
+            done < "$out_dir/IMAGE-DIGESTS.txt"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-sbom-${{ steps.release.outputs.tag }}
+          path: release-sbom/*
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Attach SBOMs to GitHub release
+        if: steps.release.outputs.upload-release-assets == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
+          gh release upload "$RELEASE_TAG" release-sbom/* --repo "$GITHUB_REPOSITORY"

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -57,6 +57,13 @@ The repository uses GitHub security features and CI to prevent regressions:
   languages and query suites are versioned with the code. It scans Python,
   JavaScript/TypeScript, and GitHub Actions workflows on pushes and pull
   requests to `develop`, plus a weekly scheduled scan.
+- Release SBOMs are generated from the published backend and frontend container
+  image digests and attached to GitHub Releases as CycloneDX JSON, SPDX JSON,
+  and human-readable table files. These assets provide dependency transparency
+  for each release; their authenticity currently relies on GitHub-managed
+  release asset storage and the image digests recorded in the SBOM bundle.
+  `SBOM-SHA256SUMS.txt` covers the SBOM files; container image integrity is
+  verified through the GHCR image digests recorded in `IMAGE-DIGESTS.txt`.
 - Secret scanning and push protection should remain enabled for provider keys,
   tokens, credentials, and other repository secrets.
 - The normal `CI` gate validates frozen backend and frontend installs before

--- a/frontend/apps/docs-site/src/content/docs/_meta.ts
+++ b/frontend/apps/docs-site/src/content/docs/_meta.ts
@@ -1,12 +1,13 @@
-import type { MetaRecord } from 'nextra';
+import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {
-  index: 'Overview',
-  'getting-started': 'Getting Started',
-  architecture: 'Architecture',
-  'audit-logging': 'Audit Logging',
-  'api-key-management': 'API Key Management',
-  api: 'API Reference',
-}
+  index: "Overview",
+  "getting-started": "Getting Started",
+  architecture: "Architecture",
+  "audit-logging": "Audit Logging",
+  "api-key-management": "API Key Management",
+  "release-sboms": "Release SBOMs",
+  api: "API Reference",
+};
 
 export default meta;

--- a/frontend/apps/docs-site/src/content/docs/index.mdx
+++ b/frontend/apps/docs-site/src/content/docs/index.mdx
@@ -36,6 +36,12 @@ How Eneo tracks token usage for LLM requests:
 - Estimation for self-hosted models
 - How token data flows to Insights dashboards
 
+### [Release SBOMs](/docs/release-sboms)
+Downloadable SBOMs for released container images:
+- CycloneDX and SPDX files for security tooling
+- Human-readable package lists for quick review
+- Image digests and SBOM checksums for release comparison
+
 ### [API Reference](/docs/api)
 Complete API documentation for developers:
 - REST API endpoints

--- a/frontend/apps/docs-site/src/content/docs/release-sboms.mdx
+++ b/frontend/apps/docs-site/src/content/docs/release-sboms.mdx
@@ -1,0 +1,75 @@
+# Release SBOMs
+
+Each Eneo release includes Software Bill of Materials files for the published
+backend and frontend container images. The files are attached to the GitHub
+Release so you can download them for security review, compliance work, or
+release comparison.
+
+The release workflow creates SBOMs for:
+
+- `ghcr.io/eneo-ai/eneo-backend:<version>`
+- `ghcr.io/eneo-ai/eneo-frontend:<version>`
+
+For a release tag such as `v2.0.0`, the image tag is `2.0.0`.
+The SBOM filenames use the release tag, including the `v` prefix.
+
+## When SBOMs are published
+
+When maintainers publish a GitHub Release, Eneo waits for the matching backend
+and frontend images to appear in GitHub Container Registry. The workflow then
+scans the `linux/amd64` image digests and attaches the generated files to the
+same release page.
+
+Each new release gets its own SBOM files. Older release pages keep their
+original SBOM files, so you can compare one version with the next.
+
+## Files on the release page
+
+Each release publishes these files:
+
+| File | Purpose |
+| --- | --- |
+| `eneo-backend-<release-tag>-linux-amd64.cyclonedx.json` | Backend SBOM in CycloneDX JSON |
+| `eneo-backend-<release-tag>-linux-amd64.spdx.json` | Backend SBOM in SPDX JSON |
+| `eneo-backend-<release-tag>-linux-amd64.table.txt` | Backend package list for human review |
+| `eneo-frontend-<release-tag>-linux-amd64.cyclonedx.json` | Frontend SBOM in CycloneDX JSON |
+| `eneo-frontend-<release-tag>-linux-amd64.spdx.json` | Frontend SBOM in SPDX JSON |
+| `eneo-frontend-<release-tag>-linux-amd64.table.txt` | Frontend package list for human review |
+| `IMAGE-DIGESTS.txt` | Exact image tags and digests that were scanned |
+| `SBOM-SHA256SUMS.txt` | SHA-256 checksums for the SBOM bundle |
+
+Use the `.table.txt` files when you want to inspect the package list quickly.
+Use CycloneDX or SPDX when you need to import the SBOM into another tool.
+
+## What the SBOM covers
+
+The SBOMs describe packages Syft finds inside the released container images.
+For the backend image, this usually includes Debian packages, Python packages,
+and binaries. For the frontend image, this usually includes Debian packages,
+npm packages, and binaries.
+
+The SBOMs are generated from immutable image digest references, not only from
+tags. `IMAGE-DIGESTS.txt` records the digest references used during the scan.
+
+## What the SBOM does not cover
+
+An SBOM is an inventory. It does not decide whether a package is vulnerable or
+whether a vulnerability is reachable in Eneo.
+
+Use vulnerability scanners such as Grype, Trivy, GitHub Advanced Security, or
+your internal tooling if you need vulnerability findings based on the SBOM.
+
+The current release assets are not signed. Their authenticity relies on
+GitHub-managed release asset storage and the image digests recorded in
+`IMAGE-DIGESTS.txt`.
+
+## Checking a release
+
+1. Open the GitHub Release page for the version you use.
+2. Download the backend and frontend `.table.txt` files for a quick review.
+3. Download CycloneDX or SPDX files for your security tooling.
+4. Check `IMAGE-DIGESTS.txt` if you need the exact image digests scanned.
+5. Check `SBOM-SHA256SUMS.txt` if you need file checksums for the SBOM bundle.
+
+To compare two releases, compare the SBOM files from both release pages. Package
+additions, removals, and version changes show what changed between the images.


### PR DESCRIPTION
## Summary
- Adds a `Release SBOM` workflow for GitHub Releases.
- Generates SBOMs for the published backend and frontend container images.
- Attaches CycloneDX JSON, SPDX JSON, human-readable package tables, image digests, and SBOM checksums to each release.
- Adds docs for users in the docs site and records the trust boundary in the security policy.

## Why
Users should be able to download the SBOM for the exact Eneo release they run. The useful source of truth is the shipped container image, not the source tree alone. This lets users compare releases, inspect dependency changes, and feed the files into their own security or compliance tooling.

Source-tree or per-PR SBOMs are out of scope here because users deploy released container images, while PRs already run CI, Dependency Review, CodeQL, and Docker builds. We can add a PR-level SBOM later if a real consumer needs it, but it should not be the first step.

## How it works
1. A maintainer publishes a GitHub Release, for example `v2.0.0`.
2. The workflow derives the image tag from the release tag, for example `2.0.0`.
3. The workflow waits for these GHCR images to exist:
   - `ghcr.io/eneo-ai/eneo-backend:<version>`
   - `ghcr.io/eneo-ai/eneo-frontend:<version>`
4. It resolves the `linux/amd64` platform digest for each image.
5. It scans the immutable digest reference with Syft, for example `ghcr.io/eneo-ai/eneo-backend@sha256:...`.
6. It uploads the generated files to the same GitHub Release.

The workflow does not use `--clobber` when uploading release assets. If assets already exist, the upload fails instead of replacing historical SBOM files.

## Published files
Each release gets these files:

- `eneo-backend-<release-tag>-linux-amd64.cyclonedx.json`
- `eneo-backend-<release-tag>-linux-amd64.spdx.json`
- `eneo-backend-<release-tag>-linux-amd64.table.txt`
- `eneo-frontend-<release-tag>-linux-amd64.cyclonedx.json`
- `eneo-frontend-<release-tag>-linux-amd64.spdx.json`
- `eneo-frontend-<release-tag>-linux-amd64.table.txt`
- `IMAGE-DIGESTS.txt`
- `SBOM-SHA256SUMS.txt`

CycloneDX and SPDX are for tooling. The table files are for quick human review. `IMAGE-DIGESTS.txt` records the exact image digests scanned. `SBOM-SHA256SUMS.txt` covers the SBOM bundle files.

## What changed
- `.github/workflows/release_sbom.yml` owns release SBOM generation and release asset upload.
- `docs/SECURITY.md` documents release SBOMs and the current trust boundary.
- `frontend/apps/docs-site/src/content/docs/release-sboms.mdx` explains what is published, what it covers, and how users should read the files.
- `frontend/apps/docs-site/src/content/docs/_meta.ts` and `frontend/apps/docs-site/src/content/docs/index.mdx` add the docs-site navigation entry.

## What was deliberately not changed
- No vulnerability scanning policy was added.
- No Grype or Trivy step was added.
- No SBOM signing, cosign, or in-toto attestation was added.
- No source-tree SBOM is generated.
- No generated SBOM files are committed to the repository.
- No Docker image build or platform behavior was changed.

## Risk and rollback
The new workflow is separate from the image build workflow. If SBOM generation fails, image publishing is not affected.

The workflow may start before the release image build has finished, so it polls for the expected GHCR image tags. If the tag appears but does not expose a `linux/amd64` platform manifest, the workflow fails with a clear error.

Rollback is to revert this PR. Published images and the existing release image workflow are unaffected.

## Recommended follow-up
After merge, run `Release SBOM` manually against a recent release tag such as `v2.0.0-rc.2` with `upload_release_assets: false`. That exercises the GitHub-hosted runner path without attaching files to an existing release.

For a later PR, consider signed SBOM attestations with OIDC/cosign if the project wants stronger provenance than GitHub release asset storage plus recorded image digests.

## Validation
- PASS: workflow YAML parsed with `yq`.
- PASS: embedded workflow shell parsed with `bash -n`.
- PASS: workflow checked with `actionlint`.
- PASS: changed files passed `git diff --check`.
- PASS: changed files passed `pre-commit run --files ...`.
- PASS: docs site built with `bun run build`.
- PASS: local Syft smoke generated SBOMs from `v2.0.0-rc.2` backend and frontend `linux/amd64` image digests.
- PASS: PR checks have passed on GitHub.
- PASS: Claude peer-loop reviewed the implementation, docs-site page, and PR description.
