### PR TITLE
fix(completion-models): surface provider outages to API consumers

### DIFF
--- a/backend/src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py
+++ b/backend/src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import re
+import socket
 import uuid
 from typing import (
     TYPE_CHECKING,
@@ -10,19 +11,28 @@ from typing import (
     AsyncIterator,
     Callable,
     Literal,
+    NoReturn,
     Optional,
     Protocol,
     TypedDict,
     cast,
 )
 
+import aiohttp
+import httpx
 import litellm
 from litellm.exceptions import (
+    APIConnectionError,
     APIError,
     AuthenticationError,
     BadRequestError,
+    InternalServerError,
     RateLimitError,
+    ServiceUnavailableError,
+    Timeout,
 )
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
 from typing_extensions import override
 
 from intric.ai_models.completion_models.completion_model import (
@@ -44,6 +54,35 @@ from intric.model_providers.infrastructure.tenant_model_credential_resolver impo
 )
 
 logger = get_logger(__name__)
+
+PROVIDER_UNAVAILABLE_MESSAGE = (
+    "AI service is temporarily unavailable. Please try again later."
+)
+PROVIDER_UNAVAILABLE_CODE = "provider_unavailable"
+# Some providers wrap DNS/socket failures in generic APIError/RuntimeError types.
+# Keep this fallback narrow so transient upstream failures stay distinguishable.
+_PROVIDER_UNAVAILABLE_TEXT = (
+    "cannot connect",
+    "connection refused",
+    "connection reset",
+    "connection timed out",
+    "temporary failure in name resolution",
+    "name or service not known",
+    "service unavailable",
+    "timed out",
+)
+_PROVIDER_UNAVAILABLE_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    APIConnectionError,
+    Timeout,
+    ServiceUnavailableError,
+    InternalServerError,
+    httpx.ConnectError,
+    httpx.TimeoutException,
+    aiohttp.ClientError,
+    socket.gaierror,
+    ConnectionError,
+    TimeoutError,
+)
 
 
 # Regex to match Qwen3 thinking blocks: <think>...</think>
@@ -137,6 +176,27 @@ def _acompletion_call(**kwargs: Any) -> Any:
     return cast(Callable[..., Any], getattr(litellm, "acompletion"))(**kwargs)
 
 
+def _exception_chain(exc: BaseException) -> list[BaseException]:
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        chain.append(current)
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+    return chain
+
+
+def _is_provider_unavailable_error(exc: BaseException) -> bool:
+    for chained in _exception_chain(exc):
+        if isinstance(chained, _PROVIDER_UNAVAILABLE_EXCEPTIONS):
+            return True
+        error_text = str(chained).lower()
+        if any(marker in error_text for marker in _PROVIDER_UNAVAILABLE_TEXT):
+            return True
+    return False
+
+
 def _tool_metadata_arguments(tool: ToolCallMetadata) -> dict[str, Any] | None:
     return cast(dict[str, Any] | None, cast(Any, tool).arguments)
 
@@ -194,6 +254,44 @@ class TenantModelAdapter(CompletionModelAdapter):
         # Example: "openai/openai/gpt-4" -> sends "openai/gpt-4" to custom endpoint
         self.litellm_model = f"{provider_type}/{model.name}"
         self.provider_type = provider_type
