### PR TITLE
fix(embeddings): set encoding_format to "float" for strict OpenAI APIs (#339)

### DIFF
--- a/backend/src/intric/embedding_models/infrastructure/adapters/litellm_embeddings.py
+++ b/backend/src/intric/embedding_models/infrastructure/adapters/litellm_embeddings.py
@@ -138,10 +138,16 @@ class LiteLLMEmbeddingAdapter(EmbeddingModelAdapter):
                 )
                 return []
 
-            # Prepare the parameters for the embeddings
+            # Prepare the parameters for the embeddings.
+            # Set encoding_format explicitly: LiteLLM otherwise defaults it to
+            # null for OpenAI-compatible providers, which strict APIs (e.g.
+            # Berget.ai) reject with "Expected 'float' | 'base64', received
+            # null". "float" is the universal default and matches our expected
+            # list-of-floats output.
             params: dict[str, object] = {
                 "input": texts,
                 "model": self.litellm_model,
+                "encoding_format": "float",
             }
 
             # If dimensions exists on the model, add it to the parameters


### PR DESCRIPTION
## Problem

When using an OpenAI provider type pointing at a strict OpenAI-compatible API (e.g. Berget.ai) with an embedding model, LiteLLM sends `encoding_format: null` in the request body. Strict APIs reject this with a 400:

```
Expected 'float' | 'base64', received null
```

Root cause: `_get_embeddings()` did not set `encoding_format`, and LiteLLM defaults it to `null` rather than omitting it.

Fixes #339.

## Change

Set `encoding_format: "float"` explicitly in the `params` dict in `_get_embeddings()` (`backend/src/intric/embedding_models/infrastructure/adapters/litellm_embeddings.py`).

`"float"` is the universal default and matches our expected list-of-floats output, so it is set unconditionally rather than scoped to OpenAI. This keeps Azure, Infinity, and vLLM unaffected (they already accept/ignore `float`).

## Acceptance criteria

- [x] OpenAI-type embedding requests include `encoding_format: "float"` (not null)
- [x] Embedding models on Berget.ai (and similar strict OpenAI-compatible APIs) work with OpenAI provider type
- [x] Existing embedding providers (Azure, Infinity, vLLM) are not broken by the change