### PR TITLE
chore(security): attest release SBOM artifacts

### DIFF
--- a/.github/workflows/build_and_push_images.yml
+++ b/.github/workflows/build_and_push_images.yml
@@ -35,6 +35,7 @@ jobs:
       contents: write
       packages: write
       attestations: write
+      artifact-metadata: write
       id-token: write
 
     steps:
@@ -148,6 +149,7 @@ jobs:
           ./scripts/inject-backend-version.sh "$VERSION"
 
       - name: Build and push backend Docker image
+        id: build-backend
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./backend
@@ -159,6 +161,13 @@ jobs:
           labels: ${{ steps.meta-backend.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Attest backend image provenance
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}
+          subject-digest: ${{ steps.build-backend.outputs.digest }}
+          push-to-registry: true
 
       # Frontend build and push
       - name: Extract frontend metadata
@@ -191,6 +200,7 @@ jobs:
           ./scripts/sync-frontend-with-backend.sh "${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:$BACKEND_TAG"
 
       - name: Build and push frontend Docker image
+        id: build-frontend
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./frontend
@@ -200,6 +210,13 @@ jobs:
           labels: ${{ steps.meta-frontend.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Attest frontend image provenance
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.FRONTEND_IMAGE_NAME }}
+          subject-digest: ${{ steps.build-frontend.outputs.digest }}
+          push-to-registry: true
 
       # Summary of what was built
       - name: Build Summary

--- a/.github/workflows/release_sbom.yml
+++ b/.github/workflows/release_sbom.yml
@@ -19,6 +19,9 @@ on:
 permissions:
   contents: write
   packages: read
+  attestations: write
+  artifact-metadata: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.release.tag_name || inputs.tag }}
@@ -31,6 +34,7 @@ env:
   PLATFORM_OS: linux
   PLATFORM_ARCH: amd64
   SYFT_VERSION: v1.44.0
+  CDXGEN_VERSION: 12.4.4
   CYCLONEDX_BOM_VERSION: "7.3.0"
   CYCLONEDX_SPEC_VERSION: "1.6"
 
@@ -70,8 +74,23 @@ jobs:
             echo "upload-release-assets=$upload_release_assets"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Checkout release source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ steps.release.outputs.tag }}
+          persist-credentials: false
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.0
+
+      - name: Install frontend dependencies for source SBOM
+        working-directory: frontend
+        run: bun install --frozen-lockfile
 
       - name: Log in to GHCR
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -277,10 +296,38 @@ jobs:
             rm -rf "$script_dir"
           }
 
