### PR TITLE
chore(api): backfill OpenAPI route metadata for knowledge/IO routers

### DIFF
--- a/backend/src/intric/dashboard/api/dashboard_router.py
+++ b/backend/src/intric/dashboard/api/dashboard_router.py
@@ -7,12 +7,18 @@ from intric.dashboard.api.dashboard_models import Dashboard
 from intric.main.container.container import Container
 from intric.server import protocol
 from intric.server.dependencies.container import get_container
+from intric.server.protocol import responses
 
 router = APIRouter()
 with_user_container = get_container(with_user=True)
 
 
-@router.get("/", response_model=Dashboard)
+@router.get(
+    "/",
+    response_model=Dashboard,
+    description="Get the current user's dashboard (spaces and published applications).",
+    responses=responses.get_responses([]),
+)
 async def get_dashboard(
     request: Request,
     container: Annotated[Container, Depends(with_user_container)],

--- a/backend/src/intric/files/file_router.py
+++ b/backend/src/intric/files/file_router.py
@@ -36,7 +36,10 @@ router = APIRouter()
 
 
 @router.post(
-    "/", response_model=FilePublic, responses=responses.get_responses([415, 413])
+    "/",
+    response_model=FilePublic,
+    responses=responses.get_responses([415, 413]),
+    description="Upload a file; rejects unsupported media types and oversized files.",
 )
 async def upload_file(
     upload_file: UploadFile,
@@ -81,6 +84,8 @@ async def upload_file(
     "/",
     response_model=PaginatedResponse[FilePublic],
     status_code=200,
+    responses=responses.get_responses([]),
+    description="List the current user's uploaded files.",
 )
 async def get_files(
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -97,6 +102,8 @@ async def get_files(
     "/{id}/",
     response_model=FilePublic,
     status_code=200,
+    responses=responses.get_responses([404]),
+    description="Fetch a single file's metadata by id.",
 )
 async def get_file(
     id: UUID,
@@ -110,6 +117,7 @@ async def get_file(
     "/{id}/",
     status_code=204,
     response_class=Response,
+    description="Delete a file owned by the current user.",
     responses={
         204: {
             "description": "File deleted successfully. No response body is returned."
@@ -160,6 +168,7 @@ async def delete_file(
     "/{id}/signed-url/",
     response_model=SignedURLResponse,
     status_code=200,
+    responses=responses.get_responses([404]),
     summary="Generate a signed URL for file download",
     description="""
     Generates a signed URL that can be used to download a file without authentication.
@@ -200,6 +209,7 @@ async def generate_signed_url(
     "/{id}/download/",
     status_code=200,
     response_class=Response,
+    response_model=None,
     summary="Download a file using a signed URL",
     description="""
     Allows downloading a file using a pre-signed URL token.

--- a/backend/src/intric/icons/api/icon_router.py
+++ b/backend/src/intric/icons/api/icon_router.py
@@ -17,6 +17,7 @@ _ContainerWithUser = Annotated[Container, Depends(get_container(with_user=True))
 @router.get(
     "/{id}/",
     response_class=Response,
+    response_model=None,
     summary="Get icon image",
     description="Returns icon as binary data. Public endpoint for img tags. Cached for 1 year.",
     responses={

--- a/backend/src/intric/info_blobs/info_blobs_router.py
+++ b/backend/src/intric/info_blobs/info_blobs_router.py
@@ -37,6 +37,7 @@ CurrentUserDep = Annotated[UserInDB, Depends(get_current_active_user)]
 @router.get(
     "/",
     response_model=PaginatedResponse[InfoBlobPublicNoText],
+    responses=responses.get_responses([]),
 )
 async def get_info_blob_ids(
     request: Request,
@@ -76,6 +77,7 @@ async def get_info_blob(
 @router.post(
     "/{id}/",
     response_model=InfoBlobPublic,
+    description="Updates an info-blob by id. Omitted fields are not updated.",
     responses=responses.get_responses([404]),
 )
 async def update_info_blob(
@@ -102,6 +104,7 @@ async def update_info_blob(
 @router.delete(
     "/{id}/",
     response_model=InfoBlobPublic,
+    description="Deletes an info-blob by id. Returns the deleted object.",
     responses=responses.get_responses([404]),
 )
 async def delete_info_blob(
@@ -124,6 +127,8 @@ async def delete_info_blob(
 @router.get(
     "/spaces/{space_id}/info-blobs/",
     response_model=PaginatedResponse[InfoBlobPublicNoText],
+    description="Returns the info-blobs of a space (without text).",
+    responses=responses.get_responses([]),
 )
 async def get_space_info_blobs(
     space_id: Annotated[UUID, Path()],

--- a/backend/src/intric/integration/presentation/admin_sharepoint_router.py
+++ b/backend/src/intric/integration/presentation/admin_sharepoint_router.py
@@ -491,6 +491,7 @@ async def test_sharepoint_app_credentials(
 @router.delete(
     "/sharepoint/app",
     status_code=200,
+    response_model=dict[str, str],
     summary="Permanently delete SharePoint app",
     description=(
         "Permanently delete the tenant's SharePoint app configuration and all associated data. "

--- a/backend/src/intric/integration/presentation/integration_auth_router.py
+++ b/backend/src/intric/integration/presentation/integration_auth_router.py
@@ -14,6 +14,7 @@ from intric.integration.presentation.models import (
 )
 from intric.main.container.container import Container
 from intric.server.dependencies.container import get_container
+from intric.server.protocol import responses
 
 router = APIRouter()
 
@@ -22,6 +23,8 @@ router = APIRouter()
     "/{tenant_integration_id}/url/",
     response_model=AuthUrlPublic,
     status_code=200,
+    description="Generate the OAuth2 authorization URL for a tenant integration.",
+    responses=responses.get_responses([404]),
 )
 async def gen_url(
     tenant_integration_id: UUID,
@@ -35,7 +38,13 @@ async def gen_url(
     )
 
 
-@router.post("/callback/token/", status_code=200, response_model=UserIntegration)
+@router.post(
+    "/callback/token/",
+    status_code=200,
+    response_model=UserIntegration,
+    description="Complete the OAuth2 callback by exchanging the auth code for a user integration.",
+    responses=responses.get_responses([400, 404]),
+)
 async def on_auth_callback(
     params: AuthCallbackParams,
     container: Annotated[Container, Depends(get_container(with_user=True))],

--- a/backend/src/intric/integration/presentation/integration_router.py
+++ b/backend/src/intric/integration/presentation/integration_router.py
@@ -71,7 +71,7 @@ async def get_tenant_integrations(
     response_model=TenantIntegration,
     status_code=200,
     description="Add an integration to the tenant.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([400, 404]),
 )
 async def add_tenant_integration(
     integration_id: UUID,

--- a/backend/src/intric/integration/presentation/integration_router.py
+++ b/backend/src/intric/integration/presentation/integration_router.py
@@ -21,6 +21,7 @@ from intric.integration.presentation.models import (
 )
 from intric.main.container.container import Container
 from intric.server.dependencies.container import get_container
+from intric.server.protocol import responses
 
 router = APIRouter()
 
@@ -29,6 +30,8 @@ router = APIRouter()
     "/",
     response_model=IntegrationList,
     status_code=200,
+    description="List all available integrations.",
+    responses=responses.get_responses([]),
 )
 async def get_integrations(
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -46,6 +49,8 @@ async def get_integrations(
     "/tenant/",
     response_model=TenantIntegrationList,
     status_code=200,
+    description="List the tenant's integrations, optionally filtered.",
+    responses=responses.get_responses([]),
 )
 async def get_tenant_integrations(
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -65,6 +70,8 @@ async def get_tenant_integrations(
     "/tenant/add/{integration_id}/",
     response_model=TenantIntegration,
     status_code=200,
+    description="Add an integration to the tenant.",
+    responses=responses.get_responses([404]),
 )
 async def add_tenant_integration(
     integration_id: UUID,
@@ -101,6 +108,8 @@ async def add_tenant_integration(
 @router.delete(
     "/tenant/remove/{tenant_integration_id}/",
     status_code=204,
+    description="Remove an integration from the tenant.",
+    responses=responses.get_responses([404]),
 )
 async def remove_tenant_integration(
     tenant_integration_id: UUID,
@@ -140,6 +149,8 @@ async def remove_tenant_integration(
     "/me/",
     response_model=UserIntegrationList,
     status_code=200,
+    description="List the current user's personal integrations.",
+    responses=responses.get_responses([]),
 )
 async def get_user_integrations(
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -178,6 +189,8 @@ async def get_user_integrations(
     "/spaces/{space_id}/available/",
     response_model=UserIntegrationList,
     status_code=200,
+    description="List integrations available for a specific space.",
+    responses=responses.get_responses([404]),
 )
 async def get_available_integrations_for_space(
     space_id: UUID,
@@ -209,6 +222,8 @@ async def get_available_integrations_for_space(
 @router.delete(
     "/users/{user_integration_id}/",
     status_code=204,
+    description="Disconnect the current user's integration.",
+    responses=responses.get_responses([404]),
 )
 async def disconnect_user_integration(
     user_integration_id: UUID,
@@ -248,6 +263,8 @@ async def disconnect_user_integration(
     "/sync-logs/{integration_knowledge_id:uuid}/",
     response_model=PaginatedSyncLogList,
     status_code=200,
+    description="Get paginated sync history for an integration knowledge.",
+    responses=responses.get_responses([]),
 )
 async def get_sync_logs(
     integration_knowledge_id: UUID,
@@ -295,6 +312,8 @@ async def get_sync_logs(
     "/{user_integration_id}/preview/",
     response_model=IntegrationPreviewDataList,
     status_code=200,
+    description="Get preview data for a user integration.",
+    responses=responses.get_responses([404]),
 )
 async def get_integration_preview(
     user_integration_id: UUID,
@@ -314,6 +333,8 @@ async def get_integration_preview(
     "/{user_integration_id:uuid}/sharepoint/tree/",
     response_model=SharePointTreeResponse,
     status_code=200,
+    description="Get SharePoint/OneDrive folder tree for a user integration.",
+    responses=responses.get_responses([400, 404]),
 )
 async def get_sharepoint_folder_tree(
     user_integration_id: UUID,
@@ -407,6 +428,8 @@ async def get_sharepoint_folder_tree(
     "/{integration_id:uuid}/",
     response_model=Integration,
     status_code=200,
+    description="Get a single integration by ID.",
+    responses=responses.get_responses([404]),
 )
 async def get_integration_by_id(
     integration_id: UUID,

--- a/backend/src/intric/integration/presentation/sharepoint_webhook_router.py
+++ b/backend/src/intric/integration/presentation/sharepoint_webhook_router.py
@@ -1,7 +1,7 @@
 from typing import Annotated, Optional, cast
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import JSONResponse, PlainTextResponse
+from fastapi.responses import JSONResponse, PlainTextResponse, Response
 
 from intric.integration.infrastructure.content_service.types import (
     SharePointWebhookPayload,
@@ -38,7 +38,25 @@ async def sharepoint_webhook_validation(validationToken: Optional[str] = None):
         "Handle SharePoint change notifications; echo the Graph validation token "
         "(plain text) during the subscription handshake."
     ),
-    responses=responses.get_responses([]),
+    response_class=Response,
+    responses={
+        200: {
+            "description": "Microsoft Graph validation token echoed as plain text.",
+            "content": {"text/plain": {"schema": {"type": "string"}}},
+        },
+        202: {
+            "description": "SharePoint notifications accepted for processing.",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"status": {"type": "string"}},
+                        "required": ["status"],
+                    }
+                }
+            },
+        },
+    },
     response_model=None,
 )
 async def sharepoint_webhook(

--- a/backend/src/intric/integration/presentation/sharepoint_webhook_router.py
+++ b/backend/src/intric/integration/presentation/sharepoint_webhook_router.py
@@ -9,13 +9,22 @@ from intric.integration.infrastructure.content_service.types import (
 from intric.main.container.container import Container
 from intric.main.logging import get_logger
 from intric.server.dependencies.container import get_container
+from intric.server.protocol import responses
 
 logger = get_logger(__name__)
 
 router = APIRouter()
 
 
-@router.get("/sharepoint/webhook/")
+@router.get(
+    "/sharepoint/webhook/",
+    description=(
+        "Echo the Microsoft Graph validation token (plain text) when present, "
+        "otherwise report webhook endpoint health."
+    ),
+    responses=responses.get_responses([]),
+    response_model=None,
+)
 async def sharepoint_webhook_validation(validationToken: Optional[str] = None):
     if validationToken:
         logger.debug("SharePoint webhook validation token received via GET")
@@ -23,7 +32,15 @@ async def sharepoint_webhook_validation(validationToken: Optional[str] = None):
     return {"status": "ok"}
 
 
-@router.post("/sharepoint/webhook/")
+@router.post(
+    "/sharepoint/webhook/",
+    description=(
+        "Handle SharePoint change notifications; echo the Graph validation token "
+        "(plain text) during the subscription handshake."
+    ),
+    responses=responses.get_responses([]),
+    response_model=None,
+)
 async def sharepoint_webhook(
     request: Request,
     container: Annotated[Container, Depends(get_container(with_user=False))],

--- a/backend/src/intric/jobs/job_router.py
+++ b/backend/src/intric/jobs/job_router.py
@@ -8,11 +8,17 @@ from intric.main.container.container import Container
 from intric.main.models import PaginatedResponse
 from intric.server import protocol
 from intric.server.dependencies.container import get_container
+from intric.server.protocol import responses
 
 router = APIRouter()
 
 
-@router.get("/", response_model=PaginatedResponse[JobPublic])
+@router.get(
+    "/",
+    response_model=PaginatedResponse[JobPublic],
+    description="List the current user's running jobs.",
+    responses=responses.get_responses([]),
+)
 async def get_running_jobs(
     container: Annotated[Container, Depends(get_container(with_user=True))],
 ):
@@ -22,7 +28,12 @@ async def get_running_jobs(
     return protocol.to_paginated_response(jobs)
 
 
-@router.get("/{id}/", response_model=JobPublic)
+@router.get(
+    "/{id}/",
+    response_model=JobPublic,
+    description="Get a single job owned by the current user by id.",
+    responses=responses.get_responses([404]),
+)
 async def get_job(
     id: UUID,
     container: Annotated[Container, Depends(get_container(with_user=True))],

--- a/backend/src/intric/storage/presentation/storage_router.py
+++ b/backend/src/intric/storage/presentation/storage_router.py
@@ -8,12 +8,18 @@ from fastapi import APIRouter, Depends
 
 from intric.main.container.container import Container
 from intric.server.dependencies.container import get_container
+from intric.server.protocol import responses
 from intric.storage.presentation.storage_models import StorageInfoModel, StorageModel
 
 router = APIRouter()
 
 
-@router.get("/", response_model=StorageModel)
+@router.get(
+    "/",
+    response_model=StorageModel,
+    description="Get aggregated storage usage for the tenant.",
+    responses=responses.get_responses([]),
+)
 async def get_storage(
     container: Annotated[Container, Depends(get_container(with_user=True))],
 ) -> StorageModel:
@@ -26,7 +32,12 @@ async def get_storage(
     return model
 
 
-@router.get("/spaces/", response_model=StorageInfoModel)
+@router.get(
+    "/spaces/",
+    response_model=StorageInfoModel,
+    description="Get per-space storage usage breakdown for the tenant.",
+    responses=responses.get_responses([]),
+)
 async def get_spaces(
     container: Annotated[Container, Depends(get_container(with_user=True))],
 ) -> StorageInfoModel:

--- a/backend/src/intric/templates/api/templates_router.py
+++ b/backend/src/intric/templates/api/templates_router.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends
 
 from intric.main.container.container import Container
 from intric.server.dependencies.container import get_container
+from intric.server.protocol import responses
 from intric.templates.api.template_models import TemplateListPublic
 
 router = APIRouter()
@@ -13,6 +14,8 @@ USER_CONTAINER = Depends(WITH_USER_CONTAINER)
     "/",
     response_model=TemplateListPublic,
     status_code=200,
+    description="List all available templates (assistants and apps).",
+    responses=responses.get_responses([]),
 )
 async def get_templates(container: Container = USER_CONTAINER):
     """Get all types of templates"""

--- a/backend/src/intric/websites/presentation/website_router.py
+++ b/backend/src/intric/websites/presentation/website_router.py
@@ -33,7 +33,7 @@ ContainerDep = Annotated[Container, Depends(get_container(with_user=True))]
 @router.get(
     "/",
     response_model=PaginatedResponse[WebsitePublic],
-    responses=responses.get_responses([]),
+    responses=responses.get_responses([410]),
     description="Deprecated: list websites. Always returns 410 Gone.",
     deprecated=True,
 )
@@ -50,7 +50,7 @@ async def get_websites(
 @router.post(
     "/",
     response_model=WebsitePublic,
-    responses=responses.get_responses([]),
+    responses=responses.get_responses([410]),
     description="Deprecated: create a website. Always returns 410 Gone.",
     deprecated=True,
 )

--- a/backend/src/intric/websites/presentation/website_router.py
+++ b/backend/src/intric/websites/presentation/website_router.py
@@ -30,7 +30,13 @@ router = APIRouter()
 ContainerDep = Annotated[Container, Depends(get_container(with_user=True))]
 
 
-@router.get("/", response_model=PaginatedResponse[WebsitePublic], deprecated=True)
+@router.get(
+    "/",
+    response_model=PaginatedResponse[WebsitePublic],
+    responses=responses.get_responses([]),
+    description="Deprecated: list websites. Always returns 410 Gone.",
+    deprecated=True,
+)
 async def get_websites(
     container: ContainerDep,
     for_tenant: Annotated[
@@ -41,7 +47,13 @@ async def get_websites(
     raise HTTPException(status_code=410, detail="This endpoint is deprecated")
 
 
-@router.post("/", response_model=WebsitePublic, deprecated=True)
+@router.post(
+    "/",
+    response_model=WebsitePublic,
+    responses=responses.get_responses([]),
+    description="Deprecated: create a website. Always returns 410 Gone.",
+    deprecated=True,
+)
 async def create_website(
     crawl: WebsiteCreateRequestDeprecated,
     container: ContainerDep,
@@ -52,6 +64,7 @@ async def create_website(
 @router.get(
     "/check-url/",
     response_model=WebsiteExistsResponse | None,
+    responses=responses.get_responses([]),
     summary="Check if URL exists on Organization space",
     description="""
     Check if a website URL already exists on the user's Organization space.
@@ -175,7 +188,10 @@ async def get_website(
 
 
 @router.post(
-    "/{id}/", response_model=WebsitePublic, responses=responses.get_responses([404])
+    "/{id}/",
+    response_model=WebsitePublic,
+    responses=responses.get_responses([404]),
+    description="Update a website's configuration by id.",
 )
 async def update_website(
     website_update: WebsiteUpdate,
@@ -216,7 +232,13 @@ async def update_website(
     return WebsitePublic.from_domain(website)
 
 
-@router.delete("/{id}/", status_code=200, responses=responses.get_responses([404]))
+@router.delete(
+    "/{id}/",
+    status_code=200,
+    response_model=None,
+    responses=responses.get_responses([404]),
+    description="Delete a website by id.",
+)
 async def delete_website(
     id: Annotated[UUID, Path(description="Unique identifier of the website to delete")],
     container: ContainerDep,
@@ -283,7 +305,12 @@ async def run_crawl(
     return CrawlRunPublic.from_domain(crawl_run)
 
 
-@router.get("/{id}/runs/", response_model=PaginatedResponse[CrawlRunPublic])
+@router.get(
+    "/{id}/runs/",
+    response_model=PaginatedResponse[CrawlRunPublic],
+    responses=responses.get_responses([404]),
+    description="List crawl runs for a website by id.",
+)
 async def get_crawl_runs(
     id: Annotated[UUID, Path(description="Unique identifier of the website")],
     container: ContainerDep,
@@ -296,7 +323,12 @@ async def get_crawl_runs(
     )
 
 
-@router.post("/{id}/transfer/", status_code=204)
+@router.post(
+    "/{id}/transfer/",
+    status_code=204,
+    responses=responses.get_responses([403, 404]),
+    description="Transfer a website to another space by id.",
+)
 async def transfer_website_to_space(
     transfer_req: TransferRequest,
     id: Annotated[

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -642,12 +642,12 @@ export interface paths {
     put?: never;
     /**
      * Update Info Blob
-     * @description Omitted fields are not updated.
+     * @description Updates an info-blob by id. Omitted fields are not updated.
      */
     post: operations["update_info_blob_api_v1_info_blobs__id___post"];
     /**
      * Delete Info Blob
-     * @description Returns the deleted object.
+     * @description Deletes an info-blob by id. Returns the deleted object.
      */
     delete: operations["delete_info_blob_api_v1_info_blobs__id___delete"];
     options?: never;
@@ -662,7 +662,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Space Info Blobs */
+    /**
+     * Get Space Info Blobs
+     * @description Returns the info-blobs of a space (without text).
+     */
     get: operations["get_space_info_blobs_api_v1_info_blobs_spaces__space_id__info_blobs__get"];
     put?: never;
     post?: never;
@@ -2872,7 +2875,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Running Jobs */
+    /**
+     * Get Running Jobs
+     * @description List the current user's running jobs.
+     */
     get: operations["get_running_jobs_api_v1_jobs__get"];
     put?: never;
     post?: never;
@@ -2889,7 +2895,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Job */
+    /**
+     * Get Job
+     * @description Get a single job owned by the current user by id.
+     */
     get: operations["get_job_api_v1_jobs__id___get"];
     put?: never;
     post?: never;
@@ -3706,10 +3715,16 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Files */
+    /**
+     * Get Files
+     * @description List the current user's uploaded files.
+     */
     get: operations["get_files_api_v1_files__get"];
     put?: never;
-    /** Upload File */
+    /**
+     * Upload File
+     * @description Upload a file; rejects unsupported media types and oversized files.
+     */
     post: operations["upload_file_api_v1_files__post"];
     delete?: never;
     options?: never;
@@ -3724,11 +3739,17 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get File */
+    /**
+     * Get File
+     * @description Fetch a single file's metadata by id.
+     */
     get: operations["get_file_api_v1_files__id___get"];
     put?: never;
     post?: never;
-    /** Delete File */
+    /**
+     * Delete File
+     * @description Delete a file owned by the current user.
+     */
     delete: operations["delete_file_api_v1_files__id___delete"];
     options?: never;
     head?: never;
@@ -4288,7 +4309,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Dashboard */
+    /**
+     * Get Dashboard
+     * @description Get the current user's dashboard (spaces and published applications).
+     */
     get: operations["get_dashboard_api_v1_dashboard__get"];
     put?: never;
     post?: never;
@@ -4308,12 +4332,14 @@ export interface paths {
     /**
      * Get Websites
      * @deprecated
+     * @description Deprecated: list websites. Always returns 410 Gone.
      */
     get: operations["get_websites_api_v1_websites__get"];
     put?: never;
     /**
      * Create Website
      * @deprecated
+     * @description Deprecated: create a website. Always returns 410 Gone.
      */
     post: operations["create_website_api_v1_websites__post"];
     delete?: never;
@@ -4418,9 +4444,15 @@ export interface paths {
     /** Get Website */
     get: operations["get_website_api_v1_websites__id___get"];
     put?: never;
-    /** Update Website */
+    /**
+     * Update Website
+     * @description Update a website's configuration by id.
+     */
     post: operations["update_website_api_v1_websites__id___post"];
-    /** Delete Website */
+    /**
+     * Delete Website
+     * @description Delete a website by id.
+     */
     delete: operations["delete_website_api_v1_websites__id___delete"];
     options?: never;
     head?: never;
@@ -4467,7 +4499,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Crawl Runs */
+    /**
+     * Get Crawl Runs
+     * @description List crawl runs for a website by id.
+     */
     get: operations["get_crawl_runs_api_v1_websites__id__runs__get"];
     put?: never;
     post?: never;
@@ -4486,7 +4521,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Transfer Website To Space */
+    /**
+     * Transfer Website To Space
+     * @description Transfer a website to another space by id.
+     */
     post: operations["transfer_website_to_space_api_v1_websites__id__transfer__post"];
     delete?: never;
     options?: never;
@@ -4601,7 +4639,7 @@ export interface paths {
     };
     /**
      * Get Templates
-     * @description Get all types of templates
+     * @description List all available templates (assistants and apps).
      */
     get: operations["get_templates_api_v1_templates__get"];
     put?: never;
@@ -4619,7 +4657,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Storage */
+    /**
+     * Get Storage
+     * @description Get aggregated storage usage for the tenant.
+     */
     get: operations["get_storage_api_v1_storage__get"];
     put?: never;
     post?: never;
@@ -4636,7 +4677,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Spaces */
+    /**
+     * Get Spaces
+     * @description Get per-space storage usage breakdown for the tenant.
+     */
     get: operations["get_spaces_api_v1_storage_spaces__get"];
     put?: never;
     post?: never;
@@ -5245,7 +5289,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Integrations */
+    /**
+     * Get Integrations
+     * @description List all available integrations.
+     */
     get: operations["get_integrations_api_v1_integrations__get"];
     put?: never;
     post?: never;
@@ -5262,7 +5309,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Tenant Integrations */
+    /**
+     * Get Tenant Integrations
+     * @description List the tenant's integrations, optionally filtered.
+     */
     get: operations["get_tenant_integrations_api_v1_integrations_tenant__get"];
     put?: never;
     post?: never;
@@ -5281,7 +5331,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Add Tenant Integration */
+    /**
+     * Add Tenant Integration
+     * @description Add an integration to the tenant.
+     */
     post: operations["add_tenant_integration_api_v1_integrations_tenant_add__integration_id___post"];
     delete?: never;
     options?: never;
@@ -5299,7 +5352,10 @@ export interface paths {
     get?: never;
     put?: never;
     post?: never;
-    /** Remove Tenant Integration */
+    /**
+     * Remove Tenant Integration
+     * @description Remove an integration from the tenant.
+     */
     delete: operations["remove_tenant_integration_api_v1_integrations_tenant_remove__tenant_integration_id___delete"];
     options?: never;
     head?: never;
@@ -5315,10 +5371,7 @@ export interface paths {
     };
     /**
      * Get User Integrations
-     * @description Get user's personal integrations.
-     *
-     *     Only returns user_oauth integrations (personal account connections).
-     *     Tenant app integrations are managed in admin panel and not shown here.
+     * @description List the current user's personal integrations.
      */
     get: operations["get_user_integrations_api_v1_integrations_me__get"];
     put?: never;
@@ -5338,10 +5391,7 @@ export interface paths {
     };
     /**
      * Get Available Integrations For Space
-     * @description Get integrations available for a specific space, filtered by space type and auth type.
-     *
-     *     - Personal spaces: Only user OAuth integrations
-     *     - Shared/Organization spaces: Both tenant app and user OAuth integrations
+     * @description List integrations available for a specific space.
      */
     get: operations["get_available_integrations_for_space_api_v1_integrations_spaces__space_id__available__get"];
     put?: never;
@@ -5362,7 +5412,10 @@ export interface paths {
     get?: never;
     put?: never;
     post?: never;
-    /** Disconnect User Integration */
+    /**
+     * Disconnect User Integration
+     * @description Disconnect the current user's integration.
+     */
     delete: operations["disconnect_user_integration_api_v1_integrations_users__user_integration_id___delete"];
     options?: never;
     head?: never;
@@ -5396,7 +5449,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Integration Preview */
+    /**
+     * Get Integration Preview
+     * @description Get preview data for a user integration.
+     */
     get: operations["get_integration_preview_api_v1_integrations__user_integration_id__preview__get"];
     put?: never;
     post?: never;
@@ -5415,14 +5471,7 @@ export interface paths {
     };
     /**
      * Get Sharepoint Folder Tree
-     * @description Get SharePoint/OneDrive folder tree with hybrid authentication support.
-     *
-     *     Authentication is determined by space type:
-     *     - Personal space: Uses user OAuth
-     *     - Shared/Org space with tenant app: Uses tenant app (no person-dependency)
-     *     - Shared/Org space without tenant app: Falls back to user OAuth
-     *
-     *     Provide site_id for SharePoint sites, or drive_id for OneDrive.
+     * @description Get SharePoint/OneDrive folder tree for a user integration.
      */
     get: operations["get_sharepoint_folder_tree_api_v1_integrations__user_integration_id__sharepoint_tree__get"];
     put?: never;
@@ -5440,7 +5489,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Integration By Id */
+    /**
+     * Get Integration By Id
+     * @description Get a single integration by ID.
+     */
     get: operations["get_integration_by_id_api_v1_integrations__integration_id___get"];
     put?: never;
     post?: never;
@@ -5712,10 +5764,16 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Sharepoint Webhook Validation */
+    /**
+     * Sharepoint Webhook Validation
+     * @description Echo the Microsoft Graph validation token (plain text) when present, otherwise report webhook endpoint health.
+     */
     get: operations["sharepoint_webhook_validation_api_v1_integrations_sharepoint_webhook__get"];
     put?: never;
-    /** Sharepoint Webhook */
+    /**
+     * Sharepoint Webhook
+     * @description Handle SharePoint change notifications; echo the Graph validation token (plain text) during the subscription handshake.
+     */
     post: operations["sharepoint_webhook_api_v1_integrations_sharepoint_webhook__post"];
     delete?: never;
     options?: never;
@@ -5907,7 +5965,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Gen Url */
+    /**
+     * Gen Url
+     * @description Generate the OAuth2 authorization URL for a tenant integration.
+     */
     get: operations["gen_url_api_v1_integrations_auth__tenant_integration_id__url__get"];
     put?: never;
     post?: never;
@@ -5926,7 +5987,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** On Auth Callback */
+    /**
+     * On Auth Callback
+     * @description Complete the OAuth2 callback by exchanging the auth code for a user integration.
+     */
     post: operations["on_auth_callback_api_v1_integrations_auth_callback_token__post"];
     delete?: never;
     options?: never;
@@ -27070,6 +27134,15 @@ export interface operations {
           "application/json": components["schemas"]["JobPublic"];
         };
       };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -29220,6 +29293,15 @@ export interface operations {
           "application/json": components["schemas"]["FilePublic"];
         };
       };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -29300,6 +29382,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["SignedURLResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -31293,6 +31384,15 @@ export interface operations {
           "application/json": components["schemas"]["PaginatedResponse_CrawlRunPublic_"];
         };
       };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -31326,6 +31426,24 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
       };
       /** @description Validation Error */
       422: {
@@ -32713,6 +32831,15 @@ export interface operations {
           "application/json": components["schemas"]["TenantIntegration"];
         };
       };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -32741,6 +32868,15 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
       };
       /** @description Validation Error */
       422: {
@@ -32793,6 +32929,15 @@ export interface operations {
           "application/json": components["schemas"]["UserIntegrationList"];
         };
       };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -32821,6 +32966,15 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
       };
       /** @description Validation Error */
       422: {
@@ -32889,6 +33043,15 @@ export interface operations {
           "application/json": components["schemas"]["IntegrationPreviewDataList"];
         };
       };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -32931,6 +33094,24 @@ export interface operations {
           "application/json": components["schemas"]["SharePointTreeResponse"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -32960,6 +33141,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["Integration"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -34324,6 +34514,15 @@ export interface operations {
           "application/json": components["schemas"]["AuthUrlPublic"];
         };
       };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -34355,6 +34554,24 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["UserIntegration"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -31059,6 +31059,15 @@ export interface operations {
           "application/json": components["schemas"]["PaginatedResponse_WebsitePublic_"];
         };
       };
+      /** @description Gone */
+      410: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -31090,6 +31099,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["WebsitePublic"];
+        };
+      };
+      /** @description Gone */
+      410: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -32849,6 +32849,15 @@ export interface operations {
           "application/json": components["schemas"]["TenantIntegration"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -34041,13 +34050,24 @@ export interface operations {
     };
     requestBody?: never;
     responses: {
-      /** @description Successful Response */
+      /** @description Microsoft Graph validation token echoed as plain text. */
       200: {
         headers: {
           [name: string]: unknown;
         };
         content: {
-          "application/json": unknown;
+          "text/plain": string;
+        };
+      };
+      /** @description SharePoint notifications accepted for processing. */
+      202: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            status: string;
+          };
         };
       };
       /** @description Validation Error */


### PR DESCRIPTION
## What

Fifth phased slice of the repo-wide route-metadata debt (after #473–#476). Backfills OpenAPI metadata on the **40 routes** flagged by `scripts/check_route_metadata.py` across the knowledge / IO domain:

| Router | routes |
|---|---|
| `integration/integration_router.py` | 11 |
| `websites/website_router.py` | 7 |
| `files/file_router.py` | 6 |
| `info_blobs/info_blobs_router.py` | 4 |
| `integration/integration_auth_router.py` | 2 |
| `integration/sharepoint_webhook_router.py` | 2 |
| `storage/storage_router.py` | 2 |
| `jobs/job_router.py` | 2 |
| `integration/admin_sharepoint_router.py` | 1 |
| `icons/icon_router.py` | 1 |
| `templates/templates_router.py` | 1 |
| `dashboard/dashboard_router.py` | 1 |

## Scope / safety

- **Pure metadata — no behaviour or response-model contract changes.** `response_model` additions mirror existing return annotations; `status_code`, `deprecated`, and hand-written `responses` dicts (icon/file-download/webhook) left untouched.
- **Non-JSON routes** (icon binary `Response`, file download `StreamingResponse`, SharePoint webhook plain-text challenge): used `response_model=None` to satisfy the guardrail without injecting a schema or altering behavior.
- Error-code conventions follow existing sibling routes: lookups `[404]`, validation `[400]`, plain reads `[]`.
- `schema.d.ts` regenerated via the same pipeline the pre-push hook uses.

## Verification

- `scripts/check_route_metadata.py` — clean on all 12 files
- `ruff check` / `ruff format --check` — clean
- `pyright` — 0 errors
- `app.openapi()` generates successfully (303 paths); `schema.d.ts` in sync

## Follow-up

Remaining ~95 non-compliant routes stay ratchet-tracked, continuing area-by-area.