### PR TITLE
fix(alembic): place model-lifecycle migrations after session migration

### DIFF
--- a/backend/alembic/versions/20260401_fix_migration_history_cascade.py
+++ b/backend/alembic/versions/20260401_fix_migration_history_cascade.py
@@ -4,7 +4,7 @@ Store model names directly in migration history so records survive
 model deletion. Change FK ondelete from CASCADE to SET NULL.
 
 Revision ID: fix_migration_history
-Revises: 202604291030
+Revises: 202605061100
 Create Date: 2026-04-01
 
 """
@@ -14,7 +14,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic
 revision = "fix_migration_history"
-down_revision = "202604291030"
+down_revision = "202605061100"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/202605061100_sessions_nullable_user_id_add_api_key_id.py
+++ b/backend/alembic/versions/202605061100_sessions_nullable_user_id_add_api_key_id.py
@@ -19,7 +19,7 @@ This migration:
    invisible to user-scoped listings and dereferences nothing useful.
 
 Revision ID: 202605061100
-Revises: 20260501_backfill_model_costs
+Revises: 202604291030
 Create Date: 2026-05-06
 """
 
@@ -29,7 +29,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic
 revision = "202605061100"
-down_revision = "20260501_backfill_model_costs"
+down_revision = "202604291030"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
The migrations from #315 branched from 20260319_add_nickname (mid-chain) so databases already stamped at 202605061100 never ran them. Reorder so the 5 new migrations follow 202605061100 and `upgrade head` picks them up.
