### PR TITLE
chore(releases): add backend Python runtime SBOM

### DIFF
--- a/.github/workflows/release_sbom.yml
+++ b/.github/workflows/release_sbom.yml
@@ -31,6 +31,8 @@ env:
   PLATFORM_OS: linux
   PLATFORM_ARCH: amd64
   SYFT_VERSION: v1.44.0
+  CYCLONEDX_BOM_VERSION: "7.3.0"
+  CYCLONEDX_SPEC_VERSION: "1.6"
 
 jobs:
   release-sbom:
@@ -142,6 +144,10 @@ jobs:
 
             printf '%s %s %s\n' "$component" "$image_ref" "$digest_ref" >> "$out_dir/IMAGE-DIGESTS.txt"
 
+            if [[ "$component" == "backend" ]]; then
+              backend_digest_ref="$digest_ref"
+            fi
+
             "$SYFT_CMD" "registry:$digest_ref" \
               --platform "$PLATFORM" \
               -q \
@@ -150,7 +156,130 @@ jobs:
               -o "syft-table=$out_dir/${asset_prefix}.table.txt"
           }
 
+          generate_backend_python_runtime_sbom() {
+            local backend_digest_ref="$1"
+            local asset_prefix="eneo-backend-python-runtime-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}"
+            local script_dir
+            local container_script
+            local output_file="/out/${asset_prefix}.cyclonedx.json"
+
+            if [[ -z "$backend_digest_ref" ]]; then
+              echo "::error::Backend image digest reference is required for the Python runtime SBOM." >&2
+              exit 1
+            fi
+
+            script_dir="$(mktemp -d)"
+            container_script="$script_dir/generate-python-runtime-sbom.sh"
+            cat > "$container_script" <<'PYTHON_RUNTIME_SBOM'
+          set -eu
+
+          runtime_python="/app/.venv/bin/python"
+          runtime_distributions="/tmp/runtime-distributions.json"
+          tool_venv="/tmp/cdx-tool"
+
+          if [ ! -x "$runtime_python" ]; then
+            echo "Runtime Python not found at $runtime_python" >&2
+            exit 1
+          fi
+
+          mkdir -p "$HOME"
+
+          "$runtime_python" - <<'PY' > "$runtime_distributions"
+          import importlib.metadata as metadata
+          import json
+          import sysconfig
+
+          paths = sorted({sysconfig.get_paths()[key] for key in ("purelib", "platlib")})
+          rows = []
+          seen = set()
+
+          for dist in metadata.distributions(path=paths):
+              name = dist.metadata.get("Name") or dist.name
+              version = dist.version
+              key = (name, version)
+              if key in seen:
+                  continue
+              seen.add(key)
+              rows.append({"name": name, "version": version})
+
+          print(json.dumps(sorted(rows, key=lambda row: row["name"].lower())))
+          PY
+
+          "$runtime_python" -m venv "$tool_venv"
+          "$tool_venv/bin/python" -m pip install -q --no-cache-dir --disable-pip-version-check "cyclonedx-bom==$CYCLONEDX_BOM_VERSION"
+          "$tool_venv/bin/cyclonedx-py" environment "$runtime_python" \
+            --spec-version "$CYCLONEDX_SPEC_VERSION" \
+            --output-format JSON \
+            --output-file "$OUTPUT_FILE" \
+            --validate
+
+          "$runtime_python" - "$runtime_distributions" "$OUTPUT_FILE" "$CYCLONEDX_SPEC_VERSION" <<'PY'
+          import json
+          import re
+          import sys
+
+          runtime_path, sbom_path, expected_spec = sys.argv[1:]
+
+          def normalize(name: str) -> str:
+              return re.sub(r"[-_.]+", "-", name).lower()
+
+          with open(runtime_path, encoding="utf-8") as handle:
+              runtime = json.load(handle)
+          with open(sbom_path, encoding="utf-8") as handle:
+              bom = json.load(handle)
+
+          if bom.get("bomFormat") != "CycloneDX":
+              raise SystemExit("Generated Python runtime SBOM is not CycloneDX JSON")
+          if bom.get("specVersion") != expected_spec:
+              raise SystemExit(
+                  f"Expected CycloneDX specVersion {expected_spec}, got {bom.get('specVersion')}"
+              )
+
+          components = bom.get("components") or []
+          if not components:
+              raise SystemExit("Generated Python runtime SBOM has no components")
+
+          component_pairs = {
+              (normalize(component.get("name", "")), str(component.get("version", "")))
+              for component in components
+              if component.get("name") and component.get("version")
+          }
+          missing = [
+              f"{dist['name']}=={dist['version']}"
+              for dist in runtime
+              if (normalize(dist["name"]), str(dist["version"])) not in component_pairs
+          ]
+          if missing:
+              raise SystemExit(
+                  "Generated Python runtime SBOM is missing installed distributions: "
+                  + ", ".join(missing[:20])
+              )
+
+          print(
+              f"Validated {len(runtime)} installed Python distributions "
+              f"against {len(components)} SBOM components."
+          )
+          PY
+          PYTHON_RUNTIME_SBOM
+
+            docker run --rm -i \
+              --platform "$PLATFORM" \
+              --user "$(id -u):$(id -g)" \
+              -e HOME=/tmp/cdx-home \
+              -e CYCLONEDX_BOM_VERSION \
+              -e CYCLONEDX_SPEC_VERSION \
+              -e OUTPUT_FILE="$output_file" \
+              -v "$PWD/$out_dir:/out" \
+              -v "$script_dir:/cdx-script:ro" \
+              --entrypoint /bin/sh \
+              "$backend_digest_ref" "/cdx-script/$(basename "$container_script")"
+
+            rm -rf "$script_dir"
+          }
+
+          backend_digest_ref=""
           generate_component_sbom "backend" "$BACKEND_IMAGE"
