### PR TITLE
fix(cors): seed PUBLIC_ORIGIN into allowed_origins so CORS works on fresh installs

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -83,7 +83,9 @@ URL_SIGNING_KEY=
 # PUBLIC_ORIGIN (REQUIRED for OIDC authentication)
 # The externally-reachable URL where users access Eneo
 # Used to construct OIDC redirect_uri (e.g., {PUBLIC_ORIGIN}/auth/callback)
-# Auto-seeded into allowed_origins for SSR login during init_db/migrations
+# Seeded into allowed_origins for the default/first tenant during init_db and on
+# migration, so CORS works out of the box. Multi-tenant or multi-origin setups
+# must register additional origins via the sysadmin allowed-origins API.
 # Must match:
 #   1. What users see in their browser address bar
 #   2. What's registered in your OIDC provider (Auth0, Azure AD, etc.)

--- a/backend/alembic/versions/202606041200_seed_allowed_origins_from_public_origin.py
+++ b/backend/alembic/versions/202606041200_seed_allowed_origins_from_public_origin.py
@@ -1,0 +1,105 @@
+"""Backfill allowed_origins from PUBLIC_ORIGIN (2.0.x CORS regression fix)
+
+2.0.0 changed CORS from effectively allow-all (``allow_origins=["*"]``) to a
+strict DB-backed allowlist (``allow_origins=[]``). An origin is now accepted
+only if it is localhost or matches a row in ``allowed_origins``. Fresh installs
+start with an empty table, so the backend omits ``Access-Control-Allow-Origin``
+and the SPA cannot reach the API.
+
+The originally intended auto-seed of ``PUBLIC_ORIGIN`` was built and then dropped
+before 2.0.0 shipped, leaving only a (false) doc comment. This migration restores
+it: register the configured ``PUBLIC_ORIGIN`` for the default/first tenant so
+upgraded and fresh single-tenant installs work without manual SQL.
+
+Scope: seeds a single origin for one tenant from one global env var. Multi-tenant
+or multi-origin deployments still register additional origins via the sysadmin
+API (``POST {api_prefix}/sysadmin/allowed-origins/``).
+
+Revision ID: 202606041200
+Revises: 20260603_transcription_migrate
+Create Date: 2026-06-04
+"""
+
+import logging
+import os
+from typing import Optional
+
+from sqlalchemy.sql import text
+
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision = "202606041200"
+down_revision = "20260603_transcription_migrate"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.env")
+
+
+def _resolve_origin() -> Optional[str]:
+    """Return a normalized http(s) origin from the environment, or None.
+
+    Lenient on purpose: a missing or malformed value must skip the backfill, not
+    abort the migration. Mirrors the normalization used in ``init_db.py``.
+    """
+    for candidate in (os.getenv("PUBLIC_ORIGIN"), os.getenv("ORIGIN")):
+        if not candidate:
+            continue
+        origin = candidate.strip().rstrip("/")
+        if origin.startswith(("http://", "https://")):
+            return origin
+    return None
+
+
+def upgrade() -> None:
+    origin = _resolve_origin()
+    if origin is None:
+        logger.warning(
+            "[allowed_origins] PUBLIC_ORIGIN/ORIGIN not set or invalid; "
+            "skipping CORS backfill. Frontend origins must be registered "
+            "manually via the sysadmin allowed-origins API."
+        )
+        return
+
+    conn = op.get_bind()
+
+    default_tenant_name = os.getenv("DEFAULT_TENANT_NAME")
+    tenant = None
+    if default_tenant_name:
+        tenant = conn.execute(
+            text("SELECT id, name FROM tenants WHERE name = :name"),
+            {"name": default_tenant_name},
+        ).fetchone()
+    if tenant is None:
+        tenant = conn.execute(
+            text("SELECT id, name FROM tenants ORDER BY name ASC LIMIT 1")
+        ).fetchone()
+    if tenant is None:
+        logger.info("[allowed_origins] No tenants found; nothing to backfill.")
+        return
+
+    tenant_id, tenant_name = tenant
+
+    # Unique constraint is (tenant_id, url) since 202602041600_add_api_keys_v2;
+    # ON CONFLICT must match it. id/created_at/updated_at have server defaults.
+    conn.execute(
+        text(
+            "INSERT INTO allowed_origins (url, tenant_id) "
+            "VALUES (:url, :tenant_id) "
+            "ON CONFLICT (tenant_id, url) DO NOTHING"
+        ),
+        {"url": origin, "tenant_id": tenant_id},
+    )
+
+    logger.info(
+        "[allowed_origins] Backfilled origin '%s' for tenant '%s'. Additional "
+        "origins/tenants must be added via the sysadmin allowed-origins API.",
+        origin,
+        tenant_name,
+    )
+
+
+def downgrade() -> None:
+    # No-op: never delete tenant CORS configuration on downgrade.
+    pass

