### PR TITLE
chore(releases): label SBOM release assets

### DIFF
--- a/.github/workflows/release_sbom.yml
+++ b/.github/workflows/release_sbom.yml
@@ -187,4 +187,15 @@ jobs:
           set -euo pipefail
 
           gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
-          gh release upload "$RELEASE_TAG" release-sbom/* --repo "$GITHUB_REPOSITORY"
+          release_assets=(
+            "release-sbom/eneo-backend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.cyclonedx.json#Backend SBOM - CycloneDX JSON"
+            "release-sbom/eneo-backend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.spdx.json#Backend SBOM - SPDX JSON"
+            "release-sbom/eneo-backend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.table.txt#Backend packages - readable table"
+            "release-sbom/eneo-frontend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.cyclonedx.json#Frontend SBOM - CycloneDX JSON"
+            "release-sbom/eneo-frontend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.spdx.json#Frontend SBOM - SPDX JSON"
+            "release-sbom/eneo-frontend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.table.txt#Frontend packages - readable table"
+            "release-sbom/IMAGE-DIGESTS.txt#Image digests scanned"
+            "release-sbom/SBOM-SHA256SUMS.txt#SBOM file checksums"
+          )
+
+          gh release upload "$RELEASE_TAG" "${release_assets[@]}" --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Summary
- Adds GitHub Release display labels for SBOM assets.
- Keeps the generated filenames unchanged for scripts and tooling.
- Makes each asset easier to scan on the release page: backend/frontend, format, readable table, image digests, and checksums.

## Why
GitHub Release assets are shown as a flat list. Labels make the list easier for humans to read without adding folders, ZIP bundles, or another artifact format.

## What changed
- `.github/workflows/release_sbom.yml` now uploads release assets with labels such as `Backend SBOM - CycloneDX JSON`, `Frontend packages - readable table`, and `Image digests scanned`.
- The actual asset files are still the same files produced by the workflow.

## What was deliberately not changed
- No ZIP bundle was added.
- No release asset filenames changed.
- No SBOM generation behavior changed.
- No docs update was added because the existing docs already document the real filenames and file purposes.

## Deletion / consolidation
No deletion or consolidation. This only labels the existing release upload inputs.

## Risk and rollback
Risk is limited to the upload step. If label syntax is rejected by `gh release upload`, the release asset upload fails loudly and the generated workflow artifact remains available.

Rollback is to revert this commit, which returns to unlabeled asset uploads.

## Validation
- PASS: `yq -r '.jobs."release-sbom".steps[] | select(has("run")) | .run' .github/workflows/release_sbom.yml | bash -n`
- PASS: `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color=false .github/workflows/release_sbom.yml`
- PASS: `git diff --check -- .github/workflows/release_sbom.yml`
- PASS: `pre-commit run --files .github/workflows/release_sbom.yml`
