### PR TITLE
fix(audit): complete ACTION_METADATA coverage and guard it

### DIFF
--- a/backend/src/intric/audit/domain/action_metadata.py
+++ b/backend/src/intric/audit/domain/action_metadata.py
@@ -84,6 +84,14 @@ ACTION_METADATA: dict[str, ActionMetadata] = {
         "name_sv": "API-nyckel roterad",
         "description_sv": "Loggar när en API-nyckel roteras",
     },
+    ActionType.API_KEY_EXPIRATION_EXTENDED.value: {
+        "name_sv": "API-nyckels giltighet förlängd",
+        "description_sv": "Loggar när en API-nyckels giltighetstid förlängs",
+    },
+    ActionType.API_KEY_PURGED.value: {
+        "name_sv": "API-nyckel rensad",
+        "description_sv": "Loggar när en utgången API-nyckel rensas permanent",
+    },
     ActionType.API_KEY_EXPIRED.value: {
         "name_sv": "API-nyckel utgången",
         "description_sv": "Loggar när en API-nyckel löper ut",
@@ -107,6 +115,51 @@ ACTION_METADATA: dict[str, ActionMetadata] = {
     ActionType.MODULE_ADDED_TO_TENANT.value: {
         "name_sv": "Modul aktiverad",
         "description_sv": "Loggar när en modul aktiveras för organisationen",
+    },
+    # SCIM Provisioning Actions (11)
+    ActionType.SCIM_USER_PROVISIONED.value: {
+        "name_sv": "SCIM-användare etablerad",
+        "description_sv": "Loggar när en användare etableras via SCIM",
+    },
+    ActionType.SCIM_USER_RECONCILED.value: {
+        "name_sv": "SCIM-användare avstämd",
+        "description_sv": "Loggar när en SCIM-användare matchas mot en befintlig användare",
+    },
+    ActionType.SCIM_USER_REACTIVATED.value: {
+        "name_sv": "SCIM-användare återaktiverad",
+        "description_sv": "Loggar när en avetablerad SCIM-användare återaktiveras",
+    },
+    ActionType.SCIM_USER_DEPROVISIONED.value: {
+        "name_sv": "SCIM-användare avetablerad",
+        "description_sv": "Loggar när en användare avetableras via SCIM",
+    },
+    ActionType.SCIM_USER_UPDATED.value: {
+        "name_sv": "SCIM-användare uppdaterad",
+        "description_sv": "Loggar ändringar av en SCIM-användare",
+    },
+    ActionType.SCIM_GROUP_CREATED.value: {
+        "name_sv": "SCIM-grupp skapad",
+        "description_sv": "Loggar när en grupp skapas via SCIM",
+    },
+    ActionType.SCIM_GROUP_REACTIVATED.value: {
+        "name_sv": "SCIM-grupp återaktiverad",
+        "description_sv": "Loggar när en raderad SCIM-grupp återaktiveras",
+    },
+    ActionType.SCIM_GROUP_UPDATED.value: {
+        "name_sv": "SCIM-grupp uppdaterad",
+        "description_sv": "Loggar ändringar av en SCIM-grupp",
+    },
+    ActionType.SCIM_GROUP_DELETED.value: {
+        "name_sv": "SCIM-grupp raderad",
+        "description_sv": "Loggar när en grupp raderas via SCIM",
+    },
+    ActionType.SCIM_TOKEN_CREATED.value: {
+        "name_sv": "SCIM-token skapad",
+        "description_sv": "Loggar när en SCIM-provisioneringstoken skapas",
+    },
+    ActionType.SCIM_TOKEN_REVOKED.value: {
+        "name_sv": "SCIM-token revokerad",
+        "description_sv": "Loggar när en SCIM-provisioneringstoken revokeras",
     },
     # User Actions (41) - Assistants, Spaces, Apps, Files, etc.
     ActionType.ASSISTANT_CREATED.value: {
@@ -376,7 +429,11 @@ ACTION_METADATA: dict[str, ActionMetadata] = {
         "name_sv": "Systemunderhåll",
         "description_sv": "Loggar planerat systemunderhåll",
     },
-    # Audit Access (2)
+    # Audit Access (3)
+    ActionType.AUDIT_SESSION_CREATED.value: {
+        "name_sv": "Granskningssession skapad",
+        "description_sv": "Loggar när en session för granskningsåtkomst skapas",
+    },
     ActionType.AUDIT_LOG_VIEWED.value: {
         "name_sv": "Granskningsloggar visade",
         "description_sv": "Loggar när granskningsloggar visas",

--- a/backend/tests/unit/test_audit_category_mappings.py
+++ b/backend/tests/unit/test_audit_category_mappings.py
@@ -1,5 +1,6 @@
 """Unit tests for audit category mappings."""
 
+from intric.audit.domain.action_metadata import ACTION_METADATA
 from intric.audit.domain.action_types import ActionType
 from intric.audit.domain.category_mappings import (
     CATEGORY_DESCRIPTIONS,
@@ -191,6 +192,39 @@ class TestCategoryMappings:
             assert CATEGORY_MAPPINGS[action_type] == "audit_access", (
                 f"{action_type} should be mapped to 'audit_access'"
             )
+
+
+class TestActionMetadata:
+    """Test suite for ACTION_METADATA completeness."""
+
+    def test_all_action_types_have_metadata(self):
+        """Every ActionType must have a Swedish display entry in ACTION_METADATA.
+
+        Without this guard, a new action gets an auto-generated English-ish
+        fallback label in the audit config UI and is skipped by
+        ensure_all_actions_configured(), which keys off ACTION_METADATA.
+        """
+        all_action_values = set(action.value for action in ActionType)
+        documented_actions = set(ACTION_METADATA.keys())
+
+        missing = all_action_values - documented_actions
+        assert not missing, (
+            f"The following action types are missing from ACTION_METADATA: {missing}"
+        )
+
+    def test_all_metadata_keys_are_valid_action_types(self):
+        """Every ACTION_METADATA key must be a valid ActionType string value."""
+        all_action_values = set(action.value for action in ActionType)
+        for action in ACTION_METADATA.keys():
+            assert action in all_action_values, (
+                f"{action} is not a valid ActionType value"
+            )
+
+    def test_all_metadata_entries_are_non_empty(self):
+        """Every entry must provide non-empty Swedish name and description."""
+        for action, metadata in ACTION_METADATA.items():
+            assert metadata["name_sv"], f"{action} has empty name_sv"
+            assert metadata["description_sv"], f"{action} has empty description_sv"
 
 
 class TestGetCategoryForAction:


### PR DESCRIPTION
## Problem

The SCIM provisioning server (#443) added 11 `SCIM_*` action types to `ActionType` and `CATEGORY_MAPPINGS`, but **not** to `ACTION_METADATA`. Because develop validates `CATEGORY_MAPPINGS` completeness but had no equivalent guard for `ACTION_METADATA`, the gap went unnoticed.

Consequence on develop today: the 11 SCIM actions (plus three older ones — `api_key_expiration_extended`, `api_key_purged`, `audit_session_created`) fall back to auto-generated English-ish labels in the audit config UI and are silently skipped by `ensure_all_actions_configured()`, which keys off `ACTION_METADATA`.

## Change

- Add Swedish `name_sv`/`description_sv` for all **14** missing actions in `action_metadata.py`.
- Add a `TestActionMetadata` guard in `test_audit_category_mappings.py` asserting every `ActionType` has an `ACTION_METADATA` entry (plus reverse validity + non-empty checks) — mirroring the existing `CATEGORY_MAPPINGS` completeness test.

Now a new action without metadata fails CI instead of silently degrading the audit config UI.

## Testing

`uv run pytest tests/unit/ -k audit` → 284 passed.