### PR TITLE
test(actors): guard website tenant-permission gate in shared spaces

### DIFF
--- a/backend/tests/unittests/actors/test_space_actor.py
+++ b/backend/tests/unittests/actors/test_space_actor.py
@@ -1084,3 +1084,82 @@ def test_viewer_without_shared_spaces_has_no_org_space_access(
         )
         is False
     )
+
+
+# Resource tenant-permission gate applies to shared spaces too — regression
+# guard for the bug where the gate was scoped to `is_personal()` only, letting
+# any EDITOR/ADMIN member create websites in a shared space even when their
+# role lacked the `websites` tenant permission (fixed in #348). READ stays
+# exempt so distributed knowledge remains visible.
+
+
+def _permissions_without_websites():
+    return {p for p in ALL_PERMISSIONS if p != Permission.WEBSITES}
+
+
+def test_editor_without_websites_cannot_create_website_in_shared_space(
+    shared_space: MockSpace,
+):
+    user = MockUser(
+        id=50,
+        role=MockSpaceRole.EDITOR,
+        permissions=_permissions_without_websites(),
+    )
+    shared_space.members = {user.id: user}
+    actor = SpaceActor(user, shared_space)
+    assert actor.can_create_websites() is False
+
+
+def test_admin_without_websites_cannot_create_website_in_shared_space(
+    shared_space: MockSpace,
+):
+    user = MockUser(
+        id=51,
+        role=MockSpaceRole.ADMIN,
+        permissions=_permissions_without_websites(),
+    )
+    shared_space.members = {user.id: user}
+    actor = SpaceActor(user, shared_space)
+    assert actor.can_create_websites() is False
+    assert actor.can_edit_websites() is False
+    assert actor.can_delete_websites() is False
+
+
+def test_editor_without_websites_can_still_read_websites_in_shared_space(
+    shared_space: MockSpace,
+):
+    """READ is exempt from the tenant gate so members keep seeing distributed
+    web knowledge even when their role omits the `websites` permission."""
+    user = MockUser(
+        id=52,
+        role=MockSpaceRole.EDITOR,
+        permissions=_permissions_without_websites(),
+    )
+    shared_space.members = {user.id: user}
+    actor = SpaceActor(user, shared_space)
+    assert actor.can_read_websites() is True
+
+
+def test_editor_with_websites_can_create_website_in_shared_space(
+    shared_space: MockSpace,
+):
+    """Counterpart: the gate must not over-block — an EDITOR member whose role
+    includes `websites` retains full CRUD."""
+    user = MockUser(
+        id=53,
+        role=MockSpaceRole.EDITOR,
+        permissions=ALL_PERMISSIONS,
+    )
+    shared_space.members = {user.id: user}
+    actor = SpaceActor(user, shared_space)
+    assert actor.can_create_websites() is True
+
+
+def test_owner_without_websites_cannot_create_website_in_personal_space(
+    personal_space: MockSpace,
+):
+    """The same tenant gate also covers personal spaces."""
+    owner = MockUser(id=54, permissions=_permissions_without_websites())
+    personal_space.user_id = owner.id
+    actor = SpaceActor(owner, personal_space)
+    assert actor.can_create_websites() is False


### PR DESCRIPTION
## Background

A bug report described that a user whose role lacks the **websites** ("webb kunskap") permission could still add web knowledge in a **shared space**, while it was correctly blocked in personal spaces.

The bug was real but is **already fixed** on `develop`. The resource tenant-permission gate in `SpaceActor.can_perform_action` was once scoped to `is_personal()` only:

```python
if self.space.is_personal() and resource_type in PERMISSION_RESOURCES:
```

so in shared spaces only the member role (EDITOR/ADMIN) was consulted — and `SHARED_SPACE_PERMISSIONS` grants those roles full CRUD on `WEBSITE`. PR #348 (commit `8d1ef29f3`) made the gate apply to all spaces:

```python
if resource_type in PERMISSION_RESOURCES and not self._is_service_api_key():
```

READ stays exempt for `WEBSITE`/`INTEGRATION_KNOWLEDGE` so distributed knowledge remains visible.

## The gap this PR closes

There was **no test** locking this in. Every `editor_user`/`admin_user` fixture in `test_space_actor.py` carries `ALL_PERMISSIONS`, so reintroducing the `is_personal()` restriction would pass silently. The existing `test_member_without_shared_spaces_*` cases cover the `SHARED_SPACES` permission, not resource permissions like `WEBSITES`.

## Changes

Adds a `_permissions_without_websites()` helper and 5 regression cases:

- EDITOR member without `websites` **cannot** create a website in a shared space
- ADMIN member without `websites` **cannot** create/edit/delete in a shared space
- EDITOR member without `websites` **can** still read distributed web knowledge (READ exemption)
- EDITOR member **with** `websites` retains full CRUD (gate does not over-block)
- Personal-space owner without `websites` **cannot** create a website (gate covers personal spaces too)

Test-only; no production code changes.

## Verification

`tests/unittests/actors/test_space_actor.py` — 62 passed (57 existing + 5 new). The new cases assert `False` for exactly the scenario the old `is_personal()`-scoped gate let through, so they fail if the regression returns.