+          generate_backend_python_runtime_sbom "$backend_digest_ref"
           generate_component_sbom "frontend" "$FRONTEND_IMAGE"
 
           (
@@ -168,6 +297,8 @@ jobs:
             while read -r component image_ref digest_ref; do
               echo "| $component | \`$image_ref\` | \`$digest_ref\` |"
             done < "$out_dir/IMAGE-DIGESTS.txt"
+            echo ""
+            echo "Generated a backend Python runtime SBOM from \`/app/.venv\` in the backend image."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload workflow artifact
@@ -176,7 +307,7 @@ jobs:
           name: release-sbom-${{ steps.release.outputs.tag }}
           path: release-sbom/*
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 7
 
       - name: Attach SBOMs to GitHub release
         if: steps.release.outputs.upload-release-assets == 'true'
@@ -188,12 +319,13 @@ jobs:
 
           gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null
           release_assets=(
-            "release-sbom/eneo-backend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.cyclonedx.json#Backend SBOM - CycloneDX JSON"
-            "release-sbom/eneo-backend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.spdx.json#Backend SBOM - SPDX JSON"
-            "release-sbom/eneo-backend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.table.txt#Backend packages - readable table"
-            "release-sbom/eneo-frontend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.cyclonedx.json#Frontend SBOM - CycloneDX JSON"
-            "release-sbom/eneo-frontend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.spdx.json#Frontend SBOM - SPDX JSON"
-            "release-sbom/eneo-frontend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.table.txt#Frontend packages - readable table"
+            "release-sbom/eneo-backend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.cyclonedx.json#Backend image SBOM - CycloneDX JSON"
+            "release-sbom/eneo-backend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.spdx.json#Backend image SBOM - SPDX JSON"
+            "release-sbom/eneo-backend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.table.txt#Backend image packages - readable table"
+            "release-sbom/eneo-backend-python-runtime-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.cyclonedx.json#Backend Python runtime SBOM - CycloneDX JSON"
+            "release-sbom/eneo-frontend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.cyclonedx.json#Frontend image SBOM - CycloneDX JSON"
+            "release-sbom/eneo-frontend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.spdx.json#Frontend image SBOM - SPDX JSON"
+            "release-sbom/eneo-frontend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.table.txt#Frontend image packages - readable table"
             "release-sbom/IMAGE-DIGESTS.txt#Image digests scanned"
             "release-sbom/SBOM-SHA256SUMS.txt#SBOM file checksums"
           )

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -59,9 +59,11 @@ The repository uses GitHub security features and CI to prevent regressions:
   requests to `develop`, plus a weekly scheduled scan.
 - Release SBOMs are generated from the published backend and frontend container
   image digests and attached to GitHub Releases as CycloneDX JSON, SPDX JSON,
-  and human-readable table files. These assets provide dependency transparency
-  for each release; their authenticity currently relies on GitHub-managed
-  release asset storage and the image digests recorded in the SBOM bundle.
+  and human-readable table files. The backend release also includes a narrower
+  CycloneDX SBOM for the Python runtime installed in `/app/.venv` inside the
+  released backend image. These assets provide dependency transparency for each
+  release; their authenticity currently relies on GitHub-managed release asset
+  storage and the image digests recorded in the SBOM bundle.
   `SBOM-SHA256SUMS.txt` covers the SBOM files; container image integrity is
   verified through the GHCR image digests recorded in `IMAGE-DIGESTS.txt`.
 - Secret scanning and push protection should remain enabled for provider keys,

--- a/frontend/apps/docs-site/src/content/docs/release-sboms.mdx
+++ b/frontend/apps/docs-site/src/content/docs/release-sboms.mdx
@@ -29,12 +29,13 @@ Each release publishes these files:
 
 | File | Purpose |
 | --- | --- |
-| `eneo-backend-<release-tag>-linux-amd64.cyclonedx.json` | Backend SBOM in CycloneDX JSON |
-| `eneo-backend-<release-tag>-linux-amd64.spdx.json` | Backend SBOM in SPDX JSON |
-| `eneo-backend-<release-tag>-linux-amd64.table.txt` | Backend package list for human review |
-| `eneo-frontend-<release-tag>-linux-amd64.cyclonedx.json` | Frontend SBOM in CycloneDX JSON |
-| `eneo-frontend-<release-tag>-linux-amd64.spdx.json` | Frontend SBOM in SPDX JSON |
-| `eneo-frontend-<release-tag>-linux-amd64.table.txt` | Frontend package list for human review |
+| `eneo-backend-<release-tag>-linux-amd64.cyclonedx.json` | Backend image SBOM in CycloneDX JSON |
+| `eneo-backend-<release-tag>-linux-amd64.spdx.json` | Backend image SBOM in SPDX JSON |
+| `eneo-backend-<release-tag>-linux-amd64.table.txt` | Backend image package list for human review |
+| `eneo-backend-python-runtime-<release-tag>-linux-amd64.cyclonedx.json` | Backend Python runtime SBOM in CycloneDX JSON |
+| `eneo-frontend-<release-tag>-linux-amd64.cyclonedx.json` | Frontend image SBOM in CycloneDX JSON |
+| `eneo-frontend-<release-tag>-linux-amd64.spdx.json` | Frontend image SBOM in SPDX JSON |
+| `eneo-frontend-<release-tag>-linux-amd64.table.txt` | Frontend image package list for human review |
 | `IMAGE-DIGESTS.txt` | Exact image tags and digests that were scanned |
 | `SBOM-SHA256SUMS.txt` | SHA-256 checksums for the SBOM bundle |
 
@@ -47,6 +48,11 @@ The SBOMs describe packages Syft finds inside the released container images.
 For the backend image, this usually includes Debian packages, Python packages,
 and binaries. For the frontend image, this usually includes Debian packages,
 npm packages, and binaries.
+
+The backend Python runtime SBOM is narrower. It is generated from the Python
+environment installed at `/app/.venv` inside the released backend image. It is
+useful when you specifically want the Python runtime dependency inventory, but
+it does not replace the full backend image SBOM.
 
 The SBOMs are generated from immutable image digest references, not only from
 tags. `IMAGE-DIGESTS.txt` records the digest references used during the scan.
@@ -67,9 +73,11 @@ GitHub-managed release asset storage and the image digests recorded in
 
 1. Open the GitHub Release page for the version you use.
 2. Download the backend and frontend `.table.txt` files for a quick review.
-3. Download CycloneDX or SPDX files for your security tooling.
-4. Check `IMAGE-DIGESTS.txt` if you need the exact image digests scanned.
-5. Check `SBOM-SHA256SUMS.txt` if you need file checksums for the SBOM bundle.
+3. Download CycloneDX or SPDX image SBOMs for your security tooling.
+4. Download the backend Python runtime SBOM if you only need the Python
+   dependency inventory for the backend runtime environment.
+5. Check `IMAGE-DIGESTS.txt` if you need the exact image digests scanned.
+6. Check `SBOM-SHA256SUMS.txt` if you need file checksums for the SBOM bundle.
 
 To compare two releases, compare the SBOM files from both release pages. Package
 additions, removals, and version changes show what changed between the images.


### PR DESCRIPTION
## Summary
- Adds one backend-only Python runtime SBOM asset to the existing release SBOM workflow.
- Generates `eneo-backend-python-runtime-<release-tag>-linux-amd64.cyclonedx.json` from `/app/.venv` inside the resolved backend image digest.
- Keeps existing Syft backend/frontend image SBOMs unchanged as the full container inventory.
- Clarifies release asset labels and documentation so image SBOMs and the narrower Python runtime SBOM are distinct.

## Why
The release image digest remains the source of truth for published SBOMs. Syft already provides the full backend and frontend container inventory. The additional CycloneDX Python runtime SBOM gives a Python-specific dependency view for the backend runtime environment without adding PR SBOM generation, vulnerability gates, SBOM merging, signing, VEX, or a separate workflow.

## What changed
- `.github/workflows/release_sbom.yml`: installs pinned `cyclonedx-bom==7.3.0` into a temporary tool venv inside the backend image container, generates CycloneDX 1.6 from `/app/.venv/bin/python`, validates the generated SBOM against `importlib.metadata`, includes the new file in `SBOM-SHA256SUMS.txt`, and uploads it as a labeled release asset.
- `.github/workflows/release_sbom.yml`: keeps workflow-dispatch dry runs as temporary workflow artifacts and reduces artifact retention to 7 days; GitHub Release assets are still only uploaded when release publication or explicit upload is requested.
- `docs/SECURITY.md` and `frontend/apps/docs-site/src/content/docs/release-sboms.mdx`: document the new backend Python runtime SBOM and clarify that it complements, not replaces, the full image SBOM.

## What was deliberately not changed
- No new workflow was added.
- No PR-time SBOM generation was added.
- No vulnerability scanning, release gate, Dependency-Track upload, VEX, signing, attestation, or SBOM merge step was added.
- The existing Syft CycloneDX, SPDX, and table assets remain the primary full image SBOM outputs.

## Deletion / consolidation
No duplicate logic was removed. The change extends the existing release SBOM workflow rather than adding another workflow or release path.

## Risk and rollback
Risk is limited to the release SBOM workflow. The new step pulls/runs the resolved backend image digest and depends on PyPI availability for the pinned CycloneDX Python tool during SBOM generation. If it causes release workflow issues, revert this PR to return to the previous Syft-only asset set. Existing published image artifacts and application runtime behavior are not changed.

## Validation
- `yq -r '.jobs."release-sbom".steps[] | select(has("run")) | .run' .github/workflows/release_sbom.yml | bash -n` passed.
- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color=false .github/workflows/release_sbom.yml` passed.
- `git diff --check -- .github/workflows/release_sbom.yml docs/SECURITY.md frontend/apps/docs-site/src/content/docs/release-sboms.mdx` passed.
- Full extracted `Generate image SBOMs` step passed from `/tmp` against `v2.0.0-rc.2`, producing 9 release SBOM files.
- The generated backend Python runtime SBOM validated as CycloneDX 1.6 with 163 components and matched all 163 installed Python distributions from `/app/.venv`.
- `SBOM-SHA256SUMS.txt` included `eneo-backend-python-runtime-v2.0.0-rc.2-linux-amd64.cyclonedx.json`.
- `pre-commit run --files .github/workflows/release_sbom.yml docs/SECURITY.md frontend/apps/docs-site/src/content/docs/release-sboms.mdx` passed.