+          validate_cyclonedx_sbom() {
+            local file="$1"
+            local description="$2"
+
+            jq -e --arg description "$description" '
+              .bomFormat == "CycloneDX"
+              and ((.components // []) | length > 0)
+              or halt_error(1)
+            ' "$file" >/dev/null || {
+              echo "::error::$description is not a non-empty CycloneDX SBOM: $file" >&2
+              exit 1
+            }
+          }
+
+          generate_frontend_source_sbom() {
+            local asset_prefix="eneo-frontend-source-${RELEASE_TAG}"
+            local output_file="$out_dir/${asset_prefix}.cyclonedx.json"
+
+            npx --yes "@cyclonedx/cdxgen@$CDXGEN_VERSION" \
+              -r frontend \
+              -o "$output_file" \
+              --spec-version "$CYCLONEDX_SPEC_VERSION" \
+              --validate
+
+            validate_cyclonedx_sbom "$output_file" "Frontend source dependency SBOM"
+          }
+
           backend_digest_ref=""
           generate_component_sbom "backend" "$BACKEND_IMAGE"
           generate_backend_python_runtime_sbom "$backend_digest_ref"
           generate_component_sbom "frontend" "$FRONTEND_IMAGE"
+          generate_frontend_source_sbom
 
           (
             cd "$out_dir"
@@ -299,6 +346,7 @@ jobs:
             done < "$out_dir/IMAGE-DIGESTS.txt"
             echo ""
             echo "Generated a backend Python runtime SBOM from \`/app/.venv\` in the backend image."
+            echo "Generated a frontend source dependency SBOM from the checked-out release tag."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload workflow artifact
@@ -308,6 +356,12 @@ jobs:
           path: release-sbom/*
           if-no-files-found: error
           retention-days: 7
+
+      - name: Attest release SBOM assets
+        if: steps.release.outputs.upload-release-assets == 'true'
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
+        with:
+          subject-path: release-sbom/*
 
       - name: Attach SBOMs to GitHub release
         if: steps.release.outputs.upload-release-assets == 'true'
@@ -326,6 +380,7 @@ jobs:
             "release-sbom/eneo-frontend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.cyclonedx.json#Frontend image SBOM - CycloneDX JSON"
             "release-sbom/eneo-frontend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.spdx.json#Frontend image SBOM - SPDX JSON"
             "release-sbom/eneo-frontend-${RELEASE_TAG}-${PLATFORM_OS}-${PLATFORM_ARCH}.table.txt#Frontend image packages - readable table"
+            "release-sbom/eneo-frontend-source-${RELEASE_TAG}.cyclonedx.json#Frontend source dependencies - CycloneDX JSON"
             "release-sbom/IMAGE-DIGESTS.txt#Image digests scanned"
             "release-sbom/SBOM-SHA256SUMS.txt#SBOM file checksums"
           )

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -61,11 +61,15 @@ The repository uses GitHub security features and CI to prevent regressions:
   image digests and attached to GitHub Releases as CycloneDX JSON, SPDX JSON,
   and human-readable table files. The backend release also includes a narrower
   CycloneDX SBOM for the Python runtime installed in `/app/.venv` inside the
-  released backend image. These assets provide dependency transparency for each
-  release; their authenticity currently relies on GitHub-managed release asset
-  storage and the image digests recorded in the SBOM bundle.
-  `SBOM-SHA256SUMS.txt` covers the SBOM files; container image integrity is
-  verified through the GHCR image digests recorded in `IMAGE-DIGESTS.txt`.
+  released backend image. The frontend release also includes a source dependency
+  SBOM generated with CycloneDX Generator after installing the frontend from the
+  checked-out release tag with the frozen Bun lockfile, so JavaScript
+  dependencies remain visible even when the runtime image only contains the
+  bundled build output. Release SBOM assets are attested through GitHub artifact
+  attestations, and the pushed backend and frontend images include provenance
+  attestations in GHCR.
+  `SBOM-SHA256SUMS.txt` covers the SBOM files; `IMAGE-DIGESTS.txt` records the
+  exact image digests scanned.
 - Secret scanning and push protection should remain enabled for provider keys,
   tokens, credentials, and other repository secrets.
 - The normal `CI` gate validates frozen backend and frontend installs before

--- a/frontend/apps/docs-site/src/content/docs/index.mdx
+++ b/frontend/apps/docs-site/src/content/docs/index.mdx
@@ -37,10 +37,11 @@ How Eneo tracks token usage for LLM requests:
 - How token data flows to Insights dashboards
 
 ### [Release SBOMs](/docs/release-sboms)
-Downloadable SBOMs for released container images:
+Downloadable SBOMs and attestations for released artifacts:
 - CycloneDX and SPDX files for security tooling
+- Frontend source dependency inventory from the release lockfile
 - Human-readable package lists for quick review
-- Image digests and SBOM checksums for release comparison
+- Image digests, checksums, and provenance verification
 
 ### [API Reference](/docs/api)
 Complete API documentation for developers:

--- a/frontend/apps/docs-site/src/content/docs/release-sboms.mdx
+++ b/frontend/apps/docs-site/src/content/docs/release-sboms.mdx
@@ -21,14 +21,20 @@ When maintainers publish a GitHub Release, the release SBOM workflow runs
 automatically:
 
 1. The workflow reads the release tag and derives the container image tag.
-2. It waits for the matching backend and frontend images in GitHub Container
+2. It checks out the release tag for source-based dependency inventory.
+3. It waits for the matching backend and frontend images in GitHub Container
    Registry.
-3. It resolves the immutable `linux/amd64` image digest for each image.
-4. It scans those digest references, not only the mutable image tags.
-5. It uploads the generated files to the same GitHub Release page.
+4. It resolves the immutable `linux/amd64` image digest for each image.
+5. It scans those digest references, not only the mutable image tags.
+6. It installs frontend dependencies with Bun's frozen lockfile and generates a
+   frontend source dependency SBOM.
+7. It uploads the generated files to the same GitHub Release page.
+8. It attests the release SBOM assets with GitHub artifact attestations.
 
 Each release keeps its own SBOM files. Older release pages keep their original
-assets, so you can compare one version with the next.
+assets, so you can compare one version with the next. The backend and frontend
+container images also get provenance attestations when they are built and pushed
+to GitHub Container Registry.
 
 The same workflow can also run manually as a dry run. In dry-run mode it creates
 the files as a temporary workflow artifact and does not attach them to the
@@ -69,20 +75,27 @@ flowchart TD
 
   syft["Syft scans full images<br/>backend and frontend"]
   python["CycloneDX Python scans<br/>backend /app/.venv"]
+  source["CycloneDX Generator scans frontend source<br/>installed from frozen lockfile"]
 
   imageSboms["Image SBOM assets<br/>CycloneDX, SPDX, table"]
   runtimeSbom["Backend Python runtime SBOM<br/>CycloneDX JSON"]
+  sourceSbom["Frontend source dependency SBOM<br/>CycloneDX JSON"]
   verification["Verification files<br/>image digests and checksums"]
+  attestation["GitHub artifact attestations<br/>for release SBOM assets"]
 
   release --> tag --> digests
   manual --> tag
   digests --> syft
   digests --> python
+  tag --> source
   syft --> imageSboms
   python --> runtimeSbom
+  source --> sourceSbom
   imageSboms --> verification
   runtimeSbom --> verification
+  sourceSbom --> verification
   verification --> upload["Attach assets to<br/>the same GitHub Release"]
+  verification --> attestation
   manual -. dry run .-> artifact["Temporary workflow artifact"]
 
   classDef trigger fill:#eff6ff,stroke:#2563eb,color:#0f172a
@@ -93,9 +106,9 @@ flowchart TD
 
   class release,manual,tag trigger
   class digests source
-  class syft,python scanner
-  class imageSboms,runtimeSbom asset
-  class verification,upload,artifact output
+  class syft,python,source scanner
+  class imageSboms,runtimeSbom,sourceSbom asset
+  class verification,upload,artifact,attestation output
 ```
 
 </div>
@@ -127,6 +140,12 @@ Eneo scans the released image digests instead of source lockfiles because the
 image digest is the shipped artifact. Lockfiles describe build input; the image
 describes what users receive.
 
+There is one deliberate exception: the frontend source dependency SBOM. The
+frontend runtime image contains the bundled build output, not the full Bun
+workspace dependency tree. The source dependency SBOM keeps the JavaScript
+dependency inventory visible for scanners and reviewers. Treat it as build-input
+dependency inventory, not as a byte-for-byte inventory of the runtime image.
+
 ## Files on the release page
 
 Each release publishes these files:
@@ -140,6 +159,7 @@ Each release publishes these files:
 | `eneo-frontend-<release-tag>-linux-amd64.cyclonedx.json` | Frontend image SBOM in CycloneDX JSON |
 | `eneo-frontend-<release-tag>-linux-amd64.spdx.json` | Frontend image SBOM in SPDX JSON |
 | `eneo-frontend-<release-tag>-linux-amd64.table.txt` | Frontend image package list for human review |
+| `eneo-frontend-source-<release-tag>.cyclonedx.json` | Frontend source dependency SBOM in CycloneDX JSON |
 | `IMAGE-DIGESTS.txt` | Exact image tags and digests that were scanned |
 | `SBOM-SHA256SUMS.txt` | SHA-256 checksums for the SBOM bundle |
 
@@ -160,8 +180,14 @@ For the backend image, this usually includes:
 For the frontend image, this usually includes:
 
 - operating system packages
-- npm packages present in the image
+- npm packages still identifiable from the bundled runtime image
 - binaries and other package metadata Syft can identify
+
+The frontend source dependency SBOM is broader than the frontend image SBOM. It
+is generated from the checked-out release tag after the workflow runs
+`bun install --frozen-lockfile` against `frontend/bun.lock`. It can include
+build-time dependencies that are not present as separate packages in the runtime
+image.
 
 The backend Python runtime SBOM is narrower. It is generated from the Python
 environment installed at `/app/.venv` inside the released backend image. It is
@@ -182,12 +208,35 @@ Use `eneo-backend-python-runtime-<release-tag>-linux-amd64.cyclonedx.json` when
 you want a focused view of the Python packages installed in the backend runtime
 environment.
 
+Use `eneo-frontend-source-<release-tag>.cyclonedx.json` when you want a focused
+view of frontend JavaScript dependencies from the release source and lockfile.
+
 Use the `.table.txt` files when you want to read the package list without
 importing an SBOM into another tool.
 
 Use `IMAGE-DIGESTS.txt` to see which GHCR image digests were scanned. Use
 `SBOM-SHA256SUMS.txt` to check the downloaded SBOM files against the checksums
 published with the release.
+
+Use GitHub artifact attestations when you need cryptographic evidence that a
+release SBOM asset was generated by Eneo's GitHub Actions workflow:
+
+```bash
+gh attestation verify ./eneo-backend-v2.0.0-linux-amd64.cyclonedx.json \
+  --repo eneo-ai/eneo
+```
+
+The backend and frontend container images also have provenance attestations in
+GitHub Container Registry:
+
+```bash
+gh attestation verify oci://ghcr.io/eneo-ai/eneo-backend:2.0.0 \
+  --repo eneo-ai/eneo
+```
+
+If an image package is private, verification follows normal GitHub and GHCR
+access rules. No separate identity provider is required to read or verify the
+SBOM.
 
 ## What the SBOM does not cover
 
@@ -197,9 +246,9 @@ whether a vulnerability is reachable in Eneo.
 Use vulnerability scanners such as Grype, Trivy, GitHub Advanced Security, or
 your internal tooling if you need vulnerability findings based on the SBOM.
 
-The current release assets are not signed. Their authenticity relies on
-GitHub-managed release asset storage and the image digests recorded in
-`IMAGE-DIGESTS.txt`.
+The attestations prove where the release SBOM assets and container images came
+from. They do not decide whether a dependency is vulnerable or whether a
+vulnerability is reachable in Eneo.
 
 The current release workflow publishes `linux/amd64` SBOM files. If Eneo adds
 more release platforms later, each platform should get its own SBOM files
@@ -218,10 +267,17 @@ These references explain the formats and tools used by Eneo:
   image SBOMs.
 - [CycloneDX Python](https://github.com/CycloneDX/cyclonedx-python) is used for
   the backend Python runtime SBOM.
+- [CycloneDX Generator](https://github.com/CycloneDX/cdxgen) is used for the
+  frontend source dependency SBOM.
 - [Anchore SBOM Action](https://github.com/anchore/sbom-action) provides the
   GitHub Action helpers used to download Syft in the release workflow.
 - [SPDX](https://spdx.dev/learn/overview/) is the other machine-readable SBOM
   format published for each image.
+- [GitHub artifact attestations](https://docs.github.com/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations)
+  provide cryptographic provenance for the release SBOM assets and container
+  images.
+- [SLSA provenance](https://slsa.dev/spec/v1.1/provenance) describes where a
+  built artifact came from and how it was produced.
 
 ## Check a release
 
@@ -231,8 +287,11 @@ These references explain the formats and tools used by Eneo:
 3. Download CycloneDX or SPDX image SBOMs for your security tooling.
 4. Download the backend Python runtime SBOM if you only need the Python
    dependency inventory for the backend runtime environment.
-5. Check `IMAGE-DIGESTS.txt` if you need the exact image digests scanned.
-6. Check `SBOM-SHA256SUMS.txt` if you need file checksums for the SBOM bundle.
+5. Download the frontend source dependency SBOM if you need the JavaScript
+   dependency inventory from the release source and lockfile.
+6. Check `IMAGE-DIGESTS.txt` if you need the exact image digests scanned.
+7. Check `SBOM-SHA256SUMS.txt` if you need file checksums for the SBOM bundle.
+8. Use `gh attestation verify` if you need cryptographic provenance.
 
 To compare two releases, compare the SBOM files from both release pages. Package
 additions, removals, and version changes show what changed between the images.


### PR DESCRIPTION
## Summary
- Adds GitHub artifact attestations for generated release SBOM assets when they are uploaded to a GitHub Release.
- Adds provenance attestations for backend and frontend images pushed to GHCR.
- Adds a frontend source dependency CycloneDX SBOM generated from the checked-out release tag after `bun install --frozen-lockfile`.
- Updates the security docs and docs-site SBOM page to explain the release assets, attestations, and verification flow.

## Why
The release workflow already scans the published GHCR image digests, which remains the source of truth for shipped container contents. The main gap was provenance: `SBOM-SHA256SUMS.txt` is useful for file integrity, but it is stored beside the files it describes. GitHub artifact attestations add verifiable provenance from the GitHub Actions run that generated the release assets.

The frontend runtime image contains bundled output, so the image SBOM can under-represent JavaScript build dependencies. The source dependency SBOM gives scanners and reviewers a clearer frontend dependency inventory without adding PR SBOM generation or release gates.

## What changed
- `.github/workflows/release_sbom.yml`
  - checks out the release tag before SBOM generation;
  - installs frontend dependencies with Bun using the frozen lockfile;
  - generates `eneo-frontend-source-<release-tag>.cyclonedx.json` with CycloneDX Generator;
  - includes the new file in `SBOM-SHA256SUMS.txt`, workflow artifacts, and release uploads;
  - attests the release SBOM asset files only when `upload_release_assets=true`.
- `.github/workflows/build_and_push_images.yml`
  - publishes provenance attestations for pushed backend and frontend GHCR images.
- `docs/SECURITY.md` and `frontend/apps/docs-site/src/content/docs/release-sboms.mdx`
  - document the new source SBOM, artifact attestations, image provenance, and verification commands.
- `frontend/apps/docs-site/src/content/docs/index.mdx`
  - updates the docs landing-page summary for release SBOMs.

## What was deliberately not changed
- No PR SBOM workflow was added.
- No vulnerability gate, VEX publishing, Dependency-Track integration, or release blocking policy was added.
- No SBOM merge step was added; separate assets stay explicit and easier to inspect.
- No image SBOM OCI referrer publishing was added yet; this PR covers release-file attestations and image build provenance.
- No external identity provider setup is required. GitHub Actions handles the OIDC token used for keyless attestation.

## Deletion / consolidation
No files or compatibility paths were deleted. This keeps the release workflow as the single owner for downloadable release SBOM assets and extends the existing image build workflow for image provenance.

## Risk and rollback
- Release workflow risk is limited to release/manual SBOM generation. The new source SBOM adds a Bun install and `npx @cyclonedx/cdxgen` during that workflow.
- Attestation upload for release SBOMs is skipped during dry runs and runs only when `upload_release_assets=true`.
- Image build workflow now writes provenance metadata to GHCR for pushed images. If that causes registry or permission issues, revert the attestation steps and the added workflow permissions.
- Rollback is a straight revert of this commit; existing Syft image SBOM assets remain unchanged.

## Validation
- `git diff --check -- .github/workflows/build_and_push_images.yml .github/workflows/release_sbom.yml docs/SECURITY.md frontend/apps/docs-site/src/content/docs/index.mdx frontend/apps/docs-site/src/content/docs/release-sboms.mdx` passed.
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest .github/workflows/release_sbom.yml` passed.
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -shellcheck '' .github/workflows/build_and_push_images.yml .github/workflows/release_sbom.yml` passed.
- Extracted `run:` shell blocks from `.github/workflows/release_sbom.yml` and ran `bash -n`; passed.
- `pre-commit run --files .github/workflows/build_and_push_images.yml .github/workflows/release_sbom.yml docs/SECURITY.md frontend/apps/docs-site/src/content/docs/index.mdx frontend/apps/docs-site/src/content/docs/release-sboms.mdx` passed.
- `pre-commit run --files frontend/apps/docs-site/src/content/docs/release-sboms.mdx` passed after the final wording amend.
- `bun run build` in `frontend/apps/docs-site` passed. It still reports the existing unrelated `@next/next/no-img-element` warning in `src/mdx-components.js`.
- Local CycloneDX Generator checks produced valid CycloneDX 1.6 frontend source SBOMs from a clean frontend checkout.
- Docker-based CycloneDX Generator check with `ghcr.io/cyclonedx/cdxgen-bun:v12.4.4` produced a valid CycloneDX 1.6 frontend source SBOM after `bun install --frozen-lockfile`.
- GitHub Actions dry run passed: `release_sbom.yml`, branch `feature/security-sbom-attestations`, tag `v2.0.0-rc.2`, `upload_release_assets=false`, run `26627284364`.
- Downloaded the dry-run workflow artifact and confirmed it includes `eneo-frontend-source-v2.0.0-rc.2.cyclonedx.json` plus the existing image/runtime SBOM files and checksum files.
- The dry run correctly skipped release upload and release SBOM attestation because `upload_release_assets=false`.

Note: the dry run showed GitHub's Node.js 20 deprecation annotation for existing third-party actions. That is separate from this change and should be handled as a follow-up workflow maintenance task.
