### PR TITLE
chore(api): backfill OpenAPI route metadata for spaces & users routers

### DIFF
--- a/backend/src/intric/spaces/api/space_router.py
+++ b/backend/src/intric/spaces/api/space_router.py
@@ -305,7 +305,7 @@ async def update_space(
     response_model=UpdateSpaceDryRunResponse,
     status_code=200,
     description="Get a preview of the impact of changing the security classification of a space.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def get_security_classification_impact_analysis(
     id: UUID,

--- a/backend/src/intric/spaces/api/space_router.py
+++ b/backend/src/intric/spaces/api/space_router.py
@@ -87,7 +87,7 @@ async def forbid_org_space(
     response_model=SpacePublic,
     status_code=201,
     description="Create a new shared space.",
-    responses=responses.get_responses([400, 403]),
+    responses=responses.get_responses([403]),
 )
 async def create_space(
     create_space_req: CreateSpaceRequest,
@@ -1439,7 +1439,10 @@ async def change_group_member_role(
 @router.delete(
     "/{id}/group-members/{group_id}/",
     status_code=204,
-    description="Remove a user group from a space.",
+    description=(
+        "Remove a user group from a space. Members lose access granted via this "
+        "group, but may still have access through direct membership or other groups."
+    ),
     responses=responses.get_responses([400, 403, 404]),
     dependencies=[Depends(forbid_org_space)],
 )

--- a/backend/src/intric/spaces/api/space_router.py
+++ b/backend/src/intric/spaces/api/space_router.py
@@ -86,6 +86,8 @@ async def forbid_org_space(
     "/",
     response_model=SpacePublic,
     status_code=201,
+    description="Create a new shared space.",
+    responses=responses.get_responses([400, 403]),
 )
 async def create_space(
     create_space_req: CreateSpaceRequest,
@@ -141,6 +143,10 @@ async def get_space(
     "/{id}/",
     response_model=SpacePublic,
     status_code=200,
+    description=(
+        "Update a space's settings (name, description, models, MCP servers, "
+        "security classification, data retention)."
+    ),
     responses=responses.get_responses([400, 403, 404]),
 )
 async def update_space(
@@ -299,6 +305,7 @@ async def update_space(
     response_model=UpdateSpaceDryRunResponse,
     status_code=200,
     description="Get a preview of the impact of changing the security classification of a space.",
+    responses=responses.get_responses([404]),
 )
 async def get_security_classification_impact_analysis(
     id: UUID,
@@ -319,6 +326,7 @@ async def get_security_classification_impact_analysis(
 @router.delete(
     "/{id}/",
     status_code=204,
+    description="Delete a space. Organization spaces cannot be deleted.",
     responses=responses.get_responses([403, 404]),
     dependencies=[Depends(forbid_org_space)],
 )
@@ -351,6 +359,8 @@ async def delete_space(
     "/",
     response_model=PaginatedResponse[SpaceSparse],
     status_code=200,
+    description="List spaces the current user can access.",
+    responses=responses.get_responses([]),
 )
 async def get_spaces(
     request: Request,
@@ -405,6 +415,7 @@ async def get_space_applications(
     "/{id}/applications/assistants/",
     response_model=AssistantPublic,
     status_code=201,
+    description="Create an assistant in a space, optionally from a template.",
     responses=responses.get_responses([400, 403, 404]),
     dependencies=[Depends(forbid_org_space)],
 )
@@ -497,6 +508,7 @@ async def create_group_chat(
     "/{id}/applications/apps/",
     response_model=AppPublic,
     status_code=201,
+    description="Create an app in a space, optionally from a template.",
     responses=responses.get_responses([400, 403, 404]),
     dependencies=[Depends(forbid_org_space)],
 )
@@ -538,6 +550,7 @@ async def create_app(
     "/{id}/applications/services/",
     response_model=CreateSpaceServiceResponse,
     status_code=201,
+    description="Create a service in a space.",
     responses=responses.get_responses([400, 403, 404]),
     dependencies=[Depends(forbid_org_space)],
 )
@@ -584,6 +597,7 @@ async def get_space_knowledge(
     "/{id}/knowledge/groups/",
     response_model=CollectionPublic,
     status_code=201,
+    description="Create a knowledge collection in a space.",
     responses=responses.get_responses([400, 403, 404]),
 )
 async def create_space_groups(
@@ -734,6 +748,8 @@ async def create_space_websites(
     "/{id}/knowledge/integrations/add/{user_integration_id}/",
     response_model=JobPublic,
     status_code=202,  # Changed to 202 Accepted since job is queued
+    description="Add integration knowledge to a space. Returns a job to track import progress.",
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def create_space_integration_knowledge(
     id: UUID,
@@ -798,6 +814,8 @@ async def create_space_integration_knowledge(
     "/{id}/knowledge/integrations/add/{user_integration_id}/batch/",
     response_model=CreateSpaceIntegrationKnowledgeBatchResponse,
     status_code=202,
+    description="Add multiple integration knowledge items to a space in a single batch.",
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def create_space_integration_knowledge_batch(
     id: UUID,
@@ -908,6 +926,8 @@ async def create_space_integration_knowledge_batch(
 @router.delete(
     "/{id}/knowledge/integrations/remove/{integration_knowledge_id}/",
     status_code=204,
+    description="Remove integration knowledge from a space.",
+    responses=responses.get_responses([403, 404]),
 )
 async def delete_space_integration_knowledge(
     id: UUID,
@@ -952,6 +972,8 @@ async def delete_space_integration_knowledge(
 @router.patch(
     "/{id}/knowledge/integrations/wrappers/{wrapper_id}/",
     response_model=list[IntegrationKnowledgePublic],
+    description="Rename an integration knowledge wrapper in a space.",
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def update_integration_knowledge_wrapper(
     id: UUID,
@@ -974,6 +996,8 @@ async def update_integration_knowledge_wrapper(
 @router.delete(
     "/{id}/knowledge/integrations/wrappers/{wrapper_id}/",
     status_code=204,
+    description="Remove an integration knowledge wrapper and its items from a space.",
+    responses=responses.get_responses([403, 404]),
 )
 async def delete_integration_knowledge_wrapper(
     id: UUID,
@@ -990,6 +1014,8 @@ async def delete_integration_knowledge_wrapper(
 @router.patch(
     "/{id}/knowledge/integrations/{integration_knowledge_id}/",
     response_model=IntegrationKnowledgePublic,
+    description="Rename integration knowledge in a space.",
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def update_integration_knowledge(
     id: UUID,
@@ -1010,6 +1036,8 @@ async def update_integration_knowledge(
     "/{id}/knowledge/integrations/{integration_knowledge_id}/sync/",
     response_model=JobPublic,
     status_code=202,
+    description="Trigger a full re-sync of integration knowledge. Returns a job to track progress.",
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def trigger_integration_full_sync(
     id: UUID,
@@ -1048,6 +1076,7 @@ async def trigger_integration_full_sync(
 @router.post(
     "/{id}/members/",
     response_model=SpaceMember,
+    description="Add a user as a member of a space with a given role.",
     responses=responses.get_responses([403, 404]),
     dependencies=[Depends(forbid_org_space)],
 )
@@ -1115,6 +1144,7 @@ async def add_space_member(
 @router.patch(
     "/{id}/members/{user_id}/",
     response_model=SpaceMember,
+    description="Change a space member's role.",
     responses=responses.get_responses([403, 404, 400]),
     dependencies=[Depends(forbid_org_space)],
 )
@@ -1195,6 +1225,7 @@ async def change_role_of_member(
 @router.delete(
     "/{id}/members/{user_id}/",
     status_code=204,
+    description="Remove a member from a space.",
     responses=responses.get_responses([403, 404, 400]),
     dependencies=[Depends(forbid_org_space)],
 )
@@ -1284,6 +1315,7 @@ async def get_space_group_members(
     "/{id}/group-members/",
     response_model=SpaceGroupMember,
     status_code=201,
+    description="Attach a user group to a space. Groups cannot be attached to personal spaces.",
     responses=responses.get_responses([400, 403, 404]),
     dependencies=[Depends(forbid_org_space)],
 )
@@ -1339,6 +1371,7 @@ async def add_space_group_member(
 @router.patch(
     "/{id}/group-members/{group_id}/",
     response_model=SpaceGroupMember,
+    description="Change the role of a user group in a space.",
     responses=responses.get_responses([400, 403, 404]),
     dependencies=[Depends(forbid_org_space)],
 )
@@ -1406,6 +1439,7 @@ async def change_group_member_role(
 @router.delete(
     "/{id}/group-members/{group_id}/",
     status_code=204,
+    description="Remove a user group from a space.",
     responses=responses.get_responses([400, 403, 404]),
     dependencies=[Depends(forbid_org_space)],
 )
@@ -1464,7 +1498,12 @@ async def remove_space_group_member(
     )
 
 
-@router.get("/type/personal/", response_model=SpacePublic)
+@router.get(
+    "/type/personal/",
+    response_model=SpacePublic,
+    description="Get the current user's personal space.",
+    responses=responses.get_responses([]),
+)
 async def get_personal_space(
     container: Annotated[Container, Depends(get_container(with_user=True))],
 ):
@@ -1479,6 +1518,8 @@ async def get_personal_space(
 @router.get(
     "/type/organization/",
     response_model=SpacePublic,
+    description="Get the organization (tenant) space. Requires admin permission.",
+    responses=responses.get_responses([403]),
     dependencies=[Depends(require_permission(Permission.ADMIN))],
 )
 async def get_organization_space(

--- a/backend/src/intric/users/user_router.py
+++ b/backend/src/intric/users/user_router.py
@@ -233,7 +233,7 @@ async def _resolve_single_tenant_redirect_uri(
     response_model=AccessToken,
     name="Login",
     description="Authenticate with email and password (OAuth2 password flow).",
-    responses=responses.get_responses([401]),
+    responses=responses.get_responses([401, 500]),
 )
 async def user_login_with_email_and_password(
     request: Request,
@@ -347,7 +347,7 @@ async def user_login_with_email_and_password(
     "/login/openid-connect/mobilityguard/",
     response_model=AccessToken,
     description="Authenticate via OpenID Connect (MobilityGuard / generic OIDC provider).",
-    responses=responses.get_responses([401]),
+    responses=responses.get_responses([400, 401, 500, 502]),
 )
 async def login_with_mobilityguard(
     request: Request,
@@ -691,7 +691,10 @@ async def login_with_mobilityguard(
 @router.get(
     "/",
     response_model=CursorPaginatedResponse[UserSparse],
-    description="List users in the current tenant (admin).",
+    description=(
+        "List users in the current tenant. Available to authenticated tenant "
+        "members; API keys require admin scope and permission."
+    ),
     responses=responses.get_responses([403]),
     dependencies=[
         Depends(require_api_key_scope_check(resource_type="admin", path_param=None)),
@@ -1123,7 +1126,7 @@ async def update_user(
     "/admin/{id}/",
     status_code=204,
     description="Delete a user from the tenant (admin).",
-    responses=responses.get_responses([403, 404]),
+    responses=responses.get_responses([400, 403, 404]),
     dependencies=[Depends(require_permission(Permission.ADMIN))],
 )
 async def delete_user(

--- a/backend/src/intric/users/user_router.py
+++ b/backend/src/intric/users/user_router.py
@@ -232,6 +232,7 @@ async def _resolve_single_tenant_redirect_uri(
     "/login/token/",
     response_model=AccessToken,
     name="Login",
+    description="Authenticate with email and password (OAuth2 password flow).",
     responses=responses.get_responses([401]),
 )
 async def user_login_with_email_and_password(
@@ -342,7 +343,12 @@ async def user_login_with_email_and_password(
         )
 
 
-@router.post("/login/openid-connect/mobilityguard/", response_model=AccessToken)
+@router.post(
+    "/login/openid-connect/mobilityguard/",
+    response_model=AccessToken,
+    description="Authenticate via OpenID Connect (MobilityGuard / generic OIDC provider).",
+    responses=responses.get_responses([401]),
+)
 async def login_with_mobilityguard(
     request: Request,
     openid_connect_login: OpenIdConnectLogin,
@@ -685,6 +691,8 @@ async def login_with_mobilityguard(
 @router.get(
     "/",
     response_model=CursorPaginatedResponse[UserSparse],
+    description="List users in the current tenant (admin).",
+    responses=responses.get_responses([403]),
     dependencies=[
         Depends(require_api_key_scope_check(resource_type="admin", path_param=None)),
         Depends(require_api_key_permission(ApiKeyPermission.ADMIN)),
@@ -916,6 +924,8 @@ async def get_current_user_tenant(
     "/admin/invite/",
     response_model=UserAdminView,
     status_code=201,
+    description="Invite a new user to the tenant (admin).",
+    responses=responses.get_responses([400, 403]),
     dependencies=[Depends(require_permission(Permission.ADMIN))],
 )
 async def invite_user(
@@ -990,6 +1000,8 @@ async def invite_user(
 @users_admin_router.patch(
     "/admin/{id}/",
     response_model=UserAdminView,
+    description="Update a user in the tenant (admin).",
+    responses=responses.get_responses([400, 403, 404]),
     dependencies=[Depends(require_permission(Permission.ADMIN))],
 )
 async def update_user(
@@ -1110,6 +1122,8 @@ async def update_user(
 @users_admin_router.delete(
     "/admin/{id}/",
     status_code=204,
+    description="Delete a user from the tenant (admin).",
+    responses=responses.get_responses([403, 404]),
     dependencies=[Depends(require_permission(Permission.ADMIN))],
 )
 async def delete_user(
@@ -1179,6 +1193,8 @@ async def delete_user(
 @router.post(
     "/provision/",
     status_code=201,
+    description="Provision a user from a Zitadel access token.",
+    response_model=None,
     responses=responses.get_responses([403]),
 )
 async def provision_user(

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -4288,7 +4288,7 @@ export interface paths {
     post?: never;
     /**
      * Remove Space Group Member
-     * @description Remove a user group from a space.
+     * @description Remove a user group from a space. Members lose access granted via this group, but may still have access through direct membership or other groups.
      */
     delete: operations["remove_space_group_member_api_v1_spaces__id__group_members__group_id___delete"];
     options?: never;
@@ -29775,15 +29775,6 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["SpacePublic"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Forbidden */

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -545,7 +545,7 @@ export interface paths {
     };
     /**
      * Get Tenant Users
-     * @description List users in the current tenant (admin).
+     * @description List users in the current tenant. Available to authenticated tenant members; API keys require admin scope and permission.
      */
     get: operations["get_tenant_users_api_v1_users__get"];
     put?: never;
@@ -19593,6 +19593,15 @@ export interface operations {
         };
         content?: never;
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Forbidden */
       403: {
         headers: {
@@ -19724,6 +19733,15 @@ export interface operations {
           "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   login_with_mobilityguard_api_v1_users_login_openid_connect_mobilityguard__post: {
@@ -19748,6 +19766,15 @@ export interface operations {
           "application/json": components["schemas"]["AccessToken"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Unauthorized */
       401: {
         headers: {
@@ -19764,6 +19791,24 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Bad Gateway */
+      502: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
     };
@@ -29929,6 +29974,24 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["UpdateSpaceDryRunResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -461,7 +461,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Invite User */
+    /**
+     * Invite User
+     * @description Invite a new user to the tenant (admin).
+     */
     post: operations["invite_user_api_v1_users_admin_invite__post"];
     delete?: never;
     options?: never;
@@ -479,11 +482,17 @@ export interface paths {
     get?: never;
     put?: never;
     post?: never;
-    /** Delete User */
+    /**
+     * Delete User
+     * @description Delete a user from the tenant (admin).
+     */
     delete: operations["delete_user_api_v1_users_admin__id___delete"];
     options?: never;
     head?: never;
-    /** Update User */
+    /**
+     * Update User
+     * @description Update a user in the tenant (admin).
+     */
     patch: operations["update_user_api_v1_users_admin__id___patch"];
     trace?: never;
   };
@@ -498,7 +507,7 @@ export interface paths {
     put?: never;
     /**
      * Login
-     * @description OAuth2 Login with comprehensive error handling and logging
+     * @description Authenticate with email and password (OAuth2 password flow).
      */
     post: operations["Login_api_v1_users_login_token__post"];
     delete?: never;
@@ -518,7 +527,7 @@ export interface paths {
     put?: never;
     /**
      * Login With Mobilityguard
-     * @description OpenID Connect Login (generic OIDC provider).
+     * @description Authenticate via OpenID Connect (MobilityGuard / generic OIDC provider).
      */
     post: operations["login_with_mobilityguard_api_v1_users_login_openid_connect_mobilityguard__post"];
     delete?: never;
@@ -536,17 +545,7 @@ export interface paths {
     };
     /**
      * Get Tenant Users
-     * @description List tenant members for member/group pickers.
-     *
-     *     Returns `UserSparse` (id, email, username, timestamps) — a strict subset
-     *     of the information any authenticated tenant member can retrieve via
-     *     Microsoft 365 / Outlook GAL. Tenant-scoped at the repo layer; mutations
-     *     on /users/admin/* remain gated on Permission.ADMIN.
-     *
-     *     Bearer tokens: any authenticated tenant member may list. API keys: must
-     *     be tenant-scoped with admin permission — the route-level guards above
-     *     stash deferred-enforcement state consumed by `_resolve_api_key`, which
-     *     is a no-op for bearer auth where `request.state.api_key` is unset.
+     * @description List users in the current tenant (admin).
      */
     get: operations["get_tenant_users_api_v1_users__get"];
     put?: never;
@@ -600,7 +599,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Provision User */
+    /**
+     * Provision User
+     * @description Provision a user from a Zitadel access token.
+     */
     post: operations["provision_user_api_v1_users_provision__post"];
     delete?: never;
     options?: never;
@@ -3847,10 +3849,16 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Spaces */
+    /**
+     * Get Spaces
+     * @description List spaces the current user can access.
+     */
     get: operations["get_spaces_api_v1_spaces__get"];
     put?: never;
-    /** Create Space */
+    /**
+     * Create Space
+     * @description Create a new shared space.
+     */
     post: operations["create_space_api_v1_spaces__post"];
     delete?: never;
     options?: never;
@@ -3869,11 +3877,17 @@ export interface paths {
     get: operations["get_space_api_v1_spaces__id___get"];
     put?: never;
     post?: never;
-    /** Delete Space */
+    /**
+     * Delete Space
+     * @description Delete a space. Organization spaces cannot be deleted.
+     */
     delete: operations["delete_space_api_v1_spaces__id___delete"];
     options?: never;
     head?: never;
-    /** Update Space */
+    /**
+     * Update Space
+     * @description Update a space's settings (name, description, models, MCP servers, security classification, data retention).
+     */
     patch: operations["update_space_api_v1_spaces__id___patch"];
     trace?: never;
   };
@@ -3923,7 +3937,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Create Space Assistant */
+    /**
+     * Create Space Assistant
+     * @description Create an assistant in a space, optionally from a template.
+     */
     post: operations["create_space_assistant_api_v1_spaces__id__applications_assistants__post"];
     delete?: never;
     options?: never;
@@ -3960,7 +3977,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Create App */
+    /**
+     * Create App
+     * @description Create an app in a space, optionally from a template.
+     */
     post: operations["create_app_api_v1_spaces__id__applications_apps__post"];
     delete?: never;
     options?: never;
@@ -3977,7 +3997,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Create Space Services */
+    /**
+     * Create Space Services
+     * @description Create a service in a space.
+     */
     post: operations["create_space_services_api_v1_spaces__id__applications_services__post"];
     delete?: never;
     options?: never;
@@ -4011,7 +4034,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Create Space Groups */
+    /**
+     * Create Space Groups
+     * @description Create a knowledge collection in a space.
+     */
     post: operations["create_space_groups_api_v1_spaces__id__knowledge_groups__post"];
     delete?: never;
     options?: never;
@@ -4067,7 +4093,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Create Space Integration Knowledge */
+    /**
+     * Create Space Integration Knowledge
+     * @description Add integration knowledge to a space. Returns a job to track import progress.
+     */
     post: operations["create_space_integration_knowledge_api_v1_spaces__id__knowledge_integrations_add__user_integration_id___post"];
     delete?: never;
     options?: never;
@@ -4084,7 +4113,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Create Space Integration Knowledge Batch */
+    /**
+     * Create Space Integration Knowledge Batch
+     * @description Add multiple integration knowledge items to a space in a single batch.
+     */
     post: operations["create_space_integration_knowledge_batch_api_v1_spaces__id__knowledge_integrations_add__user_integration_id__batch__post"];
     delete?: never;
     options?: never;
@@ -4102,7 +4134,10 @@ export interface paths {
     get?: never;
     put?: never;
     post?: never;
-    /** Delete Space Integration Knowledge */
+    /**
+     * Delete Space Integration Knowledge
+     * @description Remove integration knowledge from a space.
+     */
     delete: operations["delete_space_integration_knowledge_api_v1_spaces__id__knowledge_integrations_remove__integration_knowledge_id___delete"];
     options?: never;
     head?: never;
@@ -4119,11 +4154,17 @@ export interface paths {
     get?: never;
     put?: never;
     post?: never;
-    /** Delete Integration Knowledge Wrapper */
+    /**
+     * Delete Integration Knowledge Wrapper
+     * @description Remove an integration knowledge wrapper and its items from a space.
+     */
     delete: operations["delete_integration_knowledge_wrapper_api_v1_spaces__id__knowledge_integrations_wrappers__wrapper_id___delete"];
     options?: never;
     head?: never;
-    /** Update Integration Knowledge Wrapper */
+    /**
+     * Update Integration Knowledge Wrapper
+     * @description Rename an integration knowledge wrapper in a space.
+     */
     patch: operations["update_integration_knowledge_wrapper_api_v1_spaces__id__knowledge_integrations_wrappers__wrapper_id___patch"];
     trace?: never;
   };
@@ -4140,7 +4181,10 @@ export interface paths {
     delete?: never;
     options?: never;
     head?: never;
-    /** Update Integration Knowledge */
+    /**
+     * Update Integration Knowledge
+     * @description Rename integration knowledge in a space.
+     */
     patch: operations["update_integration_knowledge_api_v1_spaces__id__knowledge_integrations__integration_knowledge_id___patch"];
     trace?: never;
   };
@@ -4153,7 +4197,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Trigger Integration Full Sync */
+    /**
+     * Trigger Integration Full Sync
+     * @description Trigger a full re-sync of integration knowledge. Returns a job to track progress.
+     */
     post: operations["trigger_integration_full_sync_api_v1_spaces__id__knowledge_integrations__integration_knowledge_id__sync__post"];
     delete?: never;
     options?: never;
@@ -4170,7 +4217,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Add Space Member */
+    /**
+     * Add Space Member
+     * @description Add a user as a member of a space with a given role.
+     */
     post: operations["add_space_member_api_v1_spaces__id__members__post"];
     delete?: never;
     options?: never;
@@ -4188,11 +4238,17 @@ export interface paths {
     get?: never;
     put?: never;
     post?: never;
-    /** Remove Space Member */
+    /**
+     * Remove Space Member
+     * @description Remove a member from a space.
+     */
     delete: operations["remove_space_member_api_v1_spaces__id__members__user_id___delete"];
     options?: never;
     head?: never;
-    /** Change Role Of Member */
+    /**
+     * Change Role Of Member
+     * @description Change a space member's role.
+     */
     patch: operations["change_role_of_member_api_v1_spaces__id__members__user_id___patch"];
     trace?: never;
   };
@@ -4233,9 +4289,6 @@ export interface paths {
     /**
      * Remove Space Group Member
      * @description Remove a user group from a space.
-     *
-     *     All members of the group will lose access through this group membership.
-     *     Note: Users may still have access through direct membership or other groups.
      */
     delete: operations["remove_space_group_member_api_v1_spaces__id__group_members__group_id___delete"];
     options?: never;
@@ -4254,7 +4307,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Personal Space */
+    /**
+     * Get Personal Space
+     * @description Get the current user's personal space.
+     */
     get: operations["get_personal_space_api_v1_spaces_type_personal__get"];
     put?: never;
     post?: never;
@@ -4271,7 +4327,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Organization Space */
+    /**
+     * Get Organization Space
+     * @description Get the organization (tenant) space. Requires admin permission.
+     */
     get: operations["get_organization_space_api_v1_spaces_type_organization__get"];
     put?: never;
     post?: never;
@@ -19487,6 +19546,24 @@ export interface operations {
           "application/json": components["schemas"]["UserAdminView"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -19515,6 +19592,24 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
       };
       /** @description Validation Error */
       422: {
@@ -19549,6 +19644,33 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["UserAdminView"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -19626,6 +19748,15 @@ export interface operations {
           "application/json": components["schemas"]["AccessToken"];
         };
       };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -19662,6 +19793,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["CursorPaginatedResponse_UserSparse_"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -29592,6 +29732,24 @@ export interface operations {
           "application/json": components["schemas"]["SpacePublic"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -29771,6 +29929,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["UpdateSpaceDryRunResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -30261,6 +30428,33 @@ export interface operations {
           "application/json": components["schemas"]["JobPublic"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -30297,6 +30491,33 @@ export interface operations {
           "application/json": components["schemas"]["CreateSpaceIntegrationKnowledgeBatchResponse"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -30327,6 +30548,24 @@ export interface operations {
         };
         content?: never;
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -30356,6 +30595,24 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
       };
       /** @description Validation Error */
       422: {
@@ -30391,6 +30648,33 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["IntegrationKnowledgePublic"][];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -30429,6 +30713,33 @@ export interface operations {
           "application/json": components["schemas"]["IntegrationKnowledgePublic"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -30459,6 +30770,33 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["JobPublic"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -30912,6 +31250,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["SpacePublic"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
     };


### PR DESCRIPTION
## What

First phased slice of the repo-wide route-metadata debt. Backfills OpenAPI metadata on the **31 routes** flagged by `scripts/check_route_metadata.py` in two routers:

- `space_router.py` — 24 routes
- `user_router.py` — 7 routes

For each flagged decorator this adds the missing `description=`, `responses=` (with the actual error codes — `400/403/404`, `401` for auth, etc.), and `response_model=None` where a 201 returns no body. `schema.d.ts` is regenerated to match.

## Why

The `route-metadata` guardrail (#346) is a ratchet that enforces complete OpenAPI metadata on changed route lines. The full surface is 259 non-compliant routes across 60 files — far too much for one PR — so this is the first reviewable, area-scoped chunk. These two routers surfaced first because a `develop` merge re-touched their lines.

## Scope / safety

- **Pure metadata — no behaviour or response-model contract changes.** Verified by generating the backend OpenAPI: every touched route has a description and the expected response codes (303 paths total).
- Error-code conventions follow existing sibling routes: space mutations `[400, 403, 404]`, deletes `[403, 404]`, get-by-id `[404]`, lists `[]`.
- `schema.d.ts` diff (~427 lines) contains only the added descriptions and `GeneralError` error responses for these routes — no unrelated churn.

## Verification

- `scripts/check_route_metadata.py` — clean on both files
- `ruff check` / `ruff format` — clean
- `pyright` — 0 errors
- `app.openapi()` generates successfully; `schema.d.ts` regenerated via the same pipeline the pre-push hook uses

## Follow-up

Remaining ~228 non-compliant routes stay ratchet-tracked and can be cleared area-by-area in subsequent PRs.