### PR TITLE
fix(models): show tenant-configured Azure completion models

### DIFF
--- a/backend/src/intric/ai_models/ai_models_service.py
+++ b/backend/src/intric/ai_models/ai_models_service.py
@@ -145,7 +145,14 @@ class AIModelsService:
 
         models: list[CompletionModelPublic] = []
         for model in completion_models:
-            if model.family == "azure" and not get_settings().using_azure_models:
+            # See completion_model_crud_service: only the predefined global
+            # Azure models (tenant_id is None) are gated by this flag. Tenant-
+            # configured Azure models are explicit config and always shown.
+            if (
+                model.family == "azure"
+                and model.tenant_id is None
+                and not get_settings().using_azure_models
+            ):
                 continue
 
             models.append(

--- a/backend/src/intric/completion_models/application/completion_model_crud_service.py
+++ b/backend/src/intric/completion_models/application/completion_model_crud_service.py
@@ -36,7 +36,16 @@ class CompletionModelCRUDService:
 
         available_models: list["CompletionModel"] = []
         for model in models:
-            if model.family == "azure" and not get_settings().using_azure_models:
+            # `using_azure_models` gates the *predefined global* Azure models
+            # (tenant_id is None) that ship with Eneo. A tenant that explicitly
+            # configures an Azure provider gets family="azure" too, but those
+            # models are deliberate config and must never be hidden by a global
+            # deployment flag — otherwise they 200 on create yet vanish here.
+            if (
+                model.family == "azure"
+                and model.tenant_id is None
+                and not get_settings().using_azure_models
+            ):
                 continue
 
             available_models.append(model)

--- a/backend/tests/unittests/ai_models/test_ai_models_service.py
+++ b/backend/tests/unittests/ai_models/test_ai_models_service.py
@@ -203,3 +203,25 @@ async def test_azure_models_with_feature_flag_on(service: AIModelsService):
 
     assert len(models) == 3
     assert "azure" in [model.family for model in models]
+
+
+async def test_tenant_azure_models_shown_when_flag_off(service: AIModelsService):
+    # A tenant that explicitly configures an Azure provider gets family="azure"
+    # on its completion models. Those are deliberate config and must stay
+    # visible even when the global `using_azure_models` flag (which only gates
+    # the predefined global Azure models) is off. Regression for Azure
+    # completion models 200-ing on create yet never appearing in the admin
+    # list / chat picker.
+    get_settings().using_azure_models = False
+    tenant_azure = TEST_MODEL_AZURE.model_copy(update={"tenant_id": TEST_TENANT.id})
+    service.completion_model_repo.get_models.return_value = [
+        TEST_MODEL_GPT4,
+        TEST_MODEL_AZURE,  # global → hidden
+        tenant_azure,  # tenant-owned → shown
+    ]
+
+    models = await service.get_completion_models()
+
+    families = [model.family for model in models]
+    assert families.count("azure") == 1
+    assert any(model.tenant_id == TEST_TENANT.id for model in models)

--- a/backend/tests/unittests/completion_models/test_completion_model_crud_service.py
+++ b/backend/tests/unittests/completion_models/test_completion_model_crud_service.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from intric.completion_models.application.completion_model_crud_service import (
+    CompletionModelCRUDService,
+)
+from intric.main.config import get_settings
+
+
+def _build_service(repo: AsyncMock) -> CompletionModelCRUDService:
+    return CompletionModelCRUDService(
+        user=SimpleNamespace(tenant_id=uuid4()),
+        completion_model_repo=repo,
+        security_classification_repo=AsyncMock(),
+    )
+
+
+def _model(*, family: str, tenant_id=None):
+    return SimpleNamespace(family=family, tenant_id=tenant_id)
+
+
+async def test_get_completion_models_hides_only_global_azure_when_flag_off(
+    monkeypatch,
+):
+    monkeypatch.setattr(get_settings(), "using_azure_models", False)
+    global_azure = _model(family="azure")
+    tenant_azure = _model(family="azure", tenant_id=uuid4())
+    openai = _model(family="openai")
+    repo = AsyncMock()
+    repo.all.return_value = [global_azure, tenant_azure, openai]
+    service = _build_service(repo)
+
+    models = await service.get_completion_models()
+
+    assert models == [tenant_azure, openai]
+
+
+async def test_get_completion_models_shows_global_azure_when_flag_on(monkeypatch):
+    monkeypatch.setattr(get_settings(), "using_azure_models", True)
+    global_azure = _model(family="azure")
+    tenant_azure = _model(family="azure", tenant_id=uuid4())
+    repo = AsyncMock()
+    repo.all.return_value = [global_azure, tenant_azure]
+    service = _build_service(repo)
+
+    models = await service.get_completion_models()
+
+    assert models == [global_azure, tenant_azure]


### PR DESCRIPTION
## Problem

On a fresh instance, adding a **completion** model on an **Azure OpenAI** provider returns 200 OK, but the model never appears — neither in the admin Completion tab nor in the chat model picker. Adding **embedding** models on the same provider works fine.

## Root cause

Two things combine:

1. The add-model wizard sets a completion model's `family` to the provider type (`AddWizard/models/draft.ts:51`), so an Azure provider yields `family = "azure"`. Embedding models are hardcoded to `family = "openai"`, which is why embedding was unaffected.
2. Both completion read paths drop every `family == "azure"` model when the deployment flag `using_azure_models` is `false` (the default):
   - `completion_model_crud_service.get_completion_models()` — serves the admin list (`GET /api/v1/ai-models/`)
   - `ai_models_service.get_completion_models()` — chat picker

That flag was designed to gate the **predefined global** Azure models that ship with Eneo, but it was applied to *every* azure-family model — including ones a tenant explicitly configured. So tenant Azure completion models are created in the DB (with `provider_id` + `tenant_id`) yet filtered out of every list.

## Fix

Restrict the gate to global models (`tenant_id is None`). Tenant-owned Azure models are deliberate configuration and are always shown. The predefined global Azure models stay gated exactly as before.

## Verification

- New regression test `test_tenant_azure_models_shown_when_flag_off` fails on the old code (tenant Azure model dropped) and passes with the fix; the existing global-Azure-hidden test still passes.
- Full unit suite green.

## How to test on this branch

Add an Azure OpenAI provider and a completion model via the wizard — it should now appear in the admin Completion tab and the chat picker, without needing to set `USING_AZURE_MODELS=true`.

> Note: setting `USING_AZURE_MODELS=true` in the backend env is a valid workaround on current `develop` while this lands.