### PR TITLE
chore(api): backfill OpenAPI route metadata for sysadmin router

### DIFF
--- a/backend/src/intric/sysadmin/sysadmin_router.py
+++ b/backend/src/intric/sysadmin/sysadmin_router.py
@@ -197,7 +197,7 @@ async def get_user(
     "/users/{user_id}/",
     response_model=DeleteResponse,
     description="Delete a user by id.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([400, 404]),
 )
 async def delete_user(
     user_id: UUID,
@@ -240,7 +240,7 @@ async def delete_user(
     "/users/{user_id}/",
     response_model=UserInDB,
     description="Update a user by id; omitted fields are left unchanged.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([400, 404]),
 )
 async def update_user(
     user_id: UUID,
@@ -386,7 +386,7 @@ async def create_tenant(
     "/tenants/{id}/",
     response_model=TenantWithMaskedCredentials,
     description="Update a tenant by id and return it with masked credentials.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([400, 404]),
 )
 async def update_tenant(
     id: UUID,
@@ -627,7 +627,7 @@ async def get_completion_models(
     "/tenants/{id}/completion-models/{completion_model_id}/",
     response_model=CompletionModelPublic,
     description="Enable or disable a completion model for a specific tenant.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([400, 404]),
 )
 async def enable_completion_model(
     id: UUID,
@@ -680,7 +680,7 @@ async def enable_completion_model(
     "/tenants/{id}/embedding-models/{embedding_model_id}/",
     response_model=EmbeddingModelPublicLegacy,
     description="Enable or disable an embedding model for a specific tenant.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([400, 404]),
 )
 async def enable_embedding_model(
     id: UUID,
@@ -817,7 +817,7 @@ async def delete_origin(
     "/tenants/{tenant_id}/usage-stats/recalculate",
     response_model=dict[str, str | bool],
     description="Recalculate usage statistics for a specific tenant.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([404, 500]),
 )
 async def recalculate_tenant_usage_statistics(
     tenant_id: UUID,

--- a/backend/src/intric/sysadmin/sysadmin_router.py
+++ b/backend/src/intric/sysadmin/sysadmin_router.py
@@ -842,19 +842,18 @@ async def recalculate_tenant_usage_statistics(
                 "success": True,
             }
         else:
-            from fastapi import HTTPException
-
             raise HTTPException(
                 status_code=404, detail=f"Tenant {tenant_id} not found or not active"
             )
 
+    except HTTPException:
+        # Preserve the explicit 404 above; only unexpected errors become 500.
+        raise
     except Exception as e:
         logger.error(
             f"Error recalculating usage statistics for tenant {tenant_id}: {str(e)}",
             exc_info=True,
         )
-        from fastapi import HTTPException
-
         raise HTTPException(
             status_code=500,
             detail=f"Error recalculating usage statistics for tenant {tenant_id}: {str(e)}",

--- a/backend/src/intric/sysadmin/sysadmin_router.py
+++ b/backend/src/intric/sysadmin/sysadmin_router.py
@@ -124,6 +124,7 @@ class OIDCDebugToggleResponse(BaseModel):
 @router.post(
     "/users/",
     response_model=UserCreated,
+    description="Register a new user as sysadmin and return the created user with an access token.",
     responses=responses.get_responses([400, 401]),
 )
 async def register_new_user(
@@ -163,7 +164,12 @@ async def register_new_user(
     )
 
 
-@router.get("/users/", response_model=PaginatedResponse[UserInDB])
+@router.get(
+    "/users/",
+    response_model=PaginatedResponse[UserInDB],
+    description="List all users across all tenants.",
+    responses=responses.get_responses([]),
+)
 async def get_all_users(
     container: Annotated[Container, Depends(get_container())],
 ):
@@ -173,7 +179,12 @@ async def get_all_users(
     return protocol.to_paginated_response(users_in_db)
 
 
-@router.get("/users/{user_id}/", response_model=UserInDB)
+@router.get(
+    "/users/{user_id}/",
+    response_model=UserInDB,
+    description="Get a single user by id.",
+    responses=responses.get_responses([404]),
+)
 async def get_user(
     user_id: UUID,
     container: Annotated[Container, Depends(get_container())],
@@ -182,7 +193,12 @@ async def get_user(
     return await user_service.get_user(user_id)
 
 
-@router.delete("/users/{user_id}/", response_model=DeleteResponse)
+@router.delete(
+    "/users/{user_id}/",
+    response_model=DeleteResponse,
+    description="Delete a user by id.",
+    responses=responses.get_responses([404]),
+)
 async def delete_user(
     user_id: UUID,
     container: Annotated[Container, Depends(get_container())],
@@ -220,7 +236,12 @@ async def delete_user(
     return DeleteResponse(success=success)
 
 
-@router.post("/users/{user_id}/", response_model=UserInDB)
+@router.post(
+    "/users/{user_id}/",
+    response_model=UserInDB,
+    description="Update a user by id; omitted fields are left unchanged.",
+    responses=responses.get_responses([404]),
+)
 async def update_user(
     user_id: UUID,
     user_update: UserUpdatePublic,
@@ -267,7 +288,13 @@ async def update_user(
     return updated_user
 
 
-@router.post("/users/{user_id}/access-token/", include_in_schema=False)
+@router.post(
+    "/users/{user_id}/access-token/",
+    include_in_schema=False,
+    response_model=None,
+    description="Issue an access token for the given user.",
+    responses=responses.get_responses([404]),
+)
 async def get_access_token(
     user_id: UUID,
     container: Annotated[Container, Depends(get_container())],
@@ -280,7 +307,12 @@ async def get_access_token(
     return auth_service.create_access_token_for_user(user)
 
 
-@router.get("/tenants/", response_model=PaginatedResponse[TenantWithMaskedCredentials])
+@router.get(
+    "/tenants/",
+    response_model=PaginatedResponse[TenantWithMaskedCredentials],
+    description="List all tenants with API credentials masked, optionally filtered by domain.",
+    responses=responses.get_responses([]),
+)
 async def get_tenants(
     container: Annotated[Container, Depends(get_container())],
     domain: Annotated[str | None, Query()] = None,
@@ -312,6 +344,7 @@ async def get_tenants(
 @router.post(
     "/tenants/",
     response_model=TenantWithMaskedCredentials,
+    description="Create a new tenant and return it with masked credentials.",
     responses=responses.get_responses([400]),
 )
 async def create_tenant(
@@ -352,6 +385,7 @@ async def create_tenant(
 @router.post(
     "/tenants/{id}/",
     response_model=TenantWithMaskedCredentials,
+    description="Update a tenant by id and return it with masked credentials.",
     responses=responses.get_responses([404]),
 )
 async def update_tenant(
@@ -407,6 +441,7 @@ async def update_tenant(
 @router.delete(
     "/tenants/{id}/",
     response_model=TenantWithMaskedCredentials,
+    description="Delete a tenant by id and return it with masked credentials.",
     responses=responses.get_responses([404]),
 )
 async def delete_tenant_by_id(
@@ -447,7 +482,12 @@ async def delete_tenant_by_id(
     return TenantWithMaskedCredentials.from_tenant(deleted_tenant)
 
 
-@router.get("/predefined-roles/")
+@router.get(
+    "/predefined-roles/",
+    response_model=None,
+    description="List the predefined roles loaded from configuration.",
+    responses=responses.get_responses([]),
+)
 async def get_predefined_roles():
     from intric.server.dependencies.predefined_roles import (
         load_predefined_roles_from_config,
@@ -456,7 +496,12 @@ async def get_predefined_roles():
     return load_predefined_roles_from_config()
 
 
-@router.post("/crawl-all-weekly-websites/")
+@router.post(
+    "/crawl-all-weekly-websites/",
+    response_model=None,
+    description="Trigger crawls for all websites scheduled to run weekly.",
+    responses=responses.get_responses([]),
+)
 async def crawl_all_weekly_websites(
     container: Annotated[Container, Depends(get_container())],
 ):
@@ -581,6 +626,7 @@ async def get_completion_models(
 @router.post(
     "/tenants/{id}/completion-models/{completion_model_id}/",
     response_model=CompletionModelPublic,
+    description="Enable or disable a completion model for a specific tenant.",
     responses=responses.get_responses([404]),
 )
 async def enable_completion_model(
@@ -633,6 +679,7 @@ async def enable_completion_model(
 @router.post(
     "/tenants/{id}/embedding-models/{embedding_model_id}/",
     response_model=EmbeddingModelPublicLegacy,
+    description="Enable or disable an embedding model for a specific tenant.",
     responses=responses.get_responses([404]),
 )
 async def enable_embedding_model(
@@ -682,7 +729,12 @@ async def enable_embedding_model(
     return CompletionModelSparse.model_validate(model)
 
 
-@router.post("/allowed-origins/", response_model=AllowedOriginInDB)
+@router.post(
+    "/allowed-origins/",
+    response_model=AllowedOriginInDB,
+    description="Add an allowed CORS origin for a tenant.",
+    responses=responses.get_responses([]),
+)
 async def add_origin(
     origin: AllowedOriginCreate,
     container: Annotated[Container, Depends(get_container())],
@@ -709,7 +761,12 @@ async def add_origin(
     return created
 
 
-@router.get("/allowed-origins/", response_model=PaginatedResponse[AllowedOriginInDB])
+@router.get(
+    "/allowed-origins/",
+    response_model=PaginatedResponse[AllowedOriginInDB],
+    description="List allowed CORS origins, optionally filtered by tenant.",
+    responses=responses.get_responses([]),
+)
 async def get_origins(
     container: Annotated[Container, Depends(get_container())],
     tenant_id: Annotated[UUID | None, Query()] = None,
@@ -724,7 +781,12 @@ async def get_origins(
     return protocol.to_paginated_response(allowed_origins)
 
 
-@router.delete("/allowed-origins/{id}/", status_code=204)
+@router.delete(
+    "/allowed-origins/{id}/",
+    status_code=204,
+    description="Delete an allowed CORS origin by id (idempotent).",
+    responses=responses.get_responses([]),
+)
 async def delete_origin(
     id: UUID,
     container: Annotated[Container, Depends(get_container())],
@@ -753,6 +815,8 @@ async def delete_origin(
 
 @router.post(
     "/tenants/{tenant_id}/usage-stats/recalculate",
+    response_model=dict[str, str | bool],
+    description="Recalculate usage statistics for a specific tenant.",
     responses=responses.get_responses([404]),
 )
 async def recalculate_tenant_usage_statistics(
@@ -799,6 +863,8 @@ async def recalculate_tenant_usage_statistics(
 
 @router.post(
     "/system/usage-stats/recalculate-all",
+    response_model=dict[str, str | bool],
+    description="Recalculate usage statistics for all active tenants.",
     responses=responses.get_responses([500]),
 )
 async def recalculate_all_tenants_usage_statistics(
@@ -844,6 +910,7 @@ async def recalculate_all_tenants_usage_statistics(
 @router.post(
     "/tenants/{tenant_id}/completion-models/{model_id}/migrate",
     response_model=MigrationResult,
+    description="Migrate completion model usage from one model to another for a specific tenant.",
     responses=responses.get_responses([400, 403, 404, 500]),
 )
 async def migrate_completion_model_for_tenant(
@@ -986,6 +1053,7 @@ async def migrate_completion_model_for_tenant(
 @router.post(
     "/system/completion-models/{model_id}/migrate-all-tenants",
     response_model=dict,
+    description="Migrate completion model usage from one model to another across all active tenants.",
     responses=responses.get_responses([400, 403, 404, 500]),
 )
 async def migrate_completion_model_for_all_tenants(
@@ -1234,6 +1302,7 @@ async def migrate_completion_model_for_all_tenants(
 @router.post(
     "/completion-models/create",
     response_model=CompletionModelSparse,
+    description="Create global completion model metadata (system-wide operation).",
     responses=responses.get_responses([400, 401]),
 )
 async def create_completion_model(
@@ -1273,6 +1342,7 @@ async def create_completion_model(
 @router.put(
     "/completion-models/{id}/metadata",
     response_model=CompletionModelSparse,
+    description="Update global completion model metadata (system-wide operation).",
     responses=responses.get_responses([404, 401]),
 )
 async def update_completion_model_metadata(
@@ -1315,6 +1385,8 @@ async def update_completion_model_metadata(
 
 @router.delete(
     "/completion-models/{id}",
+    response_model=None,
+    description="Soft-delete global completion model metadata (system-wide operation).",
     responses=responses.get_responses([404, 400, 401]),
 )
 async def delete_completion_model(
@@ -1365,6 +1437,7 @@ async def delete_completion_model(
 @router.post(
     "/embedding-models/create",
     response_model=EmbeddingModelSparse,
+    description="Create global embedding model metadata (system-wide operation).",
     responses=responses.get_responses([400, 401]),
 )
 async def create_embedding_model(
@@ -1398,6 +1471,7 @@ async def create_embedding_model(
 @router.put(
     "/embedding-models/{id}/metadata",
     response_model=EmbeddingModelSparse,
+    description="Update global embedding model metadata (system-wide operation).",
     responses=responses.get_responses([404, 401]),
 )
 async def update_embedding_model_metadata(
@@ -1440,6 +1514,8 @@ async def update_embedding_model_metadata(
 
 @router.delete(
     "/embedding-models/{id}",
+    response_model=None,
+    description="Soft-delete global embedding model metadata (system-wide operation).",
     responses=responses.get_responses([404, 400, 401]),
 )
 async def delete_embedding_model(

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -5941,10 +5941,16 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get All Users */
+    /**
+     * Get All Users
+     * @description List all users across all tenants.
+     */
     get: operations["get_all_users_api_v1_sysadmin_users__get"];
     put?: never;
-    /** Register New User */
+    /**
+     * Register New User
+     * @description Register a new user as sysadmin and return the created user with an access token.
+     */
     post: operations["register_new_user_api_v1_sysadmin_users__post"];
     delete?: never;
     options?: never;
@@ -5959,15 +5965,21 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get User */
+    /**
+     * Get User
+     * @description Get a single user by id.
+     */
     get: operations["get_user_api_v1_sysadmin_users__user_id___get"];
     put?: never;
     /**
      * Update User
-     * @description Omitted fields are not updated.
+     * @description Update a user by id; omitted fields are left unchanged.
      */
     post: operations["update_user_api_v1_sysadmin_users__user_id___post"];
-    /** Delete User */
+    /**
+     * Delete User
+     * @description Delete a user by id.
+     */
     delete: operations["delete_user_api_v1_sysadmin_users__user_id___delete"];
     options?: never;
     head?: never;
@@ -5983,21 +5995,14 @@ export interface paths {
     };
     /**
      * Get Tenants
-     * @description Get all tenants with masked API credentials.
-     *
-     *     Returns tenant information with API keys masked to show only last 4 characters.
-     *     This prevents exposing full API keys through the API endpoint.
-     *
-     *     Args:
-     *         domain: Optional domain filter
-     *         container: Dependency injection container
-     *
-     *     Returns:
-     *         Paginated list of tenants with masked credentials
+     * @description List all tenants with API credentials masked, optionally filtered by domain.
      */
     get: operations["get_tenants_api_v1_sysadmin_tenants__get"];
     put?: never;
-    /** Create Tenant */
+    /**
+     * Create Tenant
+     * @description Create a new tenant and return it with masked credentials.
+     */
     post: operations["create_tenant_api_v1_sysadmin_tenants__post"];
     delete?: never;
     options?: never;
@@ -6014,9 +6019,15 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Update Tenant */
+    /**
+     * Update Tenant
+     * @description Update a tenant by id and return it with masked credentials.
+     */
     post: operations["update_tenant_api_v1_sysadmin_tenants__id___post"];
-    /** Delete Tenant By Id */
+    /**
+     * Delete Tenant By Id
+     * @description Delete a tenant by id and return it with masked credentials.
+     */
     delete: operations["delete_tenant_by_id_api_v1_sysadmin_tenants__id___delete"];
     options?: never;
     head?: never;
@@ -6030,7 +6041,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Predefined Roles */
+    /**
+     * Get Predefined Roles
+     * @description List the predefined roles loaded from configuration.
+     */
     get: operations["get_predefined_roles_api_v1_sysadmin_predefined_roles__get"];
     put?: never;
     post?: never;
@@ -6049,7 +6063,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Crawl All Weekly Websites */
+    /**
+     * Crawl All Weekly Websites
+     * @description Trigger crawls for all websites scheduled to run weekly.
+     */
     post: operations["crawl_all_weekly_websites_api_v1_sysadmin_crawl_all_weekly_websites__post"];
     delete?: never;
     options?: never;
@@ -6124,7 +6141,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Enable Completion Model */
+    /**
+     * Enable Completion Model
+     * @description Enable or disable a completion model for a specific tenant.
+     */
     post: operations["enable_completion_model_api_v1_sysadmin_tenants__id__completion_models__completion_model_id___post"];
     delete?: never;
     options?: never;
@@ -6141,7 +6161,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Enable Embedding Model */
+    /**
+     * Enable Embedding Model
+     * @description Enable or disable an embedding model for a specific tenant.
+     */
     post: operations["enable_embedding_model_api_v1_sysadmin_tenants__id__embedding_models__embedding_model_id___post"];
     delete?: never;
     options?: never;
@@ -6156,10 +6179,16 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Origins */
+    /**
+     * Get Origins
+     * @description List allowed CORS origins, optionally filtered by tenant.
+     */
     get: operations["get_origins_api_v1_sysadmin_allowed_origins__get"];
     put?: never;
-    /** Add Origin */
+    /**
+     * Add Origin
+     * @description Add an allowed CORS origin for a tenant.
+     */
     post: operations["add_origin_api_v1_sysadmin_allowed_origins__post"];
     delete?: never;
     options?: never;
@@ -6177,7 +6206,10 @@ export interface paths {
     get?: never;
     put?: never;
     post?: never;
-    /** Delete Origin */
+    /**
+     * Delete Origin
+     * @description Delete an allowed CORS origin by id (idempotent).
+     */
     delete: operations["delete_origin_api_v1_sysadmin_allowed_origins__id___delete"];
     options?: never;
     head?: never;
@@ -6196,9 +6228,6 @@ export interface paths {
     /**
      * Recalculate Tenant Usage Statistics
      * @description Recalculate usage statistics for a specific tenant.
-     *
-     *     This endpoint is intended for tenant-specific administrative operations,
-     *     such as fixing usage statistics for a particular tenant.
      */
     post: operations["recalculate_tenant_usage_statistics_api_v1_sysadmin_tenants__tenant_id__usage_stats_recalculate_post"];
     delete?: never;
@@ -6219,9 +6248,6 @@ export interface paths {
     /**
      * Recalculate All Tenants Usage Statistics
      * @description Recalculate usage statistics for all active tenants.
-     *
-     *     This endpoint is intended for system-wide administrative operations,
-     *     such as bulk recalculation of usage statistics across all tenants.
      */
     post: operations["recalculate_all_tenants_usage_statistics_api_v1_sysadmin_system_usage_stats_recalculate_all_post"];
     delete?: never;
@@ -6241,18 +6267,7 @@ export interface paths {
     put?: never;
     /**
      * Migrate Completion Model For Tenant
-     * @description Migrate completion model usage for a specific tenant.
-     *
-     *     This endpoint allows system administrators to migrate all usage from one
-     *     completion model to another for a specific tenant. This is useful for:
-     *     - Migrating tenants away from deprecated models
-     *     - Consolidating model usage
-     *     - Fixing model configurations for specific tenants
-     *
-     *     Args:
-     *         tenant_id: UUID of the tenant to migrate
-     *         model_id: UUID of the source model to migrate from
-     *         migration_request: Details of the migration (target model, entity types, etc.)
+     * @description Migrate completion model usage from one model to another for a specific tenant.
      */
     post: operations["migrate_completion_model_for_tenant_api_v1_sysadmin_tenants__tenant_id__completion_models__model_id__migrate_post"];
     delete?: never;
@@ -6272,17 +6287,7 @@ export interface paths {
     put?: never;
     /**
      * Migrate Completion Model For All Tenants
-     * @description Migrate completion model usage for all active tenants.
-     *
-     *     This endpoint allows system administrators to migrate all usage from one
-     *     completion model to another across all active tenants. This is useful for:
-     *     - Deprecating models system-wide
-     *     - Migrating to newer model versions
-     *     - Consolidating model usage across the entire system
-     *
-     *     Args:
-     *         model_id: UUID of the source model to migrate from
-     *         migration_request: Details of the migration (target model, entity types, etc.)
+     * @description Migrate completion model usage from one model to another across all active tenants.
      */
     post: operations["migrate_completion_model_for_all_tenants_api_v1_sysadmin_system_completion_models__model_id__migrate_all_tenants_post"];
     delete?: never;
@@ -6302,12 +6307,7 @@ export interface paths {
     put?: never;
     /**
      * Create Completion Model
-     * @description Create a new completion model (system-wide operation).
-     *
-     *     Requires: X-API-Key header with ENEO_SUPER_API_KEY
-     *
-     *     This creates the model metadata only. To enable it for a tenant,
-     *     use POST /api/v1/completion-models/{id}/ with tenant credentials.
+     * @description Create global completion model metadata (system-wide operation).
      */
     post: operations["create_completion_model_api_v1_sysadmin_completion_models_create_post"];
     delete?: never;
@@ -6326,11 +6326,7 @@ export interface paths {
     get?: never;
     /**
      * Update Completion Model Metadata
-     * @description Update completion model metadata (system-wide operation).
-     *
-     *     Requires: X-API-Key header with ENEO_SUPER_API_KEY
-     *
-     *     Updates global model metadata. Does not affect tenant-specific settings.
+     * @description Update global completion model metadata (system-wide operation).
      */
     put: operations["update_completion_model_metadata_api_v1_sysadmin_completion_models__id__metadata_put"];
     post?: never;
@@ -6352,12 +6348,7 @@ export interface paths {
     post?: never;
     /**
      * Delete Completion Model
-     * @description Soft-delete a completion model (system-wide operation).
-     *
-     *     Requires: X-API-Key header with ENEO_SUPER_API_KEY
-     *
-     *     WARNING: Affects all tenants. Use with caution.
-     *     Set force=true to hard-delete (may break references).
+     * @description Soft-delete global completion model metadata (system-wide operation).
      */
     delete: operations["delete_completion_model_api_v1_sysadmin_completion_models__id__delete"];
     options?: never;
@@ -6376,12 +6367,7 @@ export interface paths {
     put?: never;
     /**
      * Create Embedding Model
-     * @description Create a new embedding model (system-wide operation).
-     *
-     *     Requires: X-API-Key header with ENEO_SUPER_API_KEY
-     *
-     *     This creates the model metadata only. To enable it for a tenant,
-     *     use POST /api/v1/embedding-models/{id}/ with tenant credentials.
+     * @description Create global embedding model metadata (system-wide operation).
      */
     post: operations["create_embedding_model_api_v1_sysadmin_embedding_models_create_post"];
     delete?: never;
@@ -6400,11 +6386,7 @@ export interface paths {
     get?: never;
     /**
      * Update Embedding Model Metadata
-     * @description Update embedding model metadata (system-wide operation).
-     *
-     *     Requires: X-API-Key header with ENEO_SUPER_API_KEY
-     *
-     *     Updates global model metadata. Does not affect tenant-specific settings.
+     * @description Update global embedding model metadata (system-wide operation).
      */
     put: operations["update_embedding_model_metadata_api_v1_sysadmin_embedding_models__id__metadata_put"];
     post?: never;
@@ -6426,12 +6408,7 @@ export interface paths {
     post?: never;
     /**
      * Delete Embedding Model
-     * @description Delete an embedding model (system-wide operation).
-     *
-     *     Requires: X-API-Key header with ENEO_SUPER_API_KEY
-     *
-     *     WARNING: Deletion affects all tenants. Use with caution.
-     *     Set force=true to hard-delete (may erase historical info_blob attribution).
+     * @description Soft-delete global embedding model metadata (system-wide operation).
      */
     delete: operations["delete_embedding_model_api_v1_sysadmin_embedding_models__id__delete"];
     options?: never;
@@ -34459,6 +34436,15 @@ export interface operations {
           "application/json": components["schemas"]["UserInDB"];
         };
       };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -34494,6 +34480,15 @@ export interface operations {
           "application/json": components["schemas"]["UserInDB"];
         };
       };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -34523,6 +34518,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["DeleteResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -34480,6 +34480,15 @@ export interface operations {
           "application/json": components["schemas"]["UserInDB"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -34518,6 +34527,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["DeleteResponse"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -34635,6 +34653,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["TenantWithMaskedCredentials"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -34887,6 +34914,15 @@ export interface operations {
           "application/json": components["schemas"]["CompletionModelPublic"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -34930,6 +34966,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["EmbeddingModelPublicLegacy"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -35083,6 +35128,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
     };


### PR DESCRIPTION
## What

Third phased slice of the repo-wide route-metadata debt (after #473, #474). Backfills OpenAPI metadata on the **27 routes** flagged by `scripts/check_route_metadata.py` in `sysadmin/sysadmin_router.py`.

For each flagged decorator: added the missing `description=`, `responses=` (actual error codes), and `response_model=` where missing — from each handler's `-> Type` return annotation, or `response_model=None` for handlers returning a raw token / plain success dict.

## Scope / safety

- **Pure metadata — no behaviour or response-model contract changes.** `response_model` additions mirror existing return annotations; `status_code` and `include_in_schema` left untouched (the hidden `/users/{id}/access-token/` route stays hidden).
- Error-code conventions follow existing sibling routes: lookups `[404]`, permission/superuser-gated mutations keep their `[403]`/`[400]`, plain admin lists `[]`. Pre-existing `responses` lists were left as-is.
- `schema.d.ts` regenerated via the same pipeline the pre-push hook uses.

## Verification

- `scripts/check_route_metadata.py` — clean
- `ruff check` / `ruff format --check` — clean
- `pyright` — 0 errors
- `app.openapi()` generates successfully; `schema.d.ts` in sync

## Note

A few pre-existing `responses` lists are narrower than the handler's real error paths (e.g. usage-stats routes can raise 500 but list only `[404]`). Left untouched here to keep this a pure metadata-completeness pass; can be tightened separately.

## Follow-up

Remaining ~172 non-compliant routes stay ratchet-tracked, continuing area-by-area.