### PR TITLE
ci(e2e): build web app outside the Playwright webServer timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,22 @@ jobs:
         working-directory: frontend/apps/web
         run: bun x playwright@1.58.2 install --with-deps chromium
 
+      # Build the production app up front so the Playwright webServer only has to
+      # start `preview`. A full `vite build` inside the webServer's 180s timeout
+      # is the root cause of the flaky "Timed out waiting from config.webServer":
+      # its wall-clock straddles 180s on shared runners. SVELTE_KIT_OUT_DIR must
+      # match playwright.config.ts so `preview` serves exactly this build; the
+      # backend URLs are read at runtime (via $env/dynamic) so they don't affect
+      # the artifact, but we set them to mirror the previous build environment.
+      - name: Build web app for E2E
+        working-directory: frontend/apps/web
+        env:
+          SVELTE_KIT_OUT_DIR: .svelte-kit-e2e
+          NODE_OPTIONS: --max-old-space-size=6144
+          ENEO_BACKEND_URL: http://localhost:8124
+          PUBLIC_ENEO_BACKEND_URL: http://localhost:8124
+        run: bun run build
+
       - name: Run E2E tests
         working-directory: frontend/apps/web
         env:

--- a/frontend/apps/web/playwright.config.ts
+++ b/frontend/apps/web/playwright.config.ts
@@ -44,7 +44,15 @@ export default defineConfig({
     }
   ],
   webServer: {
-    command: `bun run build && bun run preview --port ${PORT} --strictPort`,
+    // In CI the build runs as its own workflow step (see ci.yml "Build web app
+    // for E2E"), so the webServer only has to start `preview`. Keeping the build
+    // out of this timeout budget is what makes it reliable: a full production
+    // build whose wall-clock straddles 180s on shared runners is the root cause
+    // of the intermittent "Timed out waiting from config.webServer" failures.
+    // Locally we still build+preview so `bun run test:e2e` works out of the box.
+    command: process.env.CI
+      ? `bun run preview --port ${PORT} --strictPort`
+      : `bun run build && bun run preview --port ${PORT} --strictPort`,
     port: PORT,
     reuseExistingServer: !process.env.CI,
     timeout: 180_000,


### PR DESCRIPTION
## Problem

The Frontend E2E job fails intermittently with:

```
Error: Timed out waiting 180000ms from config.webServer.
```

### Root cause

Playwright's `webServer` runs the app via:

```ts
command: `bun run build && bun run preview --port 4173 --strictPort`,
timeout: 180_000,
```

`bun run build` is a full `NODE_ENV=production vite build`. The single 180s `timeout` must cover **both** the production build **and** `preview` binding the port. The build's wall-clock time straddles 180s on shared GitHub-hosted runners (variable CPU/IO, 6 GB heap GC pressure, uncached build, unconfigured `manualChunks`). When a runner is slow, the build alone exceeds 180s and Playwright kills the process before `preview` ever listens → timeout.

**Evidence it's this and not a real failure:**
- The failure log ends mid-`vite build` (chunking/circular-dependency warnings) immediately before the timeout — `preview` had not started yet.
- The job flipped from ✓ to timeout across a commit whose only diff was a whitespace reformat of a backend file — runtime-impossible unless build time simply varies around the ceiling.
- No `retries` configured; `reuseExistingServer: false` in CI → no cushion.

## Fix

Move the production build into its own CI step (`Build web app for E2E`) so its time no longer counts against the webServer timeout. In CI the webServer now only starts `preview` (seconds, well within 180s). Locally the command still does `build && preview`, so `bun run test:e2e` works out of the box.

### Why this is safe (no change to the built artifact)

`ENEO_BACKEND_URL` / `PUBLIC_ENEO_BACKEND_URL` are read via `$env/dynamic/*` (runtime), not inlined at build, so building in a separate step produces an identical artifact. `SVELTE_KIT_OUT_DIR=.svelte-kit-e2e` is kept in sync between the build step and `preview` so the previewed build is exactly the one built.

## Notes

- Frontend/CI-only change; no application code touched.
- Validated: `ci.yml` parses as valid YAML; `playwright.config.ts` typechecks.