### PR TITLE
chore(devx): add per-branch database snapshot scripts

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -19,6 +19,63 @@ Useful variants:
 ./scripts/run_pyright_in_devcontainer.sh src/intric/files/file_router.py
 ```
 
+## Per-branch database snapshots
+
+Switching git branches when a feature branch has applied Alembic migrations normally forces a manual downgrade or a wipe. Two helper scripts at the repo root turn this into a `git stash`-like workflow against the devcontainer Postgres.
+
+The active database (`backend/.env`'s `POSTGRES_DB`, typically `postgres`) is never renamed. Instead, branch state lives in side databases named `eneo_<sanitized-branch>`, plus a baseline `eneo_develop`.
+
+### Scripts
+
+- `./scripts/dev-db-init.sh` — bring the active DB to the right state for the current branch. Restores `eneo_<branch>` if a snapshot exists, otherwise clones from `eneo_develop`. Runs `alembic upgrade head` at the end. On first run it offers to bootstrap `eneo_develop` from the current active DB.
+- `./scripts/dev-db-commit.sh` — save the current active DB as `eneo_<branch>`. Overwrites any prior snapshot for that branch. Run before switching away if you want to come back to this exact state.
+
+Both scripts kick the backend's Postgres connection during the clone/drop; restart the backend (and worker, if running) afterwards. The exact restart command is printed by `dev-db-init.sh`.
+
+### Typical loop
+
+```bash
+git checkout new-feature
+./scripts/dev-db-init.sh         # clones from eneo_develop (first time on this branch)
+# ...work, add a migration, mutate data...
+./scripts/dev-db-commit.sh       # snapshot before switching away
+
+git checkout other-feature
+./scripts/dev-db-init.sh         # restores eneo_other_feature (or clones develop if none yet)
+```
+
+### One-off: bootstrap `eneo_develop` when you're already on a feature branch
+
+If the branch has migrations beyond `develop` and you want to seed the baseline without losing work:
+
+```bash
+# 1. Save current branch state
+./scripts/dev-db-commit.sh
+
+# 2. Find develop's alembic head by reading the down_revision of the branch's
+#    first new migration:
+git diff develop...HEAD --name-only -- alembic/versions/ | head -1
+# then: grep down_revision <that-file>
+
+# 3. Still on the branch (so alembic sees branch migrations), downgrade active to develop's head
+docker exec -u vscode eneo_devcontainer-eneo-1 bash -i -c \
+  "cd /workspace/backend && uv run alembic downgrade <develop-head-rev>"
+
+# 4. Switch git, then bootstrap
+git checkout develop
+./scripts/dev-db-init.sh         # answer 'y' to the bootstrap prompt
+```
+
+The branch snapshot from step 1 is untouched by step 3, so `git checkout <branch> && ./scripts/dev-db-init.sh` restores it later.
+
+### Inspecting state
+
+```bash
+docker exec -i eneo_devcontainer-db-1 psql -U postgres -c "\l" | grep eneo_
+docker exec -i eneo_devcontainer-db-1 psql -U postgres -d eneo_<branch> \
+  -c "select version_num from alembic_version;"
+```
+
 ## Environment variables
 
 | Variable                         | Required | Explanation                                              |

--- a/scripts/dev-db-commit.sh
+++ b/scripts/dev-db-commit.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DB_CONTAINER="eneo_devcontainer-db-1"
+ENV_FILE="${REPO_ROOT}/backend/.env"
+
+psql_t1() {
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d template1 -v ON_ERROR_STOP=1 "$@"
+}
+
+kick_connections() {
+  psql_t1 -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$1' AND pid <> pg_backend_pid();" >/dev/null
+}
+
+branch="$(git -C "$REPO_ROOT" symbolic-ref --short HEAD 2>/dev/null || true)"
+if [ -z "$branch" ]; then
+  echo "Error: no symbolic branch (detached HEAD?). Check out a branch first." >&2
+  exit 1
+fi
+sanitized="$(printf '%s' "$branch" | tr '/' '_' | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9_')"
+snapshot="eneo_${sanitized}"
+
+active="$(grep -E '^POSTGRES_DB=' "$ENV_FILE" | head -1 | cut -d= -f2-)"
+if [ -z "$active" ]; then
+  echo "Error: could not read POSTGRES_DB from $ENV_FILE" >&2
+  exit 1
+fi
+
+if [ "$active" = "$snapshot" ]; then
+  echo "Error: active DB ($active) equals branch snapshot name ($snapshot)." >&2
+  echo "This design keeps the active DB and snapshots distinct. Update backend/.env to use a fixed name (e.g. 'postgres')." >&2
+  exit 1
+fi
+
+echo "Snapshotting active DB '$active' → '$snapshot' (branch: $branch)..."
+kick_connections "$active"
+psql_t1 -c "DROP DATABASE IF EXISTS $snapshot;"
+psql_t1 -c "CREATE DATABASE $snapshot WITH TEMPLATE $active;"
+echo "Snapshot '$snapshot' saved. Backend connection was kicked — restart if needed."

--- a/scripts/dev-db-commit.sh
+++ b/scripts/dev-db-commit.sh
@@ -2,8 +2,21 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-DB_CONTAINER="eneo_devcontainer-db-1"
 ENV_FILE="${REPO_ROOT}/backend/.env"
+
+PROJECT="$(docker ps --filter label=com.docker.compose.service=eneo \
+                     --format '{{.Label "com.docker.compose.project"}}' | head -1)"
+if [ -z "$PROJECT" ]; then
+  echo "Error: no running compose project with an 'eneo' service. Is the devcontainer up?" >&2
+  exit 1
+fi
+DB_CONTAINER="$(docker ps --filter label=com.docker.compose.project="$PROJECT" \
+                          --filter label=com.docker.compose.service=db \
+                          --format '{{.Names}}' | head -1)"
+if [ -z "$DB_CONTAINER" ]; then
+  echo "Error: could not discover db container in project '$PROJECT'." >&2
+  exit 1
+fi
 
 psql_t1() {
   docker exec -i "$DB_CONTAINER" psql -U postgres -d template1 -v ON_ERROR_STOP=1 "$@"

--- a/scripts/dev-db-init.sh
+++ b/scripts/dev-db-init.sh
@@ -2,10 +2,33 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-DB_CONTAINER="eneo_devcontainer-db-1"
-APP_CONTAINER="eneo_devcontainer-eneo-1"
 ENV_FILE="${REPO_ROOT}/backend/.env"
 BASELINE="eneo_develop"
+
+PROJECT="$(docker ps --filter label=com.docker.compose.service=eneo \
+                     --format '{{.Label "com.docker.compose.project"}}' | head -1)"
+if [ -z "$PROJECT" ]; then
+  echo "Error: no running compose project with an 'eneo' service. Is the devcontainer up?" >&2
+  exit 1
+fi
+DB_CONTAINER="$(docker ps --filter label=com.docker.compose.project="$PROJECT" \
+                          --filter label=com.docker.compose.service=db \
+                          --format '{{.Names}}' | head -1)"
+APP_CONTAINER="$(docker ps --filter label=com.docker.compose.project="$PROJECT" \
+                           --filter label=com.docker.compose.service=eneo \
+                           --format '{{.Names}}' | head -1)"
+if [ -z "$DB_CONTAINER" ] || [ -z "$APP_CONTAINER" ]; then
+  echo "Error: could not discover db/eneo containers in project '$PROJECT'." >&2
+  exit 1
+fi
+
+# Detect whether we're running inside the eneo devcontainer (docker socket is
+# mounted, so docker commands work either way; this lets us skip the wasteful
+# `docker exec into self` for alembic and adjust the restart-instructions).
+IN_APP_CONTAINER=0
+if [ -f /.dockerenv ] && [ "$REPO_ROOT" = "/workspace" ]; then
+  IN_APP_CONTAINER=1
+fi
 
 psql_t1() {
   docker exec -i "$DB_CONTAINER" psql -U postgres -d template1 -v ON_ERROR_STOP=1 "$@"
@@ -86,10 +109,22 @@ psql_t1 -c "CREATE DATABASE $active WITH TEMPLATE $source_db;"
 echo "Active DB '$active' replaced with contents of '$source_db'."
 
 echo "Running alembic upgrade head..."
-docker exec -u vscode "$APP_CONTAINER" bash -i -c "cd /workspace/backend && uv run alembic upgrade head"
+if [ $IN_APP_CONTAINER -eq 1 ]; then
+  ( cd "${REPO_ROOT}/backend" && PATH="${HOME}/.local/bin:${PATH}" uv run alembic upgrade head )
+else
+  docker exec -u vscode "$APP_CONTAINER" bash -i -c "cd /workspace/backend && uv run alembic upgrade head"
+fi
 
-cat <<EOF
+if [ $IN_APP_CONTAINER -eq 1 ]; then
+  cat <<EOF
+
+Done. Restart backend with:
+  cd /workspace/backend && uv run start
+EOF
+else
+  cat <<EOF
 
 Done. Restart backend with:
   docker exec -u vscode $APP_CONTAINER bash -i -c "cd /workspace/backend && uv run start"
 EOF
+fi

--- a/scripts/dev-db-init.sh
+++ b/scripts/dev-db-init.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DB_CONTAINER="eneo_devcontainer-db-1"
+APP_CONTAINER="eneo_devcontainer-eneo-1"
+ENV_FILE="${REPO_ROOT}/backend/.env"
+BASELINE="eneo_develop"
+
+psql_t1() {
+  docker exec -i "$DB_CONTAINER" psql -U postgres -d template1 -v ON_ERROR_STOP=1 "$@"
+}
+
+db_exists() {
+  local n
+  n="$(psql_t1 -tAc "SELECT 1 FROM pg_database WHERE datname='$1'")"
+  [ "$n" = "1" ]
+}
+
+kick_connections() {
+  psql_t1 -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '$1' AND pid <> pg_backend_pid();" >/dev/null
+}
+
+confirm() {
+  local prompt="$1" ans
+  read -r -p "$prompt [y/N] " ans
+  ans="$(printf '%s' "$ans" | tr 'A-Z' 'a-z')"
+  [ "$ans" = "y" ] || [ "$ans" = "yes" ]
+}
+
+assume_yes=0
+[ "${1:-}" = "-y" ] && assume_yes=1
+
+branch="$(git -C "$REPO_ROOT" symbolic-ref --short HEAD 2>/dev/null || true)"
+if [ -z "$branch" ]; then
+  echo "Error: no symbolic branch (detached HEAD?). Check out a branch first." >&2
+  exit 1
+fi
+sanitized="$(printf '%s' "$branch" | tr '/' '_' | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9_')"
+snapshot="eneo_${sanitized}"
+
+active="$(grep -E '^POSTGRES_DB=' "$ENV_FILE" | head -1 | cut -d= -f2-)"
+if [ -z "$active" ]; then
+  echo "Error: could not read POSTGRES_DB from $ENV_FILE" >&2
+  exit 1
+fi
+
+if [ "$active" = "$snapshot" ]; then
+  echo "Error: active DB ($active) equals branch snapshot name ($snapshot)." >&2
+  echo "This design keeps the active DB and snapshots distinct. Update backend/.env to use a fixed name (e.g. 'postgres')." >&2
+  exit 1
+fi
+
+if ! db_exists "$BASELINE"; then
+  echo "No '$BASELINE' baseline found."
+  if [ $assume_yes -eq 0 ] && ! confirm "Snapshot current active DB ($active) as $BASELINE?"; then
+    echo "Aborted."
+    exit 1
+  fi
+  kick_connections "$active"
+  psql_t1 -c "CREATE DATABASE $BASELINE WITH TEMPLATE $active;"
+  echo "Bootstrapped $BASELINE from $active."
+fi
+
+if db_exists "$snapshot"; then
+  source_db="$snapshot"
+  echo "Branch '$branch' → restoring active DB from snapshot '$snapshot'."
+else
+  source_db="$BASELINE"
+  echo "Branch '$branch' → no snapshot found; cloning active DB from '$BASELINE'."
+fi
+
+if [ $assume_yes -eq 0 ]; then
+  echo
+  echo "WARNING: this will REPLACE active DB '$active' with contents of '$source_db'."
+  echo "Uncommitted changes will be lost. Run ./scripts/db-commit first to keep them."
+  if ! confirm "Continue?"; then
+    echo "Aborted."
+    exit 1
+  fi
+fi
+
+kick_connections "$active"
+psql_t1 -c "DROP DATABASE $active;"
+psql_t1 -c "CREATE DATABASE $active WITH TEMPLATE $source_db;"
+echo "Active DB '$active' replaced with contents of '$source_db'."
+
+echo "Running alembic upgrade head..."
+docker exec -u vscode "$APP_CONTAINER" bash -i -c "cd /workspace/backend && uv run alembic upgrade head"
+
+cat <<EOF
+
+Done. Restart backend with:
+  docker exec -u vscode $APP_CONTAINER bash -i -c "cd /workspace/backend && uv run start"
+EOF

--- a/scripts/dev-db-init.sh
+++ b/scripts/dev-db-init.sh
@@ -96,16 +96,36 @@ fi
 if [ $assume_yes -eq 0 ]; then
   echo
   echo "WARNING: this will REPLACE active DB '$active' with contents of '$source_db'."
-  echo "Uncommitted changes will be lost. Run ./scripts/db-commit first to keep them."
+  echo "Uncommitted changes will be lost. Run ./scripts/dev-db-commit.sh first to keep them."
   if ! confirm "Continue?"; then
     echo "Aborted."
     exit 1
   fi
 fi
 
+restore_suffix="$(date +%s)_$$"
+restore_tmp="eneo_restore_tmp_${restore_suffix}"
+restore_old="eneo_restore_old_${restore_suffix}"
+
+if db_exists "$restore_tmp"; then
+  echo "Removing leftover restore temp DB '$restore_tmp'."
+  kick_connections "$restore_tmp"
+  psql_t1 -c "DROP DATABASE $restore_tmp;"
+fi
+
+kick_connections "$source_db"
+psql_t1 -c "CREATE DATABASE $restore_tmp WITH TEMPLATE $source_db;"
+
 kick_connections "$active"
-psql_t1 -c "DROP DATABASE $active;"
-psql_t1 -c "CREATE DATABASE $active WITH TEMPLATE $source_db;"
+psql_t1 -c "ALTER DATABASE $active RENAME TO $restore_old;"
+if ! psql_t1 -c "ALTER DATABASE $restore_tmp RENAME TO $active;"; then
+  echo "Error: failed to rename '$restore_tmp' to '$active'. Restoring previous active DB." >&2
+  psql_t1 -c "ALTER DATABASE $restore_old RENAME TO $active;" || true
+  exit 1
+fi
+
+kick_connections "$restore_old"
+psql_t1 -c "DROP DATABASE $restore_old;"
 echo "Active DB '$active' replaced with contents of '$source_db'."
 
 echo "Running alembic upgrade head..."


### PR DESCRIPTION
## Summary

  Adds two helper scripts that give the devcontainer Postgres a `git stash`-like workflow, so switching git branches when a feature branch has applied Alembic migrations no longer forces a manual downgrade or a
  wipe.

  The active database name in `backend/.env` is never mutated. Instead, branch state lives in side databases named `eneo_<branch>`, with `eneo_develop` as the baseline.

  ## What's added

  - `scripts/dev-db-init.sh` — restores active DB from `eneo_<branch>` if a snapshot exists, otherwise clones from `eneo_develop`. Runs `alembic upgrade head` at the end. On first run, offers to bootstrap
  `eneo_develop` from whatever is in the active DB.
  - `scripts/dev-db-commit.sh` — saves the active DB as `eneo_<branch>`. Overwrites any prior snapshot for that branch.
  - Section in `backend/README.md` documenting the mental model, the typical loop, and a one-off recipe for bootstrapping `eneo_develop` when you're already on a feature branch with applied migrations.

  ## How it works

  `CREATE DATABASE ... TEMPLATE` is an engine-level file copy on the same Postgres instance, so snapshots are independent of the active DB after creation. The scripts terminate connections to the source DB before
  each clone (Postgres requires no other sessions on the template) and print the exact restart command for the backend afterwards.

  ## Typical loop

  ```bash
  git checkout new-feature
  ./scripts/dev-db-init.sh         # clones from eneo_develop (first time on this branch)
  # ...work, add a migration, mutate data...
  ./scripts/dev-db-commit.sh       # snapshot before switching away

  git checkout other-feature
  ./scripts/dev-db-init.sh         # restores eneo_other_feature, or clones develop if none yet
  ```

  ## Scope

  - Devcontainer / local dev only. Nothing about production migration tooling changes.
  - `backend/.env`, `backend/src/intric/main/config.py`, `backend/alembic/env.py`, and the compose files are untouched.
  - No new Python dependencies or migrations.