--- a/backend/init_db.py
+++ b/backend/init_db.py
@@ -25,6 +25,8 @@ class Settings(BaseSettings):
     default_user_email: Optional[str] = None
     default_user_password: Optional[str] = None
 
+    public_origin: Optional[str] = None
+
 
 settings = Settings()
 
@@ -177,6 +179,67 @@ def add_tenant_user(
         conn.rollback()
 
 
+def _normalize_origin(raw_origin: Optional[str]) -> Optional[str]:
+    """Return a normalized http(s) origin, or None. Mirrors the seed migration."""
+    if not raw_origin:
+        return None
+    origin = raw_origin.strip().rstrip("/")
+    if origin.startswith(("http://", "https://")):
+        return origin
+    return None
+
+
+# Seed the configured PUBLIC_ORIGIN into allowed_origins so CORS works out of the
+# box on fresh installs. Idempotent: safe to run on every container start. The
+# unique constraint is (tenant_id, url), so ON CONFLICT must match it.
+def seed_allowed_origin(conn, public_origin, default_tenant_name):
+    origin = _normalize_origin(public_origin)
+    if origin is None:
+        print(
+            "Note! PUBLIC_ORIGIN not set or invalid. Skipping allowed_origins seed. "
+            "Frontend origins must be registered via the sysadmin allowed-origins API."
+        )
+        return
+
+    try:
+        cur = conn.cursor()
+
+        tenant = None
+        if default_tenant_name:
+            cur.execute(
+                sql.SQL("SELECT id, name FROM tenants WHERE name = %s"),
+                (default_tenant_name,),
+            )
+            tenant = cur.fetchone()
+
+        if tenant is None:
+            cur.execute(
+                sql.SQL("SELECT id, name FROM tenants ORDER BY name ASC LIMIT 1")
+            )
+            tenant = cur.fetchone()
+
+        if tenant is None:
+            print("No tenants found; skipping allowed_origins seed.")
+            cur.close()
+            return
+
+        tenant_id, tenant_name = tenant
+
+        cur.execute(
+            sql.SQL(
+                "INSERT INTO allowed_origins (url, tenant_id) VALUES (%s, %s) "
+                "ON CONFLICT (tenant_id, url) DO NOTHING"
+            ),
+            (origin, tenant_id),
+        )
+        conn.commit()
+        cur.close()
+        print(f"Allowed origin '{origin}' is registered for tenant '{tenant_name}'.")
+    except Exception as e:
+        print(f"Error seeding allowed origin: {e}")
+        conn.rollback()
+
+
 # Main script
 if __name__ == "__main__":
     # Run alembic migrations
@@ -210,6 +273,10 @@ if __name__ == "__main__":
             settings.default_user_email,
             settings.default_user_password,
         )
+
+    # Register PUBLIC_ORIGIN for CORS (idempotent; runs even when the default
+    # tenant/user block above is skipped, e.g. on upgrades of existing installs).
+    seed_allowed_origin(conn, settings.public_origin, settings.default_tenant_name)
 
     # Close the connection
     conn.close()


### PR DESCRIPTION
Backports the 2.0.x CORS regression fix (already merged to \`release/v2.0\`, shipping as v2.0.1) into \`develop\`.

## What
- New migration backfills \`PUBLIC_ORIGIN\` into \`allowed_origins\` for the default/first tenant (\`ON CONFLICT DO NOTHING\`; downgrade is a no-op).
- \`init_db.py\` re-seeds idempotently whenever it runs (self-heal on restart for deployments that run init_db on every start).
- Fixes the misleading \`.env.template\` comment.

## Migration chain
The cherry-picked migration originally chained off the release branch's head (\`202605061100\`), which already has a different child in \`develop\`. Re-pointed \`down_revision\` to develop's actual head, \`20260603_transcription_migrate\`. Verified \`alembic heads\` reports a single linear head and \`alembic upgrade head\` runs cleanly (backfilled the origin for the example tenant).

## Operational note
\`PUBLIC_ORIGIN\` must be set in the backend environment **before first start** (before the seed migration runs). The migration runs once; setting it later does not retroactively seed. Recovery: re-run \`init_db.py\` or add the origin via the sysadmin allowed-origins API.

Cherry-pick of \`8605ef5b9\` from \`release/v2.0\`.