### PR TITLE
chore(api): backfill OpenAPI route metadata for model/provider routers

### DIFF
--- a/backend/src/intric/completion_models/presentation/completion_models_router.py
+++ b/backend/src/intric/completion_models/presentation/completion_models_router.py
@@ -72,7 +72,7 @@ def get_pagination_query(request: Request) -> PaginationQuery:
     "/",
     description="List all completion models available to the organization.",
     response_model=PaginatedResponse[CompletionModelPublic],
-    responses=responses.get_responses([]),
+    responses=responses.get_responses([403]),
 )
 async def get_completion_models(
     user: Annotated[UserInDB, Depends(get_current_active_user)],
@@ -92,7 +92,7 @@ async def get_completion_models(
     "/{id}/",
     description="Update org-level settings for a completion model.",
     response_model=CompletionModelPublic,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def update_completion_model(
     id: UUID,
@@ -178,7 +178,7 @@ async def update_completion_model(
 @router.get(
     "/{model_id}/usage",
     response_model=ModelUsageStatistics,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def get_model_usage(
     model_id: UUID,
@@ -194,7 +194,7 @@ async def get_model_usage(
 @router.get(
     "/{model_id}/usage/details",
     response_model=ModelUsagePaginatedResponse,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def get_model_usage_details(
     model_id: UUID,
@@ -213,7 +213,7 @@ async def get_model_usage_details(
 @router.get(
     "/{model_id}/migration-validate",
     response_model=ValidationResult,
-    responses=responses.get_responses([400, 404]),
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def validate_migration(
     model_id: UUID,
@@ -329,7 +329,7 @@ async def migrate_model_usage(
     "/usage-summary",
     description="Get a usage summary for all completion models in the tenant.",
     response_model=list[ModelUsageSummary],
-    responses=responses.get_responses([]),
+    responses=responses.get_responses([403]),
 )
 async def get_all_models_usage_summary(
     user: Annotated[UserInDB, Depends(get_current_active_user)],
@@ -344,7 +344,7 @@ async def get_all_models_usage_summary(
 @router.get(
     "/{model_id}/migration-history",
     response_model=list[ModelMigrationHistory],
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def get_model_migration_history(
     model_id: UUID,
@@ -364,7 +364,7 @@ async def get_model_migration_history(
     "/migration-history",
     description="Get all completion model migration history for the tenant.",
     response_model=list[ModelMigrationHistory],
-    responses=responses.get_responses([]),
+    responses=responses.get_responses([403]),
 )
 async def get_all_migration_history(
     query: Annotated[PaginationQuery, Depends(get_pagination_query)],
@@ -382,7 +382,7 @@ async def get_all_migration_history(
 @router.get(
     "/migration-history/{migration_id}",
     response_model=ModelMigrationHistory,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def get_migration_history_by_id(
     migration_id: UUID,

--- a/backend/src/intric/completion_models/presentation/completion_models_router.py
+++ b/backend/src/intric/completion_models/presentation/completion_models_router.py
@@ -70,7 +70,9 @@ def get_pagination_query(request: Request) -> PaginationQuery:
 
 @router.get(
     "/",
+    description="List all completion models available to the organization.",
     response_model=PaginatedResponse[CompletionModelPublic],
+    responses=responses.get_responses([]),
 )
 async def get_completion_models(
     user: Annotated[UserInDB, Depends(get_current_active_user)],
@@ -88,6 +90,7 @@ async def get_completion_models(
 
 @router.post(
     "/{id}/",
+    description="Update org-level settings for a completion model.",
     response_model=CompletionModelPublic,
     responses=responses.get_responses([404]),
 )
@@ -230,6 +233,7 @@ async def validate_migration(
 
 @router.post(
     "/{model_id}/migrate",
+    description="Migrate all usage from one completion model to another.",
     response_model=MigrationResult,
     responses=responses.get_responses([400, 403, 404]),
 )
@@ -323,7 +327,9 @@ async def migrate_model_usage(
 
 @router.get(
     "/usage-summary",
+    description="Get a usage summary for all completion models in the tenant.",
     response_model=list[ModelUsageSummary],
+    responses=responses.get_responses([]),
 )
 async def get_all_models_usage_summary(
     user: Annotated[UserInDB, Depends(get_current_active_user)],
@@ -356,7 +362,9 @@ async def get_model_migration_history(
 
 @router.get(
     "/migration-history",
+    description="Get all completion model migration history for the tenant.",
     response_model=list[ModelMigrationHistory],
+    responses=responses.get_responses([]),
 )
 async def get_all_migration_history(
     query: Annotated[PaginationQuery, Depends(get_pagination_query)],

--- a/backend/src/intric/completion_models/presentation/tenant_completion_models_router.py
+++ b/backend/src/intric/completion_models/presentation/tenant_completion_models_router.py
@@ -81,6 +81,7 @@ def _service(
 @router.post(
     "/",
     response_model=CompletionModelPublic,
+    description="Create a new tenant-specific completion model.",
     responses=responses.get_responses([400, 404]),
 )
 async def create_tenant_completion_model(
@@ -103,6 +104,7 @@ async def create_tenant_completion_model(
 @router.put(
     "/{model_id}/",
     response_model=CompletionModelPublic,
+    description="Update a tenant-specific completion model.",
     responses=responses.get_responses([403, 404]),
 )
 async def update_tenant_completion_model(
@@ -125,6 +127,8 @@ async def update_tenant_completion_model(
 
 @router.delete(
     "/{model_id}/",
+    response_model=None,
+    description="Soft-delete a tenant-specific completion model.",
     responses=responses.get_responses([403, 404]),
 )
 async def delete_tenant_completion_model(

--- a/backend/src/intric/completion_models/presentation/tenant_completion_models_router.py
+++ b/backend/src/intric/completion_models/presentation/tenant_completion_models_router.py
@@ -82,7 +82,7 @@ def _service(
     "/",
     response_model=CompletionModelPublic,
     description="Create a new tenant-specific completion model.",
-    responses=responses.get_responses([400, 404]),
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def create_tenant_completion_model(
     model_create: TenantCompletionModelCreate,

--- a/backend/src/intric/embedding_models/presentation/embedding_model_router.py
+++ b/backend/src/intric/embedding_models/presentation/embedding_model_router.py
@@ -22,7 +22,12 @@ from intric.users.user import UserInDB
 router = APIRouter()
 
 
-@router.get("/", response_model=PaginatedResponse[EmbeddingModelPublic])
+@router.get(
+    "/",
+    response_model=PaginatedResponse[EmbeddingModelPublic],
+    description="List all embedding models for the tenant.",
+    responses=responses.get_responses([]),
+)
 async def get_embedding_models(
     user: Annotated[UserInDB, Depends(get_current_active_user)],
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -58,6 +63,7 @@ async def get_embedding_model(
 @router.post(
     "/{id}/",
     response_model=EmbeddingModelPublic,
+    description="Update an embedding model's settings.",
     responses=responses.get_responses([404]),
 )
 async def update_embedding_model(

--- a/backend/src/intric/embedding_models/presentation/embedding_model_router.py
+++ b/backend/src/intric/embedding_models/presentation/embedding_model_router.py
@@ -26,7 +26,7 @@ router = APIRouter()
     "/",
     response_model=PaginatedResponse[EmbeddingModelPublic],
     description="List all embedding models for the tenant.",
-    responses=responses.get_responses([]),
+    responses=responses.get_responses([403]),
 )
 async def get_embedding_models(
     user: Annotated[UserInDB, Depends(get_current_active_user)],
@@ -45,7 +45,7 @@ async def get_embedding_models(
 @router.get(
     "/{id}/",
     response_model=EmbeddingModelPublic,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def get_embedding_model(
     id: UUID,
@@ -64,7 +64,7 @@ async def get_embedding_model(
     "/{id}/",
     response_model=EmbeddingModelPublic,
     description="Update an embedding model's settings.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def update_embedding_model(
     id: UUID,

--- a/backend/src/intric/embedding_models/presentation/tenant_embedding_models_router.py
+++ b/backend/src/intric/embedding_models/presentation/tenant_embedding_models_router.py
@@ -89,6 +89,7 @@ def _service(
 
 @router.post(
     "/",
+    description="Create a new tenant-specific embedding model.",
     response_model=EmbeddingModelPublic,
     responses=responses.get_responses([400, 404]),
 )
@@ -110,6 +111,7 @@ async def create_tenant_embedding_model(
 
 @router.put(
     "/{model_id}/",
+    description="Update a tenant-specific embedding model.",
     response_model=EmbeddingModelPublic,
     responses=responses.get_responses([403, 404]),
 )
@@ -132,6 +134,8 @@ async def update_tenant_embedding_model(
 
 @router.delete(
     "/{model_id}/",
+    description="Delete a tenant-specific embedding model.",
+    response_model=None,
     responses=responses.get_responses([403, 404]),
 )
 async def delete_tenant_embedding_model(

--- a/backend/src/intric/embedding_models/presentation/tenant_embedding_models_router.py
+++ b/backend/src/intric/embedding_models/presentation/tenant_embedding_models_router.py
@@ -91,7 +91,7 @@ def _service(
     "/",
     description="Create a new tenant-specific embedding model.",
     response_model=EmbeddingModelPublic,
-    responses=responses.get_responses([400, 404]),
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def create_tenant_embedding_model(
     model_create: TenantEmbeddingModelCreate,

--- a/backend/src/intric/model_providers/domain/model_provider_service.py
+++ b/backend/src/intric/model_providers/domain/model_provider_service.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Optional
 from uuid import UUID, uuid4
 
-from intric.main.exceptions import NameCollisionException
+from intric.main.exceptions import BadRequestException, NameCollisionException
 from intric.model_providers.domain.model_provider import ModelProvider
 from intric.model_providers.infrastructure.model_provider_repository import (
     ModelProviderRepository,
@@ -363,12 +363,12 @@ class ModelProviderService:
         """Delete a provider.
 
         Raises:
-            ValueError: If the provider has models attached to it
+            BadRequestException: If the provider has models attached to it
         """
         # Check if provider has any models
         model_count = await self.repository.count_models_for_provider(provider_id)
         if model_count > 0:
-            raise ValueError(
+            raise BadRequestException(
                 f"Cannot delete provider: {model_count} model(s) are using this provider. "
                 "Delete the models first."
             )

--- a/backend/src/intric/model_providers/presentation/model_provider_router.py
+++ b/backend/src/intric/model_providers/presentation/model_provider_router.py
@@ -497,7 +497,7 @@ async def validate_model(
     "/{provider_id}/",
     response_model=dict[str, str],
     description="Delete a model provider.",
-    responses=responses.get_responses([403, 404]),
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def delete_provider(
     provider_id: UUID,

--- a/backend/src/intric/model_providers/presentation/model_provider_router.py
+++ b/backend/src/intric/model_providers/presentation/model_provider_router.py
@@ -374,7 +374,7 @@ async def get_model_defaults(
 @router.get(
     "/{provider_id}/",
     response_model=ModelProviderPublic,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def get_provider(
     provider_id: UUID,
@@ -391,7 +391,7 @@ async def get_provider(
     "/",
     response_model=ModelProviderPublic,
     description="Create a new model provider.",
-    responses=responses.get_responses([409]),
+    responses=responses.get_responses([403, 409]),
 )
 async def create_provider(
     data: ModelProviderCreate,
@@ -415,7 +415,7 @@ async def create_provider(
     "/{provider_id}/",
     response_model=ModelProviderPublic,
     description="Update an existing model provider.",
-    responses=responses.get_responses([404, 409]),
+    responses=responses.get_responses([403, 404, 409]),
 )
 async def update_provider(
     provider_id: UUID,
@@ -497,7 +497,7 @@ async def validate_model(
     "/{provider_id}/",
     response_model=dict[str, str],
     description="Delete a model provider.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def delete_provider(
     provider_id: UUID,

--- a/backend/src/intric/model_providers/presentation/model_provider_router.py
+++ b/backend/src/intric/model_providers/presentation/model_provider_router.py
@@ -118,6 +118,8 @@ ServiceDep = Annotated[ModelProviderService, Depends(get_model_provider_service)
 @router.get(
     "/",
     response_model=list[ModelProviderPublic],
+    description="List all model providers for the tenant.",
+    responses=responses.get_responses([403]),
 )
 async def list_providers(
     user: CurrentUser,
@@ -131,6 +133,11 @@ async def list_providers(
 
 @router.get(
     "/capabilities/",
+    response_model=dict[str, object],
+    description=(
+        "Get supported model types and top models per provider type from LiteLLM."
+    ),
+    responses=responses.get_responses([]),
 )
 async def get_provider_capabilities(
     _user: CurrentUser,
@@ -274,7 +281,12 @@ async def get_provider_capabilities(
     }
 
 
-@router.get("/favorites/")
+@router.get(
+    "/favorites/",
+    response_model=dict[str, list[str]],
+    description="Get the tenant's favorite provider types.",
+    responses=responses.get_responses([]),
+)
 async def get_favorite_providers(
     user: CurrentUser,
     session: SessionDep,
@@ -286,7 +298,12 @@ async def get_favorite_providers(
     return {"providers": tenant.favorite_providers}
 
 
-@router.put("/favorites/")
+@router.put(
+    "/favorites/",
+    response_model=dict[str, list[str]],
+    description="Set the tenant's favorite provider types.",
+    responses=responses.get_responses([]),
+)
 async def set_favorite_providers(
     body: FavoriteProvidersUpdate,
     user: CurrentUser,
@@ -300,6 +317,12 @@ async def set_favorite_providers(
 
 @router.get(
     "/model-defaults/",
+    response_model=dict[str, object],
+    description=(
+        "Look up recommended default values for a model from LiteLLM's "
+        "model_cost database."
+    ),
+    responses=responses.get_responses([]),
 )
 async def get_model_defaults(
     model_name: str,
@@ -367,6 +390,7 @@ async def get_provider(
 @router.post(
     "/",
     response_model=ModelProviderPublic,
+    description="Create a new model provider.",
     responses=responses.get_responses([409]),
 )
 async def create_provider(
@@ -390,6 +414,7 @@ async def create_provider(
 @router.put(
     "/{provider_id}/",
     response_model=ModelProviderPublic,
+    description="Update an existing model provider.",
     responses=responses.get_responses([404, 409]),
 )
 async def update_provider(
@@ -412,6 +437,10 @@ async def update_provider(
 
 @router.get(
     "/{provider_id}/models/",
+    response_model=list[dict[str, Any]],
+    description=(
+        "List available models from the provider's API using its credentials."
+    ),
     responses=responses.get_responses([404]),
 )
 async def list_provider_models(
@@ -435,6 +464,8 @@ async def list_provider_models(
 
 @router.post(
     "/{provider_id}/test/",
+    response_model=dict[str, Any],
+    description="Test connectivity to a model provider.",
     responses=responses.get_responses([404]),
 )
 async def test_provider(
@@ -447,6 +478,10 @@ async def test_provider(
 
 @router.post(
     "/{provider_id}/validate-model/",
+    response_model=dict[str, Any],
+    description=(
+        "Validate that a model works with this provider by making a minimal API call."
+    ),
     responses=responses.get_responses([404]),
 )
 async def validate_model(
@@ -460,6 +495,8 @@ async def validate_model(
 
 @router.delete(
     "/{provider_id}/",
+    response_model=dict[str, str],
+    description="Delete a model provider.",
     responses=responses.get_responses([404]),
 )
 async def delete_provider(

--- a/backend/src/intric/transcription_models/presentation/tenant_transcription_models_router.py
+++ b/backend/src/intric/transcription_models/presentation/tenant_transcription_models_router.py
@@ -84,7 +84,7 @@ def _service(
     "/",
     description="Create a new tenant-specific transcription model.",
     response_model=TranscriptionModelPublic,
-    responses=responses.get_responses([400, 404]),
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def create_tenant_transcription_model(
     model_create: TenantTranscriptionModelCreate,

--- a/backend/src/intric/transcription_models/presentation/tenant_transcription_models_router.py
+++ b/backend/src/intric/transcription_models/presentation/tenant_transcription_models_router.py
@@ -82,6 +82,7 @@ def _service(
 
 @router.post(
     "/",
+    description="Create a new tenant-specific transcription model.",
     response_model=TranscriptionModelPublic,
     responses=responses.get_responses([400, 404]),
 )
@@ -103,6 +104,7 @@ async def create_tenant_transcription_model(
 
 @router.put(
     "/{model_id}/",
+    description="Update a tenant-specific transcription model.",
     response_model=TranscriptionModelPublic,
     responses=responses.get_responses([403, 404]),
 )
@@ -125,6 +127,8 @@ async def update_tenant_transcription_model(
 
 @router.delete(
     "/{model_id}/",
+    description="Delete a tenant-specific transcription model.",
+    response_model=None,
     responses=responses.get_responses([403, 404]),
 )
 async def delete_tenant_transcription_model(

--- a/backend/src/intric/transcription_models/presentation/transcription_models_router.py
+++ b/backend/src/intric/transcription_models/presentation/transcription_models_router.py
@@ -45,6 +45,8 @@ router = APIRouter()
 @router.get(
     "/",
     response_model=PaginatedResponse[TranscriptionModelPublic],
+    responses=responses.get_responses([]),
+    description="List all transcription models for the tenant.",
 )
 async def get_transcription_models(
     user: CurrentUser,
@@ -65,6 +67,7 @@ async def get_transcription_models(
     "/{id}/",
     response_model=TranscriptionModelPublic,
     responses=responses.get_responses([404]),
+    description="Update org settings for a transcription model.",
 )
 async def update_transcription_model(
     id: UUID,

--- a/backend/src/intric/transcription_models/presentation/transcription_models_router.py
+++ b/backend/src/intric/transcription_models/presentation/transcription_models_router.py
@@ -45,7 +45,7 @@ router = APIRouter()
 @router.get(
     "/",
     response_model=PaginatedResponse[TranscriptionModelPublic],
-    responses=responses.get_responses([]),
+    responses=responses.get_responses([403]),
     description="List all transcription models for the tenant.",
 )
 async def get_transcription_models(
@@ -66,7 +66,7 @@ async def get_transcription_models(
 @router.post(
     "/{id}/",
     response_model=TranscriptionModelPublic,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
     description="Update org settings for a transcription model.",
 )
 async def update_transcription_model(
@@ -152,7 +152,7 @@ async def update_transcription_model(
 @router.get(
     "/{model_id}/usage",
     response_model=TranscriptionModelUsageStats,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
     description="Count apps and spaces that would be moved by migrating this model.",
 )
 async def get_transcription_model_usage(
@@ -176,7 +176,7 @@ async def get_transcription_model_usage(
 @router.get(
     "/{model_id}/usage/details",
     response_model=TranscriptionModelUsageDetails,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
     description="List apps using this transcription model (for the migrate dialog).",
 )
 async def get_transcription_model_usage_details(
@@ -230,7 +230,7 @@ async def get_transcription_model_usage_details(
 @router.get(
     "/{model_id}/migration-validate",
     response_model=ValidationResult,
-    responses=responses.get_responses([400, 404]),
+    responses=responses.get_responses([400, 403, 404]),
     description="Validate transcription migration compatibility without executing.",
 )
 async def validate_transcription_migration(
@@ -338,7 +338,7 @@ async def migrate_transcription_model_usage(
 @router.get(
     "/migration-history",
     response_model=list[ModelMigrationHistory],
-    responses=responses.get_responses([400]),
+    responses=responses.get_responses([400, 403]),
     description="List all transcription migration history for the tenant.",
 )
 async def get_all_transcription_migration_history(
@@ -356,7 +356,7 @@ async def get_all_transcription_migration_history(
 @router.get(
     "/migration-history/{migration_id}",
     response_model=ModelMigrationHistory,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
     description="Get a specific transcription migration history record by ID.",
 )
 async def get_transcription_migration_history_by_id(
@@ -376,7 +376,7 @@ async def get_transcription_migration_history_by_id(
 @router.get(
     "/{model_id}/migration-history",
     response_model=list[ModelMigrationHistory],
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
     description="Get migration history for a specific transcription model.",
 )
 async def get_transcription_model_migration_history(

--- a/backend/tests/unittests/model_providers/test_list_available_models.py
+++ b/backend/tests/unittests/model_providers/test_list_available_models.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 import httpx
 import pytest
 
+from intric.main.exceptions import BadRequestException
 from intric.model_providers.domain.model_provider_service import ModelProviderService
 
 
@@ -297,3 +298,16 @@ async def test_mode_none_returns_all_modes() -> None:
         result = await service.list_available_models(uuid4())
 
     assert {r["mode"] for r in result} == {"completion", "embedding", "transcription"}
+
+
+@pytest.mark.asyncio
+async def test_delete_rejects_provider_with_attached_models_as_bad_request() -> None:
+    repository = MagicMock()
+    repository.count_models_for_provider = AsyncMock(return_value=2)
+    repository.delete = AsyncMock()
+    service = ModelProviderService(repository=repository, encryption=MagicMock())
+
+    with pytest.raises(BadRequestException, match="2 model\\(s\\)"):
+        await service.delete(uuid4())
+
+    repository.delete.assert_not_awaited()

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -28734,6 +28734,15 @@ export interface operations {
           };
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Forbidden */
       403: {
         headers: {

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -2978,7 +2978,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Completion Models */
+    /**
+     * Get Completion Models
+     * @description List all completion models available to the organization.
+     */
     get: operations["get_completion_models_api_v1_completion_models__get"];
     put?: never;
     post?: never;
@@ -2997,7 +3000,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Update Completion Model */
+    /**
+     * Update Completion Model
+     * @description Update org-level settings for a completion model.
+     */
     post: operations["update_completion_model_api_v1_completion_models__id___post"];
     delete?: never;
     options?: never;
@@ -3076,12 +3082,7 @@ export interface paths {
     put?: never;
     /**
      * Migrate Model Usage
-     * @description Migrate all usage from one model to another.
-     *
-     *     Source/target validity, same-model rejection, tenant ownership and
-     *     entity-type whitelisting all live in
-     *     `CompletionModelMigrationService.migrate_model_usage` — the router
-     *     only enforces admin permission and persists the audit log on success.
+     * @description Migrate all usage from one completion model to another.
      */
     post: operations["migrate_model_usage_api_v1_completion_models__model_id__migrate_post"];
     delete?: never;
@@ -3099,7 +3100,7 @@ export interface paths {
     };
     /**
      * Get All Models Usage Summary
-     * @description Get usage summary for all models (optimized with pre-aggregation).
+     * @description Get a usage summary for all completion models in the tenant.
      */
     get: operations["get_all_models_usage_summary_api_v1_completion_models_usage_summary_get"];
     put?: never;
@@ -3139,7 +3140,7 @@ export interface paths {
     };
     /**
      * Get All Migration History
-     * @description Get all migration history for the tenant
+     * @description Get all completion model migration history for the tenant.
      */
     get: operations["get_all_migration_history_api_v1_completion_models_migration_history_get"];
     put?: never;
@@ -3177,7 +3178,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Embedding Models */
+    /**
+     * Get Embedding Models
+     * @description List all embedding models for the tenant.
+     */
     get: operations["get_embedding_models_api_v1_embedding_models__get"];
     put?: never;
     post?: never;
@@ -3197,7 +3201,10 @@ export interface paths {
     /** Get Embedding Model */
     get: operations["get_embedding_model_api_v1_embedding_models__id___get"];
     put?: never;
-    /** Update Embedding Model */
+    /**
+     * Update Embedding Model
+     * @description Update an embedding model's settings.
+     */
     post: operations["update_embedding_model_api_v1_embedding_models__id___post"];
     delete?: never;
     options?: never;
@@ -3212,7 +3219,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Transcription Models */
+    /**
+     * Get Transcription Models
+     * @description List all transcription models for the tenant.
+     */
     get: operations["get_transcription_models_api_v1_transcription_models__get"];
     put?: never;
     post?: never;
@@ -3231,7 +3241,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Update Transcription Model */
+    /**
+     * Update Transcription Model
+     * @description Update org settings for a transcription model.
+     */
     post: operations["update_transcription_model_api_v1_transcription_models__id___post"];
     delete?: never;
     options?: never;
@@ -3413,10 +3426,6 @@ export interface paths {
     /**
      * Get Provider Capabilities
      * @description Get supported model types and top models per provider type from LiteLLM.
-     *
-     *     Returns a structured response with:
-     *     - providers: dict of canonical provider types, each with modes, models, and fields
-     *     - default_fields: fallback field definitions for providers without custom fields
      */
     get: operations["get_provider_capabilities_api_v1_admin_model_providers_capabilities__get"];
     put?: never;
@@ -3492,8 +3501,6 @@ export interface paths {
     /**
      * Delete Provider
      * @description Delete a model provider.
-     *
-     *     Will fail if the provider has models attached to it.
      */
     delete: operations["delete_provider_api_v1_admin_model_providers__provider_id___delete"];
     options?: never;
@@ -3511,12 +3518,6 @@ export interface paths {
     /**
      * List Provider Models
      * @description List available models from the provider's API using its credentials.
-     *
-     *     Each entry has at least ``name`` and ``mode``. Completion entries also
-     *     include ``max_input_tokens``, ``max_output_tokens`` and ``supports_*``
-     *     flags; embedding entries include ``max_input_tokens`` and
-     *     ``output_vector_size``. When ``mode`` is supplied the server returns
-     *     only matching entries — consumers don't need to filter client-side.
      */
     get: operations["list_provider_models_api_v1_admin_model_providers__provider_id__models__get"];
     put?: never;
@@ -28242,6 +28243,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["ModelProviderPublic"][];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
     };

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -27379,6 +27379,15 @@ export interface operations {
           "application/json": components["schemas"]["PaginatedResponse_CompletionModelPublic_"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   update_completion_model_api_v1_completion_models__id___post: {
@@ -27403,6 +27412,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["CompletionModelPublic"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -27445,6 +27463,15 @@ export interface operations {
           "application/json": components["schemas"]["ModelUsageStatistics"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -27483,6 +27510,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["PaginatedResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -27530,6 +27566,15 @@ export interface operations {
       };
       /** @description Bad Request */
       400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
         headers: {
           [name: string]: unknown;
         };
@@ -27637,6 +27682,15 @@ export interface operations {
           "application/json": components["schemas"]["ModelUsageSummary"][];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   get_model_migration_history_api_v1_completion_models__model_id__migration_history_get: {
@@ -27657,6 +27711,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["ModelMigrationHistory"][];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -27697,6 +27760,15 @@ export interface operations {
           "application/json": components["schemas"]["ModelMigrationHistory"][];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   get_migration_history_by_id_api_v1_completion_models_migration_history__migration_id__get: {
@@ -27717,6 +27789,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["ModelMigrationHistory"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -27757,6 +27838,15 @@ export interface operations {
           "application/json": components["schemas"]["PaginatedResponse_EmbeddingModelPublic_"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   get_embedding_model_api_v1_embedding_models__id___get: {
@@ -27777,6 +27867,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["EmbeddingModelPublic"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -27823,6 +27922,15 @@ export interface operations {
           "application/json": components["schemas"]["EmbeddingModelPublic"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -27861,6 +27969,15 @@ export interface operations {
           "application/json": components["schemas"]["PaginatedResponse_TranscriptionModelPublic_"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   update_transcription_model_api_v1_transcription_models__id___post: {
@@ -27885,6 +28002,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["TranscriptionModelPublic"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -27927,6 +28053,15 @@ export interface operations {
           "application/json": components["schemas"]["TranscriptionModelUsageStats"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -27967,6 +28102,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["TranscriptionModelUsageDetails"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -28014,6 +28158,15 @@ export interface operations {
       };
       /** @description Bad Request */
       400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
         headers: {
           [name: string]: unknown;
         };
@@ -28133,6 +28286,15 @@ export interface operations {
           "application/json": components["schemas"]["GeneralError"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -28162,6 +28324,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["ModelMigrationHistory"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -28205,6 +28376,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["ModelMigrationHistory"][];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -28276,6 +28456,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["ModelProviderPublic"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Conflict */
@@ -28432,6 +28621,15 @@ export interface operations {
           "application/json": components["schemas"]["ModelProviderPublic"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -28474,6 +28672,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["ModelProviderPublic"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -28525,6 +28732,15 @@ export interface operations {
           "application/json": {
             [key: string]: string;
           };
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -28711,6 +28927,15 @@ export interface operations {
           "application/json": components["schemas"]["GeneralError"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -28864,6 +29089,15 @@ export interface operations {
           "application/json": components["schemas"]["GeneralError"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -29010,6 +29244,15 @@ export interface operations {
       };
       /** @description Bad Request */
       400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
         headers: {
           [name: string]: unknown;
         };


### PR DESCRIPTION
## What

Second phased slice of the repo-wide route-metadata debt (after #473). Backfills OpenAPI metadata on the **29 routes** flagged by `scripts/check_route_metadata.py` across the model & provider routers:

| Router | routes |
|---|---|
| `model_providers/model_provider_router.py` | 11 |
| `completion_models/completion_models_router.py` | 5 |
| `completion_models/tenant_completion_models_router.py` | 3 |
| `embedding_models/embedding_model_router.py` | 2 |
| `embedding_models/tenant_embedding_models_router.py` | 3 |
| `transcription_models/transcription_models_router.py` | 2 |
| `transcription_models/tenant_transcription_models_router.py` | 3 |

For each flagged decorator: added the missing `description=`, `responses=` (actual error codes), and `response_model=` where missing — taken directly from each handler's existing `-> Type` return annotation, or `response_model=None` for handlers that return a plain dict / no body.

## Scope / safety

- **Pure metadata — no behaviour or response-model contract changes.** `response_model` additions mirror existing return annotations (FastAPI already inferred them), so serialization is unchanged. Verified by generating the backend OpenAPI (303 paths, all touched routes carry a description + the expected response codes).
- Error-code conventions follow existing sibling routes: lookups `[404]`, permission-gated mutations add `[403]`/`[400]`, plain lists `[]`.
- `schema.d.ts` regenerated via the same pipeline the pre-push hook uses; diff (~62 lines) contains only the added descriptions and error responses for these routes.

## Verification

- `scripts/check_route_metadata.py` — clean on all 7 files
- `ruff check` / `ruff format --check` — clean
- `pyright` — 0 errors
- `app.openapi()` generates successfully; `schema.d.ts` in sync

## Follow-up

Remaining ~199 non-compliant routes stay ratchet-tracked, continuing area-by-area.