+
+    def _record_provider_unavailable(self, *, phase: str, exc: BaseException) -> None:
+        span = trace.get_current_span()
+        if span.is_recording():
+            is_streaming = phase in {"stream_preparation", "stream_iteration"}
+            span.set_attribute("gen_ai.operation.name", "chat")
+            span.set_attribute("gen_ai.provider.name", self.provider_type)
+            span.set_attribute("gen_ai.request.model", self.model.name)
+            span.set_attribute("gen_ai.request.stream", is_streaming)
+            span.set_attribute("error.type", PROVIDER_UNAVAILABLE_CODE)
+            span.set_attribute("eneo.ai.provider_unavailable", True)
+            span.set_attribute("eneo.ai.provider_type", self.provider_type)
+            span.set_attribute("eneo.ai.model", self.litellm_model)
+            span.set_attribute("eneo.ai.operation", phase)
+            span.set_attribute("eneo.ai.error_type", exc.__class__.__name__)
+            span.record_exception(exc)
+            span.set_status(Status(StatusCode.ERROR, PROVIDER_UNAVAILABLE_MESSAGE))
+
+        logger.exception(
+            f"[TenantModelAdapter] Provider unavailable for {self.litellm_model} during {phase}",
+            extra={
+                "provider_type": self.provider_type,
+                "model": self.litellm_model,
+                "operation": phase,
+                "error_type": exc.__class__.__name__,
+                "error_code": PROVIDER_UNAVAILABLE_CODE,
+            },
+        )
+
+    def _raise_provider_unavailable(
+        self, *, phase: str, exc: BaseException
+    ) -> NoReturn:
+        self._record_provider_unavailable(phase=phase, exc=exc)
+        raise OpenAIException(
+            PROVIDER_UNAVAILABLE_MESSAGE,
+            code=PROVIDER_UNAVAILABLE_CODE,
+            details={"reason": PROVIDER_UNAVAILABLE_CODE, "retryable": True},
+        ) from exc
 
     def _mask_sensitive_params(self, params: dict[str, Any]) -> dict[str, Any]:
         """Return copy of params with masked API key for safe logging."""
@@ -772,7 +870,18 @@ class TenantModelAdapter(CompletionModelAdapter):
             )
             raise OpenAIException(f"Invalid request: {error_message}") from exc
 
+        except (
+            APIConnectionError,
+            Timeout,
+            ServiceUnavailableError,
+            InternalServerError,
+        ) as exc:
+            self._raise_provider_unavailable(phase="completion", exc=exc)
+
         except APIError as exc:
+            if _is_provider_unavailable_error(exc):
+                self._raise_provider_unavailable(phase="completion", exc=exc)
+
             error_message = str(exc)
             logger.error(
                 f"API error for tenant model {self.model.name}: {error_message}",
@@ -799,6 +908,9 @@ class TenantModelAdapter(CompletionModelAdapter):
                 raise OpenAIException(f"API error: {error_message}") from exc
 
         except Exception as exc:
+            if _is_provider_unavailable_error(exc):
+                self._raise_provider_unavailable(phase="completion", exc=exc)
+
             logger.exception(
                 f"[TenantModelAdapter] Unexpected error for {self.litellm_model}"
             )
@@ -921,7 +1033,18 @@ class TenantModelAdapter(CompletionModelAdapter):
             )
             raise OpenAIException(f"Invalid request: {error_message}") from exc
 
+        except (
+            APIConnectionError,
+            Timeout,
+            ServiceUnavailableError,
+            InternalServerError,
+        ) as exc:
+            self._raise_provider_unavailable(phase="stream_preparation", exc=exc)
+
         except APIError as exc:
