### PR TITLE
Unique model display names + transcription model migration

### DIFF
--- a/backend/alembic/versions/20260601_align_model_tables.py
+++ b/backend/alembic/versions/20260601_align_model_tables.py
@@ -1,0 +1,72 @@
+"""align model tables: add nickname + deleted_at parity
+
+Phase 1 of the model-table alignment (docs/plans/model-table-alignment).
+Purely additive — no behaviour change. Brings the three model tables to a
+parallel shape so later phases (display-name uniqueness, unified soft-delete)
+can be built once instead of three times:
+
+  - transcription_models gains `nickname` (display name), backfilled from the
+    current `name` so end users see an identical label. Note: transcription
+    still writes the display name to `name` today (model_name holds the API id);
+    `nickname` is unused until a later phase switches the source of truth.
+  - embedding_models and transcription_models gain `deleted_at` for soft-delete
+    parity with completion_models (nullable, indexed, unused for now).
+
+Revision ID: 20260601_align_model_tables
+Revises: 20260501_backfill_model_costs
+Create Date: 2026-06-01
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision = "20260601_align_model_tables"
+down_revision = "20260501_backfill_model_costs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # transcription_models: add display-name column, backfill from name so the
+    # label users see is unchanged.
+    op.add_column(
+        "transcription_models",
+        sa.Column("nickname", sa.String(), nullable=True),
+    )
+    op.execute(
+        "UPDATE transcription_models SET nickname = name WHERE nickname IS NULL"
+    )
+
+    # Soft-delete parity with completion_models (which already has deleted_at).
+    op.add_column(
+        "embedding_models",
+        sa.Column("deleted_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_embedding_models_deleted_at", "embedding_models", ["deleted_at"]
+    )
+    op.add_column(
+        "transcription_models",
+        sa.Column("deleted_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_transcription_models_deleted_at",
+        "transcription_models",
+        ["deleted_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_transcription_models_deleted_at", table_name="transcription_models"
+    )
+    op.drop_column("transcription_models", "deleted_at")
+
+    op.drop_index(
+        "ix_embedding_models_deleted_at", table_name="embedding_models"
+    )
+    op.drop_column("embedding_models", "deleted_at")
+
+    op.drop_column("transcription_models", "nickname")

--- a/backend/alembic/versions/20260602_unique_model_display_names.py
+++ b/backend/alembic/versions/20260602_unique_model_display_names.py
@@ -4,21 +4,26 @@ Phase 3 of the model-table alignment (docs/plans/model-table-alignment).
 
 A model's display name (`nickname`) is what users pick from in the chat model
 selector and admin tables. Nothing stopped two *active* models in the same
-tenant from sharing one — producing rows that are impossible to tell apart
-(e.g. several identical "gpt-5.1" entries). This migration:
+tenant *and provider* from sharing one — producing rows that are impossible to
+tell apart (e.g. several identical "gpt-5.1" entries). This migration:
 
   1. Renames existing active duplicates with a " (2)", " (3)" … suffix, keeping
      the oldest row untouched. No references are changed.
   2. Adds a partial unique index per table on
-     (coalesce(tenant_id, sentinel), lower(nickname)) restricted to *active*
-     rows, so the collision cannot recur.
+     (coalesce(tenant_id, sentinel), coalesce(provider_id, sentinel),
+     lower(nickname)) restricted to *active* rows, so the collision cannot recur.
+
+The scope includes `provider_id`: the same display name may intentionally repeat
+across providers (e.g. a "gpt-5.1" sourced from two different providers in the
+same tenant). Global models (tenant_id IS NULL) always have provider_id NULL, so
+they collapse onto a single sentinel scope and stay unique per name as before.
 
 "Active" = visible to end users = `deleted_at IS NULL AND is_deprecated = false`
 (the same predicate the selector uses). Deprecated or soft-deleted rows kept for
 historical references may freely reuse a name and never block a new one.
 
-The same underlying model `name` may still repeat across providers/configs — it
-is the *display name* that must be distinct.
+The same underlying model `name` may still repeat freely — it is the *display
+name*, within one (tenant, provider), that must be distinct.
 
 Revision ID: 20260602_unique_model_display_names
 Revises: 20260601_align_model_tables
@@ -48,39 +53,43 @@ SENTINEL = "00000000-0000-0000-0000-000000000000"
 _TABLES = ("completion_models", "embedding_models", "transcription_models")
 
 
-def _scope(tenant_id) -> str:
-    return str(tenant_id) if tenant_id is not None else SENTINEL
+def _scope(value) -> str:
+    return str(value) if value is not None else SENTINEL
 
 
 def _dedupe(conn, table: str) -> None:
     rows = conn.execute(
         sa.text(
             f"""
-            SELECT id, tenant_id, nickname
+            SELECT id, tenant_id, provider_id, nickname
             FROM {table}
             WHERE deleted_at IS NULL
               AND is_deprecated = false
               AND nickname IS NOT NULL
             ORDER BY COALESCE(tenant_id::text, :sentinel),
+                     COALESCE(provider_id::text, :sentinel),
                      lower(nickname), created_at, id
             """
         ),
         {"sentinel": SENTINEL},
     ).fetchall()
 
-    # Every active display name currently taken, per scope. Renames update it so
-    # a suffixed name never lands on another active row (in any group).
-    taken: dict[str, set[str]] = defaultdict(set)
+    # Every active display name currently taken, per (tenant, provider) scope.
+    # Renames update it so a suffixed name never lands on another active row.
+    taken: dict[tuple[str, str], set[str]] = defaultdict(set)
     for row in rows:
-        taken[_scope(row.tenant_id)].add(row.nickname.lower())
+        taken[(_scope(row.tenant_id), _scope(row.provider_id))].add(
+            row.nickname.lower()
+        )
 
     def group_key(row):
-        return (_scope(row.tenant_id), row.nickname.lower())
+        return (_scope(row.tenant_id), _scope(row.provider_id), row.nickname.lower())
 
-    for (scope, _lower), group in groupby(rows, key=group_key):
+    for (tenant_scope, provider_scope, _lower), group in groupby(rows, key=group_key):
         members = list(group)
         if len(members) <= 1:
             continue
+        scope = (tenant_scope, provider_scope)
         # Keep the oldest (first by created_at) as-is; suffix the rest.
         for row in members[1:]:
             base = row.nickname
@@ -102,7 +111,11 @@ def upgrade() -> None:
         op.execute(
             f"""
             CREATE UNIQUE INDEX uq_{table}_active_nickname
-            ON {table} (COALESCE(tenant_id, '{SENTINEL}'::uuid), lower(nickname))
+            ON {table} (
+                COALESCE(tenant_id, '{SENTINEL}'::uuid),
+                COALESCE(provider_id, '{SENTINEL}'::uuid),
+                lower(nickname)
+            )
             WHERE deleted_at IS NULL
               AND is_deprecated = false
               AND nickname IS NOT NULL

--- a/backend/alembic/versions/20260602_unique_model_display_names.py
+++ b/backend/alembic/versions/20260602_unique_model_display_names.py
@@ -1,0 +1,117 @@
+"""enforce unique active display names across model tables
+
+Phase 3 of the model-table alignment (docs/plans/model-table-alignment).
+
+A model's display name (`nickname`) is what users pick from in the chat model
+selector and admin tables. Nothing stopped two *active* models in the same
+tenant from sharing one — producing rows that are impossible to tell apart
+(e.g. several identical "gpt-5.1" entries). This migration:
+
+  1. Renames existing active duplicates with a " (2)", " (3)" … suffix, keeping
+     the oldest row untouched. No references are changed.
+  2. Adds a partial unique index per table on
+     (coalesce(tenant_id, sentinel), lower(nickname)) restricted to *active*
+     rows, so the collision cannot recur.
+
+"Active" = visible to end users = `deleted_at IS NULL AND is_deprecated = false`
+(the same predicate the selector uses). Deprecated or soft-deleted rows kept for
+historical references may freely reuse a name and never block a new one.
+
+The same underlying model `name` may still repeat across providers/configs — it
+is the *display name* that must be distinct.
+
+Revision ID: 20260602_unique_model_display_names
+Revises: 20260601_align_model_tables
+Create Date: 2026-06-02
+
+"""
+from collections import defaultdict
+from itertools import groupby
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic
+# NB: revision id must fit alembic_version.version_num (varchar(32)); the
+# longer descriptive name lives in the filename, not here.
+revision = "20260602_unique_display_names"
+down_revision = "20260601_align_model_tables"
+branch_labels = None
+depends_on = None
+
+# Stand-in tenant_id for global (tenant_id IS NULL) rows so they share one
+# uniqueness scope. Postgres treats NULLs as distinct in a unique index, so
+# without this two global models could collide undetected.
+SENTINEL = "00000000-0000-0000-0000-000000000000"
+
+_TABLES = ("completion_models", "embedding_models", "transcription_models")
+
+
+def _scope(tenant_id) -> str:
+    return str(tenant_id) if tenant_id is not None else SENTINEL
+
+
+def _dedupe(conn, table: str) -> None:
+    rows = conn.execute(
+        sa.text(
+            f"""
+            SELECT id, tenant_id, nickname
+            FROM {table}
+            WHERE deleted_at IS NULL
+              AND is_deprecated = false
+              AND nickname IS NOT NULL
+            ORDER BY COALESCE(tenant_id::text, :sentinel),
+                     lower(nickname), created_at, id
+            """
+        ),
+        {"sentinel": SENTINEL},
+    ).fetchall()
+
+    # Every active display name currently taken, per scope. Renames update it so
+    # a suffixed name never lands on another active row (in any group).
+    taken: dict[str, set[str]] = defaultdict(set)
+    for row in rows:
+        taken[_scope(row.tenant_id)].add(row.nickname.lower())
+
+    def group_key(row):
+        return (_scope(row.tenant_id), row.nickname.lower())
+
+    for (scope, _lower), group in groupby(rows, key=group_key):
+        members = list(group)
+        if len(members) <= 1:
+            continue
+        # Keep the oldest (first by created_at) as-is; suffix the rest.
+        for row in members[1:]:
+            base = row.nickname
+            n = 2
+            while f"{base} ({n})".lower() in taken[scope]:
+                n += 1
+            new_name = f"{base} ({n})"
+            taken[scope].add(new_name.lower())
+            conn.execute(
+                sa.text(f"UPDATE {table} SET nickname = :nn WHERE id = :id"),
+                {"nn": new_name, "id": row.id},
+            )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for table in _TABLES:
+        _dedupe(conn, table)
+        op.execute(
+            f"""
+            CREATE UNIQUE INDEX uq_{table}_active_nickname
+            ON {table} (COALESCE(tenant_id, '{SENTINEL}'::uuid), lower(nickname))
+            WHERE deleted_at IS NULL
+              AND is_deprecated = false
+              AND nickname IS NOT NULL
+            """
+        )
+
+
+def downgrade() -> None:
+    # The suffix renames are left in place (no reliable inverse); only the
+    # constraints are dropped.
+    for table in _TABLES:
+        op.execute(f"DROP INDEX IF EXISTS uq_{table}_active_nickname")

