### PR TITLE
chore(devcontainer): install ripgrep

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,3 +2,7 @@ FROM mcr.microsoft.com/devcontainers/python:3.11-bookworm
 
 # Remove Yarn repository (expired GPG key causes apt-get update failures)
 RUN rm -f /etc/apt/sources.list.d/yarn.list
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ripgrep \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adds ripgrep via apt so rg is available inside the devcontainer for faster code search.

## Changes
Add ripgrep to devcontainer

## Why
Codex reaches for rg most of the time, good tool to have