+            if _is_provider_unavailable_error(exc):
+                self._raise_provider_unavailable(phase="stream_preparation", exc=exc)
+
             error_message = str(exc)
             logger.error(
                 f"API error for streaming tenant model {self.model.name}: {error_message}",
@@ -948,6 +1071,9 @@ class TenantModelAdapter(CompletionModelAdapter):
                 raise OpenAIException(f"API error: {error_message}") from exc
 
         except Exception as exc:
+            if _is_provider_unavailable_error(exc):
+                self._raise_provider_unavailable(phase="stream_preparation", exc=exc)
+
             logger.exception(
                 f"[TenantModelAdapter] Unexpected error creating stream for {self.litellm_model}"
             )
@@ -1440,14 +1566,23 @@ class TenantModelAdapter(CompletionModelAdapter):
 
         except Exception as exc:
             # Mid-stream errors: yield error event instead of raising
-            logger.error(
-                f"[TenantModelAdapter] {self.litellm_model}: Error during stream iteration: {exc}",
-                exc_info=True,
-            )
+            if _is_provider_unavailable_error(exc):
+                self._record_provider_unavailable(phase="stream_iteration", exc=exc)
+                # Streaming Completion events expose numeric error_code, not JSON details.
+                error = PROVIDER_UNAVAILABLE_MESSAGE
+                error_code = 503
+            else:
+                logger.error(
+                    f"[TenantModelAdapter] {self.litellm_model}: Error during stream iteration: {exc}",
+                    exc_info=True,
+                )
+                error = f"Stream error: {str(exc)}"
+                error_code = 500
+
             yield Completion(
                 text="",
-                error=f"Stream error: {str(exc)}",
-                error_code=500,
+                error=error,
+                error_code=error_code,
                 response_type=ResponseType.ERROR,
                 stop=True,
             )

--- a/backend/src/intric/main/exceptions.py
+++ b/backend/src/intric/main/exceptions.py
@@ -153,7 +153,18 @@ class UniqueException(Exception):
 
 
 class OpenAIException(Exception):
-    pass
+    def __init__(
+        self,
+        message: str = "",
+        *,
+        code: str | None = None,
+        context: dict[str, object] | None = None,
+        details: dict[str, object] | None = None,
+    ):
+        super().__init__(message)
+        self.code = code
+        self.context = context
+        self.details = details
 
 
 class ClaudeException(Exception):

--- a/backend/tests/unit/test_exception_handlers.py
+++ b/backend/tests/unit/test_exception_handlers.py
@@ -1,7 +1,12 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from intric.main.exceptions import NotFoundException, UnauthorizedException
+from intric.main.exceptions import (
+    ErrorCodes,
+    NotFoundException,
+    OpenAIException,
+    UnauthorizedException,
+)
 from intric.server.exception_handlers import add_exception_handlers
 
 
@@ -74,3 +79,27 @@ def test_error_handler_sets_request_id_from_headers():
     assert response.status_code == 403
     payload = response.json()
     assert payload["request_id"] == request_id
+
+
+def test_openai_exception_preserves_structured_provider_error_for_api_clients():
+    client = _make_client(
+        OpenAIException(
+            "AI service is temporarily unavailable. Please try again later.",
+            code="provider_unavailable",
+            details={"reason": "provider_unavailable", "retryable": True},
+        )
+    )
+
+    response = client.get("/boom")
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["message"] == (
+        "AI service is temporarily unavailable. Please try again later."
+    )
+    assert payload["intric_error_code"] == ErrorCodes.OPENAI_ERROR
+    assert payload["code"] == "provider_unavailable"
+    assert payload["details"] == {
+        "reason": "provider_unavailable",
+        "retryable": True,
+    }

--- a/backend/tests/unit/test_tenant_model_adapter_iterate_stream.py
+++ b/backend/tests/unit/test_tenant_model_adapter_iterate_stream.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 
+import httpx
 import pytest
 
 from intric.ai_models.completion_models.completion_model import ResponseType
 from intric.completion_models.infrastructure.adapters.tenant_model_adapter import (
+    PROVIDER_UNAVAILABLE_CODE,
+    PROVIDER_UNAVAILABLE_MESSAGE,
     TenantModelAdapter,
 )
+from intric.main.exceptions import OpenAIException
 from intric.mcp_servers.infrastructure.tool_approval import (
     ToolApprovalDecision,
     ToolApprovalWaitResult,
@@ -78,7 +82,21 @@ class _FakeMCPProxy:
 def _make_adapter() -> TenantModelAdapter:
     adapter = object.__new__(TenantModelAdapter)
     adapter.litellm_model = "openai/test-model"
+    adapter.provider_type = "openai"
     adapter.model = SimpleNamespace(name="test-model")
+    return adapter
+
+
+def _make_completion_adapter() -> TenantModelAdapter:
+    adapter = _make_adapter()
+    adapter._prepare_kwargs = Mock(return_value={})
+    adapter._create_messages_from_context = Mock(
+        return_value=[{"role": "user", "content": "hello"}]
+    )
+    adapter._build_tools_from_context = Mock(return_value=[])
+    adapter._merge_mcp_tools = Mock(return_value=[])
+    adapter._get_dropped_params = Mock(return_value=set())
+    adapter._get_effective_params = Mock(return_value={})
     return adapter
 
 
@@ -92,6 +110,168 @@ async def _collect(adapter: TenantModelAdapter, stream, **kwargs):
     ):
         output.append(chunk)
     return output
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method_name", "phase"),
+    [
+        ("get_response", "completion"),
+        ("prepare_streaming", "stream_preparation"),
+    ],
+)
+async def test_provider_connectivity_failure_returns_clear_unavailable_error(
+    method_name: str,
+    phase: str,
+):
+    adapter = _make_completion_adapter()
+    span = Mock()
+    span.is_recording.return_value = True
+
+    with (
+        patch(
+            "intric.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+            AsyncMock(
+                side_effect=httpx.ConnectError("Temporary failure in name resolution")
+            ),
+        ),
+        patch(
+            "intric.completion_models.infrastructure.adapters.tenant_model_adapter.trace.get_current_span",
+            return_value=span,
+        ),
+    ):
+        with pytest.raises(OpenAIException) as exc_info:
+            if method_name == "get_response":
+                await adapter.get_response(context=SimpleNamespace(), model_kwargs={})
+            else:
+                await adapter.prepare_streaming(
+                    context=SimpleNamespace(), model_kwargs={}
+                )
+
+    exc = exc_info.value
+    assert str(exc) == PROVIDER_UNAVAILABLE_MESSAGE
+    assert exc.code == PROVIDER_UNAVAILABLE_CODE
+    assert exc.details == {"reason": PROVIDER_UNAVAILABLE_CODE, "retryable": True}
+    span.set_attribute.assert_any_call("gen_ai.operation.name", "chat")
+    span.set_attribute.assert_any_call("gen_ai.provider.name", "openai")
+    span.set_attribute.assert_any_call("gen_ai.request.model", "test-model")
+    span.set_attribute.assert_any_call(
+        "gen_ai.request.stream", method_name == "prepare_streaming"
+    )
+    span.set_attribute.assert_any_call("error.type", PROVIDER_UNAVAILABLE_CODE)
+    span.set_attribute.assert_any_call("eneo.ai.provider_unavailable", True)
+    span.set_attribute.assert_any_call("eneo.ai.operation", phase)
+    span.record_exception.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_wrapped_provider_failure_returns_clear_unavailable_error():
+    adapter = _make_completion_adapter()
+    outer_error = RuntimeError("upstream call failed")
+    outer_error.__cause__ = httpx.ConnectError("Temporary failure in name resolution")
+
+    with patch(
+        "intric.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(side_effect=outer_error),
+    ):
+        with pytest.raises(OpenAIException) as exc_info:
+            await adapter.get_response(context=SimpleNamespace(), model_kwargs={})
+
+    exc = exc_info.value
+    assert str(exc) == PROVIDER_UNAVAILABLE_MESSAGE
+    assert exc.code == PROVIDER_UNAVAILABLE_CODE
+    assert exc.details == {"reason": PROVIDER_UNAVAILABLE_CODE, "retryable": True}
+
+
+@pytest.mark.asyncio
+async def test_text_only_provider_failure_returns_clear_unavailable_error():
+    adapter = _make_completion_adapter()
+
+    with patch(
+        "intric.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(side_effect=RuntimeError("Connection refused by upstream")),
+    ):
+        with pytest.raises(OpenAIException) as exc_info:
+            await adapter.get_response(context=SimpleNamespace(), model_kwargs={})
+
+    exc = exc_info.value
+    assert str(exc) == PROVIDER_UNAVAILABLE_MESSAGE
+    assert exc.code == PROVIDER_UNAVAILABLE_CODE
+    assert exc.details == {"reason": PROVIDER_UNAVAILABLE_CODE, "retryable": True}
+
+
+@pytest.mark.asyncio
+async def test_unknown_stream_preparation_error_remains_unexpected():
+    adapter = _make_completion_adapter()
+
+    with patch(
+        "intric.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    ):
+        with pytest.raises(OpenAIException) as exc_info:
+            await adapter.prepare_streaming(context=SimpleNamespace(), model_kwargs={})
+
+    assert str(exc_info.value) == "Unknown error occurred"
+    assert getattr(exc_info.value, "code", None) is None
+
+
+@pytest.mark.asyncio
+async def test_generic_timeout_word_remains_unexpected():
+    adapter = _make_completion_adapter()
+
+    with patch(
+        "intric.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(side_effect=RuntimeError("provider timeout budget exceeded")),
+    ):
+        with pytest.raises(OpenAIException) as exc_info:
+            await adapter.prepare_streaming(context=SimpleNamespace(), model_kwargs={})
+
+    assert str(exc_info.value) == "Unknown error occurred"
+    assert getattr(exc_info.value, "code", None) is None
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_provider_failure_yields_unavailable_event():
+    adapter = _make_adapter()
+    mcp_proxy = _FakeMCPProxy()
+    span = Mock()
+    span.is_recording.return_value = True
+
+    stream = _AsyncChunkStream(
+        [_tool_call_chunk()],
+        eneo_context={
+            "mcp_proxy": mcp_proxy,
+            "messages": [],
+            "kwargs": {},
+            "has_tools": True,
+        },
+    )
+
+    with (
+        patch(
+            "intric.completion_models.infrastructure.adapters.tenant_model_adapter.litellm.acompletion",
+            AsyncMock(side_effect=httpx.ConnectError("Connection refused")),
+        ),
+        patch(
+            "intric.completion_models.infrastructure.adapters.tenant_model_adapter.trace.get_current_span",
+            return_value=span,
+        ),
+    ):
+        completions = await _collect(
+            adapter,
+            stream,
+            require_tool_approval=False,
+            approval_manager=None,
+            approval_context=None,
+            pending_approval_ids=set(),
+        )
+
+    errors = [c for c in completions if c.response_type == ResponseType.ERROR]
+    assert len(errors) == 1
+    assert errors[0].error == PROVIDER_UNAVAILABLE_MESSAGE
+    assert errors[0].error_code == 503
+    span.set_attribute.assert_any_call("gen_ai.request.stream", True)
+    span.set_attribute.assert_any_call("error.type", PROVIDER_UNAVAILABLE_CODE)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TL;DR
Model-provider outages now return a clear, retryable `503 provider_unavailable` response instead of collapsing into a generic unknown error. The fix is scoped to the completion provider adapter, keeps login/auth untouched, avoids exposing raw provider/DNS/socket details to clients, and adds OpenTelemetry attributes for production traceability.

## Summary
- Detects provider connectivity, DNS, timeout, and service-unavailable failures from LiteLLM/http clients, including wrapped exceptions.
- Returns a stable API shape for non-streaming failures: existing `OPENAI_ERROR`, plus `code=provider_unavailable` and `details.retryable=true`.
- Emits a safe `503` stream error for mid-stream provider failures without changing the streaming event schema.
- Records provider-unavailable failures in logs and on the active OpenTelemetry span using standard GenAI/error attributes plus Eneo phase details.
- Adds regression tests for structured API responses, wrapped provider errors, text-only provider errors, false-positive timeout wording, unknown errors, streaming failures, and OTel attributes.

## Why
Provider/network outages from model backends could previously surface as a generic `Unknown error occurred` 503. That made it hard for API consumers and operators to distinguish a temporary upstream provider issue from unrelated server errors.

The right owner for this is `TenantModelAdapter`, because it is the boundary that calls LiteLLM/provider APIs and knows whether the failure happened during completion setup, stream preparation, or stream iteration. The general API exception handler remains responsible for serializing structured exception metadata into the response body.

## What changed
- `backend/src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py`
  - Classifies provider-unavailable failures before generic error handling.
  - Keeps the text fallback narrow and documented for provider wrappers that collapse DNS/socket failures into generic exceptions.
  - Raises `OpenAIException` with `code=provider_unavailable` and `details.retryable=true` for setup failures.
  - Emits a provider-unavailable stream error event with `error_code=503` for mid-stream failures.
  - Records `gen_ai.operation.name`, `gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.request.stream`, `error.type`, and Eneo-specific phase attributes.
- `backend/src/intric/main/exceptions.py`
  - Extends `OpenAIException` with optional `code`, `context`, and `details` while keeping existing call sites compatible.
- Tests
  - Covers the API response contract, provider failure classification, false-positive guards, streaming behavior, and OTel attributes.

## API consumer behavior
- Request/response endpoints that fail before streaming return HTTP `503` with the existing `intric_error_code=OPENAI_ERROR`, plus `code=provider_unavailable` and `details.retryable=true`.
- Streaming `Completion` events do not currently expose JSON `code`/`details` fields. To avoid a release-breaking streaming schema change, mid-stream provider failures use `error_code=503` and the safe provider-unavailable message.
- Raw DNS/socket/provider exception text is kept in logs/traces, not exposed to clients.

## What was deliberately not changed
- No login, auth, or landing-page behavior was changed.
- No new public error enum or generated-client-visible contract was added.
- No streaming event schema change was introduced.

## Risk and rollback
Risk is limited to completion-model error handling. The main behavior change is that provider connectivity and availability failures now produce a clearer 503 response body and clearer stream error event instead of a generic unknown error.

Rollback is straightforward: revert this commit to restore the previous generic `OpenAIException` behavior. Existing `OpenAIException("...")` call sites remain compatible with the new constructor.

## Validation
- `uv run ruff format --check src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py src/intric/main/exceptions.py tests/unit/test_tenant_model_adapter_iterate_stream.py tests/unit/test_exception_handlers.py` - passed
- `uv run ruff check src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py src/intric/main/exceptions.py tests/unit/test_tenant_model_adapter_iterate_stream.py tests/unit/test_exception_handlers.py` - passed
- `POSTGRES_USER=test POSTGRES_HOST=localhost POSTGRES_PASSWORD=test POSTGRES_PORT=5432 POSTGRES_DB=test REDIS_HOST=localhost REDIS_PORT=6379 UPLOAD_FILE_TO_SESSION_MAX_SIZE=1000 UPLOAD_IMAGE_TO_SESSION_MAX_SIZE=500 UPLOAD_MAX_FILE_SIZE=2000 TRANSCRIPTION_MAX_FILE_SIZE=1500 MAX_IN_QUESTION=100 API_PREFIX=/api API_KEY_LENGTH=32 API_KEY_HEADER_NAME=X-API-Key JWT_AUDIENCE=test JWT_ISSUER=test JWT_EXPIRY_TIME=3600 JWT_ALGORITHM=HS256 JWT_SECRET=test-secret JWT_TOKEN_PREFIX=Bearer URL_SIGNING_KEY=test-signing-key ENCRYPTION_KEY=yPIAaWTENh5knUuz75NYHblR3672X-7lH-W6AD4F1hs= uv run pytest tests/unit/test_tenant_model_adapter_iterate_stream.py tests/unit/test_exception_handlers.py -q` - passed (`17 passed`)
- `uv run pyright src/intric/main/exceptions.py src/intric/completion_models/infrastructure/adapters/tenant_model_adapter.py tests/unit/test_exception_handlers.py tests/unit/test_tenant_model_adapter_iterate_stream.py` - passed (`0 errors`)