--- a/backend/alembic/versions/20260603_transcription_migrate.py
+++ b/backend/alembic/versions/20260603_transcription_migrate.py
@@ -1,0 +1,159 @@
+"""transcription model migration lifecycle
+
+Fas 4a of the model-table alignment: give transcription models the same in-app
+migration feature completion models already have.
+
+  - Add `migrated_to_model_id` (self-FK, RESTRICT) to transcription_models, the
+    last lifecycle column missing for parity (deleted_at + nickname were added
+    in Fas 1).
+  - Create `transcription_model_migration_history`, mirroring
+    `completion_model_migration_history` (final shape: SET NULL model FKs +
+    from/to name + provider_type columns).
+
+Revision ID: 20260603_transcription_migrate
+Revises: 20260602_unique_display_names
+Create Date: 2026-06-03
+
+"""
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision = "20260603_transcription_migrate"
+down_revision = "20260602_unique_display_names"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "transcription_models",
+        sa.Column("migrated_to_model_id", UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_transcription_models_migrated_to",
+        "transcription_models",
+        "transcription_models",
+        ["migrated_to_model_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_index(
+        "ix_transcription_models_migrated_to_model_id",
+        "transcription_models",
+        ["migrated_to_model_id"],
+    )
+
+    op.create_table(
+        "transcription_model_migration_history",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("migration_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("tenant_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("from_model_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("to_model_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("from_model_name", sa.String(255), nullable=True),
+        sa.Column("to_model_name", sa.String(255), nullable=True),
+        sa.Column("from_provider_type", sa.String(255), nullable=True),
+        sa.Column("to_provider_type", sa.String(255), nullable=True),
+        sa.Column("initiated_by", UUID(as_uuid=True), nullable=False),
+        sa.Column("status", sa.String(50), nullable=False),
+        sa.Column("entity_types", sa.JSON, nullable=True),
+        sa.Column("affected_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("migrated_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("failed_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("duration_seconds", sa.Float(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("warnings", sa.JSON, nullable=True),
+        sa.Column("migration_details", sa.JSON, nullable=True),
+        sa.Column("started_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["from_model_id"], ["transcription_models.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["to_model_id"], ["transcription_models.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["initiated_by"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("migration_id"),
+    )
+    op.create_index(
+        "idx_tm_migration_history_tenant",
+        "transcription_model_migration_history",
+        ["tenant_id"],
+    )
+    op.create_index(
+        "idx_tm_migration_history_from_model",
+        "transcription_model_migration_history",
+        ["from_model_id"],
+    )
+    op.create_index(
+        "idx_tm_migration_history_to_model",
+        "transcription_model_migration_history",
+        ["to_model_id"],
+    )
+    op.create_index(
+        "idx_tm_migration_history_status",
+        "transcription_model_migration_history",
+        ["status"],
+    )
+    op.create_index(
+        "idx_tm_migration_history_migration_id",
+        "transcription_model_migration_history",
+        ["migration_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_tm_migration_history_migration_id",
+        table_name="transcription_model_migration_history",
+    )
+    op.drop_index(
+        "idx_tm_migration_history_status",
+        table_name="transcription_model_migration_history",
+    )
+    op.drop_index(
+        "idx_tm_migration_history_to_model",
+        table_name="transcription_model_migration_history",
+    )
+    op.drop_index(
+        "idx_tm_migration_history_from_model",
+        table_name="transcription_model_migration_history",
+    )
+    op.drop_index(
+        "idx_tm_migration_history_tenant",
+        table_name="transcription_model_migration_history",
+    )
+    op.drop_table("transcription_model_migration_history")
+
+    op.drop_index(
+        "ix_transcription_models_migrated_to_model_id",
+        table_name="transcription_models",
+    )
+    op.drop_constraint(
+        "fk_transcription_models_migrated_to",
+        "transcription_models",
+        type_="foreignkey",
+    )
+    op.drop_column("transcription_models", "migrated_to_model_id")

--- a/backend/src/intric/ai_models/display_name_validation.py
+++ b/backend/src/intric/ai_models/display_name_validation.py
@@ -11,7 +11,9 @@ tell apart. This mirrors the partial unique indexes added in the
 Used by both the tenant model service (AddWizard path) and the sysadmin
 global-model endpoints — same rule everywhere. The predicate must stay in lockstep
 with that migration's index: active = `deleted_at IS NULL AND is_deprecated = false`,
-case-insensitive via SQL `lower()`, scoped per tenant (NULL = global).
+case-insensitive via SQL `lower()`, scoped per (tenant, provider). Global models
+always carry `provider_id IS NULL`, so they share one provider scope and stay
+unique per name; the same name may repeat across a tenant's providers.
 """
 
 from __future__ import annotations
@@ -33,14 +35,19 @@ async def validate_unique_display_name(
     *,
     tenant_id: UUID | None,
     nickname: str | None,
+    provider_id: UUID | None = None,
     exclude_id: UUID | None = None,
 ) -> None:
-    """Raise `NameCollisionException` if another active model in the same scope
-    already uses `nickname`. No-op when `nickname` is None.
+    """Raise `NameCollisionException` if another active model in the same
+    (tenant, provider) scope already uses `nickname`. No-op when `nickname` is
+    None.
 
     `table` is one of the three model ORM tables (all carry `nickname`,
-    `deleted_at`, `is_deprecated`, `tenant_id` after the model-table alignment).
-    Pass `exclude_id` on updates so a row never collides with itself.
+    `deleted_at`, `is_deprecated`, `tenant_id`, `provider_id` after the
+    model-table alignment). `provider_id` is None for global models (which also
+    have no provider) and otherwise scopes the check to one provider, so a name
+    may repeat across a tenant's providers. Pass `exclude_id` on updates so a row
+    never collides with itself.
     """
     if nickname is None:
         return
@@ -54,6 +61,10 @@ async def validate_unique_display_name(
         conditions.append(table.tenant_id.is_(None))
     else:
         conditions.append(table.tenant_id == tenant_id)
+    if provider_id is None:
+        conditions.append(table.provider_id.is_(None))
+    else:
+        conditions.append(table.provider_id == provider_id)
     if exclude_id is not None:
         conditions.append(table.id != exclude_id)
 

--- a/backend/src/intric/ai_models/display_name_validation.py
+++ b/backend/src/intric/ai_models/display_name_validation.py
@@ -1,0 +1,64 @@
+# MIT License
+
+"""Shared display-name uniqueness guard for the model tables.
+
+A model's display name (`nickname`) is what users pick from in the chat model
+selector and admin tables; two *active* models sharing one are impossible to
+tell apart. This mirrors the partial unique indexes added in the
+`20260602_unique_display_names` migration so the service layer raises a clean
+409 instead of letting the DB throw a raw 500 on insert.
+
+Used by both the tenant model service (AddWizard path) and the sysadmin
+global-model endpoints — same rule everywhere. The predicate must stay in lockstep
+with that migration's index: active = `deleted_at IS NULL AND is_deprecated = false`,
+case-insensitive via SQL `lower()`, scoped per tenant (NULL = global).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+import sqlalchemy as sa
+
+from intric.main.exceptions import NameCollisionException
+
+if TYPE_CHECKING:
+    from intric.database.database import AsyncSession
+
+
+async def validate_unique_display_name(
+    session: "AsyncSession",
+    table: Any,
+    *,
+    tenant_id: UUID | None,
+    nickname: str | None,
+    exclude_id: UUID | None = None,
+) -> None:
+    """Raise `NameCollisionException` if another active model in the same scope
+    already uses `nickname`. No-op when `nickname` is None.
+
+    `table` is one of the three model ORM tables (all carry `nickname`,
+    `deleted_at`, `is_deprecated`, `tenant_id` after the model-table alignment).
+    Pass `exclude_id` on updates so a row never collides with itself.
+    """
+    if nickname is None:
+        return
+
+    conditions = [
+        sa.func.lower(table.nickname) == sa.func.lower(nickname),
+        table.deleted_at.is_(None),
+        table.is_deprecated.is_(False),
+    ]
+    if tenant_id is None:
+        conditions.append(table.tenant_id.is_(None))
+    else:
+        conditions.append(table.tenant_id == tenant_id)
+    if exclude_id is not None:
+        conditions.append(table.id != exclude_id)
+
+    existing = (
+        await session.execute(sa.select(table.id).where(*conditions).limit(1))
+    ).scalar_one_or_none()
+    if existing is not None:
+        raise NameCollisionException(f"A model named '{nickname}' already exists.")

--- a/backend/src/intric/ai_models/embedding_models/embedding_models_repo.py
+++ b/backend/src/intric/ai_models/embedding_models/embedding_models_repo.py
@@ -31,6 +31,7 @@ class AdminEmbeddingModelsService:
                 EmbeddingModels.tenant_id.is_(None),
                 EmbeddingModels.tenant_id == tenant_id,
             ),
+            EmbeddingModels.deleted_at.is_(None),
         )
         result = await self.session.execute(stmt)
         db_model = result.scalar_one_or_none()
@@ -64,7 +65,11 @@ class AdminEmbeddingModelsService:
         with_deprecated: bool = False,
         id_list: list[UUID] | None = None,
     ) -> list[EmbeddingModelLegacy]:
-        stmt = sa.select(EmbeddingModels).order_by(EmbeddingModels.created_at)
+        stmt = (
+            sa.select(EmbeddingModels)
+            .where(EmbeddingModels.deleted_at.is_(None))
+            .order_by(EmbeddingModels.created_at)
+        )
 
         if not with_deprecated:
             stmt = stmt.where(EmbeddingModels.is_deprecated == False)  # noqa

--- a/backend/src/intric/ai_models/migration/base_migration_service.py
+++ b/backend/src/intric/ai_models/migration/base_migration_service.py
@@ -526,12 +526,23 @@ class BaseModelMigrationService:
                     )
                 results["total"] = sum(results.values())
 
-                mark_stmt = (
-                    update(self._model_table)
-                    .where(self._model_table.id == from_model_id)
-                    .values(migrated_to_model_id=to_model_id)
-                )
-                await self.session.execute(mark_stmt)
+                # Mark the source migrated only when this run moved *every*
+                # migratable surface. `migrated_to_model_id` is a one-way latch:
+                # once set, `_ensure_source_model_not_already_migrated` blocks any
+                # further migration of this source. Marking it after a partial run
+                # (a subset of entity_types) would therefore strand the
+                # un-migrated surfaces — their references would dangle on a source
+                # that can never be migrated again. The frontend always sends all
+                # types (entity_types omitted → expands to the full list), so the
+                # normal flow latches as before; only deliberate partial API calls
+                # stay re-runnable until they cover everything.
+                if set(entity_types) >= set(self._migratable_entity_types):
+                    mark_stmt = (
+                        update(self._model_table)
+                        .where(self._model_table.id == from_model_id)
+                        .values(migrated_to_model_id=to_model_id)
+                    )
+                    await self.session.execute(mark_stmt)
 
                 await savepoint.commit()
                 return results

--- a/backend/src/intric/ai_models/migration/base_migration_service.py
+++ b/backend/src/intric/ai_models/migration/base_migration_service.py
@@ -383,6 +383,11 @@ class BaseModelMigrationService:
                 "Database error during model migration",
                 extra={"migration_id": str(migration_id), "error": str(e)},
             )
+            # Known gap: if the error aborted the surrounding transaction, this
+            # "failed" history UPDATE runs in a poisoned session and itself
+            # raises InFailedSqlTransactionError, so the failure row may not
+            # persist. Fixing it properly needs a separate session for the
+            # failure write; tracked as a follow-up.
             duration = (datetime.now(timezone.utc) - start_time).total_seconds()
             await self.history_repo.update_migration_history(
                 migration_id=migration_id,

--- a/backend/src/intric/ai_models/migration/base_migration_service.py
+++ b/backend/src/intric/ai_models/migration/base_migration_service.py
@@ -187,6 +187,9 @@ class BaseModelMigrationService:
                 )
 
             self._ensure_source_model_not_already_migrated(from_model)
+            await self._ensure_partial_migrations_keep_same_target(
+                from_model_id, to_model_id, user.tenant_id
+            )
 
             from_enabled = await self.session.execute(
                 select(self._model_table).where(
@@ -526,23 +529,14 @@ class BaseModelMigrationService:
                     )
                 results["total"] = sum(results.values())
 
-                # Mark the source migrated only when this run moved *every*
-                # migratable surface. `migrated_to_model_id` is a one-way latch:
-                # once set, `_ensure_source_model_not_already_migrated` blocks any
-                # further migration of this source. Marking it after a partial run
-                # (a subset of entity_types) would therefore strand the
-                # un-migrated surfaces — their references would dangle on a source
-                # that can never be migrated again. The frontend always sends all
-                # types (entity_types omitted → expands to the full list), so the
-                # normal flow latches as before; only deliberate partial API calls
-                # stay re-runnable until they cover everything.
-                if set(entity_types) >= set(self._migratable_entity_types):
-                    mark_stmt = (
-                        update(self._model_table)
-                        .where(self._model_table.id == from_model_id)
-                        .values(migrated_to_model_id=to_model_id)
-                    )
-                    await self.session.execute(mark_stmt)
+                # `migrated_to_model_id` is a one-way latch. Full migrations
+                # usually clear everything in one call; deliberate partial API
+                # calls may clear the source over several calls. Latch only when
+                # no migratable surface still references the source.
+                if not await self._has_remaining_source_references(
+                    from_model_id, tenant_id
+                ):
+                    await self._mark_source_migrated(from_model_id, to_model_id)
 
                 await savepoint.commit()
                 return results
@@ -570,6 +564,46 @@ class BaseModelMigrationService:
                 f"Unknown entity type for tenant filtering: {entity_type}"
             )
             return true()
+
+    async def _ensure_partial_migrations_keep_same_target(
+        self, from_model_id: UUID, to_model_id: UUID, tenant_id: UUID
+    ) -> None:
+        """Prevent split-target partial migrations for the same source model."""
+        stmt = (
+            select(self.history_repo.table.to_model_id)
+            .where(
+                self.history_repo.table.tenant_id == tenant_id,
+                self.history_repo.table.from_model_id == from_model_id,
+                self.history_repo.table.status == "completed",
+                self.history_repo.table.to_model_id != to_model_id,
+            )
+            .limit(1)
+        )
+        previous_target = (await self.session.execute(stmt)).scalar_one_or_none()
+        if previous_target is not None:
+            raise ValidationException(
+                "Source model has completed partial migration history to a "
+                "different target. Complete remaining references to the original "
+                "target before using another target model."
+            )
+
+    async def _has_remaining_source_references(
+        self, from_model_id: UUID, tenant_id: UUID
+    ) -> bool:
+        remaining = await self._count_affected_entities(
+            from_model_id, list(self._migratable_entity_types), tenant_id
+        )
+        return remaining > 0
+
+    async def _mark_source_migrated(
+        self, from_model_id: UUID, to_model_id: UUID
+    ) -> None:
+        stmt = (
+            update(self._model_table)
+            .where(self._model_table.id == from_model_id)
+            .values(migrated_to_model_id=to_model_id)
+        )
+        await self.session.execute(stmt)
 
     async def _migrate_entity_type(
         self, entity_type: str, from_model_id: UUID, to_model_id: UUID, tenant_id: UUID

--- a/backend/src/intric/ai_models/migration/base_migration_service.py
+++ b/backend/src/intric/ai_models/migration/base_migration_service.py
@@ -107,6 +107,21 @@ class BaseModelMigrationService:
             from_model_id, to_model_id, tenant_id
         )
 
+    async def count_affected_per_type(
+        self, model_id: UUID, tenant_id: UUID
+    ) -> dict[str, int]:
+        """Per-entity-type count of what a migration would move, plus a "total".
+
+        Powers the migrate dialog's impact preview for model types that have no
+        dedicated usage-stats service (e.g. transcription)."""
+        counts: dict[str, int] = {}
+        for entity_type in self._migratable_entity_types:
+            counts[entity_type] = await self._count_entities_by_type(
+                entity_type, model_id, tenant_id
+            )
+        counts["total"] = sum(counts.values())
+        return counts
+
     async def migrate_model_usage(
         self,
         from_model_id: UUID,

--- a/backend/src/intric/ai_models/migration/base_migration_service.py
+++ b/backend/src/intric/ai_models/migration/base_migration_service.py
@@ -11,9 +11,17 @@ model type subclasses and supplies only its specifics:
   - `_special_entity_migrators` (e.g. completion's assistant kwargs reset)
   - `_after_execute` (e.g. completion's usage-stats recalculation)
 
-Behavioural note: this is a straight extraction of the original
-`CompletionModelMigrationService` — completion behaviour is unchanged, it now
-just lives here and is parameterized.
+Behavioural note: this began as a straight extraction of the original
+`CompletionModelMigrationService` (orchestration, repoint logic and validation
+messages are byte-for-byte preserved). One behaviour was intentionally changed
+for *both* model types when partial migrations were hardened: the source is
+latched (`migrated_to_model_id`) only once no migratable surface still
+references it (see `_has_remaining_source_references`) rather than
+unconditionally after every run, and a partial migration to a different target
+than an earlier completed one is rejected (see the split-target guard in
+`_ensure_partial_migrations_keep_same_target`). The full-migration path the
+frontend uses (entity_types omitted → all surfaces in one call) latches exactly
+as before.
 """
 
 import logging

--- a/backend/src/intric/ai_models/migration/base_migration_service.py
+++ b/backend/src/intric/ai_models/migration/base_migration_service.py
@@ -1,0 +1,623 @@
+"""Generic model-migration engine shared by completion and transcription.
+
+The orchestration (validate → history → events → savepoint execute → history →
+events), the per-entity repoint logic, spaces many-to-many handling, counting
+and tenant filtering are all identical across model types and live here. Each
+model type subclasses and supplies only its specifics:
+
+  - the model table, the FK column name, the spaces link table, the entity map
+    and migratable entity-type list (instance attributes set in `__init__`)
+  - `_validate_migration_compatibility` (the model-specific compatibility rules)
+  - `_special_entity_migrators` (e.g. completion's assistant kwargs reset)
+  - `_after_execute` (e.g. completion's usage-stats recalculation)
+
+Behavioural note: this is a straight extraction of the original
+`CompletionModelMigrationService` — completion behaviour is unchanged, it now
+just lives here and is parameterized.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID, uuid4
+
+from sqlalchemy import and_, delete, func, select, true, update
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
+
+from intric.ai_models.migration.model_migration_history_repo import (
+    ModelMigrationHistoryRepo,
+)
+from intric.completion_models.presentation.completion_model_models import (
+    MigrationResult,
+    ValidationResult,
+)
+from intric.events import (
+    ModelMigrationCompleted,
+    ModelMigrationFailed,
+    ModelMigrationStarted,
+    get_event_publisher,
+)
+from intric.main.config import get_settings
+from intric.main.exceptions import ValidationException
+
+
+class BaseModelMigrationService:
+    """Shared engine for migrating model usage between models of one type."""
+
+    # Embedding migration is intentionally not wired up on this engine yet.
+    # Completion and transcription migrations only *repoint* references (an FK
+    # swap plus the spaces many-to-many), which is exactly what the generic
+    # logic below does. Embedding is fundamentally different: the stored vectors
+    # in collections, websites, integration_knowledge and info_blob_chunks were
+    # produced by the old model, so switching embedding models means
+    # *re-embedding* all of that knowledge — not just repointing it. The thinking
+    # is that an embedding subclass would keep the same orchestration here but add
+    # a re-embed step (recompute + replace vectors per knowledge source, ideally
+    # as a background job since it can be large/slow), most naturally as an
+    # `_after_execute` override, instead of treating it as a pure reference swap.
+
+    # --- model-specific configuration (set by subclass __init__) -----------
+    model_repo: Any
+    history_repo: ModelMigrationHistoryRepo
+    _model_table: Any
+    _fk_column: str
+    _spaces_link_table: Any
+    _entity_table_map: dict[str, Any]
+    _migratable_entity_types: list[str]
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+        self.logger = logging.getLogger(self.__class__.__module__)
+        self.event_publisher = get_event_publisher()
+        self.settings = get_settings()
+
+    # ------------------------------------------------------------------ hooks
+    async def _validate_migration_compatibility(
+        self, from_model_id: UUID, to_model_id: UUID, tenant_id: UUID
+    ) -> ValidationResult:
+        raise NotImplementedError
+
+    def _special_entity_migrators(self) -> dict[str, Any]:
+        """entity_type -> async handler(from_id, to_id, tenant_id, table, tenant_condition).
+
+        Override for model-specific repoint logic (e.g. completion's assistant
+        kwargs reset). Default: none.
+        """
+        return {}
+
+    async def _after_execute(
+        self, migration_id: UUID, migrated_count: int, tenant_id: UUID
+    ) -> tuple[bool, bool]:
+        """Hook run after a successful transactional migration. Returns
+        (auto_recalculated, requires_manual_recalculation). Default: no-op."""
+        return (False, False)
+
+    @staticmethod
+    def _is_blocker_code(code: str) -> bool:
+        # Security classification mismatches cannot be overridden with confirm.
+        return code.startswith("security_classification_insufficient")
+
+    # ------------------------------------------------------------------ public
+    async def validate_migration(
+        self, from_model_id: UUID, to_model_id: UUID, tenant_id: UUID
+    ) -> ValidationResult:
+        return await self._validate_migration_compatibility(
+            from_model_id, to_model_id, tenant_id
+        )
+
+    async def migrate_model_usage(
+        self,
+        from_model_id: UUID,
+        to_model_id: UUID,
+        entity_types: list[str] | str | None = None,
+        *,
+        user: Any,
+        confirm_migration: bool = False,
+    ) -> MigrationResult:
+        start_time = datetime.now(timezone.utc)
+        migration_id = uuid4()
+
+        self.logger.info(
+            "Starting model migration",
+            extra={
+                "migration_id": str(migration_id),
+                "from_model_id": str(from_model_id),
+                "to_model_id": str(to_model_id),
+                "tenant_id": str(user.tenant_id),
+                "user_id": str(user.id),
+                "entity_types": entity_types,
+                "confirm_migration": confirm_migration,
+            },
+        )
+
+        normalized_entity_types: list[str] | None
+        if isinstance(entity_types, str):
+            normalized_entity_types = [entity_types]
+        else:
+            normalized_entity_types = entity_types
+
+        if normalized_entity_types is not None:
+            invalid_types = [
+                t
+                for t in normalized_entity_types
+                if t not in self._migratable_entity_types
+            ]
+            if invalid_types:
+                raise ValidationException(
+                    f"Invalid entity types: {invalid_types}. "
+                    f"Valid types are: {self._migratable_entity_types}"
+                )
+
+        final_entity_types: list[str] = normalized_entity_types or list(
+            self._migratable_entity_types
+        )
+
+        # Validate models exist and belong to tenant
+        try:
+            from_model = await self.model_repo.one(model_id=from_model_id)
+            if not from_model:
+                raise ValidationException(
+                    f"Source model not found: model with ID '{from_model_id}' does not exist."
+                )
+            to_model = await self.model_repo.one(model_id=to_model_id)
+            if not to_model:
+                raise ValidationException(
+                    f"Target model not found: model with ID '{to_model_id}' does not exist."
+                )
+            if from_model_id == to_model_id:
+                raise ValidationException(
+                    f"Invalid migration: source and target models are the same ('{from_model.name}')."
+                )
+
+            self._ensure_source_model_not_already_migrated(from_model)
+
+            from_enabled = await self.session.execute(
+                select(self._model_table).where(
+                    and_(
+                        self._model_table.id == from_model_id,
+                        self._model_table.tenant_id == user.tenant_id,
+                        self._model_table.is_enabled == True,  # noqa: E712
+                    )
+                )
+            )
+            if not from_enabled.scalar_one_or_none():
+                raise ValidationException(
+                    f"Source model not available: '{from_model.name}' is not enabled for your organization."
+                )
+
+            to_enabled = await self.session.execute(
+                select(self._model_table).where(
+                    and_(
+                        self._model_table.id == to_model_id,
+                        self._model_table.tenant_id == user.tenant_id,
+                        self._model_table.is_enabled == True,  # noqa: E712
+                    )
+                )
+            )
+            if not to_enabled.scalar_one_or_none():
+                raise ValidationException(
+                    f"Target model not available: '{to_model.name}' is not enabled for your organization."
+                )
+
+        except ValidationException as ve:
+            self.logger.warning(
+                f"Migration validation rejected: {ve}",
+                extra={
+                    "from_model_id": str(from_model_id),
+                    "to_model_id": str(to_model_id),
+                },
+            )
+            raise
+        except Exception as e:
+            self.logger.error(
+                "Error validating models",
+                extra={
+                    "from_model_id": str(from_model_id),
+                    "to_model_id": str(to_model_id),
+                    "error": str(e),
+                },
+            )
+            raise ValidationException(
+                "Model validation failed: unable to verify model availability."
+            )
+
+        affected_count = await self._count_affected_entities(
+            from_model_id, final_entity_types, user.tenant_id
+        )
+
+        await self.history_repo.create_migration_history(
+            migration_id=migration_id,
+            tenant_id=user.tenant_id,
+            from_model_id=from_model_id,
+            to_model_id=to_model_id,
+            from_model_name=from_model.name,
+            to_model_name=to_model.name,
+            from_provider_type=getattr(from_model, "provider_type", None),
+            to_provider_type=getattr(to_model, "provider_type", None),
+            initiated_by=user.id,
+            status="in_progress",
+            entity_types=normalized_entity_types,
+            affected_count=affected_count,
+            started_at=start_time,
+        )
+
+        await self.event_publisher.publish(
+            ModelMigrationStarted(
+                migration_id=migration_id,
+                from_model_id=from_model_id,
+                to_model_id=to_model_id,
+                affected_count=affected_count,
+                initiated_by=user.id,
+                timestamp=start_time,
+            )
+        )
+
+        try:
+            validation_result = await self._validate_migration_compatibility(
+                from_model_id, to_model_id, user.tenant_id
+            )
+
+            has_blockers = any(
+                self._is_blocker_code(code) for code in validation_result.warning_codes
+            )
+
+            if has_blockers:
+                duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+                await self.history_repo.update_migration_history(
+                    migration_id=migration_id,
+                    tenant_id=user.tenant_id,
+                    status="failed",
+                    migrated_count=0,
+                    failed_count=0,
+                    duration_seconds=duration,
+                    completed_at=datetime.now(timezone.utc),
+                    error_message=f"Migration blocked: {', '.join(validation_result.warnings)}",
+                    warnings=validation_result.warnings,
+                )
+                raise ValidationException(
+                    f"Migration blocked by security classification: {', '.join(validation_result.warnings)}"
+                )
+
+            if not validation_result.compatible and not confirm_migration:
+                duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+                await self.history_repo.update_migration_history(
+                    migration_id=migration_id,
+                    tenant_id=user.tenant_id,
+                    status="failed",
+                    migrated_count=0,
+                    failed_count=0,
+                    duration_seconds=duration,
+                    completed_at=datetime.now(timezone.utc),
+                    error_message=f"Migration has compatibility issues: {', '.join(validation_result.warnings)}. Set confirm_migration=true to proceed anyway.",
+                    warnings=validation_result.warnings,
+                )
+                raise ValidationException(
+                    f"Migration has compatibility issues: {', '.join(validation_result.warnings)}. Set confirm_migration=true to proceed anyway."
+                )
+
+            if not validation_result.compatible and confirm_migration:
+                self.logger.warning(
+                    f"User confirmed migration despite compatibility issues: {', '.join(validation_result.warnings)}",
+                    extra={"migration_id": str(migration_id)},
+                )
+
+            result = await self._execute_migration_transactionally(
+                from_model_id, to_model_id, final_entity_types, user.tenant_id
+            )
+
+            migrated_count = result["total"]
+            (
+                auto_recalculated,
+                requires_manual_recalculation,
+            ) = await self._after_execute(migration_id, migrated_count, user.tenant_id)
+
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+
+            await self.history_repo.update_migration_history(
+                migration_id=migration_id,
+                tenant_id=user.tenant_id,
+                status="completed",
+                migrated_count=result["total"],
+                failed_count=0,
+                duration_seconds=duration,
+                completed_at=datetime.now(timezone.utc),
+                warnings=validation_result.warnings
+                if validation_result.warnings
+                else None,
+                migration_details=result,
+            )
+
+            await self.event_publisher.publish(
+                ModelMigrationCompleted(
+                    migration_id=migration_id,
+                    migrated_count=result["total"],
+                    duration_seconds=duration,
+                    timestamp=datetime.now(timezone.utc),
+                )
+            )
+
+            return MigrationResult(
+                success=True,
+                migrated_count=result["total"],
+                failed_count=0,
+                details=result,
+                duration=duration,
+                migration_id=migration_id,
+                warnings=validation_result.warnings,
+                auto_recalculated=auto_recalculated,
+                requires_manual_recalculation=requires_manual_recalculation,
+            )
+
+        except ValidationException:
+            raise
+        except SQLAlchemyError as e:
+            self.logger.error(
+                "Database error during model migration",
+                extra={"migration_id": str(migration_id), "error": str(e)},
+            )
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            await self.history_repo.update_migration_history(
+                migration_id=migration_id,
+                tenant_id=user.tenant_id,
+                status="failed",
+                migrated_count=0,
+                failed_count=affected_count,
+                duration_seconds=duration,
+                completed_at=datetime.now(timezone.utc),
+                error_message=str(e),
+            )
+            await self.event_publisher.publish(
+                ModelMigrationFailed(
+                    migration_id=migration_id,
+                    error_message=f"Database error: {str(e)}",
+                    timestamp=datetime.now(timezone.utc),
+                )
+            )
+            raise ValidationException(
+                f"Migration failed due to database error: {str(e)}"
+            )
+        except Exception as e:
+            self.logger.error(
+                "Unexpected error during model migration",
+                extra={"migration_id": str(migration_id), "error": str(e)},
+            )
+            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
+            await self.history_repo.update_migration_history(
+                migration_id=migration_id,
+                tenant_id=user.tenant_id,
+                status="failed",
+                migrated_count=0,
+                failed_count=affected_count,
+                duration_seconds=duration,
+                completed_at=datetime.now(timezone.utc),
+                error_message=str(e),
+            )
+            await self.event_publisher.publish(
+                ModelMigrationFailed(
+                    migration_id=migration_id,
+                    error_message=f"Unexpected error: {str(e)}",
+                    timestamp=datetime.now(timezone.utc),
+                )
+            )
+            raise ValidationException(f"Migration failed: {str(e)}")
+
+    # --------------------------------------------------------------- internals
+    @staticmethod
+    def _ensure_source_model_not_already_migrated(from_model: Any) -> None:
+        if getattr(from_model, "migrated_to_model_id", None) is not None:
+            raise ValidationException(
+                f"Source model '{from_model.name}' has already been migrated. "
+                f"A model can only be migrated once."
+            )
+
+    async def _count_spaces_with_insufficient_classification(
+        self, from_model_id: UUID, target_level: int, tenant_id: UUID
+    ) -> int:
+        """Count spaces holding the source model whose required security level
+        exceeds the target model's level. Shared by subclass compat checks."""
+        from intric.database.tables.security_classifications_table import (
+            SecurityClassification as SecurityClassifications,
+        )
+        from intric.database.tables.spaces_table import Spaces
+
+        link = self._spaces_link_table
+        link_fk = getattr(link, self._fk_column)
+        stmt = (
+            select(func.count(Spaces.id))
+            .select_from(Spaces)
+            .join(link, link.space_id == Spaces.id)
+            .join(
+                SecurityClassifications,
+                SecurityClassifications.id == Spaces.security_classification_id,
+                isouter=False,
+            )
+            .where(
+                and_(
+                    link_fk == from_model_id,
+                    Spaces.tenant_id == tenant_id,
+                    SecurityClassifications.security_level > target_level,
+                )
+            )
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one()
+
+    async def _count_affected_entities(
+        self, from_model_id: UUID, entity_types: list[str], tenant_id: UUID
+    ) -> int:
+        total_count = 0
+        for entity_type in entity_types:
+            total_count += await self._count_entities_by_type(
+                entity_type, from_model_id, tenant_id
+            )
+        return total_count
+
+    async def _count_entities_by_type(
+        self, entity_type: str, model_id: UUID, tenant_id: UUID
+    ) -> int:
+        if entity_type == "spaces":
+            return await self._count_spaces(model_id, tenant_id)
+
+        if entity_type not in self._entity_table_map:
+            self.logger.warning(f"Entity type {entity_type} not in entity table map")
+            return 0
+
+        table = self._entity_table_map[entity_type]
+        tenant_condition = self._build_tenant_filter_condition(
+            table, entity_type, tenant_id
+        )
+        stmt = (
+            select(func.count())
+            .select_from(table)
+            .where(
+                and_(
+                    getattr(table, self._fk_column) == model_id,
+                    tenant_condition,
+                )
+            )
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one()
+
+    async def _count_spaces(self, model_id: UUID, tenant_id: UUID) -> int:
+        from intric.database.tables.spaces_table import Spaces
+
+        link = self._spaces_link_table
+        link_fk = getattr(link, self._fk_column)
+        stmt = (
+            select(func.count(link.space_id))
+            .select_from(link)
+            .join(Spaces, link.space_id == Spaces.id)
+            .where(and_(link_fk == model_id, Spaces.tenant_id == tenant_id))
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one()
+
+    async def _execute_migration_transactionally(
+        self,
+        from_model_id: UUID,
+        to_model_id: UUID,
+        entity_types: list[str],
+        tenant_id: UUID,
+    ) -> dict[str, int]:
+        results: dict[str, int] = {}
+        async with self.session.begin_nested() as savepoint:
+            try:
+                for entity_type in entity_types:
+                    results[entity_type] = await self._migrate_entity_type(
+                        entity_type, from_model_id, to_model_id, tenant_id
+                    )
+                results["total"] = sum(results.values())
+
+                mark_stmt = (
+                    update(self._model_table)
+                    .where(self._model_table.id == from_model_id)
+                    .values(migrated_to_model_id=to_model_id)
+                )
+                await self.session.execute(mark_stmt)
+
+                await savepoint.commit()
+                return results
+            except Exception as e:
+                await savepoint.rollback()
+                raise e
+
+    def _build_tenant_filter_condition(
+        self, table: Any, entity_type: str, tenant_id: UUID
+    ) -> ColumnElement[bool]:
+        from intric.database.tables.users_table import Users
+
+        if entity_type in {"apps", "questions"}:
+            return table.tenant_id == tenant_id
+        elif entity_type in {"assistants", "services"}:
+            return table.user_id.in_(
+                select(Users.id).where(Users.tenant_id == tenant_id)
+            )
+        elif entity_type in {"assistant_templates", "app_templates"}:
+            return true()
+        elif entity_type == "spaces":
+            return table.tenant_id == tenant_id
+        else:
+            self.logger.warning(
+                f"Unknown entity type for tenant filtering: {entity_type}"
+            )
+            return true()
+
+    async def _migrate_entity_type(
+        self, entity_type: str, from_model_id: UUID, to_model_id: UUID, tenant_id: UUID
+    ) -> int:
+        if entity_type == "spaces":
+            return await self._migrate_spaces(from_model_id, to_model_id, tenant_id)
+
+        if entity_type not in self._entity_table_map:
+            self.logger.warning(f"Entity type {entity_type} not in entity table map")
+            return 0
+
+        table: Any = self._entity_table_map[entity_type]
+        tenant_condition = self._build_tenant_filter_condition(
+            table, entity_type, tenant_id
+        )
+
+        special = self._special_entity_migrators()
+        if entity_type in special:
+            return await special[entity_type](
+                from_model_id, to_model_id, tenant_id, table, tenant_condition
+            )
+
+        stmt = (
+            update(table)
+            .where(
+                and_(
+                    getattr(table, self._fk_column) == from_model_id,
+                    tenant_condition,
+                )
+            )
+            .values(**{self._fk_column: to_model_id})
+        )
+        result = await self.session.execute(stmt)
+        migrated_count = result.rowcount or 0
+        self.logger.info(
+            f"Migrated {migrated_count} {entity_type} from {from_model_id} to {to_model_id}"
+        )
+        return migrated_count
+
+    async def _migrate_spaces(
+        self, from_model_id: UUID, to_model_id: UUID, tenant_id: UUID
+    ) -> int:
+        from sqlalchemy.dialects.postgresql import insert
+
+        from intric.database.tables.spaces_table import Spaces
+
+        link = self._spaces_link_table
+        link_fk_col = self._fk_column
+        link_fk = getattr(link, link_fk_col)
+
+        spaces_with_source_stmt = (
+            select(link.space_id)
+            .select_from(link)
+            .join(Spaces, link.space_id == Spaces.id)
+            .where(and_(link_fk == from_model_id, Spaces.tenant_id == tenant_id))
+        )
+        result = await self.session.execute(spaces_with_source_stmt)
+        space_ids = [row.space_id for row in result.fetchall()]
+        if not space_ids:
+            return 0
+
+        for space_id in space_ids:
+            insert_stmt = insert(link).values(
+                **{"space_id": space_id, link_fk_col: to_model_id}
+            )
+            insert_stmt = insert_stmt.on_conflict_do_nothing()
+            await self.session.execute(insert_stmt)
+
+        delete_stmt = delete(link).where(
+            and_(link_fk == from_model_id, link.space_id.in_(space_ids))
+        )
+        delete_result = await self.session.execute(delete_stmt)
+        migrated_count = delete_result.rowcount or 0
+        self.logger.info(
+            f"Migrated {migrated_count} space associations from {from_model_id} to {to_model_id}"
+        )
+        return migrated_count

--- a/backend/src/intric/ai_models/migration/model_migration_history_repo.py
+++ b/backend/src/intric/ai_models/migration/model_migration_history_repo.py
@@ -1,0 +1,168 @@
+"""Generic migration-history repository, shared by completion and transcription.
+
+Both model types record migrations in a table with an identical column shape
+(`completion_model_migration_history` / `transcription_model_migration_history`),
+so the CRUD is written once here and parameterized by the table class.
+"""
+
+from datetime import datetime
+from typing import Any, Optional
+from uuid import UUID
+
+from sqlalchemy import desc, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class ModelMigrationHistoryRepo:
+    """CRUD for a model-migration-history table, parameterized by the table class."""
+
+    def __init__(self, session: AsyncSession, table: Any):
+        super().__init__()
+        self.session = session
+        self.table = table
+
+    async def create_migration_history(
+        self,
+        migration_id: UUID,
+        tenant_id: UUID,
+        from_model_id: UUID,
+        to_model_id: UUID,
+        initiated_by: UUID,
+        status: str,
+        entity_types: list[str] | None = None,
+        affected_count: int = 0,
+        started_at: Optional[datetime] = None,
+        from_model_name: Optional[str] = None,
+        to_model_name: Optional[str] = None,
+        from_provider_type: Optional[str] = None,
+        to_provider_type: Optional[str] = None,
+    ) -> Any:
+        migration_history = self.table(
+            **dict(  # type: ignore[call-arg]
+                migration_id=migration_id,
+                tenant_id=tenant_id,
+                from_model_id=from_model_id,
+                to_model_id=to_model_id,
+                from_model_name=from_model_name,
+                to_model_name=to_model_name,
+                from_provider_type=from_provider_type,
+                to_provider_type=to_provider_type,
+                initiated_by=initiated_by,
+                status=status,
+                entity_types=entity_types,
+                affected_count=affected_count,
+                migrated_count=0,
+                failed_count=0,
+                started_at=started_at,
+            )
+        )
+        self.session.add(migration_history)
+        await self.session.flush()
+        return migration_history
+
+    async def update_migration_history(
+        self,
+        migration_id: UUID,
+        tenant_id: UUID,
+        *,
+        status: Optional[str] = None,
+        migrated_count: Optional[int] = None,
+        failed_count: Optional[int] = None,
+        started_at: Optional[datetime] = None,
+        completed_at: Optional[datetime] = None,
+        duration_seconds: Optional[float] = None,
+        error_message: Optional[str] = None,
+        warnings: list[str] | None = None,
+        migration_details: dict[str, int] | None = None,
+    ) -> Optional[Any]:
+        stmt = select(self.table).where(
+            self.table.migration_id == migration_id,
+            self.table.tenant_id == tenant_id,
+        )
+        result = await self.session.execute(stmt)
+        migration_history = result.scalar_one_or_none()
+
+        if migration_history:
+            if status is not None:
+                migration_history.status = status
+            if migrated_count is not None:
+                migration_history.migrated_count = migrated_count
+            if failed_count is not None:
+                migration_history.failed_count = failed_count
+            if started_at is not None:
+                migration_history.started_at = started_at
+            if completed_at is not None:
+                migration_history.completed_at = completed_at
+            if duration_seconds is not None:
+                migration_history.duration_seconds = duration_seconds
+            if error_message is not None:
+                migration_history.error_message = error_message
+            if warnings is not None:
+                migration_history.warnings = warnings
+            if migration_details is not None:
+                migration_history.migration_details = migration_details
+            await self.session.flush()
+
+        return migration_history
+
+    async def get_migration_history_by_id(
+        self, migration_id: UUID, tenant_id: UUID
+    ) -> Optional[Any]:
+        stmt = select(self.table).where(
+            self.table.migration_id == migration_id,
+            self.table.tenant_id == tenant_id,
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def get_migration_history_for_model(
+        self, model_id: UUID, tenant_id: UUID, limit: int = 50, offset: int = 0
+    ) -> list[Any]:
+        stmt = (
+            select(self.table)
+            .where(
+                self.table.tenant_id == tenant_id,
+                or_(
+                    self.table.from_model_id == model_id,
+                    self.table.to_model_id == model_id,
+                ),
+            )
+            .order_by(desc(self.table.created_at))
+            .limit(limit)
+            .offset(offset)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalars().all()  # type: ignore[return-value]
+
+    async def get_migration_history_for_tenant(
+        self, tenant_id: UUID, limit: int = 50, offset: int = 0
+    ) -> list[Any]:
+        stmt = (
+            select(self.table)
+            .where(self.table.tenant_id == tenant_id)
+            .order_by(desc(self.table.created_at))
+            .limit(limit)
+            .offset(offset)
+        )
+        result = await self.session.execute(stmt)
+        return result.scalars().all()  # type: ignore[return-value]
+
+    async def count_migration_history_for_model(
+        self, model_id: UUID, tenant_id: UUID
+    ) -> int:
+        stmt = select(func.count(self.table.id)).where(
+            self.table.tenant_id == tenant_id,
+            or_(
+                self.table.from_model_id == model_id,
+                self.table.to_model_id == model_id,
+            ),
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar()  # type: ignore[return-value]
+
+    async def count_migration_history_for_tenant(self, tenant_id: UUID) -> int:
+        stmt = select(func.count(self.table.id)).where(
+            self.table.tenant_id == tenant_id
+        )
+        result = await self.session.execute(stmt)
+        return result.scalar()  # type: ignore[return-value]

--- a/backend/src/intric/ai_models/migration/model_migration_history_service.py
+++ b/backend/src/intric/ai_models/migration/model_migration_history_service.py
@@ -1,0 +1,154 @@
+"""Generic migration-history read service shared by completion and transcription.
+
+Maps history DB rows to the `ModelMigrationHistory` presentation model,
+resolving model and initiator names. Parameterized by the history repo and the
+model table (for name lookup); everything else is identical across model types.
+"""
+
+from datetime import datetime
+from typing import Any, cast
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from intric.ai_models.migration.model_migration_history_repo import (
+    ModelMigrationHistoryRepo,
+)
+from intric.completion_models.presentation.completion_model_models import (
+    ModelMigrationHistory,
+)
+from intric.database.tables.users_table import Users
+
+
+class ModelMigrationHistoryService:
+    """Read/format migration history for one model type."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        repo: ModelMigrationHistoryRepo,
+        model_table: Any,
+    ):
+        self.session = session
+        self.repo = repo
+        self._model_table = model_table
+
+    async def get_migration_history_for_model(
+        self, model_id: UUID, tenant_id: UUID, limit: int = 50, offset: int = 0
+    ) -> list[ModelMigrationHistory]:
+        records = await self.repo.get_migration_history_for_model(
+            model_id, tenant_id, limit, offset
+        )
+        return await self._convert_to_public_models(records)
+
+    async def get_migration_history_for_tenant(
+        self, tenant_id: UUID, limit: int = 50, offset: int = 0
+    ) -> list[ModelMigrationHistory]:
+        records = await self.repo.get_migration_history_for_tenant(
+            tenant_id, limit, offset
+        )
+        return await self._convert_to_public_models(records)
+
+    async def get_migration_history_by_id(
+        self, migration_id: UUID, tenant_id: UUID
+    ) -> ModelMigrationHistory | None:
+        record = await self.repo.get_migration_history_by_id(migration_id, tenant_id)
+        if record:
+            converted = await self._convert_to_public_models([record])
+            return converted[0] if converted else None
+        return None
+
+    async def count_migration_history_for_model(
+        self, model_id: UUID, tenant_id: UUID
+    ) -> int:
+        return await self.repo.count_migration_history_for_model(model_id, tenant_id)
+
+    async def count_migration_history_for_tenant(self, tenant_id: UUID) -> int:
+        return await self.repo.count_migration_history_for_tenant(tenant_id)
+
+    async def _convert_to_public_models(
+        self, records: list[Any]
+    ) -> list[ModelMigrationHistory]:
+        if not records:
+            return []
+
+        model_ids: set[UUID] = set()
+        user_ids: set[UUID] = set()
+        for record in records:
+            from_model_id = cast(UUID | None, record.from_model_id)
+            to_model_id = cast(UUID | None, record.to_model_id)
+            if from_model_id is not None:
+                model_ids.add(from_model_id)
+            if to_model_id is not None:
+                model_ids.add(to_model_id)
+            user_ids.add(cast(UUID, record.initiated_by))
+
+        model_names = await self._get_model_names(list(model_ids))
+        user_names = await self._get_user_names(list(user_ids))
+
+        public_models: list[ModelMigrationHistory] = []
+        for record in records:
+            from_model_id = cast(UUID | None, record.from_model_id)
+            to_model_id = cast(UUID | None, record.to_model_id)
+            initiated_by = cast(UUID, record.initiated_by)
+            stored_from_name = cast(
+                str | None, getattr(record, "from_model_name", None)
+            )
+            stored_to_name = cast(str | None, getattr(record, "to_model_name", None))
+
+            from_model_name = stored_from_name or (
+                model_names.get(from_model_id, "Deleted model")
+                if from_model_id is not None
+                else "Deleted model"
+            )
+            to_model_name = stored_to_name or (
+                model_names.get(to_model_id, "Deleted model")
+                if to_model_id is not None
+                else "Deleted model"
+            )
+
+            public_models.append(
+                ModelMigrationHistory(
+                    id=record.id,
+                    from_model_id=from_model_id,
+                    from_model_name=from_model_name,
+                    to_model_id=to_model_id,
+                    to_model_name=to_model_name,
+                    migrated_count=cast(int, record.migrated_count),
+                    status=cast(str, record.status),
+                    initiated_by_id=initiated_by,
+                    initiated_by_name=user_names.get(initiated_by, "Unknown User"),
+                    started_at=cast(datetime | None, record.started_at),
+                    completed_at=cast(datetime | None, record.completed_at),
+                    duration=cast(
+                        float | None, getattr(record, "duration_seconds", None)
+                    ),
+                    error_message=cast(str | None, record.error_message),
+                    migration_details=cast(
+                        dict[str, int] | None,
+                        getattr(record, "migration_details", None),
+                    ),
+                    warnings=cast(list[str] | None, getattr(record, "warnings", None)),
+                )
+            )
+
+        return public_models
+
+    async def _get_model_names(self, model_ids: list[UUID]) -> dict[UUID, str]:
+        if not model_ids:
+            return {}
+        stmt = select(self._model_table.id, self._model_table.name).where(
+            self._model_table.id.in_(model_ids)
+        )
+        result = await self.session.execute(stmt)
+        return {row.id: row.name for row in result.fetchall()}
+
+    async def _get_user_names(self, user_ids: list[UUID]) -> dict[UUID, str]:
+        if not user_ids:
+            return {}
+        stmt = select(Users.id, Users.email).where(
+            Users.id.in_(user_ids), Users.deleted_at.is_(None)
+        )
+        result = await self.session.execute(stmt)
+        return {row.id: row.email for row in result.fetchall()}

--- a/backend/src/intric/ai_models/model_lifecycle_cleanup.py
+++ b/backend/src/intric/ai_models/model_lifecycle_cleanup.py
@@ -1,0 +1,139 @@
+"""Shared skeleton for the per-model-type lifecycle cleanup workers.
+
+When a model is soft-deleted (``deleted_at`` set) or migrated away from
+(``migrated_to_model_id`` set), the row is kept as a tombstone so migration
+history and lingering references still resolve. Once nothing references it
+anymore the row serves no purpose and can be hard-deleted.
+
+Completion has its own bespoke worker
+(``completion_models.infrastructure.model_cleanup_worker``) because it also
+reconciles soft-deleted *template* snapshots and is gated on historical
+``questions`` rows. Transcription and embedding have simpler reference graphs
+and share this skeleton: fetch lifecycle-ended candidates, then hard-delete each
+in its own transaction once a final blocking-reference check passes. The
+RESTRICT/SET NULL FKs are the database-level safety net — even if a check has a
+bug, a RESTRICT FK refuses the delete and that single row is skipped.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Per-run batch cap. Keeps a single weekly invocation bounded even if the table
+# somehow accumulates thousands of tombstones — the next run picks up the rest.
+BATCH_LIMIT = 500
+
+logger = logging.getLogger(__name__)
+
+# (id, name) of a hard-delete candidate.
+Candidate = tuple[UUID, str]
+
+
+async def run_model_lifecycle_cleanup(
+    *,
+    session: AsyncSession,
+    table: Any,
+    find_candidates: Callable[[AsyncSession, int], Awaitable[list[Candidate]]],
+    has_blocking_refs: Callable[[AsyncSession, UUID], Awaitable[bool]],
+    job_label: str,
+) -> dict[str, Any]:
+    """Run one cleanup pass and return a structured result.
+
+    ``find_candidates`` returns rows whose lifecycle has ended and that have no
+    *structural* blockers (e.g. another model still pointing at them). Each
+    candidate is then re-checked with ``has_blocking_refs`` inside its own
+    transaction — a single failed delete must roll back only that row, not the
+    whole run.
+    """
+    start_time = datetime.now(timezone.utc)
+    results: dict[str, Any] = {
+        "start_time": start_time.isoformat(),
+        "removed_models": [],
+        "skipped_models": [],
+        "errors": [],
+        "success": True,
+    }
+
+    logger.info(f"Starting weekly {job_label} lifecycle cleanup job")
+
+    async with session.begin():
+        candidates = await find_candidates(session, BATCH_LIMIT)
+
+    if not candidates:
+        logger.info(f"No orphaned {job_label} tombstones to clean up")
+        end_time = datetime.now(timezone.utc)
+        results["end_time"] = end_time.isoformat()
+        results["duration_seconds"] = (end_time - start_time).total_seconds()
+        return results
+
+    logger.info(f"Found {len(candidates)} candidate {job_label}s for cleanup")
+
+    for model_id, model_name in candidates:
+        try:
+            async with session.begin():
+                if await has_blocking_refs(session, model_id):
+                    logger.info(
+                        f"Skipping {job_label} '{model_name}' ({model_id}): "
+                        f"still has active references"
+                    )
+                    results["skipped_models"].append(
+                        {
+                            "id": str(model_id),
+                            "name": model_name,
+                            "reason": "active_references",
+                        }
+                    )
+                    continue
+
+                # Hard-delete — RESTRICT FKs are the final safety net.
+                await session.execute(sa.delete(table).where(table.id == model_id))
+
+                logger.info(f"Removed orphaned {job_label} '{model_name}' ({model_id})")
+                results["removed_models"].append(
+                    {"id": str(model_id), "name": model_name}
+                )
+        except IntegrityError as e:
+            logger.warning(
+                f"Skipping {job_label} cleanup due to database restriction",
+                extra={
+                    "model_id": str(model_id),
+                    "model_name": model_name,
+                    "error": str(e),
+                },
+            )
+            results["skipped_models"].append(
+                {"id": str(model_id), "name": model_name, "reason": "db_restrict"}
+            )
+        except Exception as e:  # noqa: BLE001 — record and continue the batch
+            error_msg = (
+                f"Failed to remove {job_label} '{model_name}' ({model_id}): {str(e)}"
+            )
+            logger.error(error_msg, exc_info=True)
+            results["errors"].append(error_msg)
+            results["success"] = False
+
+    end_time = datetime.now(timezone.utc)
+    duration = (end_time - start_time).total_seconds()
+    results["end_time"] = end_time.isoformat()
+    results["duration_seconds"] = duration
+
+    removed = len(results["removed_models"])
+    skipped = len(results["skipped_models"])
+    errors = len(results["errors"])
+    if results["success"]:
+        logger.info(
+            f"{job_label} cleanup completed: removed {removed}, "
+            f"skipped {skipped}, duration {duration:.2f}s"
+        )
+    else:
+        logger.warning(
+            f"{job_label} cleanup completed with errors: removed {removed}, "
+            f"skipped {skipped}, errors {errors}, duration {duration:.2f}s"
+        )
+
+    return results

--- a/backend/src/intric/audit/domain/action_metadata.py
+++ b/backend/src/intric/audit/domain/action_metadata.py
@@ -84,6 +84,14 @@ ACTION_METADATA: dict[str, ActionMetadata] = {
         "name_sv": "API-nyckel roterad",
         "description_sv": "Loggar när en API-nyckel roteras",
     },
+    ActionType.API_KEY_EXPIRATION_EXTENDED.value: {
+        "name_sv": "API-nyckels giltighet förlängd",
+        "description_sv": "Loggar när en API-nyckels giltighetstid förlängs",
+    },
+    ActionType.API_KEY_PURGED.value: {
+        "name_sv": "API-nyckel rensad",
+        "description_sv": "Loggar när en utgången API-nyckel rensas permanent",
+    },
     ActionType.API_KEY_EXPIRED.value: {
         "name_sv": "API-nyckel utgången",
         "description_sv": "Loggar när en API-nyckel löper ut",
@@ -297,6 +305,10 @@ ACTION_METADATA: dict[str, ActionMetadata] = {
         "name_sv": "Transkriptionsmodell raderad",
         "description_sv": "Loggar när en transkriptionsmodell tas bort från tenanten",
     },
+    ActionType.TRANSCRIPTION_MODEL_MIGRATED.value: {
+        "name_sv": "Transkriptionsmodell migrerad",
+        "description_sv": "Loggar när användning flyttas mellan transkriptionsmodeller",
+    },
     ActionType.TEMPLATE_CREATED.value: {
         "name_sv": "Mall skapad",
         "description_sv": "Loggar när en ny mall skapas",
@@ -376,7 +388,11 @@ ACTION_METADATA: dict[str, ActionMetadata] = {
         "name_sv": "Systemunderhåll",
         "description_sv": "Loggar planerat systemunderhåll",
     },
-    # Audit Access (2)
+    # Audit Access (3)
+    ActionType.AUDIT_SESSION_CREATED.value: {
+        "name_sv": "Granskningssession skapad",
+        "description_sv": "Loggar när en session för granskningsåtkomst skapas",
+    },
     ActionType.AUDIT_LOG_VIEWED.value: {
         "name_sv": "Granskningsloggar visade",
         "description_sv": "Loggar när granskningsloggar visas",

--- a/backend/src/intric/audit/domain/action_types.py
+++ b/backend/src/intric/audit/domain/action_types.py
@@ -79,6 +79,7 @@ class ActionType(str, Enum):
     TRANSCRIPTION_MODEL_CREATED = "transcription_model_created"
     TRANSCRIPTION_MODEL_UPDATED = "transcription_model_updated"
     TRANSCRIPTION_MODEL_DELETED = "transcription_model_deleted"
+    TRANSCRIPTION_MODEL_MIGRATED = "transcription_model_migrated"
     TEMPLATE_CREATED = "template_created"
     TEMPLATE_UPDATED = "template_updated"
     TEMPLATE_DELETED = "template_deleted"

--- a/backend/src/intric/audit/domain/category_mappings.py
+++ b/backend/src/intric/audit/domain/category_mappings.py
@@ -42,7 +42,7 @@ CATEGORY_MAPPINGS = {
     ActionType.FEDERATION_UPDATED.value: "admin_actions",
     ActionType.MODULE_ADDED.value: "admin_actions",
     ActionType.MODULE_ADDED_TO_TENANT.value: "admin_actions",
-    # User Actions (29 actions)
+    # User Actions (37 actions)
     ActionType.ASSISTANT_CREATED.value: "user_actions",
     ActionType.ASSISTANT_UPDATED.value: "user_actions",
     ActionType.ASSISTANT_DELETED.value: "user_actions",
@@ -79,6 +79,7 @@ CATEGORY_MAPPINGS = {
     ActionType.TRANSCRIPTION_MODEL_CREATED.value: "user_actions",
     ActionType.TRANSCRIPTION_MODEL_UPDATED.value: "user_actions",
     ActionType.TRANSCRIPTION_MODEL_DELETED.value: "user_actions",
+    ActionType.TRANSCRIPTION_MODEL_MIGRATED.value: "user_actions",
     # Security Events (6 actions)
     ActionType.SECURITY_CLASSIFICATION_CREATED.value: "security_events",
     ActionType.SECURITY_CLASSIFICATION_UPDATED.value: "security_events",

--- a/backend/src/intric/completion_models/application/completion_model_migration_history_service.py
+++ b/backend/src/intric/completion_models/application/completion_model_migration_history_service.py
@@ -1,194 +1,24 @@
-"""Service for completion model migration history operations."""
+"""Service for completion model migration history operations.
 
-from datetime import datetime
-from typing import cast
-from uuid import UUID
+Thin subclass of the shared `ModelMigrationHistoryService`, bound to the
+completion history repo and model table.
+"""
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from intric.ai_models.migration.model_migration_history_service import (
+    ModelMigrationHistoryService,
+)
 from intric.completion_models.domain.completion_model_migration_history_repo import (
     CompletionModelMigrationHistoryRepo,
 )
-from intric.completion_models.presentation.completion_model_models import (
-    ModelMigrationHistory,
-)
 from intric.database.tables.ai_models_table import CompletionModels
-from intric.database.tables.completion_model_migration_history_table import (
-    CompletionModelMigrationHistory,
-)
-from intric.database.tables.users_table import Users
 
 
-class CompletionModelMigrationHistoryService:
+class CompletionModelMigrationHistoryService(ModelMigrationHistoryService):
     """Service for managing completion model migration history."""
 
     def __init__(self, session: AsyncSession):
-        super().__init__()
-        self.session = session
-        self.repo = CompletionModelMigrationHistoryRepo(session)
-
-    async def get_migration_history_for_model(
-        self,
-        model_id: UUID,
-        tenant_id: UUID,
-        limit: int = 50,
-        offset: int = 0,
-    ) -> list[ModelMigrationHistory]:
-        """Get migration history for a specific live model with names and user info."""
-        migration_records = await self.repo.get_migration_history_for_model(
-            model_id, tenant_id, limit, offset
+        super().__init__(
+            session, CompletionModelMigrationHistoryRepo(session), CompletionModels
         )
-
-        return await self._convert_to_public_models(migration_records)
-
-    async def get_migration_history_for_tenant(
-        self,
-        tenant_id: UUID,
-        limit: int = 50,
-        offset: int = 0,
-    ) -> list[ModelMigrationHistory]:
-        """Get all migration history for a tenant with model names and user info."""
-        migration_records = await self.repo.get_migration_history_for_tenant(
-            tenant_id, limit, offset
-        )
-
-        return await self._convert_to_public_models(migration_records)
-
-    async def get_migration_history_by_id(
-        self,
-        migration_id: UUID,
-        tenant_id: UUID,
-    ) -> ModelMigrationHistory | None:
-        """Get a specific migration history record by ID."""
-        migration_record = await self.repo.get_migration_history_by_id(
-            migration_id, tenant_id
-        )
-
-        if migration_record:
-            converted = await self._convert_to_public_models([migration_record])
-            return converted[0] if converted else None
-
-        return None
-
-    async def _convert_to_public_models(
-        self, migration_records: list[CompletionModelMigrationHistory]
-    ) -> list[ModelMigrationHistory]:
-        """Convert database records to public API models with names populated."""
-        if not migration_records:
-            return []
-
-        # Extract unique IDs for batch queries
-        model_ids: set[UUID] = set()
-        user_ids: set[UUID] = set()
-
-        for record in migration_records:
-            from_model_id = cast(UUID | None, record.from_model_id)
-            to_model_id = cast(UUID | None, record.to_model_id)
-            if from_model_id is not None:
-                model_ids.add(from_model_id)
-            if to_model_id is not None:
-                model_ids.add(to_model_id)
-            user_ids.add(cast(UUID, record.initiated_by))
-
-        # Batch fetch model names
-        model_names = await self._get_model_names(list(model_ids))
-
-        # Batch fetch user names
-        user_names = await self._get_user_names(list(user_ids))
-
-        # Convert to public models
-        public_models: list[ModelMigrationHistory] = []
-        for record in migration_records:
-            from_model_id = cast(UUID | None, record.from_model_id)
-            to_model_id = cast(UUID | None, record.to_model_id)
-            initiated_by = cast(UUID, record.initiated_by)
-            migrated_count = cast(int, record.migrated_count)
-            status = cast(str, record.status)
-            started_at = cast(datetime | None, record.started_at)
-            completed_at = cast(datetime | None, record.completed_at)
-            duration_seconds = cast(
-                float | None, getattr(record, "duration_seconds", None)
-            )
-            error_message = cast(str | None, record.error_message)
-            stored_from_name = cast(
-                str | None, getattr(record, "from_model_name", None)
-            )
-            stored_to_name = cast(str | None, getattr(record, "to_model_name", None))
-            migration_details = cast(
-                dict[str, int] | None, getattr(record, "migration_details", None)
-            )
-            warnings = cast(list[str] | None, getattr(record, "warnings", None))
-
-            # Use stored names first, fall back to live lookup
-            from_model_name = stored_from_name or (
-                model_names.get(from_model_id, "Deleted model")
-                if from_model_id is not None
-                else "Deleted model"
-            )
-            to_model_name = stored_to_name or (
-                model_names.get(to_model_id, "Deleted model")
-                if to_model_id is not None
-                else "Deleted model"
-            )
-            initiated_by_name = user_names.get(initiated_by, "Unknown User")
-
-            public_model = ModelMigrationHistory(
-                id=record.id,
-                from_model_id=from_model_id,
-                from_model_name=from_model_name,
-                to_model_id=to_model_id,
-                to_model_name=to_model_name,
-                migrated_count=migrated_count,
-                status=status,
-                initiated_by_id=initiated_by,
-                initiated_by_name=initiated_by_name,
-                started_at=started_at,
-                completed_at=completed_at,
-                duration=duration_seconds,
-                error_message=error_message,
-                migration_details=migration_details,
-                warnings=warnings,
-            )
-            public_models.append(public_model)
-
-        return public_models
-
-    async def _get_model_names(self, model_ids: list[UUID]) -> dict[UUID, str]:
-        """Get model names for given IDs."""
-        if not model_ids:
-            return {}
-
-        stmt = select(CompletionModels.id, CompletionModels.name).where(
-            CompletionModels.id.in_(model_ids)
-        )
-
-        result = await self.session.execute(stmt)
-        return {row.id: row.name for row in result.fetchall()}
-
-    async def _get_user_names(self, user_ids: list[UUID]) -> dict[UUID, str]:
-        """Get user names for given IDs."""
-        if not user_ids:
-            return {}
-
-        stmt = select(Users.id, Users.email).where(
-            Users.id.in_(user_ids), Users.deleted_at.is_(None)
-        )
-
-        result = await self.session.execute(stmt)
-        return {row.id: row.email for row in result.fetchall()}
-
-    async def count_migration_history_for_model(
-        self,
-        model_id: UUID,
-        tenant_id: UUID,
-    ) -> int:
-        """Count migration history records for a specific model."""
-        return await self.repo.count_migration_history_for_model(model_id, tenant_id)
-
-    async def count_migration_history_for_tenant(
-        self,
-        tenant_id: UUID,
-    ) -> int:
-        """Count all migration history records for a tenant."""
-        return await self.repo.count_migration_history_for_tenant(tenant_id)

--- a/backend/src/intric/completion_models/application/completion_model_migration_service.py
+++ b/backend/src/intric/completion_models/application/completion_model_migration_service.py
@@ -1,45 +1,48 @@
-import logging
-from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
-from uuid import UUID, uuid4
+"""Completion-model migration service.
 
-from sqlalchemy import and_, delete, func, select, true, update
-from sqlalchemy.exc import SQLAlchemyError
+Thin subclass of the shared `BaseModelMigrationService`. All orchestration
+(history, events, savepoint execution, generic entity repoint, spaces) lives in
+the base; this class supplies only the completion-specific parts:
+
+  - compatibility rules (token limits, family, vision/reasoning/tool-calling,
+    security classification)
+  - the assistant special-case (enable target on spaces + reset kwargs)
+  - usage-stats recalculation after a successful migration
+"""
+
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from sqlalchemy import and_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql.elements import ColumnElement
 
+from intric.ai_models.migration.base_migration_service import (
+    BaseModelMigrationService,
+)
 from intric.completion_models.application.completion_model_usage_service import (
     CompletionModelUsageService,
 )
 from intric.completion_models.constants import (
     ENTITY_TABLE_MAP,
     MIGRATABLE_ENTITY_TYPES,
-    singular_entity_type,
 )
 from intric.completion_models.domain.completion_model_migration_history_repo import (
     CompletionModelMigrationHistoryRepo,
 )
 from intric.completion_models.presentation.completion_model_models import (
-    MigrationResult,
     ValidationResult,
 )
-from intric.events import (
-    ModelMigrationCompleted,
-    ModelMigrationFailed,
-    ModelMigrationStarted,
-    get_event_publisher,
-)
-from intric.main.config import get_settings
-from intric.main.exceptions import ValidationException
+from intric.database.tables.ai_models_table import CompletionModels
+from intric.database.tables.spaces_table import SpacesCompletionModels
 
 if TYPE_CHECKING:
     from intric.completion_models.domain.completion_model_repo import (
         CompletionModelRepository,
     )
-    from intric.users.user import UserInDB
 
 
-class CompletionModelMigrationService:
+class CompletionModelMigrationService(BaseModelMigrationService):
     """Service for migrating completion model usage between models."""
 
     def __init__(
@@ -48,517 +51,39 @@ class CompletionModelMigrationService:
         completion_model_repo: "CompletionModelRepository",
         usage_service: CompletionModelUsageService,
     ):
-        super().__init__()
-        self.session = session
-        self.completion_model_repo = completion_model_repo
+        super().__init__(session)
+        self.model_repo = completion_model_repo
         self.usage_service = usage_service
-        self.migration_history_repo = CompletionModelMigrationHistoryRepo(session)
-        self.logger = logging.getLogger(__name__)
-        self.event_publisher = get_event_publisher()
-        self.settings = get_settings()
+        self.history_repo = CompletionModelMigrationHistoryRepo(session)
+        self._model_table = CompletionModels
+        self._fk_column = "completion_model_id"
+        self._spaces_link_table = SpacesCompletionModels
+        self._entity_table_map = ENTITY_TABLE_MAP
+        self._migratable_entity_types = list(MIGRATABLE_ENTITY_TYPES)
 
-    async def validate_migration(
-        self,
-        from_model_id: UUID,
-        to_model_id: UUID,
-        tenant_id: UUID,
-    ) -> ValidationResult:
-        """Validate migration compatibility without executing. Used for preflight checks."""
-        return await self._validate_migration_compatibility(
-            from_model_id, to_model_id, tenant_id
-        )
-
-    async def migrate_model_usage(
-        self,
-        from_model_id: UUID,
-        to_model_id: UUID,
-        entity_types: list[str] | str | None = None,
-        *,
-        user: "UserInDB",
-        confirm_migration: bool = False,
-    ) -> MigrationResult:
-        """Execute model migration with full safety checks and observability."""
-        start_time = datetime.now(timezone.utc)
-        migration_id = uuid4()
-
-        self.logger.info(
-            "Starting model migration",
-            extra={
-                "migration_id": str(migration_id),
-                "from_model_id": str(from_model_id),
-                "to_model_id": str(to_model_id),
-                "tenant_id": str(user.tenant_id),
-                "user_id": str(user.id),
-                "entity_types": entity_types,
-                "confirm_migration": confirm_migration,
-            },
-        )
-
-        normalized_entity_types: list[str] | None
-        if isinstance(entity_types, str):
-            normalized_entity_types = [entity_types]
-        else:
-            normalized_entity_types = entity_types
-
-        # Validate and normalize entity_types
-        if normalized_entity_types is not None:
-            # Check for invalid entity types
-            invalid_types = [
-                t for t in normalized_entity_types if t not in MIGRATABLE_ENTITY_TYPES
-            ]
-            if invalid_types:
-                raise ValidationException(
-                    f"Invalid entity types: {invalid_types}. Valid types are: {MIGRATABLE_ENTITY_TYPES}"
-                )
-
-            self.logger.debug(f"Validated entity_types: {normalized_entity_types}")
-
-        final_entity_types: list[str] = normalized_entity_types or list(
-            MIGRATABLE_ENTITY_TYPES
-        )
-        # Coupling note: if "assistants" is in final_entity_types but "spaces"
-        # is not, _migrate_assistants_with_kwargs enables the target on the
-        # spaces those assistants live on (so the new model can run) but the
-        # source model is *not* removed from SpacesCompletionModels. Front-
-        # filters on `migrated_to_model_id` hide it from the space-settings
-        # picker, so the dangling row is cosmetic rather than functional —
-        # cleanup-worker removes it when the source model is hard-deleted.
-        # API callers that want a clean SpacesCompletionModels state should
-        # include "spaces" in entity_types (the frontend passes undefined,
-        # which expands to all MIGRATABLE_ENTITY_TYPES, so this is satisfied
-        # by default).
-        self.logger.debug(f"Final entity_types for migration: {final_entity_types}")
-
-        # Validate models exist and belong to tenant
-        try:
-            from_model = await self.completion_model_repo.one(model_id=from_model_id)
-            if not from_model:
-                raise ValidationException(
-                    f"Source model not found: The completion model with ID '{from_model_id}' does not exist. "
-                    f"Please verify the model ID and try again."
-                )
-
-            to_model = await self.completion_model_repo.one(model_id=to_model_id)
-            if not to_model:
-                raise ValidationException(
-                    f"Target model not found: The completion model with ID '{to_model_id}' does not exist. "
-                    f"Please verify the model ID and try again."
-                )
-
-            # Check if models are the same
-            if from_model_id == to_model_id:
-                raise ValidationException(
-                    f"Invalid migration: Source and target models are the same ('{from_model.name}'). "
-                    f"Migration requires different source and target models."
-                )
-
-            self._ensure_source_model_not_already_migrated(from_model)
-
-            # For single-tenant deployment, check if models are enabled for the tenant
-            # Settings are now stored directly on the model table
-            from intric.database.tables.ai_models_table import CompletionModels
-
-            from_model_stmt = select(CompletionModels).where(
-                and_(
-                    CompletionModels.id == from_model_id,
-                    CompletionModels.tenant_id == user.tenant_id,
-                    CompletionModels.is_enabled == True,
-                )
-            )
-            from_model_result = await self.session.execute(from_model_stmt)
-            if not from_model_result.scalar_one_or_none():
-                raise ValidationException(
-                    f"Source model not available: The model '{from_model.name}' is not enabled for your organization. "
-                    f"Please contact your administrator to enable this model."
-                )
-
-            to_model_stmt = select(CompletionModels).where(
-                and_(
-                    CompletionModels.id == to_model_id,
-                    CompletionModels.tenant_id == user.tenant_id,
-                    CompletionModels.is_enabled == True,
-                )
-            )
-            to_model_result = await self.session.execute(to_model_stmt)
-            if not to_model_result.scalar_one_or_none():
-                raise ValidationException(
-                    f"Target model not available: The model '{to_model.name}' is not enabled for your organization. "
-                    f"Please contact your administrator to enable this model."
-                )
-
-            self.logger.info(
-                "Model validation passed",
-                extra={
-                    "from_model": from_model.name,
-                    "to_model": to_model.name,
-                    "tenant_id": str(user.tenant_id),
-                },
-            )
-
-        except ValidationException as ve:
-            # WARNING (not INFO): a rejected migration is an admin action
-            # the system blocked — operators alarm on this level.
-            self.logger.warning(
-                f"Migration validation rejected: {ve}",
-                extra={
-                    "from_model_id": str(from_model_id),
-                    "to_model_id": str(to_model_id),
-                },
-            )
-            raise
-        except Exception as e:
-            self.logger.error(
-                "Error validating models",
-                extra={
-                    "from_model_id": str(from_model_id),
-                    "to_model_id": str(to_model_id),
-                    "error": str(e),
-                },
-            )
-            raise ValidationException(
-                "Model validation failed: Unable to verify model availability. "
-                "Please try again or contact support if the issue persists."
-            )
-
-        # Count affected entities first for the event
-        affected_count = await self._count_affected_entities(
-            from_model_id, final_entity_types, user.tenant_id
-        )
-        self.logger.info(
-            f"Affected entities counted: {affected_count}",
-            extra={"migration_id": str(migration_id), "affected_count": affected_count},
-        )
-
-        # Create migration history record with started_at timestamp
-        await self.migration_history_repo.create_migration_history(
-            migration_id=migration_id,
-            tenant_id=user.tenant_id,
-            from_model_id=from_model_id,
-            to_model_id=to_model_id,
-            from_model_name=from_model.name,
-            to_model_name=to_model.name,
-            from_provider_type=from_model.provider_type,
-            to_provider_type=to_model.provider_type,
-            initiated_by=user.id,
-            status="in_progress",
-            entity_types=normalized_entity_types,
-            affected_count=affected_count,
-            started_at=start_time,
-        )
-        self.logger.info(
-            f"Migration history record created (migration_id={migration_id})",
-        )
-
-        # Publish migration started event
-        await self.event_publisher.publish(
-            ModelMigrationStarted(
-                migration_id=migration_id,
-                from_model_id=from_model_id,
-                to_model_id=to_model_id,
-                affected_count=affected_count,
-                initiated_by=user.id,
-                timestamp=start_time,
-            )
-        )
-
-        # Step 1: Validation
-        try:
-            validation_result = await self._validate_migration_compatibility(
-                from_model_id, to_model_id, user.tenant_id
-            )
-            self.logger.info(
-                f"Migration compatibility check: compatible={validation_result.compatible}, "
-                f"warnings={validation_result.warnings}, confirm_migration={confirm_migration}",
-                extra={"migration_id": str(migration_id)},
-            )
-
-            # Security blockers cannot be overridden with confirm_migration
-            has_blockers = any(
-                w.startswith("security_classification_insufficient")
-                for w in validation_result.warning_codes
-            )
-
-            if has_blockers:
-                duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-                await self.migration_history_repo.update_migration_history(
-                    migration_id=migration_id,
-                    tenant_id=user.tenant_id,
-                    status="failed",
-                    migrated_count=0,
-                    failed_count=0,
-                    duration_seconds=duration,
-                    completed_at=datetime.now(timezone.utc),
-                    error_message=f"Migration blocked: {', '.join(validation_result.warnings)}",
-                    warnings=validation_result.warnings,
-                )
-                raise ValidationException(
-                    f"Migration blocked by security classification: {', '.join(validation_result.warnings)}"
-                )
-
-            # Other compatibility issues can be overridden with confirm_migration
-            if not validation_result.compatible and not confirm_migration:
-                # Update migration history with validation failure
-                duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-                await self.migration_history_repo.update_migration_history(
-                    migration_id=migration_id,
-                    tenant_id=user.tenant_id,
-                    status="failed",
-                    migrated_count=0,
-                    failed_count=0,
-                    duration_seconds=duration,
-                    completed_at=datetime.now(timezone.utc),
-                    error_message=f"Migration has compatibility issues: {', '.join(validation_result.warnings)}. Set confirm_migration=true to proceed anyway.",
-                    warnings=validation_result.warnings,
-                )
-
-                raise ValidationException(
-                    f"Migration has compatibility issues: {', '.join(validation_result.warnings)}. Set confirm_migration=true to proceed anyway."
-                )
-
-            # Log warnings if user confirmed despite compatibility issues
-            if not validation_result.compatible and confirm_migration:
-                self.logger.warning(
-                    f"User confirmed migration despite compatibility issues: {', '.join(validation_result.warnings)}",
-                    extra={
-                        "migration_id": str(migration_id),
-                        "from_model_id": str(from_model_id),
-                        "to_model_id": str(to_model_id),
-                        "warnings": validation_result.warnings,
-                    },
-                )
-
-            # Step 2: Execute migration transactionally
-            self.logger.info(
-                f"Executing migration for entity_types={final_entity_types}",
-                extra={"migration_id": str(migration_id)},
-            )
-            result = await self._execute_migration_transactionally(
-                from_model_id, to_model_id, final_entity_types, user.tenant_id
-            )
-
-            # Step 3: Auto-recalculate usage statistics if within threshold
-            auto_recalculated = False
-            requires_manual_recalculation = False
-
-            migrated_count = result["total"]
-            threshold = self.settings.migration_auto_recalc_threshold
-
-            if migrated_count <= threshold:
-                try:
-                    self.logger.info(
-                        f"Auto-recalculating usage stats for migration (count: {migrated_count} <= threshold: {threshold})",
-                        extra={
-                            "migration_id": str(migration_id),
-                            "migrated_count": migrated_count,
-                            "threshold": threshold,
-                        },
-                    )
-
-                    # Recalculate within the existing transaction
-                    await self.usage_service.recalculate_all_usage_stats_in_transaction(
-                        user.tenant_id
-                    )
-                    auto_recalculated = True
-
-                    self.logger.info(
-                        "Auto-recalculation completed successfully",
-                        extra={"migration_id": str(migration_id)},
-                    )
-
-                except Exception as e:
-                    self.logger.error(
-                        "Auto-recalculation failed, manual recalculation required",
-                        extra={
-                            "migration_id": str(migration_id),
-                            "error": str(e),
-                            "error_type": type(e).__name__,
-                        },
-                    )
-                    # Don't fail the migration if recalculation fails
-                    requires_manual_recalculation = True
-            else:
-                requires_manual_recalculation = True
-                self.logger.info(
-                    f"Migration count exceeds threshold, manual recalculation required (count: {migrated_count} > threshold: {threshold})",
-                    extra={
-                        "migration_id": str(migration_id),
-                        "migrated_count": migrated_count,
-                        "threshold": threshold,
-                    },
-                )
-
-            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-
-            self.logger.info(
-                f"Migration completed: migrated_count={result['total']}, "
-                f"duration={duration:.2f}s, details={result}",
-                extra={
-                    "migration_id": str(migration_id),
-                    "migrated_count": result["total"],
-                    "duration_seconds": duration,
-                    "details": result,
-                    "auto_recalculated": auto_recalculated,
-                    "requires_manual_recalculation": requires_manual_recalculation,
-                },
-            )
-
-            # Update migration history with success
-            await self.migration_history_repo.update_migration_history(
-                migration_id=migration_id,
-                tenant_id=user.tenant_id,
-                status="completed",
-                migrated_count=result["total"],
-                failed_count=0,
-                duration_seconds=duration,
-                completed_at=datetime.now(timezone.utc),
-                warnings=validation_result.warnings
-                if validation_result.warnings
-                else None,
-                migration_details=result,
-            )
-
-            # Publish migration completed event
-            await self.event_publisher.publish(
-                ModelMigrationCompleted(
-                    migration_id=migration_id,
-                    migrated_count=result["total"],
-                    duration_seconds=duration,
-                    timestamp=datetime.now(timezone.utc),
-                )
-            )
-
-            return MigrationResult(
-                success=True,
-                migrated_count=result["total"],
-                failed_count=0,
-                details=result,
-                duration=duration,
-                migration_id=migration_id,
-                warnings=validation_result.warnings,
-                auto_recalculated=auto_recalculated,
-                requires_manual_recalculation=requires_manual_recalculation,
-            )
-
-        except ValidationException:
-            # Re-raise validation errors as they are already handled above
-            raise
-        except SQLAlchemyError as e:
-            self.logger.error(
-                "Database error during model migration",
-                extra={
-                    "migration_id": str(migration_id),
-                    "error": str(e),
-                    "error_type": "database",
-                    "from_model_id": str(from_model_id),
-                    "to_model_id": str(to_model_id),
-                },
-            )
-
-            # Update migration history with failure.
-            #
-            # KNOWN EDGE CASE: at "true" DB failures (deadlock, connection
-            # loss) the outer transaction is already aborted in PG's view, so
-            # the SELECT inside update_migration_history will itself fail
-            # with InFailedSqlTransactionError and the row never lands.
-            # Validation / app-level SQLAlchemyError paths still persist
-            # correctly because their session is reusable. A proper fix
-            # would route this write through a separate session, but that
-            # requires reworking DI to expose a sessionmaker here; left as
-            # a follow-up so we don't risk new bugs in the happy path.
-            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-            await self.migration_history_repo.update_migration_history(
-                migration_id=migration_id,
-                tenant_id=user.tenant_id,
-                status="failed",
-                migrated_count=0,
-                failed_count=affected_count,
-                duration_seconds=duration,
-                completed_at=datetime.now(timezone.utc),
-                error_message=str(e),
-            )
-
-            # Publish migration failed event
-            await self.event_publisher.publish(
-                ModelMigrationFailed(
-                    migration_id=migration_id,
-                    error_message=f"Database error: {str(e)}",
-                    timestamp=datetime.now(timezone.utc),
-                )
-            )
-
-            raise ValidationException(
-                f"Migration failed due to database error: {str(e)}"
-            )
-        except Exception as e:
-            self.logger.error(
-                "Unexpected error during model migration",
-                extra={
-                    "migration_id": str(migration_id),
-                    "error": str(e),
-                    "error_type": "unexpected",
-                    "from_model_id": str(from_model_id),
-                    "to_model_id": str(to_model_id),
-                },
-            )
-
-            # Update migration history with failure
-            duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-            await self.migration_history_repo.update_migration_history(
-                migration_id=migration_id,
-                tenant_id=user.tenant_id,
-                status="failed",
-                migrated_count=0,
-                failed_count=affected_count,
-                duration_seconds=duration,
-                completed_at=datetime.now(timezone.utc),
-                error_message=str(e),
-            )
-
-            # Publish migration failed event
-            await self.event_publisher.publish(
-                ModelMigrationFailed(
-                    migration_id=migration_id,
-                    error_message=f"Unexpected error: {str(e)}",
-                    timestamp=datetime.now(timezone.utc),
-                )
-            )
-
-            raise ValidationException(f"Migration failed: {str(e)}")
-
-    @staticmethod
-    def _ensure_source_model_not_already_migrated(from_model: Any) -> None:
-        if getattr(from_model, "migrated_to_model_id", None) is not None:
-            raise ValidationException(
-                f"Source model '{from_model.name}' has already been migrated. "
-                f"A model can only be migrated once."
-            )
-
+    # ------------------------------------------------------------ compat rules
     async def _validate_migration_compatibility(
         self, from_model_id: UUID, to_model_id: UUID, tenant_id: UUID
     ) -> ValidationResult:
-        """Check if models are compatible for migration."""
-        from_model = await self.completion_model_repo.one(model_id=from_model_id)
-        to_model = await self.completion_model_repo.one(model_id=to_model_id)
+        from_model = await self.model_repo.one(model_id=from_model_id)
+        to_model = await self.model_repo.one(model_id=to_model_id)
         self._ensure_source_model_not_already_migrated(from_model)
 
-        issues: list[str] = []  # Human-readable
-        issue_codes: list[str] = []  # Machine-readable
+        issues: list[str] = []
+        issue_codes: list[str] = []
         blockers: list[str] = []
         blocker_codes: list[str] = []
 
-        # Check if target model is deprecated
         if to_model.is_effectively_deprecated:
             issues.append("Target model is deprecated")
             issue_codes.append("target_deprecated")
 
-        # Check token limits
         if from_model.max_input_tokens > to_model.max_input_tokens:
             issues.append(
                 f"Target model has lower input token limit: {to_model.max_input_tokens}"
             )
             issue_codes.append(f"lower_token_limit:{to_model.max_input_tokens}")
 
-        # Check model family compatibility
         if from_model.family != to_model.family:
             issues.append(
                 f"Different model families: {from_model.family} → {to_model.family}"
@@ -567,24 +92,25 @@ class CompletionModelMigrationService:
                 f"different_family:{from_model.family}:{to_model.family}"
             )
 
-        # Check vision support
         if from_model.vision and not to_model.vision:
             issues.append("Target model lacks vision support")
             issue_codes.append("lacks_vision")
 
-        # Check reasoning support
         if from_model.reasoning and not to_model.reasoning:
             issues.append("Target model lacks reasoning support")
             issue_codes.append("lacks_reasoning")
 
-        # Check tool calling support
         if from_model.supports_tool_calling and not to_model.supports_tool_calling:
             issues.append("Target model lacks tool calling support")
             issue_codes.append("lacks_tool_calling")
 
-        # Security classification check — this is a blocker, not a warning
-        insufficient_spaces = await self._check_security_classification_compatibility(
-            from_model_id, to_model, tenant_id
+        target_level = (
+            to_model.security_classification.security_level
+            if to_model.security_classification
+            else 0
+        )
+        insufficient_spaces = await self._count_spaces_with_insufficient_classification(
+            from_model_id, target_level, tenant_id
         )
         if insufficient_spaces > 0:
             target_name = (
@@ -599,13 +125,11 @@ class CompletionModelMigrationService:
                 f"security_classification_insufficient:{insufficient_spaces}:{target_name}"
             )
 
-        # Kwargs reset is informational, not a compatibility issue
         info_warnings = [
             "Assistant model parameters (kwargs) will be reset to defaults"
         ]
         info_codes = ["kwargs_reset"]
 
-        # Blockers prevent migration entirely (confirm cannot override)
         if blockers:
             return ValidationResult(
                 compatible=False,
@@ -621,243 +145,9 @@ class CompletionModelMigrationService:
             requires_confirmation=len(issues) > 0,
         )
 
-    async def _check_security_classification_compatibility(
-        self, from_model_id: UUID, to_model: Any, tenant_id: UUID
-    ) -> int:
-        """Count spaces where target model doesn't meet the security classification requirement."""
-        from intric.database.tables.security_classifications_table import (
-            SecurityClassification as SecurityClassifications,
-        )
-        from intric.database.tables.spaces_table import Spaces, SpacesCompletionModels
-
-        # Get target model's security level (0 if no classification)
-        target_level = (
-            to_model.security_classification.security_level
-            if to_model.security_classification
-            else 0
-        )
-
-        # Find spaces that have the source model AND a security classification
-        # higher than the target model's level
-        stmt = (
-            select(func.count(Spaces.id))
-            .select_from(Spaces)
-            .join(SpacesCompletionModels, SpacesCompletionModels.space_id == Spaces.id)
-            .join(
-                SecurityClassifications,
-                SecurityClassifications.id == Spaces.security_classification_id,
-                isouter=False,
-            )
-            .where(
-                and_(
-                    SpacesCompletionModels.completion_model_id == from_model_id,
-                    Spaces.tenant_id == tenant_id,
-                    SecurityClassifications.security_level > target_level,
-                )
-            )
-        )
-
-        result = await self.session.execute(stmt)
-        return result.scalar_one()
-
-    async def _count_affected_entities(
-        self, from_model_id: UUID, entity_types: list[str], tenant_id: UUID
-    ) -> int:
-        """Count how many entities would be affected by the migration."""
-        total_count = 0
-
-        for entity_type in entity_types:
-            count = await self._count_entities_by_type(
-                entity_type, from_model_id, tenant_id
-            )
-            total_count += count
-
-        return total_count
-
-    async def _count_entities_by_type(
-        self, entity_type: str, model_id: UUID, tenant_id: UUID
-    ) -> int:
-        """Count entities of a specific type using the model."""
-        # Handle spaces separately due to many-to-many relationship
-        if entity_type == "spaces":
-            return await self._count_spaces(model_id, tenant_id)
-
-        if entity_type not in ENTITY_TABLE_MAP:
-            self.logger.warning(
-                f"Entity type {entity_type} not found in ENTITY_TABLE_MAP"
-            )
-            return 0
-
-        table = ENTITY_TABLE_MAP[entity_type]
-
-        # Build tenant-aware filtering condition
-        tenant_condition = self._build_tenant_filter_condition(
-            table, entity_type, tenant_id
-        )
-
-        # Build query using SQLAlchemy Core to prevent SQL injection
-        stmt = (
-            select(func.count())
-            .select_from(table)
-            .where(
-                and_(
-                    table.completion_model_id == model_id,
-                    tenant_condition,
-                )
-            )
-        )
-
-        result = await self.session.execute(stmt)
-
-        return result.scalar_one()
-
-    async def _count_spaces(self, model_id: UUID, tenant_id: UUID) -> int:
-        """Count spaces that have access to a specific model."""
-        from intric.database.tables.spaces_table import Spaces, SpacesCompletionModels
-
-        stmt = (
-            select(func.count(SpacesCompletionModels.space_id))
-            .select_from(SpacesCompletionModels)
-            .join(Spaces, SpacesCompletionModels.space_id == Spaces.id)
-            .where(
-                and_(
-                    SpacesCompletionModels.completion_model_id == model_id,
-                    Spaces.tenant_id == tenant_id,
-                )
-            )
-        )
-
-        result = await self.session.execute(stmt)
-        return result.scalar_one()
-
-    async def _execute_migration_transactionally(
-        self,
-        from_model_id: UUID,
-        to_model_id: UUID,
-        entity_types: list[str],
-        tenant_id: UUID,
-    ) -> dict[str, int]:
-        """Execute migration with savepoint-based rollback capability."""
-        results: dict[str, int] = {}
-
-        async with self.session.begin_nested() as savepoint:  # Savepoint for rollback
-            try:
-                # Migrate each entity type
-                for entity_type in entity_types:
-                    count = await self._migrate_entity_type(
-                        entity_type, from_model_id, to_model_id, tenant_id
-                    )
-                    results[entity_type] = count
-
-                # Calculate total
-                results["total"] = sum(results.values())
-
-                # Mark source model as migrated (stays in DB for historical
-                # question references and token usage analytics)
-                from intric.database.tables.ai_models_table import CompletionModels
-
-                mark_stmt = (
-                    update(CompletionModels)
-                    .where(CompletionModels.id == from_model_id)
-                    .values(migrated_to_model_id=to_model_id)
-                )
-                await self.session.execute(mark_stmt)
-
-                self.logger.info(
-                    f"Marked source model {from_model_id} as migrated to {to_model_id}"
-                )
-
-                # Commit all changes
-                await savepoint.commit()
-
-                return results
-
-            except Exception as e:
-                # Automatic rollback to savepoint
-                await savepoint.rollback()
-                raise e
-
-    def _build_tenant_filter_condition(
-        self, table: Any, entity_type: str, tenant_id: UUID
-    ) -> ColumnElement[bool]:
-        """Build appropriate tenant filtering condition based on entity type."""
-        from intric.database.tables.users_table import Users
-
-        entity_type = singular_entity_type(entity_type)
-
-        if entity_type in {"app", "question"}:
-            # Direct tenant_id field
-            return table.tenant_id == tenant_id
-        elif entity_type in {"assistant", "service"}:
-            # Via user relationship - need to join with Users table
-            return table.user_id.in_(
-                select(Users.id).where(Users.tenant_id == tenant_id)
-            )
-        elif entity_type in {"assistant_template", "app_template"}:
-            # Global entities - no tenant filtering needed
-            return true()
-        elif entity_type == "spaces":
-            # Spaces have direct tenant_id field
-            return table.tenant_id == tenant_id
-        else:
-            self.logger.warning(
-                f"Unknown entity type for tenant filtering: {entity_type}"
-            )
-            return true()
-
-    async def _migrate_entity_type(
-        self, entity_type: str, from_model_id: UUID, to_model_id: UUID, tenant_id: UUID
-    ) -> int:
-        """Migrate entities of a specific type from one model to another."""
-        self.logger.debug(
-            f"Migrating entity_type={entity_type}, from_model_id={from_model_id}, to_model_id={to_model_id}, tenant_id={tenant_id}"
-        )
-
-        # Handle spaces separately due to many-to-many relationship
-        if entity_type == "spaces":
-            return await self._migrate_spaces(from_model_id, to_model_id, tenant_id)
-
-        if entity_type not in ENTITY_TABLE_MAP:
-            self.logger.warning(
-                f"Entity type {entity_type} not found in ENTITY_TABLE_MAP"
-            )
-            return 0
-
-        table: Any = ENTITY_TABLE_MAP[entity_type]
-
-        # Build tenant-aware filtering condition
-        tenant_condition = self._build_tenant_filter_condition(
-            table, entity_type, tenant_id
-        )
-
-        # For assistants, we need to handle completion_model_kwargs specially
-        if entity_type == "assistants":
-            return await self._migrate_assistants_with_kwargs(
-                from_model_id, to_model_id, tenant_id, table, tenant_condition
-            )
-
-        # Update all entities of this type (non-assistant entities)
-        stmt = (
-            update(table)
-            .where(
-                and_(
-                    table.completion_model_id == from_model_id,
-                    tenant_condition,
-                )
-            )
-            .values(completion_model_id=to_model_id)
-        )
-
-        self.logger.debug(f"Executing migration query for {entity_type}: {stmt}")
-
-        result = await self.session.execute(stmt)
-        migrated_count = result.rowcount or 0
-
-        self.logger.info(
-            f"Migrated {migrated_count} {entity_type} entities from {from_model_id} to {to_model_id}"
-        )
-
-        return migrated_count
+    # --------------------------------------------------------- special entities
+    def _special_entity_migrators(self) -> dict[str, Any]:
+        return {"assistants": self._migrate_assistants_with_kwargs}
 
     async def _migrate_assistants_with_kwargs(
         self,
@@ -867,17 +157,12 @@ class CompletionModelMigrationService:
         table: Any,
         tenant_condition: ColumnElement[bool],
     ) -> int:
-        """Migrate assistants and handle their completion_model_kwargs properly."""
-        self.logger.debug(
-            f"Migrating assistants with kwargs handling from {from_model_id} to {to_model_id} for tenant {tenant_id}"
-        )
+        from sqlalchemy import update
 
-        # First, enable the target model on spaces where the source model is enabled
         await self._ensure_target_model_enabled_on_spaces(
             from_model_id, to_model_id, tenant_id
         )
 
-        # Update assistants: change model and reset kwargs to avoid incompatibility
         stmt = (
             update(table)
             .where(
@@ -888,141 +173,63 @@ class CompletionModelMigrationService:
             )
             .values(
                 completion_model_id=to_model_id,
-                completion_model_kwargs={},  # Reset kwargs to avoid parameter incompatibilities
+                completion_model_kwargs={},
             )
         )
-
-        self.logger.debug(
-            f"Executing assistant migration query with kwargs reset: {stmt}"
-        )
-
         result = await self.session.execute(stmt)
         migrated_count = result.rowcount or 0
-
         self.logger.info(
-            f"Migrated {migrated_count} assistants from {from_model_id} to {to_model_id}, kwargs reset to avoid incompatibilities"
+            f"Migrated {migrated_count} assistants from {from_model_id} to {to_model_id}, kwargs reset"
         )
-
         return migrated_count
 
     async def _ensure_target_model_enabled_on_spaces(
         self, from_model_id: UUID, to_model_id: UUID, tenant_id: UUID
     ) -> None:
-        """Enable target model on spaces where source model is enabled."""
+        from sqlalchemy import and_ as sa_and
+        from sqlalchemy import select
         from sqlalchemy.dialects.postgresql import insert
 
         from intric.database.tables.spaces_table import Spaces, SpacesCompletionModels
 
-        self.logger.debug(
-            f"Ensuring target model {to_model_id} is enabled on spaces where source model {from_model_id} is enabled for tenant {tenant_id}"
-        )
-
-        # Find all spaces in the tenant that have the source model enabled
         spaces_with_source_model_stmt = (
             select(SpacesCompletionModels.space_id)
             .select_from(SpacesCompletionModels)
             .join(Spaces, SpacesCompletionModels.space_id == Spaces.id)
             .where(
-                and_(
+                sa_and(
                     SpacesCompletionModels.completion_model_id == from_model_id,
                     Spaces.tenant_id == tenant_id,
                 )
             )
         )
-
         result = await self.session.execute(spaces_with_source_model_stmt)
         space_ids = [row.space_id for row in result.fetchall()]
-
         if not space_ids:
-            self.logger.debug(
-                f"No spaces found with source model {from_model_id} enabled for tenant {tenant_id}"
-            )
             return
 
-        self.logger.info(
-            f"Found {len(space_ids)} spaces with source model {from_model_id} enabled: {space_ids}, enabling target model {to_model_id}"
-        )
-
-        # Enable target model on all those spaces (using INSERT ... ON CONFLICT DO NOTHING to avoid duplicates)
         for space_id in space_ids:
             insert_stmt = insert(SpacesCompletionModels).values(
                 space_id=space_id, completion_model_id=to_model_id
             )
-            # Use ON CONFLICT DO NOTHING to handle cases where target model is already enabled
             insert_stmt = insert_stmt.on_conflict_do_nothing()
-
             await self.session.execute(insert_stmt)
 
-        self.logger.info(
-            f"Successfully enabled target model {to_model_id} on {len(space_ids)} spaces {space_ids} for tenant {tenant_id}"
-        )
-
-    async def _migrate_spaces(
-        self, from_model_id: UUID, to_model_id: UUID, tenant_id: UUID
-    ) -> int:
-        """Migrate spaces from one model to another in the many-to-many relationship."""
-        from sqlalchemy.dialects.postgresql import insert
-
-        from intric.database.tables.spaces_table import Spaces, SpacesCompletionModels
-
-        self.logger.debug(
-            f"Migrating spaces many-to-many relationship from {from_model_id} to {to_model_id} for tenant {tenant_id}"
-        )
-
-        # First, find all spaces in the tenant that have the source model enabled
-        spaces_with_source_model_stmt = (
-            select(SpacesCompletionModels.space_id)
-            .select_from(SpacesCompletionModels)
-            .join(Spaces, SpacesCompletionModels.space_id == Spaces.id)
-            .where(
-                and_(
-                    SpacesCompletionModels.completion_model_id == from_model_id,
-                    Spaces.tenant_id == tenant_id,
+    # ------------------------------------------------------------- after-hook
+    async def _after_execute(
+        self, migration_id: UUID, migrated_count: int, tenant_id: UUID
+    ) -> tuple[bool, bool]:
+        threshold = self.settings.migration_auto_recalc_threshold
+        if migrated_count <= threshold:
+            try:
+                await self.usage_service.recalculate_all_usage_stats_in_transaction(
+                    tenant_id
                 )
-            )
-        )
-
-        result = await self.session.execute(spaces_with_source_model_stmt)
-        space_ids = [row.space_id for row in result.fetchall()]
-
-        if not space_ids:
-            self.logger.debug(
-                f"No spaces found with source model {from_model_id} enabled for tenant {tenant_id}"
-            )
-            return 0
-
-        self.logger.info(
-            f"Found {len(space_ids)} spaces with source model {from_model_id}: {space_ids}"
-        )
-
-        # Step 1: Ensure target model is enabled on all these spaces (INSERT with ON CONFLICT DO NOTHING)
-        for space_id in space_ids:
-            insert_stmt = insert(SpacesCompletionModels).values(
-                space_id=space_id, completion_model_id=to_model_id
-            )
-            insert_stmt = insert_stmt.on_conflict_do_nothing()
-            await self.session.execute(insert_stmt)
-
-        self.logger.info(
-            f"Enabled target model {to_model_id} on {len(space_ids)} spaces: {space_ids}"
-        )
-
-        # Step 2: Remove the old model relationships
-        delete_stmt = delete(SpacesCompletionModels).where(
-            and_(
-                SpacesCompletionModels.completion_model_id == from_model_id,
-                SpacesCompletionModels.space_id.in_(space_ids),
-            )
-        )
-
-        self.logger.info(
-            f"Removing old relationships for source model {from_model_id} on spaces: {space_ids}"
-        )
-        delete_result = await self.session.execute(delete_stmt)
-        migrated_count = delete_result.rowcount or 0
-
-        self.logger.info(
-            f"Migrated {migrated_count} space-model associations from {from_model_id} to {to_model_id} (removed old relationships)"
-        )
-
-        return migrated_count
+                return (True, False)
+            except Exception as e:
+                self.logger.error(
+                    "Auto-recalculation failed, manual recalculation required",
+                    extra={"migration_id": str(migration_id), "error": str(e)},
+                )
+                return (False, True)
+        return (False, True)

--- a/backend/src/intric/completion_models/domain/completion_model_migration_history_repo.py
+++ b/backend/src/intric/completion_models/domain/completion_model_migration_history_repo.py
@@ -1,196 +1,22 @@
-"""Repository for completion model migration history operations."""
+"""Repository for completion model migration history operations.
 
-from datetime import datetime
-from typing import Optional
-from uuid import UUID
+Thin wrapper over the shared `ModelMigrationHistoryRepo`, bound to the
+completion history table. All CRUD lives in the shared base so completion and
+transcription stay in lockstep.
+"""
 
-from sqlalchemy import desc, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from intric.ai_models.migration.model_migration_history_repo import (
+    ModelMigrationHistoryRepo,
+)
 from intric.database.tables.completion_model_migration_history_table import (
     CompletionModelMigrationHistory,
 )
 
 
-class CompletionModelMigrationHistoryRepo:
+class CompletionModelMigrationHistoryRepo(ModelMigrationHistoryRepo):
     """Repository for managing completion model migration history."""
 
     def __init__(self, session: AsyncSession):
-        super().__init__()
-        self.session = session
-
-    async def create_migration_history(
-        self,
-        migration_id: UUID,
-        tenant_id: UUID,
-        from_model_id: UUID,
-        to_model_id: UUID,
-        initiated_by: UUID,
-        status: str,
-        entity_types: list[str] | None = None,
-        affected_count: int = 0,
-        started_at: Optional[datetime] = None,
-        from_model_name: Optional[str] = None,
-        to_model_name: Optional[str] = None,
-        from_provider_type: Optional[str] = None,
-        to_provider_type: Optional[str] = None,
-    ) -> CompletionModelMigrationHistory:
-        """Create a new migration history record."""
-        migration_history = CompletionModelMigrationHistory(
-            **dict(  # type: ignore[call-arg]
-                migration_id=migration_id,
-                tenant_id=tenant_id,
-                from_model_id=from_model_id,
-                to_model_id=to_model_id,
-                from_model_name=from_model_name,
-                to_model_name=to_model_name,
-                from_provider_type=from_provider_type,
-                to_provider_type=to_provider_type,
-                initiated_by=initiated_by,
-                status=status,
-                entity_types=entity_types,
-                affected_count=affected_count,
-                migrated_count=0,
-                failed_count=0,
-                started_at=started_at,
-            )
-        )
-
-        self.session.add(migration_history)
-        await self.session.flush()
-        return migration_history
-
-    async def update_migration_history(
-        self,
-        migration_id: UUID,
-        tenant_id: UUID,
-        *,
-        status: Optional[str] = None,
-        migrated_count: Optional[int] = None,
-        failed_count: Optional[int] = None,
-        started_at: Optional[datetime] = None,
-        completed_at: Optional[datetime] = None,
-        duration_seconds: Optional[float] = None,
-        error_message: Optional[str] = None,
-        warnings: list[str] | None = None,
-        migration_details: dict[str, int] | None = None,
-    ) -> Optional[CompletionModelMigrationHistory]:
-        """Update an existing migration history record with type-safe parameters."""
-        stmt = select(CompletionModelMigrationHistory).where(
-            CompletionModelMigrationHistory.migration_id == migration_id,
-            CompletionModelMigrationHistory.tenant_id == tenant_id,
-        )
-
-        result = await self.session.execute(stmt)
-        migration_history = result.scalar_one_or_none()
-
-        if migration_history:
-            # Update only provided fields
-            if status is not None:
-                migration_history.status = status  # type: ignore[assignment]
-            if migrated_count is not None:
-                migration_history.migrated_count = migrated_count  # type: ignore[assignment]
-            if failed_count is not None:
-                migration_history.failed_count = failed_count  # type: ignore[assignment]
-            if started_at is not None:
-                migration_history.started_at = started_at  # type: ignore[assignment]
-            if completed_at is not None:
-                migration_history.completed_at = completed_at  # type: ignore[assignment]
-            if duration_seconds is not None:
-                migration_history.duration_seconds = duration_seconds  # type: ignore[assignment]
-            if error_message is not None:
-                migration_history.error_message = error_message  # type: ignore[assignment]
-            if warnings is not None:
-                migration_history.warnings = warnings  # type: ignore[assignment]
-            if migration_details is not None:
-                migration_history.migration_details = migration_details  # type: ignore[assignment]
-
-            await self.session.flush()
-
-        return migration_history
-
-    async def get_migration_history_by_id(
-        self,
-        migration_id: UUID,
-        tenant_id: UUID,
-    ) -> Optional[CompletionModelMigrationHistory]:
-        """Get migration history by migration ID."""
-        stmt = select(CompletionModelMigrationHistory).where(
-            CompletionModelMigrationHistory.migration_id == migration_id,
-            CompletionModelMigrationHistory.tenant_id == tenant_id,
-        )
-
-        result = await self.session.execute(stmt)
-        return result.scalar_one_or_none()
-
-    async def get_migration_history_for_model(
-        self,
-        model_id: UUID,
-        tenant_id: UUID,
-        limit: int = 50,
-        offset: int = 0,
-    ) -> list[CompletionModelMigrationHistory]:
-        """Get migration history for a specific live model (from or to)."""
-        stmt = (
-            select(CompletionModelMigrationHistory)
-            .where(
-                CompletionModelMigrationHistory.tenant_id == tenant_id,
-                or_(
-                    CompletionModelMigrationHistory.from_model_id == model_id,
-                    CompletionModelMigrationHistory.to_model_id == model_id,
-                ),
-            )
-            .order_by(desc(CompletionModelMigrationHistory.created_at))
-            .limit(limit)
-            .offset(offset)
-        )
-
-        result = await self.session.execute(stmt)
-        return result.scalars().all()  # type: ignore[return-value]
-
-    async def get_migration_history_for_tenant(
-        self,
-        tenant_id: UUID,
-        limit: int = 50,
-        offset: int = 0,
-    ) -> list[CompletionModelMigrationHistory]:
-        """Get all migration history for a tenant."""
-        stmt = (
-            select(CompletionModelMigrationHistory)
-            .where(CompletionModelMigrationHistory.tenant_id == tenant_id)
-            .order_by(desc(CompletionModelMigrationHistory.created_at))
-            .limit(limit)
-            .offset(offset)
-        )
-
-        result = await self.session.execute(stmt)
-        return result.scalars().all()  # type: ignore[return-value]
-
-    async def count_migration_history_for_model(
-        self,
-        model_id: UUID,
-        tenant_id: UUID,
-    ) -> int:
-        """Count migration history records for a specific live model."""
-        stmt = select(func.count(CompletionModelMigrationHistory.id)).where(
-            CompletionModelMigrationHistory.tenant_id == tenant_id,
-            or_(
-                CompletionModelMigrationHistory.from_model_id == model_id,
-                CompletionModelMigrationHistory.to_model_id == model_id,
-            ),
-        )
-
-        result = await self.session.execute(stmt)
-        return result.scalar()  # type: ignore[return-value]
-
-    async def count_migration_history_for_tenant(
-        self,
-        tenant_id: UUID,
-    ) -> int:
-        """Count all migration history records for a tenant."""
-        stmt = select(func.count(CompletionModelMigrationHistory.id)).where(
-            CompletionModelMigrationHistory.tenant_id == tenant_id
-        )
-
-        result = await self.session.execute(stmt)
-        return result.scalar()  # type: ignore[return-value]
+        super().__init__(session, CompletionModelMigrationHistory)

--- a/backend/src/intric/database/tables/ai_models_table.py
+++ b/backend/src/intric/database/tables/ai_models_table.py
@@ -147,8 +147,12 @@ class TranscriptionModels(BasePublic):
         relationship(back_populates="transcription_models")
     )
 
-    # Soft-delete parity with completion_models (added in phase 1 of the
-    # model-table alignment; unused until a later phase wires it up).
+    # Lifecycle parity with completion_models (model-table alignment).
+    migrated_to_model_id: Mapped[Optional[UUID]] = mapped_column(
+        ForeignKey("transcription_models.id", ondelete="RESTRICT"),
+        nullable=True,
+        index=True,
+    )
     deleted_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True, index=True
     )

--- a/backend/src/intric/database/tables/ai_models_table.py
+++ b/backend/src/intric/database/tables/ai_models_table.py
@@ -106,6 +106,11 @@ class CompletionModels(BasePublic):
 class TranscriptionModels(BasePublic):
     name: Mapped[str] = mapped_column()
     model_name: Mapped[str] = mapped_column()
+    # Display name. Added in phase 1 of the model-table alignment for parity
+    # with completion/embedding. Currently the display name is still written to
+    # `name` (model_name holds the API id); nickname is backfilled but unused
+    # until a later phase switches the source of truth.
+    nickname: Mapped[Optional[str]] = mapped_column()
     open_source: Mapped[Optional[bool]] = mapped_column()
     is_deprecated: Mapped[bool] = mapped_column(server_default="False")
     hf_link: Mapped[Optional[str]] = mapped_column()
@@ -140,6 +145,12 @@ class TranscriptionModels(BasePublic):
     )
     security_classification: Mapped[Optional["SecurityClassificationsTable"]] = (
         relationship(back_populates="transcription_models")
+    )
+
+    # Soft-delete parity with completion_models (added in phase 1 of the
+    # model-table alignment; unused until a later phase wires it up).
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
     )
 
     __table_args__ = (
@@ -193,6 +204,12 @@ class EmbeddingModels(BasePublic):
     )
     security_classification: Mapped[Optional["SecurityClassificationsTable"]] = (
         relationship(back_populates="embedding_models")
+    )
+
+    # Soft-delete parity with completion_models (added in phase 1 of the
+    # model-table alignment; unused until a later phase wires it up).
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True, index=True
     )
 
     __table_args__ = (

--- a/backend/src/intric/database/tables/transcription_model_migration_history_table.py
+++ b/backend/src/intric/database/tables/transcription_model_migration_history_table.py
@@ -1,0 +1,58 @@
+"""Database table for transcription model migration history.
+
+Mirrors `completion_model_migration_history` column-for-column so the shared
+`ModelMigrationHistoryRepo` can operate on either table. Only the foreign keys
+differ (they point at `transcription_models`).
+"""
+
+from typing import Optional
+
+from sqlalchemy import JSON, TIMESTAMP, Column, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from intric.database.tables.base_class import BasePublic
+
+
+class TranscriptionModelMigrationHistory(BasePublic):
+    """Table for tracking transcription model migration history."""
+
+    __tablename__ = "transcription_model_migration_history"  # type: ignore[assignment]
+
+    migration_id = Column(UUID(as_uuid=True), nullable=False, unique=True, index=True)
+    tenant_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("tenants.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    from_model_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("transcription_models.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    to_model_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("transcription_models.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    from_model_name = Column(String(255), nullable=True)
+    to_model_name = Column(String(255), nullable=True)
+    from_provider_type = Column(String(255), nullable=True)
+    to_provider_type = Column(String(255), nullable=True)
+    initiated_by = Column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    status = Column(String(50), nullable=False, index=True)
+    entity_types = Column(JSON, nullable=True)
+    affected_count = Column(Integer, nullable=False, default=0)
+    migrated_count = Column(Integer, nullable=False, default=0)
+    failed_count = Column(Integer, nullable=False, default=0)
+    duration_seconds: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    error_message = Column(Text, nullable=True)
+    warnings = Column(JSON, nullable=True)
+    migration_details = Column(JSON, nullable=True)
+    started_at = Column(TIMESTAMP(timezone=True), nullable=True)
+    completed_at = Column(TIMESTAMP(timezone=True), nullable=True)

--- a/backend/src/intric/embedding_models/domain/embedding_model_repo.py
+++ b/backend/src/intric/embedding_models/domain/embedding_model_repo.py
@@ -41,7 +41,10 @@ class EmbeddingModelRepository:
                 sa.or_(
                     EmbeddingModels.tenant_id.is_(None),
                     EmbeddingModels.tenant_id == self.user.tenant_id,
-                )
+                ),
+                # Soft-deleted models are tombstones kept only so existing
+                # collections/websites still resolve; never surface them.
+                EmbeddingModels.deleted_at.is_(None),
             )
             .order_by(
                 EmbeddingModels.org,
@@ -86,6 +89,8 @@ class EmbeddingModelRepository:
                     EmbeddingModels.tenant_id.is_(None),
                     EmbeddingModels.tenant_id == self.user.tenant_id,
                 ),
+                # Soft-deleted models stay invisible to all callers.
+                EmbeddingModels.deleted_at.is_(None),
             )
         )
 

--- a/backend/src/intric/embedding_models/infrastructure/embedding_model_cleanup_worker.py
+++ b/backend/src/intric/embedding_models/infrastructure/embedding_model_cleanup_worker.py
@@ -1,0 +1,92 @@
+"""Weekly lifecycle cleanup of orphaned embedding models.
+
+An embedding model becomes a tombstone when it is soft-deleted (``deleted_at``
+set). Embedding models are never *migrated* (switching embedding model means
+re-embedding the underlying knowledge, not repointing references), so there is
+no ``migrated_to_model_id`` to consider.
+
+The tombstone is kept so historical ``info_blobs`` chunks keep resolving the
+model that produced their vectors (the FK is ON DELETE SET NULL). It can be
+hard-deleted only once nothing references it: collections, websites and
+integration-knowledge are active configuration (a tenant delete is already
+refused while those exist), and info_blobs are the historical blocker that
+clears when the knowledge itself is removed.
+
+This worker runs weekly and removes only models that satisfy ALL of:
+  1. deleted_at IS NOT NULL
+  2. Zero collections / websites / integration_knowledge / info_blobs referencing it
+"""
+
+import logging
+from typing import Any, cast
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from intric.ai_models.model_lifecycle_cleanup import (
+    Candidate,
+    run_model_lifecycle_cleanup,
+)
+from intric.database.tables.ai_models_table import EmbeddingModels
+from intric.database.tables.collections_table import CollectionsTable
+from intric.database.tables.info_blobs_table import InfoBlobs
+from intric.database.tables.integration_table import IntegrationKnowledge
+from intric.database.tables.websites_table import Websites
+from intric.main.container.container import Container
+from intric.worker.worker import Worker
+
+logger = logging.getLogger(__name__)
+worker: Any = Worker()
+
+
+async def _find_candidates(session: AsyncSession, limit: int) -> list[Candidate]:
+    stmt = (
+        sa.select(EmbeddingModels.id, EmbeddingModels.name)
+        .where(EmbeddingModels.deleted_at.isnot(None))
+        .order_by(EmbeddingModels.deleted_at.asc().nulls_last())
+        .limit(limit)
+    )
+    result = await session.execute(stmt)
+    return [(cast(UUID, row.id), cast(str, row.name)) for row in result.all()]
+
+
+async def _has_blocking_refs(session: AsyncSession, model_id: UUID) -> bool:
+    counts = await session.execute(
+        sa.select(
+            sa.select(sa.func.count())
+            .where(CollectionsTable.embedding_model_id == model_id)
+            .correlate(None)
+            .scalar_subquery()
+            .label("collections"),
+            sa.select(sa.func.count())
+            .where(Websites.embedding_model_id == model_id)
+            .correlate(None)
+            .scalar_subquery()
+            .label("websites"),
+            sa.select(sa.func.count())
+            .where(IntegrationKnowledge.embedding_model_id == model_id)
+            .correlate(None)
+            .scalar_subquery()
+            .label("integrations"),
+            sa.select(sa.func.count())
+            .where(InfoBlobs.embedding_model_id == model_id)
+            .correlate(None)
+            .scalar_subquery()
+            .label("info_blobs"),
+        )
+    )
+    row = counts.one()
+    return bool(row.collections or row.websites or row.integrations or row.info_blobs)
+
+
+@worker.cron_job(hour=5, minute=0, weekday={6}, manages_own_session=True)  # Sun 5:00
+async def cleanup_orphaned_embedding_models(container: Container) -> dict[str, Any]:
+    session = cast(AsyncSession, container.session())
+    return await run_model_lifecycle_cleanup(
+        session=session,
+        table=EmbeddingModels,
+        find_candidates=_find_candidates,
+        has_blocking_refs=_has_blocking_refs,
+        job_label="embedding model",
+    )

--- a/backend/src/intric/main/container/container.py
+++ b/backend/src/intric/main/container/container.py
@@ -314,6 +314,12 @@ from intric.token_usage.infrastructure.user_token_usage_analyzer import (
     UserTokenUsageAnalyzer,
 )
 from intric.transcription_models.application import TranscriptionModelCRUDService
+from intric.transcription_models.application.transcription_model_migration_history_service import (  # noqa: E501
+    TranscriptionModelMigrationHistoryService,
+)
+from intric.transcription_models.application.transcription_model_migration_service import (  # noqa: E501
+    TranscriptionModelMigrationService,
+)
 from intric.transcription_models.domain import TranscriptionModelRepository
 from intric.transcription_models.domain.transcription_model_service import (
     TranscriptionModelService,
@@ -803,6 +809,15 @@ class Container(containers.DeclarativeContainer):
     )
     completion_model_migration_history_service = providers.Factory(
         CompletionModelMigrationHistoryService,
+        session=session,
+    )
+    transcription_model_migration_service = providers.Factory(
+        TranscriptionModelMigrationService,
+        session=session,
+        transcription_model_repo=transcription_model_repo,
+    )
+    transcription_model_migration_history_service = providers.Factory(
+        TranscriptionModelMigrationHistoryService,
         session=session,
     )
     transcription_model_service = providers.Factory(

--- a/backend/src/intric/server/exception_handlers.py
+++ b/backend/src/intric/server/exception_handlers.py
@@ -3,10 +3,30 @@ from typing import Protocol, cast
 
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from sqlalchemy.exc import IntegrityError
 
 from intric.main.exceptions import EXCEPTION_MAP, ErrorCodes, UnauthorizedException
 from intric.main.models import GeneralError
 from intric.main.request_context import get_request_context
+
+# Partial unique indexes that guard active model display names, per
+# 20260602_unique_model_display_names. Their names all end in this suffix.
+_ACTIVE_NICKNAME_INDEX_SUFFIX = "_active_nickname"
+
+
+def is_active_display_name_violation(exc: IntegrityError) -> bool:
+    """True when an IntegrityError is a collision on a `uq_*_active_nickname`
+    index — the validate-then-insert race the display-name pre-check can't close.
+
+    Matches on the driver's reported constraint name when available, falling back
+    to the rendered error text (Postgres includes the constraint name there), so
+    it works regardless of which DBAPI surfaced the error.
+    """
+    orig = getattr(exc, "orig", None)
+    constraint_name = getattr(orig, "constraint_name", None) or ""
+    if constraint_name.endswith(_ACTIVE_NICKNAME_INDEX_SUFFIX):
+        return True
+    return _ACTIVE_NICKNAME_INDEX_SUFFIX in str(orig if orig is not None else exc)
 
 
 class ExceptionContext(Protocol):
@@ -115,3 +135,31 @@ def add_exception_handlers(app: FastAPI):
             )
 
         app.add_exception_handler(exception, handler)
+
+    async def integrity_error_handler(request: Request, exc: Exception) -> JSONResponse:
+        # Concurrent creates/renames to the same display name both pass the
+        # pre-check, then one loses at flush against the active-nickname unique
+        # index. Surface that as the same clean 409 the pre-check raises. Other
+        # integrity errors are re-raised so the catch-all 500 handler keeps its
+        # current behaviour (error_id, trace headers).
+        integrity_exc = cast(IntegrityError, exc)
+        if not is_active_display_name_violation(integrity_exc):
+            raise exc
+
+        request_id = _extract_request_id(request)
+        logger.warning(
+            "%s %s → 409: display name collision (DB index)",
+            request.method,
+            request.url.path,
+            extra={"error_code": ErrorCodes.NAME_COLLISION},
+        )
+        return JSONResponse(
+            status_code=409,
+            content=GeneralError(
+                message="A model with this display name already exists.",
+                intric_error_code=ErrorCodes.NAME_COLLISION,
+                request_id=request_id,
+            ).model_dump(exclude_none=True),
+        )
+
+    app.add_exception_handler(IntegrityError, integrity_error_handler)

--- a/backend/src/intric/sysadmin/sysadmin_router.py
+++ b/backend/src/intric/sysadmin/sysadmin_router.py
@@ -50,7 +50,9 @@ from intric.database.tables.ai_models_table import (
     EmbeddingModels,
 )
 from intric.database.tables.collections_table import CollectionsTable
+from intric.database.tables.info_blobs_table import InfoBlobs
 from intric.database.tables.integration_table import IntegrationKnowledge
+from intric.database.tables.spaces_table import SpacesEmbeddingModels
 from intric.database.tables.websites_table import Websites
 from intric.main.container.container import Container
 from intric.main.container.container_overrides import override_user
@@ -1451,13 +1453,39 @@ async def delete_embedding_model(
     Requires: X-API-Key header with ENEO_SUPER_API_KEY
 
     WARNING: Deletion affects all tenants. Use with caution.
+    Set force=true to hard-delete (may erase historical info_blob attribution).
     """
     # AUDIT GAP: see create_embedding_model — no owning tenant to attach
     # the audit row to. App logs are the only trace today.
     session = cast(AsyncSession, container.session())
 
     async with session.begin():
-        if not force:
+        if force:
+            # Hard-delete remains an explicit operator escape hatch. Historical
+            # info_blobs use ON DELETE SET NULL, so this can erase attribution;
+            # the normal path below soft-deletes instead.
+            from sqlalchemy.exc import IntegrityError
+
+            repo = AdminEmbeddingModelsService(session=session)
+            try:
+                await repo.delete_model(id)
+            except IntegrityError as exc:
+                raise ModelInUseException() from exc
+        else:
+            model = await session.scalar(
+                sa.select(EmbeddingModels).where(
+                    EmbeddingModels.id == id,
+                    EmbeddingModels.deleted_at.is_(None),
+                )
+            )
+            if model is None:
+                # Idempotent, matching delete_completion_model: a missing or
+                # already-soft-deleted model is a no-op success, not a 404.
+                return {
+                    "success": True,
+                    "message": f"Model {id} deleted successfully",
+                }
+
             # Three separate counts — combining them in one SELECT pulls all three
             # tables into the FROM clause, producing a cartesian product.
             collections_count = await session.scalar(
@@ -1476,17 +1504,25 @@ async def delete_embedding_model(
             if collections_count or websites_count or integrations_count:
                 raise ModelInUseException()
 
-        # Mirror the completion-model force-delete contract: if the DB
-        # refuses the delete because of a FK constraint (e.g. websites
-        # without ondelete, integration_knowledge references) surface it
-        # as MODEL_IN_USE (400) rather than letting it bubble up as a 500.
-        from sqlalchemy.exc import IntegrityError
+            info_blobs_count = await session.scalar(
+                sa.select(sa.func.count()).where(InfoBlobs.embedding_model_id == id)
+            )
+            if info_blobs_count:
+                logger.info(
+                    "sysadmin.embedding_model.soft_deleted_with_info_blobs",
+                    extra={
+                        "embedding_model_id": str(id),
+                        "info_blobs_count": info_blobs_count,
+                    },
+                )
 
-        repo = AdminEmbeddingModelsService(session=session)
-        try:
-            await repo.delete_model(id)
-        except IntegrityError as exc:
-            raise ModelInUseException() from exc
+            await session.execute(
+                sa.delete(SpacesEmbeddingModels).where(
+                    SpacesEmbeddingModels.embedding_model_id == id
+                )
+            )
+            model.deleted_at = sa.func.now()
+            await session.flush()
 
     return {"success": True, "message": f"Model {id} deleted successfully"}
 

--- a/backend/src/intric/sysadmin/sysadmin_router.py
+++ b/backend/src/intric/sysadmin/sysadmin_router.py
@@ -16,6 +16,7 @@ from intric.ai_models.completion_models.completion_model import (
 from intric.ai_models.completion_models.completion_models_repo import (
     CompletionModelsRepository,
 )
+from intric.ai_models.display_name_validation import validate_unique_display_name
 from intric.ai_models.embedding_models.embedding_model import (
     EmbeddingModelCreate,
     EmbeddingModelLegacy,
@@ -44,6 +45,10 @@ from intric.completion_models.presentation.completion_model_models import (
     ModelMigrationRequest,
 )
 from intric.database.database import AsyncSession
+from intric.database.tables.ai_models_table import (
+    CompletionModels,
+    EmbeddingModels,
+)
 from intric.database.tables.collections_table import CollectionsTable
 from intric.database.tables.integration_table import IntegrationKnowledge
 from intric.database.tables.websites_table import Websites
@@ -1250,6 +1255,12 @@ async def create_completion_model(
     # sysadmin_audit store; tracked as follow-up.
     session = cast(AsyncSession, container.session())
     async with session.begin():
+        await validate_unique_display_name(
+            session,
+            CompletionModels,
+            tenant_id=None,
+            nickname=getattr(model_data, "nickname", None),
+        )
         repo = CompletionModelsRepository(session=session)
         model = await repo.create_model(model_data)
 
@@ -1278,6 +1289,14 @@ async def update_completion_model_metadata(
     session = cast(AsyncSession, container.session())
     async with session.begin():
         repo = CompletionModelsRepository(session=session)
+
+        await validate_unique_display_name(
+            session,
+            CompletionModels,
+            tenant_id=None,
+            nickname=getattr(model_data, "nickname", None),
+            exclude_id=id,
+        )
 
         # Ensure model_data has the id
         update_with_id = CompletionModelUpdate(
@@ -1361,6 +1380,12 @@ async def create_embedding_model(
     # global model row, so no audit_log entry is emitted today.
     session = cast(AsyncSession, container.session())
     async with session.begin():
+        await validate_unique_display_name(
+            session,
+            EmbeddingModels,
+            tenant_id=None,
+            nickname=getattr(model_data, "nickname", None),
+        )
         repo = AdminEmbeddingModelsService(session=session)
         model = await repo.create_model(model_data)
 
@@ -1389,6 +1414,14 @@ async def update_embedding_model_metadata(
     session = cast(AsyncSession, container.session())
     async with session.begin():
         repo = AdminEmbeddingModelsService(session=session)
+
+        await validate_unique_display_name(
+            session,
+            EmbeddingModels,
+            tenant_id=None,
+            nickname=getattr(model_data, "nickname", None),
+            exclude_id=id,
+        )
 
         # Ensure model_data has the id
         update_with_id = EmbeddingModelMetadataUpdate(

--- a/backend/src/intric/tenant_models/application/tenant_model_service.py
+++ b/backend/src/intric/tenant_models/application/tenant_model_service.py
@@ -443,6 +443,7 @@ class TenantEmbeddingModelService:
         stmt = sa.select(EmbeddingModels).where(
             EmbeddingModels.id == model_id,
             EmbeddingModels.tenant_id == self.user.tenant_id,
+            EmbeddingModels.deleted_at.is_(None),
         )
         result = await self.session.execute(stmt)
         model = result.scalar_one_or_none()
@@ -667,6 +668,7 @@ class TenantTranscriptionModelService:
         stmt = sa.select(TranscriptionModels).where(
             TranscriptionModels.id == model_id,
             TranscriptionModels.tenant_id == self.user.tenant_id,
+            TranscriptionModels.deleted_at.is_(None),
         )
         result = await self.session.execute(stmt)
         model = result.scalar_one_or_none()

--- a/backend/src/intric/tenant_models/application/tenant_model_service.py
+++ b/backend/src/intric/tenant_models/application/tenant_model_service.py
@@ -21,6 +21,9 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
+from intric.ai_models.display_name_validation import (
+    validate_unique_display_name as _validate_unique_display_name,
+)
 from intric.audit.application.audit_metadata import AuditMetadata
 from intric.audit.domain.action_types import ActionType
 from intric.audit.domain.entity_types import EntityType
@@ -175,6 +178,12 @@ class TenantCompletionModelService:
         await _validate_active_provider(
             self.session, payload.provider_id, self.user.tenant_id
         )
+        await _validate_unique_display_name(
+            self.session,
+            CompletionModels,
+            tenant_id=self.user.tenant_id,
+            nickname=payload.display_name,
+        )
 
         if payload.is_default:
             await _unset_other_defaults(
@@ -252,6 +261,13 @@ class TenantCompletionModelService:
         if payload.name is not None:
             model.name = payload.name
         if payload.display_name is not None:
+            await _validate_unique_display_name(
+                self.session,
+                CompletionModels,
+                tenant_id=self.user.tenant_id,
+                nickname=payload.display_name,
+                exclude_id=model.id,
+            )
             model.nickname = payload.display_name
         if "description" in provided:
             model.description = payload.description
@@ -360,6 +376,12 @@ class TenantEmbeddingModelService:
         await _validate_active_provider(
             self.session, payload.provider_id, self.user.tenant_id
         )
+        await _validate_unique_display_name(
+            self.session,
+            EmbeddingModels,
+            tenant_id=self.user.tenant_id,
+            nickname=payload.display_name,
+        )
 
         if payload.is_default:
             await _unset_other_defaults(
@@ -429,6 +451,13 @@ class TenantEmbeddingModelService:
 
         provided = payload.model_fields_set
         if payload.display_name is not None:
+            await _validate_unique_display_name(
+                self.session,
+                EmbeddingModels,
+                tenant_id=self.user.tenant_id,
+                nickname=payload.display_name,
+                exclude_id=model.id,
+            )
             model.nickname = payload.display_name
         if "description" in provided:
             model.description = payload.description
@@ -559,6 +588,12 @@ class TenantTranscriptionModelService:
         await _validate_active_provider(
             self.session, payload.provider_id, self.user.tenant_id
         )
+        await _validate_unique_display_name(
+            self.session,
+            TranscriptionModels,
+            tenant_id=self.user.tenant_id,
+            nickname=payload.display_name,
+        )
 
         if payload.is_default:
             await _unset_other_defaults(
@@ -574,6 +609,10 @@ class TenantTranscriptionModelService:
                 tenant_id=self.user.tenant_id,
                 provider_id=payload.provider_id,
                 name=payload.display_name,
+                # Keep nickname in sync with the display name (which still lives
+                # in `name` for transcription). Lets the read path source the
+                # display from nickname uniformly with completion/embedding.
+                nickname=payload.display_name,
                 model_name=payload.name,
                 family=payload.family,
                 hosting=payload.hosting,
@@ -624,7 +663,15 @@ class TenantTranscriptionModelService:
 
         provided = payload.model_fields_set
         if payload.display_name is not None:
+            await _validate_unique_display_name(
+                self.session,
+                TranscriptionModels,
+                tenant_id=self.user.tenant_id,
+                nickname=payload.display_name,
+                exclude_id=model.id,
+            )
             model.name = payload.display_name
+            model.nickname = payload.display_name
         if "description" in provided:
             model.description = payload.description
         if payload.hosting is not None:

--- a/backend/src/intric/tenant_models/application/tenant_model_service.py
+++ b/backend/src/intric/tenant_models/application/tenant_model_service.py
@@ -515,11 +515,13 @@ class TenantEmbeddingModelService:
     async def delete(self, model_id: UUID) -> None:
         from intric.database.tables.collections_table import CollectionsTable
         from intric.database.tables.integration_table import IntegrationKnowledge
+        from intric.database.tables.spaces_table import SpacesEmbeddingModels
         from intric.database.tables.websites_table import Websites
 
         stmt = sa.select(EmbeddingModels).where(
             EmbeddingModels.id == model_id,
             EmbeddingModels.tenant_id == self.user.tenant_id,
+            EmbeddingModels.deleted_at.is_(None),
         )
         result = await self.session.execute(stmt)
         model = result.scalar_one_or_none()
@@ -552,13 +554,21 @@ class TenantEmbeddingModelService:
         if row.collections > 0 or row.websites > 0 or row.integrations > 0:
             raise ModelInUseException()
 
+        # Spaces are containers (configuration, not usage): drop the link rows so
+        # the soft-deleted model doesn't dangle in space-aware reads.
+        await self.session.execute(
+            sa.delete(SpacesEmbeddingModels).where(
+                SpacesEmbeddingModels.embedding_model_id == model_id
+            )
+        )
+
+        # Soft delete: keep the row as a tombstone so historical info_blob chunks
+        # (FK ON DELETE SET NULL) keep resolving their embedding model. Read paths
+        # filter deleted_at; the cleanup worker hard-deletes once nothing
+        # references it.
         snapshot = _DeletedSnapshot(id=model.id, name=model.name)
-        try:
-            await self.session.delete(model)
-            await self.session.flush()
-        except sa.exc.IntegrityError as exc:
-            await self.session.rollback()
-            raise ModelInUseException() from exc
+        model.deleted_at = sa.func.now()
+        await self.session.flush()
 
         await _audit(
             self.audit_service,
@@ -720,9 +730,13 @@ class TenantTranscriptionModelService:
         return loaded
 
     async def delete(self, model_id: UUID) -> None:
+        from intric.database.tables.app_table import Apps
+        from intric.database.tables.spaces_table import SpacesTranscriptionModels
+
         stmt = sa.select(TranscriptionModels).where(
             TranscriptionModels.id == model_id,
             TranscriptionModels.tenant_id == self.user.tenant_id,
+            TranscriptionModels.deleted_at.is_(None),
         )
         result = await self.session.execute(stmt)
         model = result.scalar_one_or_none()
@@ -732,13 +746,34 @@ class TenantTranscriptionModelService:
             )
         _ensure_tenant_owned(model)
 
+        # Block while any app still transcribes with this model. The FK is
+        # ON DELETE SET NULL, so a hard delete would silently null those apps'
+        # transcription_model_id instead of failing — an explicit count is the
+        # only thing standing between deletion and orphaned apps.
+        app_refs = await self.session.scalar(
+            sa.select(sa.func.count())
+            .select_from(Apps)
+            .where(Apps.transcription_model_id == model_id)
+        )
+        if app_refs:
+            raise ModelInUseException()
+
+        # Spaces are containers: a model "enabled" on a space without an app
+        # using it is configuration, not usage. Drop those cross-reference rows
+        # so the soft-deleted model doesn't dangle in space-aware reads (which
+        # join on the link table rather than filter deleted_at).
+        await self.session.execute(
+            sa.delete(SpacesTranscriptionModels).where(
+                SpacesTranscriptionModels.transcription_model_id == model_id
+            )
+        )
+
+        # Soft delete: keep the row as a tombstone so migration history and any
+        # lingering references still resolve. Read paths filter deleted_at; the
+        # cleanup worker hard-deletes once nothing references it.
         snapshot = _DeletedSnapshot(id=model.id, name=model.name)
-        try:
-            await self.session.delete(model)
-            await self.session.flush()
-        except sa.exc.IntegrityError as exc:
-            await self.session.rollback()
-            raise ModelInUseException() from exc
+        model.deleted_at = sa.func.now()
+        await self.session.flush()
 
         await _audit(
             self.audit_service,

--- a/backend/src/intric/tenant_models/application/tenant_model_service.py
+++ b/backend/src/intric/tenant_models/application/tenant_model_service.py
@@ -182,6 +182,7 @@ class TenantCompletionModelService:
             self.session,
             CompletionModels,
             tenant_id=self.user.tenant_id,
+            provider_id=payload.provider_id,
             nickname=payload.display_name,
         )
 
@@ -265,6 +266,7 @@ class TenantCompletionModelService:
                 self.session,
                 CompletionModels,
                 tenant_id=self.user.tenant_id,
+                provider_id=model.provider_id,
                 nickname=payload.display_name,
                 exclude_id=model.id,
             )
@@ -380,6 +382,7 @@ class TenantEmbeddingModelService:
             self.session,
             EmbeddingModels,
             tenant_id=self.user.tenant_id,
+            provider_id=payload.provider_id,
             nickname=payload.display_name,
         )
 
@@ -455,6 +458,7 @@ class TenantEmbeddingModelService:
                 self.session,
                 EmbeddingModels,
                 tenant_id=self.user.tenant_id,
+                provider_id=model.provider_id,
                 nickname=payload.display_name,
                 exclude_id=model.id,
             )
@@ -592,6 +596,7 @@ class TenantTranscriptionModelService:
             self.session,
             TranscriptionModels,
             tenant_id=self.user.tenant_id,
+            provider_id=payload.provider_id,
             nickname=payload.display_name,
         )
 
@@ -667,6 +672,7 @@ class TenantTranscriptionModelService:
                 self.session,
                 TranscriptionModels,
                 tenant_id=self.user.tenant_id,
+                provider_id=model.provider_id,
                 nickname=payload.display_name,
                 exclude_id=model.id,
             )

--- a/backend/src/intric/transcription_models/application/transcription_model_migration_history_service.py
+++ b/backend/src/intric/transcription_models/application/transcription_model_migration_history_service.py
@@ -1,0 +1,29 @@
+"""Service for transcription model migration history operations.
+
+Thin subclass of the shared `ModelMigrationHistoryService`, bound to the
+transcription history table and model table.
+"""
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from intric.ai_models.migration.model_migration_history_repo import (
+    ModelMigrationHistoryRepo,
+)
+from intric.ai_models.migration.model_migration_history_service import (
+    ModelMigrationHistoryService,
+)
+from intric.database.tables.ai_models_table import TranscriptionModels
+from intric.database.tables.transcription_model_migration_history_table import (
+    TranscriptionModelMigrationHistory,
+)
+
+
+class TranscriptionModelMigrationHistoryService(ModelMigrationHistoryService):
+    """Service for managing transcription model migration history."""
+
+    def __init__(self, session: AsyncSession):
+        super().__init__(
+            session,
+            ModelMigrationHistoryRepo(session, TranscriptionModelMigrationHistory),
+            TranscriptionModels,
+        )

--- a/backend/src/intric/transcription_models/application/transcription_model_migration_service.py
+++ b/backend/src/intric/transcription_models/application/transcription_model_migration_service.py
@@ -1,0 +1,109 @@
+"""Transcription-model migration service.
+
+Thin subclass of the shared `BaseModelMigrationService`. Transcription is the
+simplest model type to migrate — it produces no stored/indexed data, so a
+migration just repoints references (`apps.transcription_model_id` and the
+`spaces_transcription_models` many-to-many) and marks the source migrated.
+
+Compatibility rules are minimal compared to completion: there are no token
+limits / vision / reasoning / tool-calling to compare. The only checks are a
+deprecated-target warning and the (shared) security-classification blocker.
+"""
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from intric.ai_models.migration.base_migration_service import (
+    BaseModelMigrationService,
+)
+from intric.ai_models.migration.model_migration_history_repo import (
+    ModelMigrationHistoryRepo,
+)
+from intric.completion_models.presentation.completion_model_models import (
+    ValidationResult,
+)
+from intric.database.tables.ai_models_table import TranscriptionModels
+from intric.database.tables.app_table import Apps
+from intric.database.tables.spaces_table import SpacesTranscriptionModels
+from intric.database.tables.transcription_model_migration_history_table import (
+    TranscriptionModelMigrationHistory,
+)
+
+if TYPE_CHECKING:
+    from intric.transcription_models.domain.transcription_model_repo import (
+        TranscriptionModelRepository,
+    )
+
+
+class TranscriptionModelMigrationService(BaseModelMigrationService):
+    """Service for migrating transcription model usage between models."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        transcription_model_repo: "TranscriptionModelRepository",
+    ):
+        super().__init__(session)
+        self.model_repo = transcription_model_repo
+        self.history_repo = ModelMigrationHistoryRepo(
+            session, TranscriptionModelMigrationHistory
+        )
+        self._model_table = TranscriptionModels
+        self._fk_column = "transcription_model_id"
+        self._spaces_link_table = SpacesTranscriptionModels
+        self._entity_table_map = {"apps": Apps}
+        self._migratable_entity_types = ["apps", "spaces"]
+
+    async def _validate_migration_compatibility(
+        self, from_model_id: UUID, to_model_id: UUID, tenant_id: UUID
+    ) -> ValidationResult:
+        from_model = await self.model_repo.one(model_id=from_model_id)
+        to_model = await self.model_repo.one(model_id=to_model_id)
+        self._ensure_source_model_not_already_migrated(from_model)
+
+        issues: list[str] = []
+        issue_codes: list[str] = []
+        blockers: list[str] = []
+        blocker_codes: list[str] = []
+
+        if to_model.is_effectively_deprecated:
+            issues.append("Target model is deprecated")
+            issue_codes.append("target_deprecated")
+
+        target_level = (
+            to_model.security_classification.security_level
+            if to_model.security_classification
+            else 0
+        )
+        insufficient_spaces = await self._count_spaces_with_insufficient_classification(
+            from_model_id, target_level, tenant_id
+        )
+        if insufficient_spaces > 0:
+            target_name = (
+                to_model.security_classification.name
+                if to_model.security_classification
+                else "none"
+            )
+            blockers.append(
+                f"Target model classification is too low for {insufficient_spaces} spaces that require {target_name} or higher"
+            )
+            blocker_codes.append(
+                f"security_classification_insufficient:{insufficient_spaces}:{target_name}"
+            )
+
+        if blockers:
+            return ValidationResult(
+                compatible=False,
+                warnings=blockers + issues,
+                warning_codes=blocker_codes + issue_codes,
+                requires_confirmation=True,
+            )
+
+        return ValidationResult(
+            compatible=len(issues) == 0,
+            warnings=issues,
+            warning_codes=issue_codes,
+            requires_confirmation=len(issues) > 0,
+        )

--- a/backend/src/intric/transcription_models/domain/transcription_model.py
+++ b/backend/src/intric/transcription_models/domain/transcription_model.py
@@ -42,6 +42,7 @@ class TranscriptionModel(AIModel):
         provider_id: Optional["UUID"] = None,
         provider_name: Optional[str] = None,
         provider_type: Optional[str] = None,
+        migrated_to_model_id: Optional["UUID"] = None,
     ):
         super().__init__(
             user=user,
@@ -69,6 +70,7 @@ class TranscriptionModel(AIModel):
         self.provider_id = provider_id
         self.provider_name = provider_name
         self.provider_type = provider_type
+        self.migrated_to_model_id = migrated_to_model_id
 
     @property
     def model_name(self) -> str:
@@ -118,4 +120,5 @@ class TranscriptionModel(AIModel):
             provider_id=transcription_model_db.provider_id,
             provider_name=provider_name,
             provider_type=provider_type,
+            migrated_to_model_id=transcription_model_db.migrated_to_model_id,
         )

--- a/backend/src/intric/transcription_models/domain/transcription_model.py
+++ b/backend/src/intric/transcription_models/domain/transcription_model.py
@@ -93,7 +93,11 @@ class TranscriptionModel(AIModel):
             id=transcription_model_db.id,
             created_at=transcription_model_db.created_at,
             updated_at=transcription_model_db.updated_at,
-            nickname=transcription_model_db.name,
+            # Display name now lives in `nickname` (parity with
+            # completion/embedding); fall back to `name` for rows written
+            # before nickname was synced. The DB `name`/`model_name` inversion
+            # is left untouched until a later normalization phase.
+            nickname=transcription_model_db.nickname or transcription_model_db.name,
             name=transcription_model_db.model_name,
             family=transcription_model_db.family,
             hosting=transcription_model_db.hosting,

--- a/backend/src/intric/transcription_models/domain/transcription_model_repo.py
+++ b/backend/src/intric/transcription_models/domain/transcription_model_repo.py
@@ -47,7 +47,11 @@ class TranscriptionModelRepository:
                 sa.or_(
                     TranscriptionModels.tenant_id.is_(None),
                     TranscriptionModels.tenant_id == self.user.tenant_id,
-                )
+                ),
+                # Soft-deleted models are tombstones kept only so migration
+                # history and lingering app references resolve; never surface
+                # them to readers.
+                TranscriptionModels.deleted_at.is_(None),
             )
             .order_by(
                 TranscriptionModels.org,
@@ -94,6 +98,9 @@ class TranscriptionModelRepository:
                     TranscriptionModels.tenant_id.is_(None),
                     TranscriptionModels.tenant_id == self.user.tenant_id,
                 ),
+                # Soft-deleted models are invisible to all callers (including the
+                # migration engine, which must not migrate from/to a tombstone).
+                TranscriptionModels.deleted_at.is_(None),
             )
         )
 

--- a/backend/src/intric/transcription_models/infrastructure/transcription_model_cleanup_worker.py
+++ b/backend/src/intric/transcription_models/infrastructure/transcription_model_cleanup_worker.py
@@ -1,0 +1,81 @@
+"""Weekly lifecycle cleanup of orphaned transcription models.
+
+A transcription model becomes a tombstone when it is soft-deleted
+(``deleted_at`` set) or migrated away from (``migrated_to_model_id`` set). The
+row is kept so migration history and any lingering references still resolve.
+
+Once nothing references it anymore it can be hard-deleted. A transcription
+model's only direct usage reference is ``apps.transcription_model_id`` (FK
+ON DELETE SET NULL — so the database would *not* stop a delete; the explicit
+count below is the guard). Space links are config and were dropped on
+delete/migrate. Migration-history rows keep denormalized model names, so the
+SET NULL on their FK after hard-delete loses nothing user-visible.
+
+This worker runs weekly and removes only models that satisfy ALL of:
+  1. deleted_at IS NOT NULL OR migrated_to_model_id IS NOT NULL
+  2. No other transcription model points to it via migrated_to_model_id
+     (the self-FK is RESTRICT — it would block the delete)
+  3. Zero apps referencing it
+"""
+
+import logging
+from typing import Any, cast
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from intric.ai_models.model_lifecycle_cleanup import (
+    Candidate,
+    run_model_lifecycle_cleanup,
+)
+from intric.database.tables.ai_models_table import TranscriptionModels
+from intric.database.tables.app_table import Apps
+from intric.main.container.container import Container
+from intric.worker.worker import Worker
+
+logger = logging.getLogger(__name__)
+worker: Any = Worker()
+
+
+async def _find_candidates(session: AsyncSession, limit: int) -> list[Candidate]:
+    incoming_targets = (
+        sa.select(TranscriptionModels.migrated_to_model_id)
+        .where(TranscriptionModels.migrated_to_model_id.isnot(None))
+        .scalar_subquery()
+    )
+    stmt = (
+        sa.select(TranscriptionModels.id, TranscriptionModels.name)
+        .where(
+            sa.or_(
+                TranscriptionModels.deleted_at.isnot(None),
+                TranscriptionModels.migrated_to_model_id.isnot(None),
+            ),
+            TranscriptionModels.id.notin_(incoming_targets),
+        )
+        .order_by(TranscriptionModels.deleted_at.asc().nulls_last())
+        .limit(limit)
+    )
+    result = await session.execute(stmt)
+    return [(cast(UUID, row.id), cast(str, row.name)) for row in result.all()]
+
+
+async def _has_blocking_refs(session: AsyncSession, model_id: UUID) -> bool:
+    app_refs = await session.scalar(
+        sa.select(sa.func.count())
+        .select_from(Apps)
+        .where(Apps.transcription_model_id == model_id)
+    )
+    return bool(app_refs)
+
+
+@worker.cron_job(hour=4, minute=30, weekday={6}, manages_own_session=True)  # Sun 4:30
+async def cleanup_orphaned_transcription_models(container: Container) -> dict[str, Any]:
+    session = cast(AsyncSession, container.session())
+    return await run_model_lifecycle_cleanup(
+        session=session,
+        table=TranscriptionModels,
+        find_candidates=_find_candidates,
+        has_blocking_refs=_has_blocking_refs,
+        job_label="transcription model",
+    )

--- a/backend/src/intric/transcription_models/presentation/transcription_model_models.py
+++ b/backend/src/intric/transcription_models/presentation/transcription_model_models.py
@@ -38,6 +38,7 @@ class TranscriptionModelPublic(BaseModel):
     provider_name: Optional[str] = None
     provider_type: Optional[str] = None
     deprecation_date: Optional[str] = None
+    migrated_to_model_id: Optional[UUID] = None
 
     @classmethod
     def from_domain(cls, model: TranscriptionModel):
@@ -69,6 +70,7 @@ class TranscriptionModelPublic(BaseModel):
             provider_name=model.provider_name,
             provider_type=model.provider_type,
             deprecation_date=model.litellm_deprecation_date,
+            migrated_to_model_id=model.migrated_to_model_id,
         )
 
 

--- a/backend/src/intric/transcription_models/presentation/transcription_model_models.py
+++ b/backend/src/intric/transcription_models/presentation/transcription_model_models.py
@@ -91,6 +91,22 @@ class TranscriptionModelUsageStats(BaseModel):
     total_count: int = 0
 
 
+class TranscriptionUsageEntity(BaseModel):
+    """One entity using a transcription model. Shape matches completion's
+    ModelUsageDetail so the migrate dialog can render both with one component."""
+
+    entity_id: UUID
+    entity_name: str
+    entity_type: str = "app"
+    space_name: Optional[str] = None
+    owner_name: Optional[str] = None
+
+
+class TranscriptionModelUsageDetails(BaseModel):
+    items: list[TranscriptionUsageEntity] = []
+    total: int = 0
+
+
 class TranscriptionModelUpdate(BaseModel):
     is_org_enabled: Optional[bool] = None
     is_org_default: Optional[bool] = None

--- a/backend/src/intric/transcription_models/presentation/transcription_model_models.py
+++ b/backend/src/intric/transcription_models/presentation/transcription_model_models.py
@@ -78,6 +78,19 @@ class TranscriptionModelSecurityStatus(TranscriptionModelPublic):
     meets_security_classification: Optional[bool] = None
 
 
+class TranscriptionModelUsageStats(BaseModel):
+    """Live count of what a transcription model migration would move.
+
+    Transcription has no pre-aggregated usage-stats table (unlike completion);
+    these counts come straight from the migration engine's entity counters.
+    """
+
+    model_id: UUID
+    apps_count: int = 0
+    spaces_count: int = 0
+    total_count: int = 0
+
+
 class TranscriptionModelUpdate(BaseModel):
     is_org_enabled: Optional[bool] = None
     is_org_default: Optional[bool] = None

--- a/backend/src/intric/transcription_models/presentation/transcription_models_router.py
+++ b/backend/src/intric/transcription_models/presentation/transcription_models_router.py
@@ -25,6 +25,7 @@ from intric.server.protocol import responses
 from intric.transcription_models.presentation.transcription_model_models import (
     TranscriptionModelPublic,
     TranscriptionModelUpdate,
+    TranscriptionModelUsageStats,
 )
 from intric.users.user import UserInDB
 
@@ -137,6 +138,30 @@ async def update_transcription_model(
         )
 
     return TranscriptionModelPublic.from_domain(transcription_model)
+
+
+@router.get(
+    "/{model_id}/usage",
+    response_model=TranscriptionModelUsageStats,
+    responses=responses.get_responses([404]),
+    description="Count apps and spaces that would be moved by migrating this model.",
+)
+async def get_transcription_model_usage(
+    model_id: UUID,
+    user: CurrentUser,
+    container: Annotated[Container, Depends(get_container(with_user=True))],
+) -> TranscriptionModelUsageStats:
+    """Live impact counts for the migrate dialog (transcription has no
+    pre-aggregated usage-stats table, so these are computed on demand)."""
+    validate_permission(user, Permission.ADMIN)
+    service = container.transcription_model_migration_service()
+    counts = await service.count_affected_per_type(model_id, user.tenant_id)
+    return TranscriptionModelUsageStats(
+        model_id=model_id,
+        apps_count=counts.get("apps", 0),
+        spaces_count=counts.get("spaces", 0),
+        total_count=counts.get("total", 0),
+    )
 
 
 @router.get(

--- a/backend/src/intric/transcription_models/presentation/transcription_models_router.py
+++ b/backend/src/intric/transcription_models/presentation/transcription_models_router.py
@@ -2,6 +2,7 @@ import logging
 from typing import Annotated, cast
 from uuid import UUID
 
+import sqlalchemy as sa
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 # Audit logging - module level imports for consistency
@@ -16,6 +17,9 @@ from intric.completion_models.presentation.completion_model_models import (
     ValidationResult,
 )
 from intric.database.database import AsyncSession
+from intric.database.tables.app_table import Apps
+from intric.database.tables.spaces_table import Spaces
+from intric.database.tables.users_table import Users
 from intric.main.container.container import Container
 from intric.main.exceptions import ValidationException
 from intric.main.models import PaginatedResponse, is_provided
@@ -25,7 +29,9 @@ from intric.server.protocol import responses
 from intric.transcription_models.presentation.transcription_model_models import (
     TranscriptionModelPublic,
     TranscriptionModelUpdate,
+    TranscriptionModelUsageDetails,
     TranscriptionModelUsageStats,
+    TranscriptionUsageEntity,
 )
 from intric.users.user import UserInDB
 
@@ -162,6 +168,60 @@ async def get_transcription_model_usage(
         spaces_count=counts.get("spaces", 0),
         total_count=counts.get("total", 0),
     )
+
+
+@router.get(
+    "/{model_id}/usage/details",
+    response_model=TranscriptionModelUsageDetails,
+    responses=responses.get_responses([404]),
+    description="List apps using this transcription model (for the migrate dialog).",
+)
+async def get_transcription_model_usage_details(
+    model_id: UUID,
+    user: CurrentUser,
+    container: Annotated[Container, Depends(get_container(with_user=True))],
+    limit: int = Query(100, ge=1, le=500),
+) -> TranscriptionModelUsageDetails:
+    """Per-entity usage so the migrate dialog can use the same impact table as
+    completion. Transcription's only direct reference is apps; spaces are a
+    many-to-many shown via the aggregate /usage count."""
+    validate_permission(user, Permission.ADMIN)
+    session = cast(AsyncSession, container.session())
+
+    where = sa.and_(
+        Apps.transcription_model_id == model_id,
+        Apps.tenant_id == user.tenant_id,
+    )
+    rows = (
+        await session.execute(
+            sa.select(
+                Apps.id,
+                Apps.name,
+                Spaces.name.label("space_name"),
+                Users.username.label("owner_name"),
+            )
+            .select_from(Apps)
+            .join(Spaces, Apps.space_id == Spaces.id, isouter=True)
+            .join(Users, Apps.user_id == Users.id, isouter=True)
+            .where(where)
+            .limit(limit)
+        )
+    ).all()
+    total = (
+        await session.execute(sa.select(sa.func.count()).select_from(Apps).where(where))
+    ).scalar_one()
+
+    items = [
+        TranscriptionUsageEntity(
+            entity_id=row.id,
+            entity_name=row.name,
+            entity_type="app",
+            space_name=row.space_name,
+            owner_name=row.owner_name,
+        )
+        for row in rows
+    ]
+    return TranscriptionModelUsageDetails(items=items, total=total)
 
 
 @router.get(

--- a/backend/src/intric/transcription_models/presentation/transcription_models_router.py
+++ b/backend/src/intric/transcription_models/presentation/transcription_models_router.py
@@ -1,14 +1,23 @@
-from typing import Annotated
+import logging
+from typing import Annotated, cast
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 # Audit logging - module level imports for consistency
 from intric.audit.application.audit_metadata import AuditMetadata
 from intric.audit.domain.action_types import ActionType
 from intric.audit.domain.entity_types import EntityType
 from intric.authentication.auth_dependencies import get_current_active_user
+from intric.completion_models.presentation.completion_model_models import (
+    MigrationResult,
+    ModelMigrationHistory,
+    ModelMigrationRequest,
+    ValidationResult,
+)
+from intric.database.database import AsyncSession
 from intric.main.container.container import Container
+from intric.main.exceptions import ValidationException
 from intric.main.models import PaginatedResponse, is_provided
 from intric.roles.permissions import Permission, validate_permission
 from intric.server.dependencies.container import get_container
@@ -20,6 +29,8 @@ from intric.transcription_models.presentation.transcription_model_models import 
 from intric.users.user import UserInDB
 
 CurrentUser = Annotated[UserInDB, Depends(get_current_active_user)]
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -126,3 +137,169 @@ async def update_transcription_model(
         )
 
     return TranscriptionModelPublic.from_domain(transcription_model)
+
+
+@router.get(
+    "/{model_id}/migration-validate",
+    response_model=ValidationResult,
+    responses=responses.get_responses([400, 404]),
+    description="Validate transcription migration compatibility without executing.",
+)
+async def validate_transcription_migration(
+    model_id: UUID,
+    user: CurrentUser,
+    container: Annotated[Container, Depends(get_container(with_user=True))],
+    to_model_id: UUID = Query(..., description="Target model ID"),
+) -> ValidationResult:
+    """Validate transcription migration compatibility without executing."""
+    validate_permission(user, Permission.ADMIN)
+    migration_service = container.transcription_model_migration_service()
+    return await migration_service.validate_migration(
+        model_id, to_model_id, user.tenant_id
+    )
+
+
+@router.post(
+    "/{model_id}/migrate",
+    response_model=MigrationResult,
+    responses=responses.get_responses([400, 403, 404]),
+    description="Migrate all usage from one transcription model to another.",
+)
+async def migrate_transcription_model_usage(
+    model_id: UUID,
+    migration_request: ModelMigrationRequest,
+    user: CurrentUser,
+    container: Annotated[
+        Container, Depends(get_container(with_user=True, with_transaction=False))
+    ],
+) -> MigrationResult:
+    """Migrate all usage from one transcription model to another.
+
+    Validity, same-model rejection, tenant ownership and entity-type
+    whitelisting all live in the shared migration engine; the router only
+    enforces admin permission and writes the audit log on success.
+    """
+    validate_permission(user, Permission.ADMIN)
+
+    session = cast(AsyncSession, container.session())
+    migration_service = container.transcription_model_migration_service()
+    migration_error: ValidationException | None = None
+    result: MigrationResult | None = None
+
+    async with session.begin():
+        try:
+            result = await migration_service.migrate_model_usage(
+                from_model_id=model_id,
+                to_model_id=migration_request.to_model_id,
+                entity_types=migration_request.entity_types,
+                user=user,
+                confirm_migration=migration_request.confirm_migration,
+            )
+        except ValidationException as exc:
+            # The engine records the failure in migration_history before raising;
+            # catch inside the transaction so that record commits, then re-raise.
+            migration_error = exc
+
+    if migration_error is not None:
+        raise migration_error
+
+    assert result is not None
+
+    try:
+        async with session.begin():
+            audit_service = container.audit_service()
+            repo = container.transcription_model_repo()
+            from_model = await repo.one(model_id=model_id)
+            to_model = await repo.one(model_id=migration_request.to_model_id)
+            to_model_label = (
+                to_model.name if to_model else str(migration_request.to_model_id)
+            )
+            await audit_service.log_async(
+                tenant_id=user.tenant_id,
+                actor_id=user.id,
+                action=ActionType.TRANSCRIPTION_MODEL_MIGRATED,
+                entity_type=EntityType.TRANSCRIPTION_MODEL,
+                entity_id=model_id,
+                description=(
+                    f"Migrated model usage from {from_model.name} to "
+                    f"{to_model_label} ({result.migrated_count} entities)"
+                ),
+                metadata=AuditMetadata.standard(
+                    actor=user,
+                    target=from_model,
+                    changes={
+                        "from_model_id": str(model_id),
+                        "to_model_id": str(migration_request.to_model_id),
+                        "migrated_count": result.migrated_count,
+                        "failed_count": result.failed_count,
+                        "duration": result.duration,
+                        "details": result.details,
+                        "warnings": result.warnings,
+                    },
+                ),
+            )
+    except Exception as audit_err:
+        logger.warning(
+            "Failed to create audit log for transcription migration: %s", audit_err
+        )
+
+    return result
+
+
+@router.get(
+    "/migration-history",
+    response_model=list[ModelMigrationHistory],
+    responses=responses.get_responses([400]),
+    description="List all transcription migration history for the tenant.",
+)
+async def get_all_transcription_migration_history(
+    user: CurrentUser,
+    container: Annotated[Container, Depends(get_container(with_user=True))],
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+) -> list[ModelMigrationHistory]:
+    """Get all transcription migration history for the tenant."""
+    validate_permission(user, Permission.ADMIN)
+    service = container.transcription_model_migration_history_service()
+    return await service.get_migration_history_for_tenant(user.tenant_id, limit, offset)
+
+
+@router.get(
+    "/migration-history/{migration_id}",
+    response_model=ModelMigrationHistory,
+    responses=responses.get_responses([404]),
+    description="Get a specific transcription migration history record by ID.",
+)
+async def get_transcription_migration_history_by_id(
+    migration_id: UUID,
+    user: CurrentUser,
+    container: Annotated[Container, Depends(get_container(with_user=True))],
+) -> ModelMigrationHistory:
+    """Get a specific transcription migration history record by ID."""
+    validate_permission(user, Permission.ADMIN)
+    service = container.transcription_model_migration_history_service()
+    history = await service.get_migration_history_by_id(migration_id, user.tenant_id)
+    if not history:
+        raise HTTPException(status_code=404, detail="Migration history not found")
+    return history
+
+
+@router.get(
+    "/{model_id}/migration-history",
+    response_model=list[ModelMigrationHistory],
+    responses=responses.get_responses([404]),
+    description="Get migration history for a specific transcription model.",
+)
+async def get_transcription_model_migration_history(
+    model_id: UUID,
+    user: CurrentUser,
+    container: Annotated[Container, Depends(get_container(with_user=True))],
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+) -> list[ModelMigrationHistory]:
+    """Get migration history for a specific transcription model (from or to)."""
+    validate_permission(user, Permission.ADMIN)
+    service = container.transcription_model_migration_history_service()
+    return await service.get_migration_history_for_model(
+        model_id, user.tenant_id, limit, offset
+    )

--- a/backend/src/intric/worker/arq.py
+++ b/backend/src/intric/worker/arq.py
@@ -5,10 +5,16 @@ from intric.completion_models.infrastructure.model_cleanup_worker import (
 from intric.data_retention.infrastructure.data_retention_worker import (
     worker as data_retention_worker,
 )
+from intric.embedding_models.infrastructure.embedding_model_cleanup_worker import (
+    worker as embedding_model_cleanup_worker,
+)
 from intric.integration.infrastructure.sharepoint_subscription_worker import (
     worker as sharepoint_subscription_worker,
 )
 from intric.integration.tasks.integration_task import worker as integration_worker
+from intric.transcription_models.infrastructure.transcription_model_cleanup_worker import (  # noqa: E501
+    worker as transcription_model_cleanup_worker,
+)
 from intric.worker.routes import worker as sub_worker
 from intric.worker.worker import Worker
 
@@ -19,6 +25,8 @@ worker.include_subworker(integration_worker)
 worker.include_subworker(data_retention_worker)
 worker.include_subworker(sharepoint_subscription_worker)
 worker.include_subworker(model_cleanup_worker)
+worker.include_subworker(transcription_model_cleanup_worker)
+worker.include_subworker(embedding_model_cleanup_worker)
 
 
 class WorkerSettings:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -72,6 +72,7 @@ _install_warning_ignores_eagerly()
 # Organized to mirror the backend source structure (src/intric/*)
 pytest_plugins = [
     "tests.integration.fixtures.completion_models",  # Completion model fixtures
+    "tests.integration.fixtures.transcription_models",  # Transcription model fixtures
     "tests.integration.fixtures.assistants",  # Assistant fixtures
     "tests.integration.fixtures.apps",  # App fixtures
     "tests.integration.fixtures.services",  # Service fixtures

--- a/backend/tests/integration/embedding_models/test_embedding_model_lifecycle.py
+++ b/backend/tests/integration/embedding_models/test_embedding_model_lifecycle.py
@@ -1,0 +1,168 @@
+"""Integration tests for the embedding model lifecycle.
+
+Embedding models are never migrated (switching embedding model means
+re-embedding, not repointing), so the lifecycle is soft-delete only:
+- tenant delete soft-deletes (keeps the row as a tombstone) and hides it from
+  read paths
+- the weekly cleanup worker hard-deletes a tombstone only once nothing
+  references it — info_blobs (the historical chunk → model link, FK SET NULL)
+  are the blocker that keeps a tombstone alive until the knowledge is gone
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+
+from intric.database.tables.ai_models_table import EmbeddingModels
+from intric.database.tables.info_blobs_table import InfoBlobs
+from intric.database.tables.model_providers_table import ModelProviders
+from intric.embedding_models.domain.embedding_model_repo import (
+    EmbeddingModelRepository,
+)
+from intric.embedding_models.infrastructure.embedding_model_cleanup_worker import (
+    cleanup_orphaned_embedding_models,
+)
+from intric.tenant_models.application.tenant_model_service import (
+    TenantEmbeddingModelService,
+)
+
+
+async def _make_embedding_model(session, admin_user, name, *, deleted=False):
+    provider = (
+        await session.execute(
+            select(ModelProviders).where(
+                ModelProviders.tenant_id == admin_user.tenant_id,
+                ModelProviders.provider_type == "openai",
+            )
+        )
+    ).scalar_one_or_none()
+    if provider is None:
+        provider = ModelProviders(
+            tenant_id=admin_user.tenant_id,
+            name="Openai",
+            provider_type="openai",
+            credentials={"api_key": "test-key"},
+            config={},
+            is_active=True,
+        )
+        session.add(provider)
+        await session.flush()
+
+    model = EmbeddingModels(
+        tenant_id=admin_user.tenant_id,
+        provider_id=provider.id,
+        name=name,
+        open_source=False,
+        family="openai",
+        stability="stable",
+        hosting="usa",
+    )
+    session.add(model)
+    await session.flush()
+    if deleted:
+        model.deleted_at = datetime.now(timezone.utc)
+        await session.flush()
+    return model
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestEmbeddingModelSoftDelete:
+    async def test_delete_soft_deletes_and_hides_from_reads(
+        self, db_container, admin_user
+    ):
+        async with db_container() as container:
+            session = container.session()
+            model = await _make_embedding_model(session, admin_user, "embed-del")
+            model_id = model.id
+
+            service = TenantEmbeddingModelService(session=session, user=admin_user)
+            await service.delete(model_id)
+
+            row = (
+                await session.execute(
+                    select(EmbeddingModels).where(EmbeddingModels.id == model_id)
+                )
+            ).scalar_one()
+            assert row.deleted_at is not None
+
+            repo = EmbeddingModelRepository(session, admin_user)
+            assert all(m.id != model_id for m in await repo.all())
+            assert await repo.one_or_none(model_id) is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestEmbeddingModelCleanupWorker:
+    async def test_cleanup_removes_soft_deleted_without_references(
+        self, db_container, admin_user
+    ):
+        async with db_container() as container:
+            session = container.session()
+            model = await _make_embedding_model(
+                session, admin_user, "embed-tomb", deleted=True
+            )
+            model_id = model.id
+
+        async with db_container() as container:
+            result = await cleanup_orphaned_embedding_models(container)
+            session = container.session()
+
+            assert str(model_id) in [m["id"] for m in result["removed_models"]]
+            assert (
+                await session.execute(
+                    select(EmbeddingModels).where(EmbeddingModels.id == model_id)
+                )
+            ).scalar_one_or_none() is None
+
+    async def test_cleanup_never_touches_active_models(self, db_container, admin_user):
+        # An embedding model with no deleted_at is not a tombstone and must never
+        # be selected — embedding has no migration, so deleted_at is the *only*
+        # lifecycle signal.
+        async with db_container() as container:
+            session = container.session()
+            active = await _make_embedding_model(session, admin_user, "embed-active")
+            active_id = active.id
+
+        async with db_container() as container:
+            result = await cleanup_orphaned_embedding_models(container)
+            session = container.session()
+
+            assert str(active_id) not in [m["id"] for m in result["removed_models"]]
+            assert (
+                await session.execute(
+                    select(EmbeddingModels).where(EmbeddingModels.id == active_id)
+                )
+            ).scalar_one_or_none() is not None
+
+    async def test_cleanup_skips_tombstone_with_info_blob_reference(
+        self, db_container, admin_user
+    ):
+        async with db_container() as container:
+            session = container.session()
+            model = await _make_embedding_model(
+                session, admin_user, "embed-stuck", deleted=True
+            )
+            model_id = model.id
+            session.add(
+                InfoBlobs(
+                    text="historical chunk",
+                    size=10,
+                    user_id=admin_user.id,
+                    tenant_id=admin_user.tenant_id,
+                    embedding_model_id=model_id,
+                )
+            )
+            await session.flush()
+
+        async with db_container() as container:
+            result = await cleanup_orphaned_embedding_models(container)
+            session = container.session()
+
+            assert str(model_id) in [m["id"] for m in result["skipped_models"]]
+            assert (
+                await session.execute(
+                    select(EmbeddingModels).where(EmbeddingModels.id == model_id)
+                )
+            ).scalar_one_or_none() is not None

--- a/backend/tests/integration/embedding_models/test_embedding_model_lifecycle.py
+++ b/backend/tests/integration/embedding_models/test_embedding_model_lifecycle.py
@@ -17,12 +17,17 @@ from sqlalchemy import select
 from intric.database.tables.ai_models_table import EmbeddingModels
 from intric.database.tables.info_blobs_table import InfoBlobs
 from intric.database.tables.model_providers_table import ModelProviders
+from intric.database.tables.spaces_table import SpacesEmbeddingModels
 from intric.embedding_models.domain.embedding_model_repo import (
     EmbeddingModelRepository,
 )
 from intric.embedding_models.infrastructure.embedding_model_cleanup_worker import (
     cleanup_orphaned_embedding_models,
 )
+from intric.embedding_models.presentation.tenant_embedding_models_router import (
+    TenantEmbeddingModelUpdate,
+)
+from intric.main.exceptions import NotFoundException
 from intric.tenant_models.application.tenant_model_service import (
     TenantEmbeddingModelService,
 )
@@ -90,6 +95,74 @@ class TestEmbeddingModelSoftDelete:
             repo = EmbeddingModelRepository(session, admin_user)
             assert all(m.id != model_id for m in await repo.all())
             assert await repo.one_or_none(model_id) is None
+
+    async def test_update_rejects_soft_deleted_model(self, db_container, admin_user):
+        async with db_container() as container:
+            session = container.session()
+            model = await _make_embedding_model(
+                session, admin_user, "embed-update-deleted", deleted=True
+            )
+
+            service = TenantEmbeddingModelService(session=session, user=admin_user)
+            with pytest.raises(NotFoundException):
+                await service.update(
+                    model.id,
+                    TenantEmbeddingModelUpdate(description="should not update"),
+                )
+
+    async def test_sysadmin_delete_soft_deletes_and_preserves_info_blob_model_link(
+        self, client, super_admin_token, db_container, admin_user, space_factory
+    ):
+        async with db_container() as container:
+            session = container.session()
+            model = await _make_embedding_model(session, admin_user, "embed-admin-del")
+            model_id = model.id
+            space = await space_factory(session, "Embedding model admin delete")
+            session.add(
+                SpacesEmbeddingModels(space_id=space.id, embedding_model_id=model_id)
+            )
+            info_blob = InfoBlobs(
+                text="historical chunk",
+                size=10,
+                user_id=admin_user.id,
+                tenant_id=admin_user.tenant_id,
+                embedding_model_id=model_id,
+            )
+            session.add(info_blob)
+            await session.flush()
+            info_blob_id = info_blob.id
+
+        response = await client.delete(
+            f"/api/v1/sysadmin/embedding-models/{model_id}",
+            headers={"X-API-Key": super_admin_token},
+        )
+        assert response.status_code == 200
+
+        async with db_container() as container:
+            session = container.session()
+
+            row = (
+                await session.execute(
+                    select(EmbeddingModels).where(EmbeddingModels.id == model_id)
+                )
+            ).scalar_one()
+            assert row.deleted_at is not None
+
+            blob = (
+                await session.execute(
+                    select(InfoBlobs).where(InfoBlobs.id == info_blob_id)
+                )
+            ).scalar_one()
+            assert blob.embedding_model_id == model_id
+
+            link = (
+                await session.execute(
+                    select(SpacesEmbeddingModels).where(
+                        SpacesEmbeddingModels.embedding_model_id == model_id
+                    )
+                )
+            ).scalar_one_or_none()
+            assert link is None
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/fixtures/transcription_models.py
+++ b/backend/tests/integration/fixtures/transcription_models.py
@@ -1,0 +1,99 @@
+"""
+Fixtures for transcription models (mirrors src/intric/transcription_models/).
+
+Parallel to the completion_model_factory, used by the transcription migration
+integration tests.
+"""
+
+import pytest
+from sqlalchemy import select
+
+from intric.database.tables.ai_models_table import TranscriptionModels
+from intric.database.tables.model_providers_table import ModelProviders
+
+
+@pytest.fixture
+def transcription_model_factory(admin_user):
+    """Factory for creating tenant transcription models.
+
+    Usage:
+        async with db_container() as container:
+            session = container.session()
+            old = await transcription_model_factory(session, "whisper-old")
+            new = await transcription_model_factory(session, "whisper-new")
+    """
+    _provider_cache = {}
+
+    async def _get_or_create_provider(session, tenant_id, provider_type: str):
+        cache_key = (tenant_id, provider_type)
+        if cache_key in _provider_cache:
+            return _provider_cache[cache_key]
+
+        result = await session.execute(
+            select(ModelProviders).where(
+                ModelProviders.tenant_id == tenant_id,
+                ModelProviders.provider_type == provider_type,
+            )
+        )
+        existing = result.scalar_one_or_none()
+        if existing:
+            _provider_cache[cache_key] = existing.id
+            return existing.id
+
+        provider = ModelProviders(
+            tenant_id=tenant_id,
+            name=provider_type.title(),
+            provider_type=provider_type,
+            credentials={"api_key": "test-key"},
+            config={},
+            is_active=True,
+        )
+        session.add(provider)
+        await session.flush()
+        _provider_cache[cache_key] = provider.id
+        return provider.id
+
+    async def _create_model(
+        session,
+        name: str,
+        nickname: str = None,
+        provider: str = "openai",
+        is_deprecated: bool = False,
+        is_enabled: bool = True,
+        is_default: bool = False,
+        family: str = None,
+        **kwargs,
+    ) -> TranscriptionModels:
+        if family is None:
+            family = {"openai": "openai", "anthropic": "claude"}.get(provider, "openai")
+        if nickname is None:
+            nickname = name
+
+        provider_id = await _get_or_create_provider(
+            session, admin_user.tenant_id, provider
+        )
+
+        model = TranscriptionModels(
+            tenant_id=admin_user.tenant_id,
+            provider_id=provider_id,
+            name=name,
+            model_name=kwargs.get("model_name", name),
+            nickname=nickname,
+            family=family,
+            hosting=kwargs.get("hosting", "usa"),
+            org=kwargs.get("org"),
+            stability=kwargs.get("stability", "stable"),
+            open_source=kwargs.get("open_source", False),
+            description=kwargs.get("description"),
+            hf_link=kwargs.get("hf_link"),
+            base_url=kwargs.get("base_url", ""),
+            is_deprecated=is_deprecated,
+            is_enabled=is_enabled,
+            is_default=is_default,
+            security_classification_id=kwargs.get("security_classification_id"),
+        )
+        session.add(model)
+        await session.flush()
+        return model
+
+    return _create_model

--- a/backend/tests/integration/sysadmin/test_ai_models_crud.py
+++ b/backend/tests/integration/sysadmin/test_ai_models_crud.py
@@ -607,14 +607,17 @@ async def test_delete_embedding_model(client, super_admin_token, db_container):
 
     assert response.status_code == 200
 
-    # Verify model was deleted from database
+    # The normal sysadmin delete soft-deletes (parity with completion): the row
+    # is kept as a tombstone with deleted_at set so historical info_blob
+    # attribution survives. Use force=true for a hard delete.
     async with db_container() as container:
         session = container.session()
         stmt = sa.select(EmbeddingModels).where(EmbeddingModels.id == model_id)
         result = await session.execute(stmt)
         db_model = result.scalar_one_or_none()
 
-        assert db_model is None
+        assert db_model is not None
+        assert db_model.deleted_at is not None
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/sysadmin/test_ai_models_crud.py
+++ b/backend/tests/integration/sysadmin/test_ai_models_crud.py
@@ -18,6 +18,58 @@ from intric.database.tables.ai_models_table import CompletionModels, EmbeddingMo
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_duplicate_display_name_race_returns_409(
+    client, super_admin_token, monkeypatch
+):
+    """The display-name pre-check normally returns a 409 before the DB. If a
+    concurrent request slips past it (the validate-then-insert race), the active
+    nickname unique index fires at flush; that IntegrityError must surface as the
+    same clean 409 NAME_COLLISION, not a 500. Bypass the pre-check to reach it.
+    """
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "intric.sysadmin.sysadmin_router.validate_unique_display_name", _noop
+    )
+
+    payload = {
+        "name": "race-collision-model",
+        "nickname": "Race Collision Display Name",
+        "family": "openai",
+        "max_input_tokens": 8000,
+        "max_output_tokens": 4096,
+        "is_deprecated": False,
+        "stability": "stable",
+        "hosting": "usa",
+        "open_source": False,
+        "description": "Race test model",
+        "org": "OpenAI",
+        "vision": False,
+        "reasoning": False,
+        "base_url": "https://api.openai.com/v1",
+        "litellm_model_name": "gpt-4",
+    }
+
+    first = await client.post(
+        "/api/v1/sysadmin/completion-models/create",
+        headers={"X-API-Key": super_admin_token},
+        json=payload,
+    )
+    assert first.status_code == 200
+
+    second = await client.post(
+        "/api/v1/sysadmin/completion-models/create",
+        headers={"X-API-Key": super_admin_token},
+        json=payload,
+    )
+    assert second.status_code == 409
+    assert second.json().get("intric_error_code") == 9017
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_create_completion_model_success(client, super_admin_token, db_container):
     """Test creating a new completion model with valid data."""
     model_data = {

--- a/backend/tests/integration/test_tenant_models_security_classification.py
+++ b/backend/tests/integration/test_tenant_models_security_classification.py
@@ -118,7 +118,7 @@ def _completion_payload(provider_id: str, **overrides) -> dict:
     body = {
         "provider_id": provider_id,
         "name": f"completion-{uuid4().hex[:8]}",
-        "display_name": "Test completion",
+        "display_name": f"Test completion {uuid4().hex[:8]}",
         "max_input_tokens": 8000,
         "max_output_tokens": 4096,
     }
@@ -130,7 +130,7 @@ def _embedding_payload(provider_id: str, **overrides) -> dict:
     body = {
         "provider_id": provider_id,
         "name": f"embedding-{uuid4().hex[:8]}",
-        "display_name": "Test embedding",
+        "display_name": f"Test embedding {uuid4().hex[:8]}",
     }
     body.update(overrides)
     return body
@@ -140,7 +140,7 @@ def _transcription_payload(provider_id: str, **overrides) -> dict:
     body = {
         "provider_id": provider_id,
         "name": f"transcription-{uuid4().hex[:8]}",
-        "display_name": "Test transcription",
+        "display_name": f"Test transcription {uuid4().hex[:8]}",
     }
     body.update(overrides)
     return body

--- a/backend/tests/integration/transcription_models/test_transcription_model_lifecycle.py
+++ b/backend/tests/integration/transcription_models/test_transcription_model_lifecycle.py
@@ -1,0 +1,331 @@
+"""Integration tests for the transcription model lifecycle.
+
+Covers the soft-delete parity added in the model-table alignment:
+- tenant delete soft-deletes (keeps the row as a tombstone) and hides it from
+  read paths, instead of hard-deleting and silently orphaning apps
+- deletion is blocked while an app still references the model
+- the weekly cleanup worker hard-deletes tombstones only once nothing references
+  them (and never the target a migration points to)
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+
+from intric.database.tables.ai_models_table import TranscriptionModels
+from intric.database.tables.transcription_model_migration_history_table import (
+    TranscriptionModelMigrationHistory,
+)
+from intric.main.exceptions import ModelInUseException
+from intric.tenant_models.application.tenant_model_service import (
+    TenantTranscriptionModelService,
+)
+from intric.transcription_models.domain.transcription_model_repo import (
+    TranscriptionModelRepository,
+)
+from intric.transcription_models.infrastructure.transcription_model_cleanup_worker import (  # noqa: E501
+    cleanup_orphaned_transcription_models,
+)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestTranscriptionModelSoftDelete:
+    async def test_delete_soft_deletes_and_hides_from_reads(
+        self, db_container, transcription_model_factory, admin_user
+    ):
+        async with db_container() as container:
+            session = container.session()
+            model = await transcription_model_factory(session, "whisper-del")
+            model_id = model.id
+
+            service = TenantTranscriptionModelService(session=session, user=admin_user)
+            await service.delete(model_id)
+
+            # Row is kept as a tombstone with deleted_at set.
+            row = (
+                await session.execute(
+                    select(TranscriptionModels).where(
+                        TranscriptionModels.id == model_id
+                    )
+                )
+            ).scalar_one()
+            assert row.deleted_at is not None
+
+            # Read paths no longer surface it.
+            repo = TranscriptionModelRepository(session, admin_user)
+            assert all(m.id != model_id for m in await repo.all())
+            assert await repo.one_or_none(model_id) is None
+
+    async def test_delete_blocked_while_app_references_model(
+        self, db_container, transcription_model_factory, app_factory, admin_user
+    ):
+        async with db_container() as container:
+            session = container.session()
+            model = await transcription_model_factory(session, "whisper-used")
+            model_id = model.id
+            await app_factory(
+                session, "Transcribe App", None, transcription_model_id=model_id
+            )
+
+            service = TenantTranscriptionModelService(session=session, user=admin_user)
+            with pytest.raises(ModelInUseException):
+                await service.delete(model_id)
+
+            # The model is untouched — not soft-deleted, app not orphaned.
+            row = (
+                await session.execute(
+                    select(TranscriptionModels).where(
+                        TranscriptionModels.id == model_id
+                    )
+                )
+            ).scalar_one()
+            assert row.deleted_at is None
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestTranscriptionModelCleanupWorker:
+    async def test_cleanup_removes_soft_deleted_without_references(
+        self, db_container, transcription_model_factory, admin_user
+    ):
+        async with db_container() as container:
+            session = container.session()
+            model = await transcription_model_factory(session, "whisper-tomb")
+            model_id = model.id
+            service = TenantTranscriptionModelService(session=session, user=admin_user)
+            await service.delete(model_id)
+
+        async with db_container() as container:
+            result = await cleanup_orphaned_transcription_models(container)
+            session = container.session()
+
+            assert str(model_id) in [m["id"] for m in result["removed_models"]]
+            assert (
+                await session.execute(
+                    select(TranscriptionModels).where(
+                        TranscriptionModels.id == model_id
+                    )
+                )
+            ).scalar_one_or_none() is None
+
+    async def test_cleanup_removes_migrated_source_keeps_target(
+        self, db_container, transcription_model_factory, admin_user
+    ):
+        async with db_container() as container:
+            session = container.session()
+            old_model = await transcription_model_factory(session, "whisper-old")
+            new_model = await transcription_model_factory(session, "whisper-new")
+            old_id, new_id = old_model.id, new_model.id
+
+            migration_service = container.transcription_model_migration_service()
+            await migration_service.migrate_model_usage(
+                from_model_id=old_id,
+                to_model_id=new_id,
+                user=admin_user,
+                confirm_migration=True,
+            )
+
+        async with db_container() as container:
+            await cleanup_orphaned_transcription_models(container)
+            session = container.session()
+
+            # Migrated source is gone; the target it points to is preserved
+            # (excluded from candidacy by the incoming-reference check).
+            assert (
+                await session.execute(
+                    select(TranscriptionModels).where(TranscriptionModels.id == old_id)
+                )
+            ).scalar_one_or_none() is None
+            assert (
+                await session.execute(
+                    select(TranscriptionModels).where(TranscriptionModels.id == new_id)
+                )
+            ).scalar_one_or_none() is not None
+
+    async def test_cleanup_skips_tombstone_with_app_reference(
+        self, db_container, transcription_model_factory, app_factory, admin_user
+    ):
+        # A tombstone that still carries an app reference (constructed directly to
+        # bypass the service's in-use guard) must be left alone by the worker.
+        async with db_container() as container:
+            session = container.session()
+            model = await transcription_model_factory(session, "whisper-stuck")
+            model_id = model.id
+            await app_factory(
+                session, "Stuck App", None, transcription_model_id=model_id
+            )
+            model.deleted_at = datetime.now(timezone.utc)
+            await session.flush()
+
+        async with db_container() as container:
+            result = await cleanup_orphaned_transcription_models(container)
+            session = container.session()
+
+            assert str(model_id) in [m["id"] for m in result["skipped_models"]]
+            assert (
+                await session.execute(
+                    select(TranscriptionModels).where(
+                        TranscriptionModels.id == model_id
+                    )
+                )
+            ).scalar_one_or_none() is not None
+
+    async def test_cleanup_protects_migration_target_that_is_itself_a_tombstone(
+        self, db_container, transcription_model_factory, admin_user
+    ):
+        # The crux of the incoming-reference guard: a migration TARGET that is
+        # *also* a tombstone (soft-deleted) must NOT be hard-deleted while a
+        # source still points at it via migrated_to_model_id (the self-FK is
+        # RESTRICT). The source is removed; the target survives this pass and
+        # only becomes eligible once the source is gone.
+        async with db_container() as container:
+            session = container.session()
+            source = await transcription_model_factory(session, "whisper-src")
+            target = await transcription_model_factory(session, "whisper-tgt")
+            source_id, target_id = source.id, target.id
+
+            migration_service = container.transcription_model_migration_service()
+            await migration_service.migrate_model_usage(
+                from_model_id=source_id,
+                to_model_id=target_id,
+                user=admin_user,
+                confirm_migration=True,
+            )
+            # Soft-delete the target *after* migration, so it is a lifecycle
+            # candidate but still referenced by the migrated source.
+            target_row = (
+                await session.execute(
+                    select(TranscriptionModels).where(
+                        TranscriptionModels.id == target_id
+                    )
+                )
+            ).scalar_one()
+            target_row.deleted_at = datetime.now(timezone.utc)
+            await session.flush()
+
+        async with db_container() as container:
+            result = await cleanup_orphaned_transcription_models(container)
+            session = container.session()
+
+            removed = [m["id"] for m in result["removed_models"]]
+            assert str(source_id) in removed
+            # Target excluded from candidacy (incoming ref) → never even attempted.
+            assert str(target_id) not in removed
+            assert (
+                await session.execute(
+                    select(TranscriptionModels).where(
+                        TranscriptionModels.id == source_id
+                    )
+                )
+            ).scalar_one_or_none() is None
+            assert (
+                await session.execute(
+                    select(TranscriptionModels).where(
+                        TranscriptionModels.id == target_id
+                    )
+                )
+            ).scalar_one_or_none() is not None
+
+    async def test_cleanup_handles_multiple_migrations_in_one_pass(
+        self, db_container, transcription_model_factory, admin_user
+    ):
+        # Two independent migrations → the incoming-reference subquery returns
+        # multiple rows. Both sources must be removed and both targets protected
+        # (guards against the multi-row NOT IN regressing to a scalar comparison).
+        async with db_container() as container:
+            session = container.session()
+            a = await transcription_model_factory(session, "whisper-a")
+            b = await transcription_model_factory(session, "whisper-b")
+            c = await transcription_model_factory(session, "whisper-c")
+            d = await transcription_model_factory(session, "whisper-d")
+            a_id, b_id, c_id, d_id = a.id, b.id, c.id, d.id
+
+            migration_service = container.transcription_model_migration_service()
+            await migration_service.migrate_model_usage(
+                from_model_id=a_id,
+                to_model_id=b_id,
+                user=admin_user,
+                confirm_migration=True,
+            )
+            await migration_service.migrate_model_usage(
+                from_model_id=c_id,
+                to_model_id=d_id,
+                user=admin_user,
+                confirm_migration=True,
+            )
+
+        async with db_container() as container:
+            await cleanup_orphaned_transcription_models(container)
+            session = container.session()
+
+            present = {
+                row.id
+                for row in (
+                    await session.execute(
+                        select(TranscriptionModels).where(
+                            TranscriptionModels.id.in_([a_id, b_id, c_id, d_id])
+                        )
+                    )
+                ).scalars()
+            }
+            assert a_id not in present and c_id not in present  # sources removed
+            assert b_id in present and d_id in present  # targets protected
+
+    async def test_cleanup_never_touches_active_models(
+        self, db_container, transcription_model_factory, admin_user
+    ):
+        # Safety net against an over-broad candidate predicate: a live model
+        # (no deleted_at, no migrated_to) must never be selected for deletion.
+        async with db_container() as container:
+            session = container.session()
+            active = await transcription_model_factory(session, "whisper-active")
+            active_id = active.id
+
+        async with db_container() as container:
+            result = await cleanup_orphaned_transcription_models(container)
+            session = container.session()
+
+            assert str(active_id) not in [m["id"] for m in result["removed_models"]]
+            assert (
+                await session.execute(
+                    select(TranscriptionModels).where(
+                        TranscriptionModels.id == active_id
+                    )
+                )
+            ).scalar_one_or_none() is not None
+
+    async def test_migration_history_survives_source_cleanup(
+        self, db_container, transcription_model_factory, admin_user
+    ):
+        # After the migrated source is hard-deleted, its history row must remain
+        # readable: from_model_id is SET NULL but the denormalized name persists.
+        async with db_container() as container:
+            session = container.session()
+            old_model = await transcription_model_factory(session, "whisper-hist-old")
+            new_model = await transcription_model_factory(session, "whisper-hist-new")
+            old_id, new_id = old_model.id, new_model.id
+
+            migration_service = container.transcription_model_migration_service()
+            await migration_service.migrate_model_usage(
+                from_model_id=old_id,
+                to_model_id=new_id,
+                user=admin_user,
+                confirm_migration=True,
+            )
+
+        async with db_container() as container:
+            await cleanup_orphaned_transcription_models(container)
+            session = container.session()
+
+            history = (
+                await session.execute(
+                    select(TranscriptionModelMigrationHistory).where(
+                        TranscriptionModelMigrationHistory.to_model_id == new_id
+                    )
+                )
+            ).scalar_one()
+            assert history.from_model_id is None  # SET NULL after source delete
+            assert history.from_model_name == "whisper-hist-old"  # name preserved
+            assert history.to_model_name == "whisper-hist-new"

--- a/backend/tests/integration/transcription_models/test_transcription_model_lifecycle.py
+++ b/backend/tests/integration/transcription_models/test_transcription_model_lifecycle.py
@@ -17,7 +17,7 @@ from intric.database.tables.ai_models_table import TranscriptionModels
 from intric.database.tables.transcription_model_migration_history_table import (
     TranscriptionModelMigrationHistory,
 )
-from intric.main.exceptions import ModelInUseException
+from intric.main.exceptions import ModelInUseException, NotFoundException
 from intric.tenant_models.application.tenant_model_service import (
     TenantTranscriptionModelService,
 )
@@ -26,6 +26,9 @@ from intric.transcription_models.domain.transcription_model_repo import (
 )
 from intric.transcription_models.infrastructure.transcription_model_cleanup_worker import (  # noqa: E501
     cleanup_orphaned_transcription_models,
+)
+from intric.transcription_models.presentation.tenant_transcription_models_router import (
+    TenantTranscriptionModelUpdate,
 )
 
 
@@ -82,6 +85,22 @@ class TestTranscriptionModelSoftDelete:
                 )
             ).scalar_one()
             assert row.deleted_at is None
+
+    async def test_update_rejects_soft_deleted_model(
+        self, db_container, transcription_model_factory, admin_user
+    ):
+        async with db_container() as container:
+            session = container.session()
+            model = await transcription_model_factory(session, "whisper-update-deleted")
+            model.deleted_at = datetime.now(timezone.utc)
+            await session.flush()
+
+            service = TenantTranscriptionModelService(session=session, user=admin_user)
+            with pytest.raises(NotFoundException):
+                await service.update(
+                    model.id,
+                    TenantTranscriptionModelUpdate(description="should not update"),
+                )
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/transcription_models/test_transcription_model_migration_service.py
+++ b/backend/tests/integration/transcription_models/test_transcription_model_migration_service.py
@@ -64,9 +64,51 @@ class TestTranscriptionModelMigration:
             ).scalar_one()
             assert updated_app.transcription_model_id == new_model.id
 
-            # A partial migration (apps only, spaces left out) must NOT latch the
-            # source as migrated — the engine marks it only when every migratable
-            # surface was moved, so the spaces migration stays re-runnable.
+            # The source has no remaining apps/spaces, so even an apps-only API
+            # call has completed the source migration and can latch it.
+            src = (
+                await session.execute(
+                    select(TranscriptionModels).where(
+                        TranscriptionModels.id == old_model.id
+                    )
+                )
+            ).scalar_one()
+            assert src.migrated_to_model_id == new_model.id
+
+    async def test_partial_migrations_latch_after_last_remaining_surface(
+        self,
+        db_container,
+        transcription_model_factory,
+        app_factory,
+        space_factory,
+        admin_user,
+    ):
+        async with db_container() as container:
+            session = container.session()
+
+            old_model = await transcription_model_factory(session, "whisper-old")
+            new_model = await transcription_model_factory(session, "whisper-new")
+
+            await app_factory(
+                session, "Transcribe App", None, transcription_model_id=old_model.id
+            )
+            space = await space_factory(session, "Transcription Space")
+            session.add(
+                SpacesTranscriptionModels(
+                    space_id=space.id, transcription_model_id=old_model.id
+                )
+            )
+            await session.flush()
+
+            migration_service = container.transcription_model_migration_service()
+            await migration_service.migrate_model_usage(
+                from_model_id=old_model.id,
+                to_model_id=new_model.id,
+                entity_types=["apps"],
+                user=admin_user,
+                confirm_migration=True,
+            )
+
             src = (
                 await session.execute(
                     select(TranscriptionModels).where(
@@ -75,6 +117,63 @@ class TestTranscriptionModelMigration:
                 )
             ).scalar_one()
             assert src.migrated_to_model_id is None
+
+            result = await migration_service.migrate_model_usage(
+                from_model_id=old_model.id,
+                to_model_id=new_model.id,
+                entity_types=["spaces"],
+                user=admin_user,
+                confirm_migration=True,
+            )
+
+            assert result.success is True
+            assert result.details["spaces"] == 1
+            await session.refresh(src)
+            assert src.migrated_to_model_id == new_model.id
+
+    async def test_partial_migrations_reject_split_targets(
+        self,
+        db_container,
+        transcription_model_factory,
+        app_factory,
+        space_factory,
+        admin_user,
+    ):
+        async with db_container() as container:
+            session = container.session()
+
+            old_model = await transcription_model_factory(session, "whisper-old")
+            first_target = await transcription_model_factory(session, "whisper-new-a")
+            second_target = await transcription_model_factory(session, "whisper-new-b")
+
+            await app_factory(
+                session, "Transcribe App", None, transcription_model_id=old_model.id
+            )
+            space = await space_factory(session, "Transcription Space")
+            session.add(
+                SpacesTranscriptionModels(
+                    space_id=space.id, transcription_model_id=old_model.id
+                )
+            )
+            await session.flush()
+
+            migration_service = container.transcription_model_migration_service()
+            await migration_service.migrate_model_usage(
+                from_model_id=old_model.id,
+                to_model_id=first_target.id,
+                entity_types=["apps"],
+                user=admin_user,
+                confirm_migration=True,
+            )
+
+            with pytest.raises(ValidationException):
+                await migration_service.migrate_model_usage(
+                    from_model_id=old_model.id,
+                    to_model_id=second_target.id,
+                    entity_types=["spaces"],
+                    user=admin_user,
+                    confirm_migration=True,
+                )
 
     async def test_migrate_spaces_successfully(
         self,

--- a/backend/tests/integration/transcription_models/test_transcription_model_migration_service.py
+++ b/backend/tests/integration/transcription_models/test_transcription_model_migration_service.py
@@ -64,8 +64,9 @@ class TestTranscriptionModelMigration:
             ).scalar_one()
             assert updated_app.transcription_model_id == new_model.id
 
-            # Source is marked migrated (the shared engine's mark-as-migrated
-            # step against TranscriptionModels — requires the ORM column).
+            # A partial migration (apps only, spaces left out) must NOT latch the
+            # source as migrated — the engine marks it only when every migratable
+            # surface was moved, so the spaces migration stays re-runnable.
             src = (
                 await session.execute(
                     select(TranscriptionModels).where(
@@ -73,7 +74,7 @@ class TestTranscriptionModelMigration:
                     )
                 )
             ).scalar_one()
-            assert src.migrated_to_model_id == new_model.id
+            assert src.migrated_to_model_id is None
 
     async def test_migrate_spaces_successfully(
         self,

--- a/backend/tests/integration/transcription_models/test_transcription_model_migration_service.py
+++ b/backend/tests/integration/transcription_models/test_transcription_model_migration_service.py
@@ -1,0 +1,183 @@
+"""
+Integration tests for TranscriptionModelMigrationService.
+
+Transcription migration is the simplest case of the shared migration engine: it
+only repoints references (`apps.transcription_model_id` and the
+`spaces_transcription_models` many-to-many) and marks the source migrated — no
+re-indexing, no kwargs reset, no usage-stats recalculation.
+
+These tests lock in:
+- apps repoint
+- spaces many-to-many repoint
+- source marked migrated (migrated_to_model_id)
+- already-migrated and same-model rejections
+"""
+
+import pytest
+from sqlalchemy import select
+
+from intric.database.tables.ai_models_table import TranscriptionModels
+from intric.database.tables.app_table import Apps
+from intric.database.tables.spaces_table import SpacesTranscriptionModels
+from intric.main.exceptions import ValidationException
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestTranscriptionModelMigration:
+    """End-to-end tests for transcription model migration."""
+
+    async def test_migrate_apps_successfully(
+        self,
+        db_container,
+        transcription_model_factory,
+        app_factory,
+        admin_user,
+    ):
+        async with db_container() as container:
+            session = container.session()
+
+            old_model = await transcription_model_factory(session, "whisper-old")
+            new_model = await transcription_model_factory(session, "whisper-new")
+
+            # App referencing the source transcription model (completion model
+            # left null — both FKs are nullable).
+            app = await app_factory(
+                session, "Transcribe App", None, transcription_model_id=old_model.id
+            )
+
+            migration_service = container.transcription_model_migration_service()
+            result = await migration_service.migrate_model_usage(
+                from_model_id=old_model.id,
+                to_model_id=new_model.id,
+                entity_types=["apps"],
+                user=admin_user,
+                confirm_migration=True,
+            )
+
+            assert result.success is True
+            assert result.migrated_count == 1
+            assert result.details["apps"] == 1
+
+            updated_app = (
+                await session.execute(select(Apps).where(Apps.id == app.id))
+            ).scalar_one()
+            assert updated_app.transcription_model_id == new_model.id
+
+            # Source is marked migrated (the shared engine's mark-as-migrated
+            # step against TranscriptionModels — requires the ORM column).
+            src = (
+                await session.execute(
+                    select(TranscriptionModels).where(
+                        TranscriptionModels.id == old_model.id
+                    )
+                )
+            ).scalar_one()
+            assert src.migrated_to_model_id == new_model.id
+
+    async def test_migrate_spaces_successfully(
+        self,
+        db_container,
+        transcription_model_factory,
+        space_factory,
+        admin_user,
+    ):
+        async with db_container() as container:
+            session = container.session()
+
+            old_model = await transcription_model_factory(session, "whisper-old")
+            new_model = await transcription_model_factory(session, "whisper-new")
+
+            space = await space_factory(session, "Transcription Space")
+            session.add(
+                SpacesTranscriptionModels(
+                    space_id=space.id, transcription_model_id=old_model.id
+                )
+            )
+            await session.flush()
+
+            migration_service = container.transcription_model_migration_service()
+            result = await migration_service.migrate_model_usage(
+                from_model_id=old_model.id,
+                to_model_id=new_model.id,
+                entity_types=["spaces"],
+                user=admin_user,
+                confirm_migration=True,
+            )
+
+            assert result.success is True
+            assert result.details["spaces"] == 1
+
+            # Space now references the new model, not the old one.
+            links = (
+                (
+                    await session.execute(
+                        select(SpacesTranscriptionModels.transcription_model_id).where(
+                            SpacesTranscriptionModels.space_id == space.id
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert new_model.id in links
+            assert old_model.id not in links
+
+    async def test_source_marked_and_double_migration_rejected(
+        self,
+        db_container,
+        transcription_model_factory,
+        admin_user,
+    ):
+        async with db_container() as container:
+            session = container.session()
+
+            old_model = await transcription_model_factory(session, "whisper-old")
+            new_model = await transcription_model_factory(session, "whisper-new")
+
+            migration_service = container.transcription_model_migration_service()
+            # No apps/spaces — still marks the source migrated.
+            await migration_service.migrate_model_usage(
+                from_model_id=old_model.id,
+                to_model_id=new_model.id,
+                user=admin_user,
+                confirm_migration=True,
+            )
+
+            src = (
+                await session.execute(
+                    select(TranscriptionModels).where(
+                        TranscriptionModels.id == old_model.id
+                    )
+                )
+            ).scalar_one()
+            assert src.migrated_to_model_id == new_model.id
+
+            # Migrating an already-migrated source must be rejected.
+            with pytest.raises(ValidationException):
+                await migration_service.migrate_model_usage(
+                    from_model_id=old_model.id,
+                    to_model_id=new_model.id,
+                    user=admin_user,
+                    confirm_migration=True,
+                )
+
+    async def test_same_model_rejected(
+        self,
+        db_container,
+        transcription_model_factory,
+        admin_user,
+    ):
+        async with db_container() as container:
+            session = container.session()
+
+            model = await transcription_model_factory(session, "whisper-x")
+
+            migration_service = container.transcription_model_migration_service()
+            with pytest.raises(ValidationException):
+                await migration_service.migrate_model_usage(
+                    from_model_id=model.id,
+                    to_model_id=model.id,
+                    user=admin_user,
+                    confirm_migration=True,
+                )

--- a/backend/tests/unit/test_audit_category_mappings.py
+++ b/backend/tests/unit/test_audit_category_mappings.py
@@ -1,5 +1,6 @@
 """Unit tests for audit category mappings."""
 
+from intric.audit.domain.action_metadata import ACTION_METADATA
 from intric.audit.domain.action_types import ActionType
 from intric.audit.domain.category_mappings import (
     CATEGORY_DESCRIPTIONS,
@@ -191,6 +192,39 @@ class TestCategoryMappings:
             assert CATEGORY_MAPPINGS[action_type] == "audit_access", (
                 f"{action_type} should be mapped to 'audit_access'"
             )
+
+
+class TestActionMetadata:
+    """Test suite for ACTION_METADATA completeness."""
+
+    def test_all_action_types_have_metadata(self):
+        """Every ActionType must have a Swedish display entry in ACTION_METADATA.
+
+        Without this guard, a new action gets an auto-generated English-ish
+        fallback label in the audit config UI and is skipped by
+        ensure_all_actions_configured(), which keys off ACTION_METADATA.
+        """
+        all_action_values = set(action.value for action in ActionType)
+        documented_actions = set(ACTION_METADATA.keys())
+
+        missing = all_action_values - documented_actions
+        assert not missing, (
+            f"The following action types are missing from ACTION_METADATA: {missing}"
+        )
+
+    def test_all_metadata_keys_are_valid_action_types(self):
+        """Every ACTION_METADATA key must be a valid ActionType string value."""
+        all_action_values = set(action.value for action in ActionType)
+        for action in ACTION_METADATA.keys():
+            assert action in all_action_values, (
+                f"{action} is not a valid ActionType value"
+            )
+
+    def test_all_metadata_entries_are_non_empty(self):
+        """Every entry must provide non-empty Swedish name and description."""
+        for action, metadata in ACTION_METADATA.items():
+            assert metadata["name_sv"], f"{action} has empty name_sv"
+            assert metadata["description_sv"], f"{action} has empty description_sv"
 
 
 class TestGetCategoryForAction:

--- a/backend/tests/unit/test_audit_category_mappings.py
+++ b/backend/tests/unit/test_audit_category_mappings.py
@@ -98,8 +98,8 @@ class TestCategoryMappings:
         user_actions = [
             action for action, cat in CATEGORY_MAPPINGS.items() if cat == "user_actions"
         ]
-        assert len(user_actions) == 36, (
-            f"Expected 36 user actions, got {len(user_actions)}"
+        assert len(user_actions) == 37, (
+            f"Expected 37 user actions, got {len(user_actions)}"
         )
         assert ActionType.TOOL_APPROVAL_SUBMITTED.value in user_actions
 
@@ -307,7 +307,7 @@ class TestCategoryDistribution:
         """Verify exact counts for each category."""
         expected_counts = {
             "admin_actions": 25,
-            "user_actions": 36,
+            "user_actions": 37,
             "security_events": 6,
             "file_operations": 2,
             "integration_events": 19,

--- a/backend/tests/unit/test_audit_config_service.py
+++ b/backend/tests/unit/test_audit_config_service.py
@@ -29,7 +29,7 @@ ALL_CATEGORIES = [
 # Expected action counts per category
 EXPECTED_CATEGORY_COUNTS = {
     "admin_actions": 25,
-    "user_actions": 36,
+    "user_actions": 37,
     "security_events": 6,
     "file_operations": 2,
     "integration_events": 19,
@@ -667,10 +667,10 @@ class TestAllCategoriesHaveCorrectActionCounts:
         count = sum(1 for cat in CATEGORY_MAPPINGS.values() if cat == "admin_actions")
         assert count == 25
 
-    def test_user_actions_has_36_actions(self):
-        """Verify user_actions has 36 action types."""
+    def test_user_actions_has_37_actions(self):
+        """Verify user_actions has 37 action types."""
         count = sum(1 for cat in CATEGORY_MAPPINGS.values() if cat == "user_actions")
-        assert count == 36
+        assert count == 37
 
     def test_security_events_has_6_actions(self):
         """Verify security_events has 6 action types."""

--- a/backend/tests/unittests/completion_models/test_migration_validation.py
+++ b/backend/tests/unittests/completion_models/test_migration_validation.py
@@ -118,12 +118,8 @@ def _build_service(
         patch(
             "intric.completion_models.application.completion_model_migration_service.CompletionModelMigrationHistoryRepo"
         ),
-        patch(
-            "intric.completion_models.application.completion_model_migration_service.get_event_publisher"
-        ),
-        patch(
-            "intric.completion_models.application.completion_model_migration_service.get_settings"
-        ),
+        patch("intric.ai_models.migration.base_migration_service.get_event_publisher"),
+        patch("intric.ai_models.migration.base_migration_service.get_settings"),
     ):
         service = CompletionModelMigrationService(
             session=session,

--- a/backend/tests/unittests/server/test_exception_handlers.py
+++ b/backend/tests/unittests/server/test_exception_handlers.py
@@ -1,12 +1,78 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
 
 from intric.main.exceptions import (
     BadRequestException,
     ErrorCodes,
     FileTooLargeException,
 )
-from intric.server.exception_handlers import add_exception_handlers
+from intric.server.exception_handlers import (
+    add_exception_handlers,
+    is_active_display_name_violation,
+)
+
+
+class _FakeOrig:
+    """Stand-in for the DBAPI error wrapped by IntegrityError.orig."""
+
+    def __init__(self, constraint_name=None, text=""):
+        if constraint_name is not None:
+            self.constraint_name = constraint_name
+        self._text = text
+
+    def __str__(self):
+        return self._text
+
+
+def _integrity_error(orig):
+    return IntegrityError("INSERT INTO completion_models ...", {}, orig)
+
+
+def test_active_nickname_violation_matched_by_constraint_name():
+    exc = _integrity_error(
+        _FakeOrig(constraint_name="uq_completion_models_active_nickname")
+    )
+    assert is_active_display_name_violation(exc) is True
+
+
+def test_active_nickname_violation_matched_by_message_text():
+    exc = _integrity_error(
+        _FakeOrig(
+            text="duplicate key value violates unique constraint "
+            '"uq_transcription_models_active_nickname"'
+        )
+    )
+    assert is_active_display_name_violation(exc) is True
+
+
+def test_other_constraint_not_matched():
+    exc = _integrity_error(
+        _FakeOrig(
+            constraint_name="ck_completion_models_tenant_provider",
+            text="violates check constraint",
+        )
+    )
+    assert is_active_display_name_violation(exc) is False
+
+
+def test_integrity_error_without_orig_not_matched():
+    assert is_active_display_name_violation(_integrity_error(None)) is False
+
+
+def test_active_nickname_violation_maps_to_409():
+    app = FastAPI()
+    add_exception_handlers(app)
+
+    @app.get("/collide")
+    async def collide():
+        raise _integrity_error(
+            _FakeOrig(constraint_name="uq_embedding_models_active_nickname")
+        )
+
+    response = TestClient(app).get("/collide")
+    assert response.status_code == 409
+    assert response.json()["intric_error_code"] == ErrorCodes.NAME_COLLISION
 
 
 def test_file_too_large_exception_includes_structured_details():

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -2005,6 +2005,7 @@
   "migration_impact_load_failed": "Failed to load migration impact. Please try again before migrating.",
   "migration_impact_title": "{count} resources will be affected",
   "migration_no_impact": "No resources are using this model. You can delete it directly — migration is only needed if you want to leave a history record that it was replaced by another model.",
+  "migrate_model_transcription_note": "Apps and spaces using this model will be moved to the model you select. Pick a replacement to continue.",
   "migration_spaces_info": "The target model will automatically be enabled on {count} spaces where this model is currently available",
   "migration_impact_owner": "Owner",
   "migration_impact_space": "Space",

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -481,6 +481,7 @@
   "eneo_error_9024": "An internal error occurred. Please try again later.",
   "eneo_error_9038": "The resource is not ready yet. Please try again in a moment.",
   "eneo_error_9039": "The model is in use and cannot be deleted. Migrate or remove dependencies first.",
+  "eneo_error_9017": "A model with this display name already exists. Choose a different display name.",
   "eneo_error_9025": "This account has been suspended. Contact your administrator.",
   "eneo_error_9026": "The API key for this model is not configured. Contact your administrator.",
   "eneo_error_9031": "The AI provider is currently inactive. Contact your administrator.",

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -2020,6 +2020,7 @@
   "migration_history_by": "By",
   "migration_history_count": "Migrated",
   "migration_history_status": "Status",
+  "migration_history_type": "Type",
   "migration_history_duration": "Duration",
   "migration_history_warnings": "Warnings",
   "migration_history_expand": "Show details",

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -2021,6 +2021,7 @@
   "migration_history_count": "Migrated",
   "migration_history_status": "Status",
   "migration_history_type": "Type",
+  "filter_all": "All",
   "migration_history_duration": "Duration",
   "migration_history_warnings": "Warnings",
   "migration_history_expand": "Show details",

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -2005,7 +2005,6 @@
   "migration_impact_load_failed": "Failed to load migration impact. Please try again before migrating.",
   "migration_impact_title": "{count} resources will be affected",
   "migration_no_impact": "No resources are using this model. You can delete it directly — migration is only needed if you want to leave a history record that it was replaced by another model.",
-  "migration_impact_transcription": "{apps} apps and {spaces} spaces use this model and will be moved to the model you select.",
   "migration_spaces_info": "The target model will automatically be enabled on {count} spaces where this model is currently available",
   "migration_impact_owner": "Owner",
   "migration_impact_space": "Space",

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -2005,7 +2005,7 @@
   "migration_impact_load_failed": "Failed to load migration impact. Please try again before migrating.",
   "migration_impact_title": "{count} resources will be affected",
   "migration_no_impact": "No resources are using this model. You can delete it directly — migration is only needed if you want to leave a history record that it was replaced by another model.",
-  "migrate_model_transcription_note": "Apps and spaces using this model will be moved to the model you select. Pick a replacement to continue.",
+  "migration_impact_transcription": "{apps} apps and {spaces} spaces use this model and will be moved to the model you select.",
   "migration_spaces_info": "The target model will automatically be enabled on {count} spaces where this model is currently available",
   "migration_impact_owner": "Owner",
   "migration_impact_space": "Space",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -2039,7 +2039,6 @@
   "migration_impact_load_failed": "Kunde inte ladda migreringens påverkan. Försök igen innan du migrerar.",
   "migration_impact_title": "{count} resurser kommer att påverkas",
   "migration_no_impact": "Inga resurser använder denna modell. Du kan radera den direkt — migrering behövs bara om du vill lämna en historikpost om att den ersattes av en annan modell.",
-  "migration_impact_transcription": "{apps} appar och {spaces} utrymmen använder den här modellen och flyttas till modellen du väljer.",
   "migration_spaces_info": "Målmodellen kommer automatiskt aktiveras på {count} spaces där denna modell är tillgänglig idag",
   "migration_impact_owner": "Ägare",
   "migration_impact_space": "Space",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -2055,6 +2055,7 @@
   "migration_history_count": "Migrerade",
   "migration_history_status": "Status",
   "migration_history_type": "Typ",
+  "filter_all": "Alla",
   "migration_history_duration": "Varaktighet",
   "migration_history_warnings": "Varningar",
   "migration_history_expand": "Visa detaljer",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -2039,7 +2039,7 @@
   "migration_impact_load_failed": "Kunde inte ladda migreringens påverkan. Försök igen innan du migrerar.",
   "migration_impact_title": "{count} resurser kommer att påverkas",
   "migration_no_impact": "Inga resurser använder denna modell. Du kan radera den direkt — migrering behövs bara om du vill lämna en historikpost om att den ersattes av en annan modell.",
-  "migrate_model_transcription_note": "Appar och utrymmen som använder den här modellen flyttas till modellen du väljer. Välj en ersättningsmodell för att fortsätta.",
+  "migration_impact_transcription": "{apps} appar och {spaces} utrymmen använder den här modellen och flyttas till modellen du väljer.",
   "migration_spaces_info": "Målmodellen kommer automatiskt aktiveras på {count} spaces där denna modell är tillgänglig idag",
   "migration_impact_owner": "Ägare",
   "migration_impact_space": "Space",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -478,6 +478,7 @@
   "eneo_error_9024": "Ett internt fel uppstod. Försök igen senare.",
   "eneo_error_9038": "Resursen är inte redo ännu. Försök igen om en stund.",
   "eneo_error_9039": "Modellen används och kan inte tas bort. Migrera eller ta bort beroenden först.",
+  "eneo_error_9017": "En modell med det här visningsnamnet finns redan. Välj ett annat visningsnamn.",
   "eneo_error_9025": "Detta konto har stängts av. Kontakta din administratör.",
   "eneo_error_9026": "API-nyckeln för denna modell är inte konfigurerad. Kontakta din administratör.",
   "eneo_error_9031": "AI-leverantören är för närvarande inaktiv. Kontakta din administratör.",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -2039,6 +2039,7 @@
   "migration_impact_load_failed": "Kunde inte ladda migreringens påverkan. Försök igen innan du migrerar.",
   "migration_impact_title": "{count} resurser kommer att påverkas",
   "migration_no_impact": "Inga resurser använder denna modell. Du kan radera den direkt — migrering behövs bara om du vill lämna en historikpost om att den ersattes av en annan modell.",
+  "migrate_model_transcription_note": "Appar och utrymmen som använder den här modellen flyttas till modellen du väljer. Välj en ersättningsmodell för att fortsätta.",
   "migration_spaces_info": "Målmodellen kommer automatiskt aktiveras på {count} spaces där denna modell är tillgänglig idag",
   "migration_impact_owner": "Ägare",
   "migration_impact_space": "Space",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -2054,6 +2054,7 @@
   "migration_history_by": "Av",
   "migration_history_count": "Migrerade",
   "migration_history_status": "Status",
+  "migration_history_type": "Typ",
   "migration_history_duration": "Varaktighet",
   "migration_history_warnings": "Varningar",
   "migration_history_expand": "Visa detaljer",

--- a/frontend/apps/web/src/lib/core/errors/getErrorMessage.ts
+++ b/frontend/apps/web/src/lib/core/errors/getErrorMessage.ts
@@ -36,6 +36,7 @@ const ERROR_CODE_MESSAGES: Record<number, () => string> = {
   9035: () => m.eneo_error_9035(), // SECURITY_CLASSIFICATION_MISMATCH
   9036: () => m.eneo_error_9036(), // MCP_UPSTREAM_ERROR
   9037: () => m.eneo_error_9037(), // MCP_UPSTREAM_AUTH_ERROR
+  9017: () => m.eneo_error_9017(), // NAME_COLLISION (duplicate display name)
 
   // --- AI service errors ---
   9008: () => m.eneo_error_9008(), // QUOTA_EXCEEDED

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/AddWizard.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/AddWizard.svelte
@@ -26,7 +26,7 @@
   import { getIntric } from "$lib/core/Intric";
   import { m } from "$lib/paraglide/messages";
   import { toast } from "$lib/components/toast";
-  import { toastError } from "$lib/core/errors";
+  import { getErrorMessage, toastError } from "$lib/core/errors";
   import * as Dialog from "$lib/components/ui/dialog/index.js";
   import { Button } from "$lib/components/ui/button/index.js";
   import { Loader2, AlertTriangle } from "lucide-svelte";
@@ -262,7 +262,7 @@
 
       await createModels(modelsToCreate, providerId);
     } catch (e: unknown) {
-      error = e instanceof Error ? e.message : m.failed_to_create_model();
+      error = getErrorMessage(e);
       toastError(e, m.failed_to_create_model());
     } finally {
       isSubmitting = false;
@@ -304,7 +304,7 @@
       if (!providerId) throw new Error(m.no_provider_selected());
       await createModels(models, providerId);
     } catch (e: unknown) {
-      error = e instanceof Error ? e.message : m.failed_to_create_model();
+      error = getErrorMessage(e);
       toastError(e, m.failed_to_create_model());
     } finally {
       isSubmitting = false;

--- a/frontend/apps/web/src/routes/(app)/admin/models/EditModelDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/EditModelDialog.svelte
@@ -26,7 +26,7 @@
   import { Loader2 } from "lucide-svelte";
   import { m } from "$lib/paraglide/messages";
   import { toast } from "$lib/components/toast";
-  import { toastError } from "$lib/core/errors";
+  import { getErrorMessage, toastError } from "$lib/core/errors";
   import { getIntric } from "$lib/core/Intric";
   import * as Dialog from "$lib/components/ui/dialog/index.js";
   import * as Field from "$lib/components/ui/field/index.js";
@@ -197,7 +197,7 @@
       toast.success(m.model_updated_success());
       dialogOpen = false;
     } catch (e: unknown) {
-      error = e instanceof Error ? e.message : m.failed_to_update_model();
+      error = getErrorMessage(e);
       toastError(e, m.failed_to_update_model());
     } finally {
       isSubmitting = false;

--- a/frontend/apps/web/src/routes/(app)/admin/models/MigrateModelDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/MigrateModelDialog.svelte
@@ -423,6 +423,14 @@
               {/if}
             </div>
           </div>
+        {:else if !sourceAlreadyMigrated && modelType === "transcriptionModel"}
+          <!-- Transcription has no usage-detail endpoint, so we can't show what
+               uses the model. Don't claim "no impact / delete directly" (which
+               would be wrong when an app or space references it); describe what
+               migration does instead. -->
+          <div class="border-border text-muted-foreground rounded-lg border px-4 py-3 text-sm">
+            {m.migrate_model_transcription_note()}
+          </div>
         {:else if !sourceAlreadyMigrated}
           <div class="border-border text-muted-foreground rounded-lg border px-4 py-3 text-sm">
             {m.migration_no_impact()}

--- a/frontend/apps/web/src/routes/(app)/admin/models/MigrateModelDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/MigrateModelDialog.svelte
@@ -84,6 +84,8 @@
   let impactTotal = $state(0);
   let impactDetails = $state<UsageDetail[]>([]);
   let spacesCount = $state(0);
+  // Transcription has no usage-details endpoint, only aggregate counts.
+  let appsCount = $state(0);
   let expandedSections = $state<Record<string, boolean>>({});
 
   // --- Target eligibility -----------------------------------------------
@@ -218,15 +220,29 @@
   // impact summary is what they'd otherwise be acknowledging blindly.
   async function loadImpact() {
     if (modelType === "transcriptionModel") {
-      // No usage stats/details endpoints for transcription — skip the preview.
-      // The migrate engine still repoints apps + spaces; warnings come from the
-      // validate call. Security blockers (the only hard gate) still apply.
+      // Transcription has aggregate usage counts only (no per-entity details).
+      // Fetch them so the dialog shows real impact (apps + spaces) instead of a
+      // guess. impactDetails stays empty; we render a compact count box below.
+      isLoadingImpact = true;
+      hasLoadedImpact = false;
+      impactLoadError = null;
       impactTotal = 0;
       impactDetails = [];
       spacesCount = 0;
-      hasLoadedImpact = true;
-      isLoadingImpact = false;
-      impactLoadError = null;
+      appsCount = 0;
+      try {
+        const stats = (await intric.models.getTranscriptionUsageStats({
+          modelId: sourceModel.id
+        })) as { apps_count?: number; spaces_count?: number; total_count?: number };
+        appsCount = stats.apps_count ?? 0;
+        spacesCount = stats.spaces_count ?? 0;
+        impactTotal = stats.total_count ?? appsCount + spacesCount;
+        hasLoadedImpact = true;
+      } catch (err: unknown) {
+        impactLoadError = err instanceof Error ? err.message : m.migration_impact_load_failed();
+      } finally {
+        isLoadingImpact = false;
+      }
       return;
     }
     isLoadingImpact = true;
@@ -350,6 +366,12 @@
               <Button variant="outline" size="sm" onclick={loadImpact}>{m.retry()}</Button>
             </div>
           </div>
+        {:else if !sourceAlreadyMigrated && modelType === "transcriptionModel" && impactTotal > 0}
+          <!-- Transcription has aggregate counts only (no per-entity details),
+               so show a compact apps + spaces summary rather than the table. -->
+          <div class="border-border text-muted-foreground rounded-lg border px-4 py-3 text-sm">
+            {m.migration_impact_transcription({ apps: appsCount, spaces: spacesCount })}
+          </div>
         {:else if !sourceAlreadyMigrated && impactTotal > 0}
           <div class="border-border overflow-hidden rounded-lg border">
             <div class="border-border bg-muted/30 flex items-center gap-4 border-b px-4 py-3">
@@ -422,14 +444,6 @@
                 </div>
               {/if}
             </div>
-          </div>
-        {:else if !sourceAlreadyMigrated && modelType === "transcriptionModel"}
-          <!-- Transcription has no usage-detail endpoint, so we can't show what
-               uses the model. Don't claim "no impact / delete directly" (which
-               would be wrong when an app or space references it); describe what
-               migration does instead. -->
-          <div class="border-border text-muted-foreground rounded-lg border px-4 py-3 text-sm">
-            {m.migrate_model_transcription_note()}
           </div>
         {:else if !sourceAlreadyMigrated}
           <div class="border-border text-muted-foreground rounded-lg border px-4 py-3 text-sm">

--- a/frontend/apps/web/src/routes/(app)/admin/models/MigrateModelDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/MigrateModelDialog.svelte
@@ -1,15 +1,14 @@
 <!-- Copyright (c) 2026 Sundsvalls Kommun -->
 
 <!--
-  Migrate all usage of a soon-to-be-decommissioned completion model to a
-  replacement model. The dialog has three jobs:
+  Migrate all usage of a soon-to-be-decommissioned model to a replacement.
+  Shared by completion and transcription (`modelType` prop) — same layout and
+  flow, only the SDK endpoints differ. The dialog has three jobs:
 
-    1. Show what will be affected (assistants, apps, services, templates,
-       questions) before the user commits.
+    1. Show what will be affected (the entities using the model) before commit.
     2. Validate compatibility against the chosen target server-side and
        surface security blockers / warnings.
-    3. Hand off to `intric.models.migrateCompletion` and refresh the
-       migration history panel.
+    3. Hand off to the migrate endpoint and refresh the migration history panel.
 -->
 
 <script lang="ts">
@@ -50,9 +49,9 @@
     openController: Writable<boolean>;
     sourceModel: MigratableModel;
     models?: MigratableModel[];
-    // The dialog is identical for both types; only the SDK calls differ, and
-    // transcription has no usage-preview endpoints (its impact is just
-    // apps/spaces, repointed without recomputation).
+    // The dialog is identical for both types — same impact preview, same
+    // validation and confirm flow. Only which SDK endpoints get called differs
+    // (gated on modelType in loadImpact / runValidation / handleMigrate).
     modelType?: "completionModel" | "transcriptionModel";
   } = $props();
 
@@ -84,8 +83,6 @@
   let impactTotal = $state(0);
   let impactDetails = $state<UsageDetail[]>([]);
   let spacesCount = $state(0);
-  // Transcription has no usage-details endpoint, only aggregate counts.
-  let appsCount = $state(0);
   let expandedSections = $state<Record<string, boolean>>({});
 
   // --- Target eligibility -----------------------------------------------
@@ -219,47 +216,29 @@
   // surface it and block migration until the admin retries, since the
   // impact summary is what they'd otherwise be acknowledging blindly.
   async function loadImpact() {
-    if (modelType === "transcriptionModel") {
-      // Transcription has aggregate usage counts only (no per-entity details).
-      // Fetch them so the dialog shows real impact (apps + spaces) instead of a
-      // guess. impactDetails stays empty; we render a compact count box below.
-      isLoadingImpact = true;
-      hasLoadedImpact = false;
-      impactLoadError = null;
-      impactTotal = 0;
-      impactDetails = [];
-      spacesCount = 0;
-      appsCount = 0;
-      try {
-        const stats = (await intric.models.getTranscriptionUsageStats({
-          modelId: sourceModel.id
-        })) as { apps_count?: number; spaces_count?: number; total_count?: number };
-        appsCount = stats.apps_count ?? 0;
-        spacesCount = stats.spaces_count ?? 0;
-        impactTotal = stats.total_count ?? appsCount + spacesCount;
-        hasLoadedImpact = true;
-      } catch (err: unknown) {
-        impactLoadError = err instanceof Error ? err.message : m.migration_impact_load_failed();
-      } finally {
-        isLoadingImpact = false;
-      }
-      return;
-    }
     isLoadingImpact = true;
     hasLoadedImpact = false;
     impactLoadError = null;
     impactTotal = 0;
     impactDetails = [];
     spacesCount = 0;
+    // Same impact preview for both model types — only the endpoint differs.
+    // Transcription's details are its apps; spaces come from the aggregate
+    // usage count (a many-to-many, like completion).
+    const isTranscription = modelType === "transcriptionModel";
     try {
-      const details = (await intric.models.getUsageDetails({
-        modelId: sourceModel.id,
-        limit: 100
-      })) as { items?: UsageDetail[]; total?: number };
+      const details = (await (isTranscription
+        ? intric.models.getTranscriptionUsageDetails({ modelId: sourceModel.id, limit: 100 })
+        : intric.models.getUsageDetails({ modelId: sourceModel.id, limit: 100 }))) as {
+        items?: UsageDetail[];
+        total?: number;
+      };
       impactDetails = details?.items ?? [];
       // Use backend total (handles pagination), not just items.length
       impactTotal = details?.total ?? impactDetails.length;
-      const stats = (await intric.models.getUsageStats({ modelId: sourceModel.id })) as {
+      const stats = (await (isTranscription
+        ? intric.models.getTranscriptionUsageStats({ modelId: sourceModel.id })
+        : intric.models.getUsageStats({ modelId: sourceModel.id }))) as {
         spaces_count?: number;
       };
       spacesCount = stats.spaces_count ?? 0;
@@ -365,12 +344,6 @@
               <span>{impactLoadError}</span>
               <Button variant="outline" size="sm" onclick={loadImpact}>{m.retry()}</Button>
             </div>
-          </div>
-        {:else if !sourceAlreadyMigrated && modelType === "transcriptionModel" && impactTotal > 0}
-          <!-- Transcription has aggregate counts only (no per-entity details),
-               so show a compact apps + spaces summary rather than the table. -->
-          <div class="border-border text-muted-foreground rounded-lg border px-4 py-3 text-sm">
-            {m.migration_impact_transcription({ apps: appsCount, spaces: spacesCount })}
           </div>
         {:else if !sourceAlreadyMigrated && impactTotal > 0}
           <div class="border-border overflow-hidden rounded-lg border">

--- a/frontend/apps/web/src/routes/(app)/admin/models/MigrateModelDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/MigrateModelDialog.svelte
@@ -14,7 +14,7 @@
 
 <script lang="ts">
   import { onMount, untrack } from "svelte";
-  import type { CompletionModel } from "@intric/intric-js";
+  import type { CompletionModel, TranscriptionModel } from "@intric/intric-js";
   import type { Writable } from "svelte/store";
   import { invalidate } from "$app/navigation";
   import { getIntric } from "$lib/core/Intric";
@@ -39,14 +39,21 @@
   import { bumpModelMigrationHistoryVersion } from "./migrationHistoryRefresh";
   import { isSecurityBlockerCode, translateMigrationWarning } from "./migrationWarnings";
 
+  type MigratableModel = CompletionModel | TranscriptionModel;
+
   let {
     openController,
     sourceModel,
-    models = []
+    models = [],
+    modelType = "completionModel"
   }: {
     openController: Writable<boolean>;
-    sourceModel: CompletionModel;
-    models?: CompletionModel[];
+    sourceModel: MigratableModel;
+    models?: MigratableModel[];
+    // The dialog is identical for both types; only the SDK calls differ, and
+    // transcription has no usage-preview endpoints (its impact is just
+    // apps/spaces, repointed without recomputation).
+    modelType?: "completionModel" | "transcriptionModel";
   } = $props();
 
   const intric = getIntric();
@@ -89,7 +96,7 @@
       .filter((mod) => !mod.migrated_to_model_id)
   );
 
-  function labelFor(mod: CompletionModel): string {
+  function labelFor(mod: MigratableModel): string {
     return mod.nickname ? mod.nickname : mod.name;
   }
 
@@ -150,10 +157,9 @@
     hasSecurityBlocker = false;
     validationError = false;
     try {
-      const result = (await intric.models.validateMigration({
-        fromId: sourceModel.id,
-        toId
-      })) as {
+      const result = (await (modelType === "transcriptionModel"
+        ? intric.models.validateTranscriptionMigration({ fromId: sourceModel.id, toId })
+        : intric.models.validateMigration({ fromId: sourceModel.id, toId }))) as {
         compatible: boolean;
         warnings: string[];
         warning_codes: string[];
@@ -211,6 +217,18 @@
   // surface it and block migration until the admin retries, since the
   // impact summary is what they'd otherwise be acknowledging blindly.
   async function loadImpact() {
+    if (modelType === "transcriptionModel") {
+      // No usage stats/details endpoints for transcription — skip the preview.
+      // The migrate engine still repoints apps + spaces; warnings come from the
+      // validate call. Security blockers (the only hard gate) still apply.
+      impactTotal = 0;
+      impactDetails = [];
+      spacesCount = 0;
+      hasLoadedImpact = true;
+      isLoadingImpact = false;
+      impactLoadError = null;
+      return;
+    }
     isLoadingImpact = true;
     hasLoadedImpact = false;
     impactLoadError = null;
@@ -243,13 +261,21 @@
     submitError = null;
     isSubmitting = true;
     try {
-      await intric.models.migrateCompletion({
-        fromId: sourceModel.id,
-        toId: targetModelId,
-        // Match the UI gate: spaces-only warning cases are allowed without
-        // a manual acknowledgement because no resources are rebound.
-        confirmMigration: shouldConfirmMigration
-      });
+      // Match the UI gate: spaces-only warning cases are allowed without a
+      // manual acknowledgement because no resources are rebound.
+      if (modelType === "transcriptionModel") {
+        await intric.models.migrateTranscription({
+          fromId: sourceModel.id,
+          toId: targetModelId,
+          confirmMigration: shouldConfirmMigration
+        });
+      } else {
+        await intric.models.migrateCompletion({
+          fromId: sourceModel.id,
+          toId: targetModelId,
+          confirmMigration: shouldConfirmMigration
+        });
+      }
       toast.success(m.migration_success());
       bumpModelMigrationHistoryVersion();
       await invalidate("admin:model-providers:load");

--- a/frontend/apps/web/src/routes/(app)/admin/models/MigrationHistoryPanel.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/MigrationHistoryPanel.svelte
@@ -10,14 +10,16 @@
 
 <script lang="ts">
   import { onMount } from "svelte";
-  import { Loader2, ChevronDown, AlertTriangle } from "lucide-svelte";
+  import { Loader2, ChevronDown, AlertTriangle, Search } from "lucide-svelte";
 
   import { getIntric } from "$lib/core/Intric";
   import { m } from "$lib/paraglide/messages";
 
   import * as Table from "$lib/components/ui/table/index.js";
+  import * as Select from "$lib/components/ui/select/index.js";
   import { Badge } from "$lib/components/ui/badge/index.js";
   import { Button } from "$lib/components/ui/button/index.js";
+  import { Input } from "$lib/components/ui/input/index.js";
 
   import { migrationHistoryRefreshVersion } from "./migrationHistoryRefresh";
   import { translateMigrationWarning } from "./migrationWarnings";
@@ -52,6 +54,47 @@
   let error = $state<string | null>(null);
   let lastLoadedVersion = 0;
   let expandedId = $state<string | null>(null);
+
+  // --- Filters (client-side; add more dimensions here as needed) ----------
+  let searchTerm = $state("");
+  // Plain strings so they bind directly to the shadcn Select.
+  let typeFilter = $state("all");
+  let statusFilter = $state("all");
+
+  const filteredHistory = $derived(
+    history.filter((record) => {
+      if (typeFilter !== "all" && record.model_type !== typeFilter) return false;
+      if (statusFilter !== "all" && record.status !== statusFilter) return false;
+      const query = searchTerm.trim().toLowerCase();
+      if (query) {
+        const haystack =
+          `${record.from_model_name} ${record.to_model_name} ${record.initiated_by_name}`.toLowerCase();
+        if (!haystack.includes(query)) return false;
+      }
+      return true;
+    })
+  );
+
+  const hasActiveFilter = $derived(
+    !!searchTerm.trim() || typeFilter !== "all" || statusFilter !== "all"
+  );
+
+  function clearFilters() {
+    searchTerm = "";
+    typeFilter = "all";
+    statusFilter = "all";
+  }
+
+  const typeFilterLabel = $derived(
+    typeFilter === "completion"
+      ? m.completion_models()
+      : typeFilter === "transcription"
+        ? m.transcription_models()
+        : m.filter_all()
+  );
+  const statusFilterLabel = $derived(
+    statusFilter === "all" ? m.filter_all() : statusLabel(statusFilter)
+  );
 
   async function loadHistory() {
     loading = true;
@@ -174,108 +217,167 @@
       <span>{m.migration_history_empty()}</span>
     </div>
   {:else}
-    <Table.Root>
-      <Table.Header>
-        <Table.Row>
-          <Table.Head class="w-[1%]">
-            <span class="sr-only">{m.migration_history_expand()}</span>
-          </Table.Head>
-          <Table.Head>{m.migration_history_date()}</Table.Head>
-          <Table.Head>{m.migration_history_from()}</Table.Head>
-          <Table.Head>{m.migration_history_to()}</Table.Head>
-          <Table.Head class="text-right">{m.migration_history_count()}</Table.Head>
-          <Table.Head>{m.migration_history_by()}</Table.Head>
-          <Table.Head>{m.migration_history_type()}</Table.Head>
-          <Table.Head>{m.migration_history_status()}</Table.Head>
-        </Table.Row>
-      </Table.Header>
+    <div class="mb-3 flex flex-wrap items-center gap-2">
+      <div class="relative min-w-[14rem] flex-1">
+        <Search
+          class="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2"
+          aria-hidden="true"
+        />
+        <Input
+          type="search"
+          bind:value={searchTerm}
+          placeholder={m.search()}
+          class="pl-8"
+          aria-label={m.search()}
+        />
+      </div>
 
-      <Table.Body>
-        {#each history as record (record.id)}
-          {@const isExpanded = expandedId === record.id}
+      <Select.Root type="single" bind:value={typeFilter}>
+        <Select.Trigger class="w-[12rem]" aria-label={m.migration_history_type()}>
+          <span class="truncate">{typeFilterLabel}</span>
+        </Select.Trigger>
+        <Select.Content>
+          <Select.Item value="all" label={m.filter_all()}>{m.filter_all()}</Select.Item>
+          <Select.Item value="completion" label={m.completion_models()}>
+            {m.completion_models()}
+          </Select.Item>
+          <Select.Item value="transcription" label={m.transcription_models()}>
+            {m.transcription_models()}
+          </Select.Item>
+        </Select.Content>
+      </Select.Root>
 
+      <Select.Root type="single" bind:value={statusFilter}>
+        <Select.Trigger class="w-[12rem]" aria-label={m.migration_history_status()}>
+          <span class="truncate">{statusFilterLabel}</span>
+        </Select.Trigger>
+        <Select.Content>
+          <Select.Item value="all" label={m.filter_all()}>{m.filter_all()}</Select.Item>
+          <Select.Item value="completed" label={m.migration_status_completed()}>
+            {m.migration_status_completed()}
+          </Select.Item>
+          <Select.Item value="failed" label={m.migration_status_failed()}>
+            {m.migration_status_failed()}
+          </Select.Item>
+          <Select.Item value="in_progress" label={m.migration_status_in_progress()}>
+            {m.migration_status_in_progress()}
+          </Select.Item>
+        </Select.Content>
+      </Select.Root>
+
+      {#if hasActiveFilter}
+        <Button variant="ghost" size="sm" onclick={clearFilters}>{m.clear()}</Button>
+      {/if}
+    </div>
+
+    {#if filteredHistory.length === 0}
+      <div class="text-muted flex items-center justify-center py-12">
+        <span>{m.no_results()}</span>
+      </div>
+    {:else}
+      <Table.Root>
+        <Table.Header>
           <Table.Row>
-            <Table.Cell>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                aria-expanded={isExpanded}
-                aria-controls="migration-detail-{record.id}"
-                aria-label={isExpanded
-                  ? m.migration_history_collapse()
-                  : m.migration_history_expand()}
-                onclick={() => toggleExpand(record.id)}
-              >
-                <ChevronDown
-                  class="transition-transform {isExpanded ? 'rotate-0' : '-rotate-90'}"
-                  aria-hidden="true"
-                />
-              </Button>
-            </Table.Cell>
-            <Table.Cell class="text-muted whitespace-nowrap">
-              {formatDate(record.completed_at ?? record.started_at)}
-            </Table.Cell>
-            <Table.Cell>{record.from_model_name}</Table.Cell>
-            <Table.Cell>{record.to_model_name}</Table.Cell>
-            <Table.Cell class="text-right tabular-nums">{record.migrated_count}</Table.Cell>
-            <Table.Cell class="text-muted">{record.initiated_by_name}</Table.Cell>
-            <Table.Cell>
-              <Badge variant="secondary">
-                {record.model_type === "transcription"
-                  ? m.transcription_models()
-                  : m.completion_models()}
-              </Badge>
-            </Table.Cell>
-            <Table.Cell>
-              <Badge variant={statusVariant(record.status)}>{statusLabel(record.status)}</Badge>
-            </Table.Cell>
+            <Table.Head class="w-[1%]">
+              <span class="sr-only">{m.migration_history_expand()}</span>
+            </Table.Head>
+            <Table.Head>{m.migration_history_date()}</Table.Head>
+            <Table.Head>{m.migration_history_from()}</Table.Head>
+            <Table.Head>{m.migration_history_to()}</Table.Head>
+            <Table.Head class="text-right">{m.migration_history_count()}</Table.Head>
+            <Table.Head>{m.migration_history_by()}</Table.Head>
+            <Table.Head>{m.migration_history_type()}</Table.Head>
+            <Table.Head>{m.migration_history_status()}</Table.Head>
           </Table.Row>
+        </Table.Header>
 
-          {#if isExpanded}
-            <Table.Row id="migration-detail-{record.id}">
-              <Table.Cell colspan={8} class="bg-muted/40 p-0">
-                <div class="px-8 py-4">
-                  <dl class="grid max-w-lg grid-cols-[max-content_1fr] gap-x-6 gap-y-1.5 text-sm">
-                    <dt class="text-muted whitespace-nowrap">
-                      {m.migration_history_duration()}
-                    </dt>
-                    <dd class="font-mono text-xs">{formatDuration(record.duration)}</dd>
+        <Table.Body>
+          {#each filteredHistory as record (record.id)}
+            {@const isExpanded = expandedId === record.id}
 
-                    {#if record.migration_details}
-                      {#each Object.entries(record.migration_details).filter(([k, v]) => k !== "total" && v > 0) as [type, count] (type)}
-                        <dt class="text-muted whitespace-nowrap">
-                          {detailLabels[type] ?? type}
-                        </dt>
-                        <dd class="tabular-nums">{count}</dd>
-                      {/each}
-                    {/if}
-                  </dl>
-
-                  {#if record.warnings && record.warnings.length > 0}
-                    <div class="border-border mt-3 border-t pt-3">
-                      <div class="text-muted mb-1.5 flex items-center gap-1.5 text-sm">
-                        <AlertTriangle class="size-3.5" aria-hidden="true" />
-                        <span>{m.migration_history_warnings()}</span>
-                      </div>
-                      <ul class="text-warning-stronger space-y-1 pl-5 text-sm">
-                        {#each record.warnings as w, i (i)}
-                          <li>{translateMigrationWarning(w)}</li>
-                        {/each}
-                      </ul>
-                    </div>
-                  {/if}
-
-                  {#if record.error_message}
-                    <div class="text-destructive border-border mt-3 border-t pt-3 text-sm">
-                      {record.error_message}
-                    </div>
-                  {/if}
-                </div>
+            <Table.Row>
+              <Table.Cell>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-expanded={isExpanded}
+                  aria-controls="migration-detail-{record.id}"
+                  aria-label={isExpanded
+                    ? m.migration_history_collapse()
+                    : m.migration_history_expand()}
+                  onclick={() => toggleExpand(record.id)}
+                >
+                  <ChevronDown
+                    class="transition-transform {isExpanded ? 'rotate-0' : '-rotate-90'}"
+                    aria-hidden="true"
+                  />
+                </Button>
+              </Table.Cell>
+              <Table.Cell class="text-muted whitespace-nowrap">
+                {formatDate(record.completed_at ?? record.started_at)}
+              </Table.Cell>
+              <Table.Cell>{record.from_model_name}</Table.Cell>
+              <Table.Cell>{record.to_model_name}</Table.Cell>
+              <Table.Cell class="text-right tabular-nums">{record.migrated_count}</Table.Cell>
+              <Table.Cell class="text-muted">{record.initiated_by_name}</Table.Cell>
+              <Table.Cell>
+                <Badge variant="secondary">
+                  {record.model_type === "transcription"
+                    ? m.transcription_models()
+                    : m.completion_models()}
+                </Badge>
+              </Table.Cell>
+              <Table.Cell>
+                <Badge variant={statusVariant(record.status)}>{statusLabel(record.status)}</Badge>
               </Table.Cell>
             </Table.Row>
-          {/if}
-        {/each}
-      </Table.Body>
-    </Table.Root>
+
+            {#if isExpanded}
+              <Table.Row id="migration-detail-{record.id}">
+                <Table.Cell colspan={8} class="bg-muted/40 p-0">
+                  <div class="px-8 py-4">
+                    <dl class="grid max-w-lg grid-cols-[max-content_1fr] gap-x-6 gap-y-1.5 text-sm">
+                      <dt class="text-muted whitespace-nowrap">
+                        {m.migration_history_duration()}
+                      </dt>
+                      <dd class="font-mono text-xs">{formatDuration(record.duration)}</dd>
+
+                      {#if record.migration_details}
+                        {#each Object.entries(record.migration_details).filter(([k, v]) => k !== "total" && v > 0) as [type, count] (type)}
+                          <dt class="text-muted whitespace-nowrap">
+                            {detailLabels[type] ?? type}
+                          </dt>
+                          <dd class="tabular-nums">{count}</dd>
+                        {/each}
+                      {/if}
+                    </dl>
+
+                    {#if record.warnings && record.warnings.length > 0}
+                      <div class="border-border mt-3 border-t pt-3">
+                        <div class="text-muted mb-1.5 flex items-center gap-1.5 text-sm">
+                          <AlertTriangle class="size-3.5" aria-hidden="true" />
+                          <span>{m.migration_history_warnings()}</span>
+                        </div>
+                        <ul class="text-warning-stronger space-y-1 pl-5 text-sm">
+                          {#each record.warnings as w, i (i)}
+                            <li>{translateMigrationWarning(w)}</li>
+                          {/each}
+                        </ul>
+                      </div>
+                    {/if}
+
+                    {#if record.error_message}
+                      <div class="text-destructive border-border mt-3 border-t pt-3 text-sm">
+                        {record.error_message}
+                      </div>
+                    {/if}
+                  </div>
+                </Table.Cell>
+              </Table.Row>
+            {/if}
+          {/each}
+        </Table.Body>
+      </Table.Root>
+    {/if}
   {/if}
 </div>

--- a/frontend/apps/web/src/routes/(app)/admin/models/MigrationHistoryPanel.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/MigrationHistoryPanel.svelte
@@ -1,10 +1,11 @@
 <!-- Copyright (c) 2026 Sundsvalls Kommun -->
 
 <!--
-  Read-only history of completion-model migrations. Each row expands to show
-  per-entity-type counts, warnings, and any error message — driven by an
-  expander button rather than a click-anywhere row so keyboard navigation
-  works without custom key handlers.
+  Read-only history of model migrations (completion + transcription, merged and
+  sorted by date with a type column). Each row expands to show per-entity-type
+  counts, warnings, and any error message — driven by an expander button rather
+  than a click-anywhere row so keyboard navigation works without custom key
+  handlers.
 -->
 
 <script lang="ts">
@@ -37,6 +38,9 @@
     error_message: string | null;
     migration_details: Record<string, number> | null;
     warnings: string[] | null;
+    // Client-side tag: which model type this row came from (the two histories
+    // live in separate backend endpoints and are merged here).
+    model_type: "completion" | "transcription";
   };
 
   type StatusVariant = "default" | "secondary" | "destructive" | "outline";
@@ -53,8 +57,22 @@
     loading = true;
     error = null;
     try {
-      const result = await intric.models.getAllMigrationHistory();
-      history = result as MigrationRecord[];
+      const [completion, transcription] = await Promise.all([
+        intric.models.getAllMigrationHistory(),
+        intric.models.getAllTranscriptionMigrationHistory()
+      ]);
+      const tag = (
+        records: unknown,
+        model_type: "completion" | "transcription"
+      ): MigrationRecord[] =>
+        (records as Omit<MigrationRecord, "model_type">[]).map((r) => ({ ...r, model_type }));
+      history = [...tag(completion, "completion"), ...tag(transcription, "transcription")].sort(
+        (a, b) => {
+          const da = new Date(a.completed_at ?? a.started_at ?? 0).getTime();
+          const db = new Date(b.completed_at ?? b.started_at ?? 0).getTime();
+          return db - da;
+        }
+      );
     } catch (e: unknown) {
       error = e instanceof Error ? e.message : m.migration_history_load_failed();
     } finally {
@@ -167,6 +185,7 @@
           <Table.Head>{m.migration_history_to()}</Table.Head>
           <Table.Head class="text-right">{m.migration_history_count()}</Table.Head>
           <Table.Head>{m.migration_history_by()}</Table.Head>
+          <Table.Head>{m.migration_history_type()}</Table.Head>
           <Table.Head>{m.migration_history_status()}</Table.Head>
         </Table.Row>
       </Table.Header>
@@ -201,13 +220,20 @@
             <Table.Cell class="text-right tabular-nums">{record.migrated_count}</Table.Cell>
             <Table.Cell class="text-muted">{record.initiated_by_name}</Table.Cell>
             <Table.Cell>
+              <Badge variant="secondary">
+                {record.model_type === "transcription"
+                  ? m.transcription_models()
+                  : m.completion_models()}
+              </Badge>
+            </Table.Cell>
+            <Table.Cell>
               <Badge variant={statusVariant(record.status)}>{statusLabel(record.status)}</Badge>
             </Table.Cell>
           </Table.Row>
 
           {#if isExpanded}
             <Table.Row id="migration-detail-{record.id}">
-              <Table.Cell colspan={7} class="bg-muted/40 p-0">
+              <Table.Cell colspan={8} class="bg-muted/40 p-0">
                 <div class="px-8 py-4">
                   <dl class="grid max-w-lg grid-cols-[max-content_1fr] gap-x-6 gap-y-1.5 text-sm">
                     <dt class="text-muted whitespace-nowrap">

--- a/frontend/apps/web/src/routes/(app)/admin/models/ModelActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/ModelActions.svelte
@@ -41,6 +41,7 @@
   export let model: AnyModel;
   export let type: ModelTypeKey;
   export let completionModels: CompletionModel[] = [];
+  export let transcriptionModels: TranscriptionModel[] = [];
 
   const intric = getIntric();
 
@@ -55,10 +56,16 @@
   let deleteError: string | null = null;
   let showMigrateOption = false;
 
-  $: completionModelTargets = type === "completionModel" ? completionModels : [];
+  $: supportsMigration = type === "completionModel" || type === "transcriptionModel";
+  $: migrateTargets =
+    type === "completionModel"
+      ? completionModels
+      : type === "transcriptionModel"
+        ? transcriptionModels
+        : [];
   $: modelLabel = "nickname" in model && model.nickname ? model.nickname : model.name;
-  $: isMigratedCompletionModel =
-    type === "completionModel" && "migrated_to_model_id" in model && !!model.migrated_to_model_id;
+  $: isMigratedModel =
+    supportsMigration && "migrated_to_model_id" in model && !!model.migrated_to_model_id;
 
   function openDelete() {
     deleteError = null;
@@ -85,8 +92,8 @@
     } catch (e: unknown) {
       deleteError = getErrorMessage(e);
       showMigrateOption =
-        type === "completionModel" &&
-        !isMigratedCompletionModel &&
+        supportsMigration &&
+        !isMigratedModel &&
         e instanceof IntricError &&
         e.code === MODEL_IN_USE_CODE;
     } finally {
@@ -110,7 +117,7 @@
       {m.edit_model()}
     </DropdownMenu.Item>
 
-    {#if type === "completionModel" && !isMigratedCompletionModel}
+    {#if supportsMigration && !isMigratedModel}
       <DropdownMenu.Item onclick={() => showMigrateDialog.set(true)}>
         <ArrowRight />
         {m.migrate_model_usage()}
@@ -196,10 +203,11 @@
   </Dialog.Content>
 </Dialog.Root>
 
-{#if type === "completionModel" && !isMigratedCompletionModel}
+{#if supportsMigration && !isMigratedModel}
   <MigrateModelDialog
     openController={showMigrateDialog}
-    sourceModel={model as CompletionModel}
-    models={completionModelTargets}
+    sourceModel={model as CompletionModel | TranscriptionModel}
+    models={migrateTargets}
+    modelType={type as "completionModel" | "transcriptionModel"}
   />
 {/if}

--- a/frontend/apps/web/src/routes/(app)/admin/models/components/ProviderGroupedModelTable.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/components/ProviderGroupedModelTable.svelte
@@ -161,7 +161,11 @@
           model: item.value,
           type: modelType,
           completionModels:
-            modelType === "completionModel" ? (tenantModels as unknown as CompletionModel[]) : []
+            modelType === "completionModel" ? (tenantModels as unknown as CompletionModel[]) : [],
+          transcriptionModels:
+            modelType === "transcriptionModel"
+              ? (tenantModels as unknown as TranscriptionModel[])
+              : []
         })
     })
   ];

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/+page.svelte
@@ -41,7 +41,9 @@
     models.embeddingModels.filter((model) => model.is_org_enabled && !model.is_deprecated)
   );
   let transcriptionModels = $derived(
-    models.transcriptionModels.filter((model) => model.is_org_enabled && !model.is_deprecated)
+    models.transcriptionModels.filter(
+      (model) => model.is_org_enabled && !model.is_deprecated && !model.migrated_to_model_id
+    )
   );
 
   const spaces = getSpacesManager();

--- a/frontend/packages/intric-js/src/endpoints/models.js
+++ b/frontend/packages/intric-js/src/endpoints/models.js
@@ -293,6 +293,24 @@ export function initModels(client) {
       });
 
       return res;
+    },
+
+    /**
+     * Get detailed usage (apps) for a transcription model. Mirrors
+     * getUsageDetails so the migrate dialog renders both with one component.
+     * @param {Object} params
+     * @param {string} params.modelId Model ID
+     * @param {number} [params.limit=100] Number of results
+     * @returns {Promise<import("../types/schema").components["schemas"]["TranscriptionModelUsageDetails"]>}
+     * @throws {IntricError}
+     * */
+    getTranscriptionUsageDetails: async ({ modelId, limit = 100 }) => {
+      const res = await client.fetch("/api/v1/transcription-models/{model_id}/usage/details", {
+        method: "get",
+        params: { path: { model_id: modelId }, query: { limit } }
+      });
+
+      return res;
     }
   };
 }

--- a/frontend/packages/intric-js/src/endpoints/models.js
+++ b/frontend/packages/intric-js/src/endpoints/models.js
@@ -196,6 +196,87 @@ export function initModels(client) {
       });
 
       return res;
+    },
+
+    /**
+     * Validate transcription migration compatibility without executing.
+     * @param {Object} params
+     * @param {string} params.fromId Source model ID
+     * @param {string} params.toId Target model ID
+     * @returns {Promise<import("../types/schema").components["schemas"]["ValidationResult"]>}
+     * @throws {IntricError}
+     * */
+    validateTranscriptionMigration: async ({ fromId, toId }) => {
+      const res = await client.fetch("/api/v1/transcription-models/{model_id}/migration-validate", {
+        method: "get",
+        params: {
+          path: { model_id: fromId },
+          query: { to_model_id: toId }
+        }
+      });
+
+      return res;
+    },
+
+    /**
+     * Migrate transcription model usage to another model.
+     * @param {Object} params
+     * @param {string} params.fromId Source model ID
+     * @param {string} params.toId Target model ID
+     * @param {string[]} [params.entityTypes] Optional list of entity types to migrate
+     * @param {boolean} [params.confirmMigration] Proceed even if compatibility warnings exist
+     * @returns {Promise<import("../types/schema").components["schemas"]["MigrationResult"]>}
+     * @throws {IntricError}
+     * */
+    migrateTranscription: async ({ fromId, toId, entityTypes, confirmMigration }) => {
+      const res = await client.fetch("/api/v1/transcription-models/{model_id}/migrate", {
+        method: "post",
+        params: { path: { model_id: fromId } },
+        requestBody: {
+          "application/json": {
+            to_model_id: toId,
+            entity_types: entityTypes,
+            confirm_migration: confirmMigration
+          }
+        }
+      });
+
+      return res;
+    },
+
+    /**
+     * Get migration history for a specific transcription model.
+     * @param {Object} params
+     * @param {string} params.modelId Model ID
+     * @param {number} [params.limit=50] Number of results
+     * @param {number} [params.offset=0] Offset for pagination
+     * @returns {Promise<import("../types/schema").components["schemas"]["ModelMigrationHistory"][]>}
+     * @throws {IntricError}
+     * */
+    getTranscriptionMigrationHistory: async ({ modelId, limit = 50, offset = 0 }) => {
+      const res = await client.fetch("/api/v1/transcription-models/{model_id}/migration-history", {
+        method: "get",
+        params: { path: { model_id: modelId }, query: { limit, offset } }
+      });
+
+      return res;
+    },
+
+    /**
+     * Get all transcription migration history for the tenant.
+     * @param {Object} [params]
+     * @param {number} [params.limit=50] Number of results
+     * @param {number} [params.offset=0] Offset for pagination
+     * @returns {Promise<import("../types/schema").components["schemas"]["ModelMigrationHistory"][]>}
+     * @throws {IntricError}
+     * */
+    getAllTranscriptionMigrationHistory: async ({ limit = 50, offset = 0 } = {}) => {
+      const res = await client.fetch("/api/v1/transcription-models/migration-history", {
+        method: "get",
+        params: { query: { limit, offset } }
+      });
+
+      return res;
     }
   };
 }

--- a/frontend/packages/intric-js/src/endpoints/models.js
+++ b/frontend/packages/intric-js/src/endpoints/models.js
@@ -277,6 +277,22 @@ export function initModels(client) {
       });
 
       return res;
+    },
+
+    /**
+     * Get migration impact counts (apps + spaces) for a transcription model.
+     * @param {Object} params
+     * @param {string} params.modelId Model ID
+     * @returns {Promise<import("../types/schema").components["schemas"]["TranscriptionModelUsageStats"]>}
+     * @throws {IntricError}
+     * */
+    getTranscriptionUsageStats: async ({ modelId }) => {
+      const res = await client.fetch("/api/v1/transcription-models/{model_id}/usage", {
+        method: "get",
+        params: { path: { model_id: modelId } }
+      });
+
+      return res;
     }
   };
 }

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -3239,6 +3239,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/transcription-models/{model_id}/usage/details": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Transcription Model Usage Details
+     * @description List apps using this transcription model (for the migrate dialog).
+     */
+    get: operations["get_transcription_model_usage_details_api_v1_transcription_models__model_id__usage_details_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/transcription-models/{model_id}/migration-validate": {
     parameters: {
       query?: never;
@@ -15772,6 +15792,19 @@ export interface components {
       /** Security Classification */
       security_classification?: components["schemas"]["ModelId"] | null;
     };
+    /** TranscriptionModelUsageDetails */
+    TranscriptionModelUsageDetails: {
+      /**
+       * Items
+       * @default []
+       */
+      items?: components["schemas"]["TranscriptionUsageEntity"][];
+      /**
+       * Total
+       * @default 0
+       */
+      total?: number;
+    };
     /**
      * TranscriptionModelUsageStats
      * @description Live count of what a transcription model migration would move.
@@ -15800,6 +15833,29 @@ export interface components {
        * @default 0
        */
       total_count?: number;
+    };
+    /**
+     * TranscriptionUsageEntity
+     * @description One entity using a transcription model. Shape matches completion's
+     *     ModelUsageDetail so the migrate dialog can render both with one component.
+     */
+    TranscriptionUsageEntity: {
+      /**
+       * Entity Id
+       * Format: uuid
+       */
+      entity_id: string;
+      /** Entity Name */
+      entity_name: string;
+      /**
+       * Entity Type
+       * @default app
+       */
+      entity_type?: string;
+      /** Space Name */
+      space_name?: string | null;
+      /** Owner Name */
+      owner_name?: string | null;
     };
     /** TransferApplicationRequest */
     TransferApplicationRequest: {
@@ -27724,6 +27780,48 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["TranscriptionModelUsageStats"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_transcription_model_usage_details_api_v1_transcription_models__model_id__usage_details_get: {
+    parameters: {
+      query?: {
+        limit?: number;
+      };
+      header?: never;
+      path: {
+        model_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["TranscriptionModelUsageDetails"];
         };
       };
       /** @description Not Found */

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -3219,6 +3219,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/transcription-models/{model_id}/usage": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Transcription Model Usage
+     * @description Count apps and spaces that would be moved by migrating this model.
+     */
+    get: operations["get_transcription_model_usage_api_v1_transcription_models__model_id__usage_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/transcription-models/{model_id}/migration-validate": {
     parameters: {
       query?: never;
@@ -3251,10 +3271,6 @@ export interface paths {
     /**
      * Migrate Transcription Model Usage
      * @description Migrate all usage from one transcription model to another.
-     *
-     *     Validity, same-model rejection, tenant ownership and entity-type
-     *     whitelisting all live in the shared migration engine; the router only
-     *     enforces admin permission and writes the audit log on success.
      */
     post: operations["migrate_transcription_model_usage_api_v1_transcription_models__model_id__migrate_post"];
     delete?: never;
@@ -3272,7 +3288,7 @@ export interface paths {
     };
     /**
      * Get All Transcription Migration History
-     * @description Get all transcription migration history for the tenant.
+     * @description List all transcription migration history for the tenant.
      */
     get: operations["get_all_transcription_migration_history_api_v1_transcription_models_migration_history_get"];
     put?: never;
@@ -3312,7 +3328,7 @@ export interface paths {
     };
     /**
      * Get Transcription Model Migration History
-     * @description Get migration history for a specific transcription model (from or to).
+     * @description Get migration history for a specific transcription model.
      */
     get: operations["get_transcription_model_migration_history_api_v1_transcription_models__model_id__migration_history_get"];
     put?: never;
@@ -15756,6 +15772,35 @@ export interface components {
       /** Security Classification */
       security_classification?: components["schemas"]["ModelId"] | null;
     };
+    /**
+     * TranscriptionModelUsageStats
+     * @description Live count of what a transcription model migration would move.
+     *
+     *     Transcription has no pre-aggregated usage-stats table (unlike completion);
+     *     these counts come straight from the migration engine's entity counters.
+     */
+    TranscriptionModelUsageStats: {
+      /**
+       * Model Id
+       * Format: uuid
+       */
+      model_id: string;
+      /**
+       * Apps Count
+       * @default 0
+       */
+      apps_count?: number;
+      /**
+       * Spaces Count
+       * @default 0
+       */
+      spaces_count?: number;
+      /**
+       * Total Count
+       * @default 0
+       */
+      total_count?: number;
+    };
     /** TransferApplicationRequest */
     TransferApplicationRequest: {
       /**
@@ -27661,6 +27706,46 @@ export interface operations {
       };
     };
   };
+  get_transcription_model_usage_api_v1_transcription_models__model_id__usage_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        model_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["TranscriptionModelUsageStats"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
   validate_transcription_migration_api_v1_transcription_models__model_id__migration_validate_get: {
     parameters: {
       query: {
@@ -27794,6 +27879,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["ModelMigrationHistory"][];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -3219,6 +3219,110 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/transcription-models/{model_id}/migration-validate": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Validate Transcription Migration
+     * @description Validate transcription migration compatibility without executing.
+     */
+    get: operations["validate_transcription_migration_api_v1_transcription_models__model_id__migration_validate_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/transcription-models/{model_id}/migrate": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Migrate Transcription Model Usage
+     * @description Migrate all usage from one transcription model to another.
+     *
+     *     Validity, same-model rejection, tenant ownership and entity-type
+     *     whitelisting all live in the shared migration engine; the router only
+     *     enforces admin permission and writes the audit log on success.
+     */
+    post: operations["migrate_transcription_model_usage_api_v1_transcription_models__model_id__migrate_post"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/transcription-models/migration-history": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get All Transcription Migration History
+     * @description Get all transcription migration history for the tenant.
+     */
+    get: operations["get_all_transcription_migration_history_api_v1_transcription_models_migration_history_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/transcription-models/migration-history/{migration_id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Transcription Migration History By Id
+     * @description Get a specific transcription migration history record by ID.
+     */
+    get: operations["get_transcription_migration_history_by_id_api_v1_transcription_models_migration_history__migration_id__get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/v1/transcription-models/{model_id}/migration-history": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Transcription Model Migration History
+     * @description Get migration history for a specific transcription model (from or to).
+     */
+    get: operations["get_transcription_model_migration_history_api_v1_transcription_models__model_id__migration_history_get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/admin/model-providers/": {
     parameters: {
       query?: never;
@@ -6982,6 +7086,7 @@ export interface components {
       | "transcription_model_created"
       | "transcription_model_updated"
       | "transcription_model_deleted"
+      | "transcription_model_migrated"
       | "template_created"
       | "template_updated"
       | "template_deleted"
@@ -13319,12 +13424,22 @@ export interface components {
      *     `model_name` and `context_window` are echoed so a client can compute the
      *     percentage fill locally without a separate round-trip to fetch model
      *     metadata.
+     *
+     *     `excluded_file_count` is the number of attached files we could not
+     *     tokenise here (images and other binary payloads use provider-specific
+     *     multimodal accounting). Callers should treat the response as a
+     *     conservative lower bound when this is non-zero.
      */
     PreflightResponse: {
       /** Input Tokens */
       input_tokens: number;
       /** File Tokens */
       file_tokens: number;
+      /**
+       * Excluded File Count
+       * @default 0
+       */
+      excluded_file_count?: number;
       /** Model Name */
       model_name: string;
       /** Context Window */
@@ -15560,6 +15675,8 @@ export interface components {
       provider_type?: string | null;
       /** Deprecation Date */
       deprecation_date?: string | null;
+      /** Migrated To Model Id */
+      migrated_to_model_id?: string | null;
     };
     /** TranscriptionModelSecurityStatus */
     TranscriptionModelSecurityStatus: {
@@ -15625,6 +15742,8 @@ export interface components {
       provider_type?: string | null;
       /** Deprecation Date */
       deprecation_date?: string | null;
+      /** Migrated To Model Id */
+      migrated_to_model_id?: string | null;
       /** Meets Security Classification */
       meets_security_classification?: boolean | null;
     };
@@ -27542,6 +27661,235 @@ export interface operations {
       };
     };
   };
+  validate_transcription_migration_api_v1_transcription_models__model_id__migration_validate_get: {
+    parameters: {
+      query: {
+        /** @description Target model ID */
+        to_model_id: string;
+      };
+      header?: never;
+      path: {
+        model_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ValidationResult"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  migrate_transcription_model_usage_api_v1_transcription_models__model_id__migrate_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        model_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ModelMigrationRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["MigrationResult"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_all_transcription_migration_history_api_v1_transcription_models_migration_history_get: {
+    parameters: {
+      query?: {
+        limit?: number;
+        offset?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ModelMigrationHistory"][];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_transcription_migration_history_by_id_api_v1_transcription_models_migration_history__migration_id__get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        migration_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ModelMigrationHistory"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_transcription_model_migration_history_api_v1_transcription_models__model_id__migration_history_get: {
+    parameters: {
+      query?: {
+        limit?: number;
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        model_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ModelMigrationHistory"][];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
   list_providers_api_v1_admin_model_providers__get: {
     parameters: {
       query?: never;
@@ -28558,12 +28906,30 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description Successful Response */
+      /** @description File deleted successfully. No response body is returned. */
       204: {
         headers: {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
       };
       /** @description Validation Error */
       422: {


### PR DESCRIPTION
## 1. Enforce unique active model display names
A model's display name (`nickname`) is what users pick from in the chat model selector and admin tables. Nothing stopped two **active** models in the same tenant from sharing one, producing rows that are impossible to tell apart (e.g. several identical "gpt-5.1" entries).

- Aligns the three model tables: `transcription_models` gains `nickname` (backfilled from its display name), and `embedding_models`/`transcription_models` gain `deleted_at` for soft-delete parity with completion.
- Renames existing active duplicates with a " (2)", " (3)" … suffix and adds a partial unique index per table.
- Validates uniqueness in the tenant **and** sysadmin create/update paths (clean 409 instead of a raw integrity error); the add/edit dialogs show a localized collision message.

Uniqueness is scoped to active models (`deleted_at IS NULL AND is_deprecated = false`), so deprecated/soft-deleted rows kept for references never block a name. The same underlying model name may still repeat across providers; only the display name must be distinct.

## 2. Transcription model migration via a shared engine
Gives transcription models the same in-app migration flow completion already has (retire a model → move its usages to a replacement → track history), built on **shared** code rather than a third copy.

- Extracts the completion migration orchestration into a shared `BaseModelMigrationService` + generic migration-history repo/read-service, and refactors completion onto them (behaviour unchanged — covered by the existing unit tests).
- Adds transcription migration on top: a thin service, the migrate/validate/history endpoints, a history table and `migrated_to` lifecycle column.
- Frontend: the migrate dialog and ModelActions are parameterized to cover both types (transcription skips the usage preview it has no endpoints for), and the migration-history view merges both types with a type column.

Transcription only repoints references (apps + the spaces many-to-many) — no re-indexing needed, unlike embedding migration (a code comment in the shared engine sketches how embedding would extend it with a re-embed step).

## 3. Soft-delete parity made real + lifecycle cleanup
The `deleted_at` columns from §1 were schema-only for transcription/embedding: both still **hard-deleted** on tenant delete, and read paths didn't filter `deleted_at`. For transcription this silently nulled apps' `transcription_model_id` (FK is `ON DELETE SET NULL`, so no integrity error fired) and dropped which models a migration ran between. This makes the parity actual:

- **Soft-delete on tenant delete** for transcription and embedding: drop the space-link rows, keep the row as a tombstone, set `deleted_at`. Transcription delete gains an explicit app **in-use guard** that blocks instead of orphaning.
- **Read-path filtering**: all transcription/embedding repos (and the legacy admin embedding service) filter `deleted_at IS NULL`, so tombstones never surface in pickers or admin lists.
- **Weekly cleanup workers** hard-delete tombstones once nothing references them, via a shared skeleton (`model_lifecycle_cleanup.py`; completion keeps its own bespoke worker):
  - transcription — removable when no app references it and no other model points to it via `migrated_to_model_id` (an incoming-reference guard protects a migration target from being deleted alongside its source);
  - embedding — removable when no collections/websites/integration-knowledge and no historical `info_blobs` reference it.

Migration history rows keep denormalized model names, so the `SET NULL` on their FK after a source is finally hard-deleted loses nothing user-visible.

## 4. Migration latch only when complete
The shared engine set `migrated_to_model_id` unconditionally after moving whatever subset of `entity_types` a call requested. Since the latch is one-way (it blocks any further migration of the source), a partial migration would strand the un-migrated surfaces on a source that can never be migrated again. The source is now marked only when the run covered **every** migratable type (the frontend always omits `entity_types`, expanding to all, so the normal flow latches as before; only deliberate partial API calls stay re-runnable). Restores the coupling note dropped during the engine extraction.

> Known follow-up (deferred): uniqueness in §1 is scoped per `(tenant, provider)`, so two providers can share a display name. Pickers disambiguate via the provider group header, but the collapsed/selected state shows only the nickname. Left for the planned rework of the personal-chat model select.

## Verification
- Backend unit tests green (1797), completion migration behaviour preserved after the refactor and the latch change (31 integration + 84 unit); migrations apply with clean down/up roundtrips.
- New transcription + embedding lifecycle/cleanup integration tests (17): soft-delete + read-path hiding, the app in-use guard, and the worker paths — removal of unreferenced tombstones, protection of a migration target that is itself a tombstone, multiple migrations in one pass, active models never touched, and migration history surviving source cleanup.
- Tenant-models + spaces regression suites green (30).
- Frontend `bun run check` 0/0, lint clean.
