### PR TITLE
ci: retry uv python install to survive transient GitHub CDN 504s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,19 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install 3.11
+        # uv downloads a prebuilt CPython from GitHub releases; that CDN
+        # occasionally returns 504s. Retry with backoff so a transient
+        # blip doesn't fail the whole run.
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if uv python install 3.11; then
+              exit 0
+            fi
+            echo "::warning::uv python install failed (attempt $attempt/5); retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+          echo "::error::uv python install failed after 5 attempts"
+          exit 1
 
       - name: Verify lockfile consistency
         run: uv lock --check
@@ -131,7 +143,19 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install 3.11
+        # uv downloads a prebuilt CPython from GitHub releases; that CDN
+        # occasionally returns 504s. Retry with backoff so a transient
+        # blip doesn't fail the whole run.
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if uv python install 3.11; then
+              exit 0
+            fi
+            echo "::warning::uv python install failed (attempt $attempt/5); retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+          echo "::error::uv python install failed after 5 attempts"
+          exit 1
 
       - name: Verify lockfile consistency
         run: uv lock --check
@@ -316,7 +340,19 @@ jobs:
           enable-cache: true
 
       - name: Set up Python
-        run: uv python install 3.11
+        # uv downloads a prebuilt CPython from GitHub releases; that CDN
+        # occasionally returns 504s. Retry with backoff so a transient
+        # blip doesn't fail the whole run.
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if uv python install 3.11; then
+              exit 0
+            fi
+            echo "::warning::uv python install failed (attempt $attempt/5); retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+          echo "::error::uv python install failed after 5 attempts"
+          exit 1
         working-directory: backend
 
       - name: Install backend dependencies


### PR DESCRIPTION
## Problem

CI intermittently fails at the `Set up Python` step with:

```
error: Failed to install cpython-3.11.13-linux-x86_64-gnu
  Caused by: Failed to download https://github.com/astral-sh/python-build-standalone/.../cpython-3.11.13...tar.gz
  Caused by: HTTP status server error (504 Gateway Timeout)
```

`uv` downloads a prebuilt CPython from the `astral-sh/python-build-standalone` GitHub releases. That CDN occasionally returns a transient **504 Gateway Timeout**, and a single blip currently fails the entire run. It is unrelated to the code under test and resolves on a plain re-run.

## Change

Wrap `uv python install 3.11` in a 5-attempt loop with linear backoff (10/20/30/40s) in all three backend jobs (`backend-quality`, `backend-tests`, and the coverage job). A transient CDN hiccup now self-heals instead of failing the workflow.

## Notes

- The unrelated `actions/setup-python@v5` step is untouched — it does not pull from python-build-standalone and is not affected by this failure mode.
- GitHub Actions does not support YAML anchors and steps cannot be shared across jobs, so the loop is repeated per job by necessity. A composite action could DRY it up later if desired; kept out of scope to keep this fix minimal.