### PR TITLE
fix(knowledge): make source pagination reactive in assistant edit

### DIFF
--- a/frontend/apps/web/src/lib/features/knowledge/components/SelectKnowledgeV2.svelte
+++ b/frontend/apps/web/src/lib/features/knowledge/components/SelectKnowledgeV2.svelte
@@ -208,11 +208,13 @@
     }
   }
 
-  function getPaginatedBlobs(id: string, blobs: InfoBlob[] | undefined) {
+  // `page` must be passed in (not read from currentPages here) so that the
+  // {@const} call sites depend on it textually — legacy reactivity only
+  // recomputes a derived value when an identifier it references is invalidated,
+  // and a read hidden inside this function body is invisible to the compiler.
+  function getPaginatedBlobs(blobs: InfoBlob[] | undefined, page: number) {
     if (!blobs) return [];
 
-    // Always use pagination for all types
-    const page = currentPages.get(id) || 1;
     const start = (page - 1) * ITEMS_PER_PAGE;
     const end = start + ITEMS_PER_PAGE;
     return blobs.slice(start, end);
@@ -678,9 +680,9 @@
       {@const isExpanded = expandedItems.has(collection.id)}
       {@const isLoading = loadingBlobs.has(collection.id)}
       {@const allBlobs = blobCache.get(collection.id)}
-      {@const blobs = getPaginatedBlobs(collection.id, allBlobs)}
-      {@const totalPages = getTotalPages(allBlobs)}
       {@const currentPage = currentPages.get(collection.id) || 1}
+      {@const blobs = getPaginatedBlobs(allBlobs, currentPage)}
+      {@const totalPages = getTotalPages(allBlobs)}
       <div class="knowledge-item-container">
         <div class="knowledge-item" class:text-negative-default={!isItemModelEnabled}>
           {#if collection.metadata.num_info_blobs > 0}
@@ -790,9 +792,9 @@
       {@const isExpanded = expandedItems.has(website.id)}
       {@const isLoading = loadingBlobs.has(website.id)}
       {@const allBlobs = blobCache.get(website.id)}
-      {@const blobs = getPaginatedBlobs(website.id, allBlobs)}
-      {@const totalPages = getTotalPages(allBlobs)}
       {@const currentPage = currentPages.get(website.id) || 1}
+      {@const blobs = getPaginatedBlobs(allBlobs, currentPage)}
+      {@const totalPages = getTotalPages(allBlobs)}
       {@const pagesCrawled = website.latest_crawl?.pages_crawled}
       {@const pagesFailed = website.latest_crawl?.pages_failed ?? 0}
       {@const hasFailures = pagesFailed > 0}
@@ -994,9 +996,9 @@
         {@const isExpanded = expandedItems.has(collection.id)}
         {@const isLoading = loadingBlobs.has(collection.id)}
         {@const allBlobs = blobCache.get(collection.id)}
-        {@const blobs = getPaginatedBlobs(collection.id, allBlobs)}
-        {@const totalPages = getTotalPages(allBlobs)}
         {@const currentPage = currentPages.get(collection.id) || 1}
+        {@const blobs = getPaginatedBlobs(allBlobs, currentPage)}
+        {@const totalPages = getTotalPages(allBlobs)}
         <div class="knowledge-item-container">
           <div class="knowledge-item" class:text-negative-default={!isItemModelEnabled}>
             {#if collection.metadata.num_info_blobs > 0}
@@ -1104,9 +1106,9 @@
         {@const isExpanded = expandedItems.has(website.id)}
         {@const isLoading = loadingBlobs.has(website.id)}
         {@const allBlobs = blobCache.get(website.id)}
-        {@const blobs = getPaginatedBlobs(website.id, allBlobs)}
-        {@const totalPages = getTotalPages(allBlobs)}
         {@const currentPage = currentPages.get(website.id) || 1}
+        {@const blobs = getPaginatedBlobs(allBlobs, currentPage)}
+        {@const totalPages = getTotalPages(allBlobs)}
         {@const pagesCrawled = website.latest_crawl?.pages_crawled}
         {@const pagesFailed = website.latest_crawl?.pages_failed ?? 0}
         {@const hasFailures = pagesFailed > 0}


### PR DESCRIPTION
## Summary

Fixes pagination for sources (text files / crawled pages) inside a knowledge collection or website when editing an assistant. With 10+ items the page indicator advanced but the list stayed on page 1.

Closes #426

## Root cause

`SelectKnowledgeV2.svelte` is a legacy-mode (Svelte 4 reactivity) component. The paginated slice was computed as `getPaginatedBlobs(id, blobs)`, which read the active page from the `currentPages` map **inside the function body**. Legacy `{@const}` values only recompute when an identifier they reference *textually* is invalidated — a read hidden inside a called function is invisible to the compiler. So on page change only the `currentPage` const (which references `currentPages` directly) updated, while the `blobs` slice did not.

## Fix

Pass the page in explicitly (`getPaginatedBlobs(blobs, page)`) and declare `currentPage` before `blobs` so the slice depends on it. Applied at all four call sites (collections + websites, in both the personal and organization sections).

Minimal, type-safe change; no behavioural change beyond restoring pagination.

## Notes

This is PR 1 of a planned two-step effort. A follow-up PR will migrate this component to Svelte 5 runes + shadcn primitives and decompose the monolith, which removes the need for this manual legacy workaround.

## Testing

- `eslint` clean on the file; pre-commit `frontend-lint` + `frontend-format` pass.
- Manual: expand a collection with >10 sources in assistant edit → Next/Previous now changes the listed files.