### PR TITLE
chore(api): backfill OpenAPI route metadata for admin/config routers

### DIFF
--- a/backend/src/intric/api/audit/routes.py
+++ b/backend/src/intric/api/audit/routes.py
@@ -674,7 +674,11 @@ async def get_user_logs(
 @router.get(
     "/logs/export",
     response_model=None,
-    description="Export audit logs to CSV or JSON Lines format.",
+    description=(
+        "Export audit logs to CSV or JSON Lines format. Default limit is 50,000 "
+        "records (configurable via max_records, max 100,000); the response includes "
+        "an X-Records-Truncated header when the limit is hit."
+    ),
     responses=responses.get_responses([403, 413]),
 )
 async def export_audit_logs(
@@ -906,8 +910,12 @@ async def export_audit_logs(
 @router.post(
     "/logs/export/async",
     response_model=ExportJobResponse,
-    description="Request an async background export of audit logs and receive a job ID.",
-    responses=responses.get_responses([403, 422, 429]),
+    description=(
+        "Request an async background export of audit logs and receive a job ID. "
+        "Limited to 2 concurrent exports per tenant; generated files are "
+        "auto-deleted after 24 hours."
+    ),
+    responses=responses.get_responses([403, 429]),
 )
 async def request_async_export(
     request: ExportJobRequest,
@@ -1091,7 +1099,10 @@ async def get_export_status(
 @router.get(
     "/logs/export/{job_id}/download",
     response_model=None,
-    description="Download the completed export file for an async export job.",
+    description=(
+        "Download the completed export file for an async export job. "
+        "Files are auto-deleted after 24 hours."
+    ),
     responses=responses.get_responses([400, 403, 404]),
 )
 async def download_export(

--- a/backend/src/intric/api/audit/routes.py
+++ b/backend/src/intric/api/audit/routes.py
@@ -972,14 +972,7 @@ async def request_async_export(
         )
 
     # Validate and normalize format
-    export_format = request.format.lower().strip()
-    if export_format == "json":
-        export_format = "jsonl"  # Accept "json" as alias for "jsonl"
-    if export_format not in ["csv", "jsonl"]:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Invalid export format: '{request.format}'. Supported formats: csv, json, jsonl",
-        )
+    export_format = "jsonl" if request.format == "json" else request.format
 
     # Generate job ID
     job_id = uuid4()

--- a/backend/src/intric/api/audit/routes.py
+++ b/backend/src/intric/api/audit/routes.py
@@ -41,6 +41,7 @@ from intric.database.tables.users_table import Users
 from intric.main.config import get_settings
 from intric.main.container.container import Container
 from intric.server.dependencies.container import get_container
+from intric.server.protocol import responses
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +147,12 @@ async def _enrich_logs_with_actor_info(
     return enriched_logs
 
 
-@router.delete("/access-session/rate-limit", status_code=204)
+@router.delete(
+    "/access-session/rate-limit",
+    status_code=204,
+    description="Reset the audit session rate limit for the current user (testing only).",
+    responses=responses.get_responses([404, 503]),
+)
 async def reset_rate_limit(
     container: Annotated[Container, Depends(get_container(with_user=True))],
 ):
@@ -193,7 +199,12 @@ async def reset_rate_limit(
     return Response(status_code=204)
 
 
-@router.post("/access-session", response_model=AccessJustificationResponse)
+@router.post(
+    "/access-session",
+    response_model=AccessJustificationResponse,
+    description="Create an audit access session with justification, stored server-side.",
+    responses=responses.get_responses([400, 403, 429, 503]),
+)
 async def create_access_session(
     request: AccessJustificationRequest,
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -330,7 +341,12 @@ async def create_access_session(
     return response
 
 
-@router.get("/logs", response_model=AuditLogListResponse)
+@router.get(
+    "/logs",
+    response_model=AuditLogListResponse,
+    description="List audit logs for the authenticated user's tenant.",
+    responses=responses.get_responses([401, 403]),
+)
 async def list_audit_logs(
     request: Request,
     actions: Annotated[Optional[list[ActionType]], Depends(parse_action_list)],
@@ -552,7 +568,12 @@ async def list_audit_logs(
     return response
 
 
-@router.get("/logs/user/{user_id}", response_model=AuditLogListResponse)
+@router.get(
+    "/logs/user/{user_id}",
+    response_model=AuditLogListResponse,
+    description="Get all audit logs where the user is actor or target (GDPR Article 15 export).",
+    responses=responses.get_responses([403, 404]),
+)
 async def get_user_logs(
     user_id: Annotated[UUID, Path(..., description="User ID for GDPR export")],
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -650,7 +671,12 @@ async def get_user_logs(
     )
 
 
-@router.get("/logs/export")
+@router.get(
+    "/logs/export",
+    response_model=None,
+    description="Export audit logs to CSV or JSON Lines format.",
+    responses=responses.get_responses([403, 413]),
+)
 async def export_audit_logs(
     container: Annotated[Container, Depends(get_container(with_user=True))],
     user_id: Annotated[
@@ -877,7 +903,12 @@ async def export_audit_logs(
 # ============================================================================
 
 
-@router.post("/logs/export/async", response_model=ExportJobResponse)
+@router.post(
+    "/logs/export/async",
+    response_model=ExportJobResponse,
+    description="Request an async background export of audit logs and receive a job ID.",
+    responses=responses.get_responses([403, 422, 429]),
+)
 async def request_async_export(
     request: ExportJobRequest,
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -996,7 +1027,12 @@ async def request_async_export(
     )
 
 
-@router.get("/logs/export/{job_id}/status", response_model=ExportJobStatusResponse)
+@router.get(
+    "/logs/export/{job_id}/status",
+    response_model=ExportJobStatusResponse,
+    description="Get the status and progress of an async export job.",
+    responses=responses.get_responses([403, 404]),
+)
 async def get_export_status(
     job_id: Annotated[UUID, Path(..., description="Export job ID")],
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -1052,7 +1088,12 @@ async def get_export_status(
     )
 
 
-@router.get("/logs/export/{job_id}/download")
+@router.get(
+    "/logs/export/{job_id}/download",
+    response_model=None,
+    description="Download the completed export file for an async export job.",
+    responses=responses.get_responses([400, 403, 404]),
+)
 async def download_export(
     job_id: Annotated[UUID, Path(..., description="Export job ID")],
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -1121,7 +1162,12 @@ async def download_export(
     )
 
 
-@router.post("/logs/export/{job_id}/cancel")
+@router.post(
+    "/logs/export/{job_id}/cancel",
+    response_model=None,
+    description="Cancel an in-progress async export job.",
+    responses=responses.get_responses([400, 403, 404]),
+)
 async def cancel_export(
     job_id: Annotated[UUID, Path(..., description="Export job ID")],
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -1171,7 +1217,12 @@ async def cancel_export(
     }
 
 
-@router.get("/retention-policy", response_model=RetentionPolicyResponse)
+@router.get(
+    "/retention-policy",
+    response_model=RetentionPolicyResponse,
+    description="Get the current audit log retention policy for the tenant.",
+    responses=responses.get_responses([403]),
+)
 async def get_retention_policy(
     container: Annotated[Container, Depends(get_container(with_user=True))],
 ):
@@ -1199,7 +1250,12 @@ async def get_retention_policy(
     return RetentionPolicyResponse.model_validate(policy.model_dump())
 
 
-@router.put("/retention-policy", response_model=RetentionPolicyResponse)
+@router.put(
+    "/retention-policy",
+    response_model=RetentionPolicyResponse,
+    description="Update the audit log retention policy for the tenant.",
+    responses=responses.get_responses([403]),
+)
 async def update_retention_policy(
     request: RetentionPolicyUpdateRequest,
     container: Annotated[Container, Depends(get_container(with_user=True))],

--- a/backend/src/intric/api/audit/schemas.py
+++ b/backend/src/intric/api/audit/schemas.py
@@ -1,10 +1,10 @@
 """Pydantic schemas for audit API."""
 
 from datetime import datetime
-from typing import Optional
+from typing import Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from intric.audit.domain.action_types import ActionType
 from intric.audit.domain.actor_types import ActorType
@@ -94,10 +94,19 @@ class ExportJobRequest(BaseModel):
     action: Optional[ActionType] = Field(None, description="Filter by action type")
     from_date: Optional[datetime] = Field(None, description="Filter from date")
     to_date: Optional[datetime] = Field(None, description="Filter to date")
-    format: str = Field("csv", description="Export format: csv or jsonl")
+    format: Literal["csv", "json", "jsonl"] = Field(
+        "csv", description="Export format: csv, json, or jsonl"
+    )
     max_records: Optional[int] = Field(
         None, ge=1, description="Maximum records to export"
     )
+
+    @field_validator("format", mode="before")
+    @classmethod
+    def normalize_format(cls, value: object) -> object:
+        if isinstance(value, str):
+            return value.lower().strip()
+        return value
 
 
 class ExportJobResponse(BaseModel):

--- a/backend/src/intric/groups_legacy/api/group_router.py
+++ b/backend/src/intric/groups_legacy/api/group_router.py
@@ -50,6 +50,7 @@ router = APIRouter()
     description=(
         "Legacy groups endpoint. Use collections/spaces instead for new integrations."
     ),
+    responses=responses.get_responses([]),
 )
 async def get_groups(
     request: Request,
@@ -86,6 +87,7 @@ async def get_group_by_id(
     description=(
         "Legacy groups endpoint. Use collections/spaces instead for new integrations."
     ),
+    responses=responses.get_responses([]),
 )
 async def create_group(
     group: CreateGroupRequest,
@@ -105,6 +107,7 @@ async def create_group(
 @router.post(
     "/{id}/",
     response_model=CollectionPublic,
+    description="Update a collection (legacy group) by id.",
     responses=responses.get_responses([404]),
 )
 async def update_group(
@@ -165,6 +168,8 @@ async def update_group(
 
 @router.delete(
     "/{id}/",
+    response_model=None,
+    description="Delete a collection (legacy group) by id.",
     responses=responses.get_responses([404]),
 )
 async def delete_group_by_id(
@@ -225,6 +230,7 @@ async def delete_group_by_id(
 @router.post(
     "/{id}/info-blobs/",
     response_model=PaginatedResponse[InfoBlobPublic],
+    description="Add info-blobs to a collection (legacy group) and embed them.",
     responses=responses.get_responses([400, 404, 403, 503]),
 )
 async def add_info_blobs(
@@ -340,6 +346,7 @@ async def get_info_blobs(
     "/{id}/info-blobs/upload/",
     response_model=JobPublic,
     status_code=202,
+    description="Upload a file to a collection (legacy group); starts a processing job.",
     responses=responses.get_responses([413, 415]),
 )
 async def upload_file(
@@ -408,6 +415,8 @@ async def upload_file(
 @router.post(
     "/{id}/searches/",
     response_model=PaginatedResponse[SemanticSearchResponse],
+    description="Run a semantic search within a collection (legacy group).",
+    responses=responses.get_responses([404]),
 )
 async def run_semantic_search(
     id: UUID,
@@ -430,7 +439,12 @@ async def run_semantic_search(
     return protocol.to_paginated_response(results)
 
 
-@router.post("/{id}/transfer/", status_code=204)
+@router.post(
+    "/{id}/transfer/",
+    status_code=204,
+    description="Transfer a collection (legacy group) to another space.",
+    responses=responses.get_responses([404]),
+)
 async def transfer_group_to_space(
     id: UUID,
     transfer_req: TransferRequest,

--- a/backend/src/intric/groups_legacy/api/group_router.py
+++ b/backend/src/intric/groups_legacy/api/group_router.py
@@ -108,7 +108,7 @@ async def create_group(
     "/{id}/",
     response_model=CollectionPublic,
     description="Update a collection (legacy group) by id.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def update_group(
     id: UUID,
@@ -170,7 +170,7 @@ async def update_group(
     "/{id}/",
     response_model=None,
     description="Delete a collection (legacy group) by id.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def delete_group_by_id(
     id: UUID,
@@ -443,7 +443,7 @@ async def run_semantic_search(
     "/{id}/transfer/",
     status_code=204,
     description="Transfer a collection (legacy group) to another space.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def transfer_group_to_space(
     id: UUID,

--- a/backend/src/intric/mcp_servers/presentation/mcp_server_router.py
+++ b/backend/src/intric/mcp_servers/presentation/mcp_server_router.py
@@ -89,6 +89,7 @@ async def get_tenant_mcp_settings(
 
 @router.post(
     "/settings/{mcp_server_id}/",
+    description="Enable an MCP server for the current tenant with optional credentials.",
     response_model=MCPServerSettingsPublic,
     responses=responses.get_responses([400, 404]),
 )
@@ -125,6 +126,7 @@ async def enable_mcp_for_tenant(
 
 @router.put(
     "/settings/{mcp_server_id}/",
+    description="Update MCP server settings for the current tenant.",
     response_model=MCPServerSettingsPublic,
     responses=responses.get_responses([400, 403, 404]),
 )
@@ -147,6 +149,7 @@ async def update_mcp_settings(
 
 @router.delete(
     "/settings/{mcp_server_id}/",
+    description="Disable an MCP server for the current tenant.",
     status_code=204,
     responses=responses.get_responses([403, 404]),
 )
@@ -182,6 +185,7 @@ async def disable_mcp_for_tenant(
 
 @router.put(
     "/settings/tools/{tool_id}/",
+    description="Update tenant-level enablement for a tool (admin only).",
     response_model=MCPServerToolPublic,
     responses=responses.get_responses([403, 404]),
 )
@@ -253,6 +257,7 @@ async def get_mcp_server(
 
 @router.post(
     "/",
+    description="Create a new MCP server in global catalog (admin only).",
     response_model=MCPServerCreateResponse,
     responses=responses.get_responses([400, 403]),
 )
@@ -321,6 +326,7 @@ async def create_mcp_server(
 
 @router.post(
     "/{id}/",
+    description="Update an MCP server in global catalog (admin only).",
     response_model=MCPServerPublic,
     responses=responses.get_responses([400, 403, 404]),
 )
@@ -413,6 +419,7 @@ async def update_mcp_server(
 
 @router.delete(
     "/{id}/",
+    description="Delete an MCP server from global catalog (admin only).",
     status_code=204,
     responses=responses.get_responses([403, 404]),
 )
@@ -467,6 +474,7 @@ async def get_mcp_server_tools(
 
 @router.post(
     "/{id}/tools/sync/",
+    description="Sync tools from remote MCP server (admin only).",
     response_model=MCPServerToolSyncResponse,
     responses=responses.get_responses([400, 403, 404]),
 )
@@ -518,6 +526,7 @@ async def sync_mcp_server_tools(
 
 @router.post(
     "/{id}/tools/review/approve/",
+    description="Approve pending tool changes (admin only).",
     response_model=ToolReviewResponse,
     responses=responses.get_responses([400, 403, 404]),
 )
@@ -562,6 +571,7 @@ async def approve_tool_changes(
 
 @router.post(
     "/{id}/tools/review/reject/",
+    description="Reject pending tool changes (admin only).",
     response_model=ToolReviewResponse,
     responses=responses.get_responses([400, 403, 404]),
 )
@@ -607,6 +617,7 @@ async def reject_tool_changes(
 
 @router.post(
     "/{id}/tools/review/approve-all/",
+    description="Approve all pending tool changes for an MCP server (admin only).",
     response_model=ToolReviewResponse,
     responses=responses.get_responses([400, 403, 404]),
 )
@@ -641,6 +652,7 @@ async def approve_all_tool_changes(
 
 @router.put(
     "/{id}/tools/{tool_id}/",
+    description="Update global default enabled status for a tool (admin only).",
     response_model=MCPServerToolPublic,
     responses=responses.get_responses([403, 404]),
 )

--- a/backend/src/intric/roles/roles_router.py
+++ b/backend/src/intric/roles/roles_router.py
@@ -44,7 +44,12 @@ async def get_permissions(
     return await service.get_permissions()
 
 
-@router.get("/templates/")
+@router.get(
+    "/templates/",
+    description="List the predefined role templates available for creating roles.",
+    responses=responses.get_responses([]),
+    response_model=None,
+)
 async def get_role_templates(
     container: Container = Depends(get_container(with_user=True)),
 ):
@@ -57,7 +62,9 @@ async def get_role_templates(
 
 @router.get(
     "/",
+    description="List all roles for the current tenant.",
     response_model=RolesPaginatedResponse,
+    responses=responses.get_responses([]),
 )
 async def get_roles(
     container: _ContainerDep,
@@ -81,7 +88,12 @@ async def get_role_by_id(
     return await service.get_role_by_uuid(role_id)
 
 
-@router.post("/", response_model=RolePublic)
+@router.post(
+    "/",
+    description="Create a new role for the current tenant.",
+    response_model=RolePublic,
+    responses=responses.get_responses([400]),
+)
 async def create_role(
     role: RoleCreateRequest,
     container: _ContainerDep,
@@ -114,6 +126,7 @@ async def create_role(
 
 @router.post(
     "/{role_id}/",
+    description="Update an existing role by id.",
     response_model=RolePublic,
     responses=responses.get_responses([404]),
 )
@@ -163,6 +176,7 @@ async def update_role(
 
 @router.delete(
     "/{role_id}/",
+    description="Delete a role by id.",
     response_model=RolePublic,
     responses=responses.get_responses([404]),
 )
@@ -201,6 +215,7 @@ async def delete_role_by_id(
 
 @router.post(
     "/{role_id}/reset/",
+    description="Reset a role's permissions to its default template.",
     response_model=RolePublic,
     responses=responses.get_responses([400, 404]),
 )
@@ -243,6 +258,7 @@ async def reset_role_to_default(
 
 @router.post(
     "/{role_id}/set-default/",
+    description="Set the given role as the tenant's default role.",
     response_model=RolePublic,
     responses=responses.get_responses([404]),
     dependencies=[Depends(require_permission(Permission.ADMIN))],
@@ -284,7 +300,9 @@ async def set_default_role(
 
 @router.post(
     "/clear-default/",
+    description="Clear the tenant's default role.",
     responses=responses.get_responses([]),
+    response_model=None,
     dependencies=[Depends(require_permission(Permission.ADMIN))],
 )
 async def clear_default_role(

--- a/backend/src/intric/roles/roles_router.py
+++ b/backend/src/intric/roles/roles_router.py
@@ -64,7 +64,7 @@ async def get_role_templates(
     "/",
     description="List all roles for the current tenant.",
     response_model=RolesPaginatedResponse,
-    responses=responses.get_responses([]),
+    responses=responses.get_responses([403]),
 )
 async def get_roles(
     container: _ContainerDep,
@@ -78,7 +78,7 @@ async def get_roles(
 @router.get(
     "/{role_id}/",
     response_model=RolePublic,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def get_role_by_id(
     role_id: UUID,
@@ -92,7 +92,7 @@ async def get_role_by_id(
     "/",
     description="Create a new role for the current tenant.",
     response_model=RolePublic,
-    responses=responses.get_responses([400]),
+    responses=responses.get_responses([400, 403]),
 )
 async def create_role(
     role: RoleCreateRequest,
@@ -128,7 +128,7 @@ async def create_role(
     "/{role_id}/",
     description="Update an existing role by id.",
     response_model=RolePublic,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def update_role(
     role_id: UUID,
@@ -178,7 +178,7 @@ async def update_role(
     "/{role_id}/",
     description="Delete a role by id.",
     response_model=RolePublic,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def delete_role_by_id(
     role_id: UUID,
@@ -217,7 +217,7 @@ async def delete_role_by_id(
     "/{role_id}/reset/",
     description="Reset a role's permissions to its default template.",
     response_model=RolePublic,
-    responses=responses.get_responses([400, 404]),
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def reset_role_to_default(
     role_id: UUID,
@@ -260,7 +260,7 @@ async def reset_role_to_default(
     "/{role_id}/set-default/",
     description="Set the given role as the tenant's default role.",
     response_model=RolePublic,
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
     dependencies=[Depends(require_permission(Permission.ADMIN))],
 )
 async def set_default_role(
@@ -301,7 +301,7 @@ async def set_default_role(
 @router.post(
     "/clear-default/",
     description="Clear the tenant's default role.",
-    responses=responses.get_responses([]),
+    responses=responses.get_responses([403]),
     response_model=None,
     dependencies=[Depends(require_permission(Permission.ADMIN))],
 )

--- a/backend/src/intric/services/service_router.py
+++ b/backend/src/intric/services/service_router.py
@@ -27,6 +27,7 @@ router = APIRouter()
     "/",
     response_model=ServicePublicWithUser,
     responses=responses.get_responses([400, 404]),
+    description="Create a service.",
 )
 async def create_service(
     service_model: ServiceCreatePublic,
@@ -47,7 +48,12 @@ async def create_service(
     return from_domain_service(service_in_db)
 
 
-@router.get("/", response_model=PaginatedResponse[ServicePublicWithUser])
+@router.get(
+    "/",
+    response_model=PaginatedResponse[ServicePublicWithUser],
+    responses=responses.get_responses([]),
+    description="List services, optionally filtered by name.",
+)
 async def get_services(
     container: Annotated[Container, Depends(get_container(with_user=True))],
     name: str | None = None,
@@ -83,6 +89,7 @@ async def get_service(
     "/{id}/",
     response_model=ServicePublicWithUser,
     responses=responses.get_responses([404]),
+    description="Update a service. Omitted fields are not updated.",
 )
 async def update_service(
     id: UUID,
@@ -103,6 +110,7 @@ async def update_service(
     "/{id}/",
     status_code=204,
     responses=responses.get_responses([403, 404]),
+    description="Delete a service.",
 )
 async def delete_service(
     id: UUID,
@@ -116,6 +124,7 @@ async def delete_service(
     "/{id}/run/",
     response_model=ServiceOutput,
     responses=responses.get_responses([404, 400]),
+    description="Run a service. The output schema depends on the service's output validation.",
 )
 async def run_service(
     input: RunService,
@@ -145,7 +154,12 @@ async def get_service_runs(
     }
 
 
-@router.post("/{id}/transfer/", status_code=204)
+@router.post(
+    "/{id}/transfer/",
+    status_code=204,
+    responses=responses.get_responses([403, 404]),
+    description="Transfer a service to another space.",
+)
 async def transfer_service_to_space(
     id: UUID,
     transfer_req: TransferApplicationRequest,

--- a/backend/src/intric/settings/settings_router.py
+++ b/backend/src/intric/settings/settings_router.py
@@ -11,7 +11,7 @@ from intric.main.logging import get_logger
 from intric.main.models import PaginatedResponse
 from intric.roles.permissions import Permission, validate_permission
 from intric.server.dependencies.container import get_container
-from intric.server.protocol import to_paginated_response
+from intric.server.protocol import responses, to_paginated_response
 from intric.settings import settings_factory
 from intric.settings.setting_service import SettingService
 from intric.settings.settings import (
@@ -26,7 +26,12 @@ router = APIRouter()
 settings_admin_router = APIRouter()
 
 
-@router.get("/", response_model=SettingsPublic)
+@router.get(
+    "/",
+    response_model=SettingsPublic,
+    description="Get the current tenant settings.",
+    responses=responses.get_responses([]),
+)
 async def get_settings(
     service: Annotated[
         SettingService,
@@ -36,7 +41,12 @@ async def get_settings(
     return await service.get_settings()
 
 
-@settings_admin_router.post("/", response_model=SettingsPublic)
+@settings_admin_router.post(
+    "/",
+    response_model=SettingsPublic,
+    description="Update tenant settings; omitted fields are not updated.",
+    responses=responses.get_responses([403]),
+)
 async def upsert_settings(
     settings: SettingsPublic,
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -47,7 +57,12 @@ async def upsert_settings(
     return await service.update_settings(settings)
 
 
-@router.get("/models/", response_model=GetModelsResponse)
+@router.get(
+    "/models/",
+    response_model=GetModelsResponse,
+    description="List available completion and embedding models.",
+    responses=responses.get_responses([]),
+)
 async def get_models(
     container: Annotated[Container, Depends(get_container(with_user=True))],
 ):
@@ -70,6 +85,8 @@ async def get_models(
 @router.get(
     "/formats/",
     response_model=PaginatedResponse[str],
+    description="List supported file format mime types.",
+    responses=responses.get_responses([]),
     dependencies=[Depends(auth_dependencies.get_current_active_user)],
 )
 def get_formats():
@@ -81,6 +98,7 @@ def get_formats():
 @settings_admin_router.patch(
     "/templates",
     response_model=SettingsPublic,
+    responses=responses.get_responses([403]),
     summary="Toggle template feature",
     description="""
 Enable or disable the template management feature for your tenant.
@@ -126,6 +144,7 @@ async def update_template_setting(
 @settings_admin_router.patch(
     "/audit-logging",
     response_model=SettingsPublic,
+    responses=responses.get_responses([403]),
     summary="Toggle global audit logging",
     description="""
 Enable or disable global audit logging for your tenant.
@@ -173,6 +192,7 @@ async def update_audit_logging_setting(
 @settings_admin_router.patch(
     "/provisioning",
     response_model=SettingsPublic,
+    responses=responses.get_responses([403]),
     summary="Toggle JIT user provisioning",
     description="""
 Enable or disable JIT (Just-In-Time) user provisioning for your tenant.
@@ -214,6 +234,7 @@ async def update_provisioning_setting(
 @settings_admin_router.patch(
     "/api-key-expiry-notifications",
     response_model=SettingsPublic,
+    responses=responses.get_responses([403]),
     summary="Toggle API key expiry notifications",
     description="""
 Toggle API key expiry notifications for your tenant.

--- a/backend/src/intric/user_groups/user_groups_router.py
+++ b/backend/src/intric/user_groups/user_groups_router.py
@@ -21,6 +21,8 @@ router = APIRouter()
 @router.get(
     "/",
     response_model=PaginatedResponse[UserGroupPublic],
+    description="List all user groups in the tenant.",
+    responses=responses.get_responses([]),
 )
 async def get_user_groups(
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -34,6 +36,7 @@ async def get_user_groups(
 @router.get(
     "/{id}/",
     response_model=UserGroupPublic,
+    description="Get a single user group by id.",
     responses=responses.get_responses([404]),
 )
 async def get_user_group_by_uuid(
@@ -44,7 +47,12 @@ async def get_user_group_by_uuid(
     return await service.get_user_group_by_uuid(id)
 
 
-@router.post("/", response_model=UserGroupPublic)
+@router.post(
+    "/",
+    response_model=UserGroupPublic,
+    description="Create a new user group.",
+    responses=responses.get_responses([]),
+)
 async def create_user_group(
     user_group: UserGroupCreateRequest,
     container: Annotated[Container, Depends(get_container(with_user=True))],
@@ -56,6 +64,7 @@ async def create_user_group(
 @router.post(
     "/{id}/",
     response_model=UserGroupPublic,
+    description="Update an existing user group by id.",
     responses=responses.get_responses([404]),
 )
 async def update_user_group(
@@ -72,6 +81,7 @@ async def update_user_group(
 @router.delete(
     "/{id}/",
     response_model=UserGroupPublic,
+    description="Delete a user group by id.",
     responses=responses.get_responses([404]),
 )
 async def delete_user_group_by_uuid(
@@ -85,6 +95,7 @@ async def delete_user_group_by_uuid(
 @router.post(
     "/{id}/users/{user_id}/",
     response_model=UserGroupPublic,
+    description="Add a user to a user group.",
     responses=responses.get_responses([404]),
 )
 async def add_user_to_user_group(
@@ -99,6 +110,7 @@ async def add_user_to_user_group(
 @router.delete(
     "/{id}/users/{user_id}/",
     response_model=UserGroupPublic,
+    description="Remove a user from a user group.",
     responses=responses.get_responses([404]),
 )
 async def delete_user_from_user_group(

--- a/backend/src/intric/user_groups/user_groups_router.py
+++ b/backend/src/intric/user_groups/user_groups_router.py
@@ -51,7 +51,7 @@ async def get_user_group_by_uuid(
     "/",
     response_model=UserGroupPublic,
     description="Create a new user group.",
-    responses=responses.get_responses([]),
+    responses=responses.get_responses([400, 403]),
 )
 async def create_user_group(
     user_group: UserGroupCreateRequest,
@@ -65,7 +65,7 @@ async def create_user_group(
     "/{id}/",
     response_model=UserGroupPublic,
     description="Update an existing user group by id.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([400, 401, 403, 404]),
 )
 async def update_user_group(
     id: UUID,
@@ -82,7 +82,7 @@ async def update_user_group(
     "/{id}/",
     response_model=UserGroupPublic,
     description="Delete a user group by id.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def delete_user_group_by_uuid(
     id: UUID,
@@ -96,7 +96,7 @@ async def delete_user_group_by_uuid(
     "/{id}/users/{user_id}/",
     response_model=UserGroupPublic,
     description="Add a user to a user group.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([401, 403, 404]),
 )
 async def add_user_to_user_group(
     id: UUID,
@@ -111,7 +111,7 @@ async def add_user_to_user_group(
     "/{id}/users/{user_id}/",
     response_model=UserGroupPublic,
     description="Remove a user from a user group.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([403, 404]),
 )
 async def delete_user_from_user_group(
     id: UUID,

--- a/backend/tests/unittests/audit/test_audit_export_schemas.py
+++ b/backend/tests/unittests/audit/test_audit_export_schemas.py
@@ -1,0 +1,25 @@
+import pytest
+from pydantic import ValidationError
+
+from intric.api.audit.schemas import ExportJobRequest
+
+
+@pytest.mark.parametrize(
+    ("raw_format", "expected"),
+    [
+        ("csv", "csv"),
+        (" JSON ", "json"),
+        ("jsonl", "jsonl"),
+    ],
+)
+def test_export_job_request_normalizes_supported_formats(
+    raw_format: str, expected: str
+) -> None:
+    request = ExportJobRequest.model_validate({"format": raw_format})
+
+    assert request.format == expected
+
+
+def test_export_job_request_rejects_unsupported_format() -> None:
+    with pytest.raises(ValidationError):
+        ExportJobRequest.model_validate({"format": "xml"})

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -10656,10 +10656,11 @@ export interface components {
       to_date?: string | null;
       /**
        * Format
-       * @description Export format: csv or jsonl
+       * @description Export format: csv, json, or jsonl
        * @default csv
+       * @enum {string}
        */
-      format?: string;
+      format?: "csv" | "json" | "jsonl";
       /**
        * Max Records
        * @description Maximum records to export
@@ -20000,6 +20001,15 @@ export interface operations {
           "application/json": components["schemas"]["CollectionPublic"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -20038,6 +20048,15 @@ export interface operations {
         };
         content: {
           "application/json": unknown;
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -20298,6 +20317,15 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
       };
       /** @description Not Found */
       404: {
@@ -36697,6 +36725,15 @@ export interface operations {
           "application/json": components["schemas"]["RolesPaginatedResponse"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   create_role_api_v1_roles__post: {
@@ -36723,6 +36760,15 @@ export interface operations {
       };
       /** @description Bad Request */
       400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
         headers: {
           [name: string]: unknown;
         };
@@ -36759,6 +36805,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["RolePublic"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -36805,6 +36860,24 @@ export interface operations {
           "application/json": components["schemas"]["RolePublic"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -36843,6 +36916,24 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["RolePublic"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -36894,6 +36985,15 @@ export interface operations {
           "application/json": components["schemas"]["GeneralError"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -36934,6 +37034,15 @@ export interface operations {
           "application/json": components["schemas"]["RolePublic"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -36970,6 +37079,15 @@ export interface operations {
         };
         content: {
           "application/json": unknown;
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
     };

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -708,9 +708,15 @@ export interface paths {
     /** Get Group By Id */
     get: operations["get_group_by_id_api_v1_groups__id___get"];
     put?: never;
-    /** Update Group */
+    /**
+     * Update Group
+     * @description Update a collection (legacy group) by id.
+     */
     post: operations["update_group_api_v1_groups__id___post"];
-    /** Delete Group By Id */
+    /**
+     * Delete Group By Id
+     * @description Delete a collection (legacy group) by id.
+     */
     delete: operations["delete_group_by_id_api_v1_groups__id___delete"];
     options?: never;
     head?: never;
@@ -729,9 +735,7 @@ export interface paths {
     put?: never;
     /**
      * Add Info Blobs
-     * @description Maximum allowed simultaneous upload is 128.
-     *
-     *     Will be embedded using the embedding model of the group.
+     * @description Add info-blobs to a collection (legacy group) and embed them.
      */
     post: operations["add_info_blobs_api_v1_groups__id__info_blobs__post"];
     delete?: never;
@@ -751,7 +755,7 @@ export interface paths {
     put?: never;
     /**
      * Upload File
-     * @description Starts a job, use the job operations to keep track of this job
+     * @description Upload a file to a collection (legacy group); starts a processing job.
      */
     post: operations["upload_file_api_v1_groups__id__info_blobs_upload__post"];
     delete?: never;
@@ -769,7 +773,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Run Semantic Search */
+    /**
+     * Run Semantic Search
+     * @description Run a semantic search within a collection (legacy group).
+     */
     post: operations["run_semantic_search_api_v1_groups__id__searches__post"];
     delete?: never;
     options?: never;
@@ -786,7 +793,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Transfer Group To Space */
+    /**
+     * Transfer Group To Space
+     * @description Transfer a collection (legacy group) to another space.
+     */
     post: operations["transfer_group_to_space_api_v1_groups__id__transfer__post"];
     delete?: never;
     options?: never;
@@ -801,12 +811,15 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Settings */
+    /**
+     * Get Settings
+     * @description Get the current tenant settings.
+     */
     get: operations["get_settings_api_v1_settings__get"];
     put?: never;
     /**
      * Upsert Settings
-     * @description Omitted fields are not updated.
+     * @description Update tenant settings; omitted fields are not updated.
      */
     post: operations["upsert_settings_api_v1_settings__post"];
     delete?: never;
@@ -824,11 +837,7 @@ export interface paths {
     };
     /**
      * Get Models
-     * @description From the response:
-     *         - use the `id` field as values for `completion_model`
-     *         - use the `id` field as values for `embedding_model`
-     *
-     *     in creating and updating `Assistants` and `Services`.
+     * @description List available completion and embedding models.
      */
     get: operations["get_models_api_v1_settings_models__get"];
     put?: never;
@@ -846,7 +855,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Formats */
+    /**
+     * Get Formats
+     * @description List supported file format mime types.
+     */
     get: operations["get_formats_api_v1_settings_formats__get"];
     put?: never;
     post?: never;
@@ -1461,18 +1473,15 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Services */
+    /**
+     * Get Services
+     * @description List services, optionally filtered by name.
+     */
     get: operations["get_services_api_v1_services__get"];
     put?: never;
     /**
      * Create Service
      * @description Create a service.
-     *
-     *     `json_schema` is required if `output_validation` is 'json'.
-     *
-     *     Conversely, `json_schema` is not evaluated if `output_format` is not 'json'.
-     *
-     *     if `output_format` is omitted, the output will not be formatted.
      */
     post: operations["create_service_api_v1_services__post"];
     delete?: never;
@@ -1493,10 +1502,13 @@ export interface paths {
     put?: never;
     /**
      * Update Service
-     * @description Omitted fields are not updated
+     * @description Update a service. Omitted fields are not updated.
      */
     post: operations["update_service_api_v1_services__id___post"];
-    /** Delete Service */
+    /**
+     * Delete Service
+     * @description Delete a service.
+     */
     delete: operations["delete_service_api_v1_services__id___delete"];
     options?: never;
     head?: never;
@@ -1515,7 +1527,7 @@ export interface paths {
     put?: never;
     /**
      * Run Service
-     * @description The schema of the output will be depending on the output validation of the service
+     * @description Run a service. The output schema depends on the service's output validation.
      */
     post: operations["run_service_api_v1_services__id__run__post"];
     delete?: never;
@@ -1533,7 +1545,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Transfer Service To Space */
+    /**
+     * Transfer Service To Space
+     * @description Transfer a service to another space.
+     */
     post: operations["transfer_service_to_space_api_v1_services__id__transfer__post"];
     delete?: never;
     options?: never;
@@ -2906,10 +2921,16 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get User Groups */
+    /**
+     * Get User Groups
+     * @description List all user groups in the tenant.
+     */
     get: operations["get_user_groups_api_v1_user_groups__get"];
     put?: never;
-    /** Create User Group */
+    /**
+     * Create User Group
+     * @description Create a new user group.
+     */
     post: operations["create_user_group_api_v1_user_groups__post"];
     delete?: never;
     options?: never;
@@ -2924,12 +2945,21 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get User Group By Uuid */
+    /**
+     * Get User Group By Uuid
+     * @description Get a single user group by id.
+     */
     get: operations["get_user_group_by_uuid_api_v1_user_groups__id___get"];
     put?: never;
-    /** Update User Group */
+    /**
+     * Update User Group
+     * @description Update an existing user group by id.
+     */
     post: operations["update_user_group_api_v1_user_groups__id___post"];
-    /** Delete User Group By Uuid */
+    /**
+     * Delete User Group By Uuid
+     * @description Delete a user group by id.
+     */
     delete: operations["delete_user_group_by_uuid_api_v1_user_groups__id___delete"];
     options?: never;
     head?: never;
@@ -2945,9 +2975,15 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Add User To User Group */
+    /**
+     * Add User To User Group
+     * @description Add a user to a user group.
+     */
     post: operations["add_user_to_user_group_api_v1_user_groups__id__users__user_id___post"];
-    /** Delete User From User Group */
+    /**
+     * Delete User From User Group
+     * @description Remove a user from a user group.
+     */
     delete: operations["delete_user_from_user_group_api_v1_user_groups__id__users__user_id___delete"];
     options?: never;
     head?: never;
@@ -4934,16 +4970,7 @@ export interface paths {
     post?: never;
     /**
      * Reset Rate Limit
-     * @description Admin utility: Reset audit session rate limit for current user.
-     *
-     *     This endpoint is only available in development/testing environments.
-     *     Use when you get rate limited during testing.
-     *
-     *     Requires: Authentication (JWT token or API key)
-     *     Requires: Development/testing environment
-     *
-     *     Note: Permission check intentionally removed to allow clearing rate limit
-     *     even when locked out. User is still authenticated via JWT.
+     * @description Reset the audit session rate limit for the current user (testing only).
      */
     delete: operations["reset_rate_limit_api_v1_audit_access_session_rate_limit_delete"];
     options?: never;
@@ -4962,22 +4989,7 @@ export interface paths {
     put?: never;
     /**
      * Create Access Session
-     * @description Create an audit access session with justification.
-     *
-     *     Stores the access justification securely in Redis (server-side) instead of
-     *     exposing it in URL parameters. Returns an HTTP-only cookie with session ID.
-     *
-     *     Security Features:
-     *     - Justification never appears in URLs or browser history
-     *     - Session ID stored in HTTP-only cookie (prevents XSS)
-     *     - Automatic expiration after 1 hour
-     *     - Tenant isolation validation
-     *     - Instant revocation capability
-     *
-     *     Requires: Authentication (JWT token or API key)
-     *     Requires: Admin permissions
-     *
-     *     Returns: Session creation confirmation with HTTP-only cookie set
+     * @description Create an audit access session with justification, stored server-side.
      */
     post: operations["create_access_session_api_v1_audit_access_session_post"];
     delete?: never;
@@ -4996,18 +5008,6 @@ export interface paths {
     /**
      * List Audit Logs
      * @description List audit logs for the authenticated user's tenant.
-     *
-     *     Security:
-     *     - Requires active audit access session (via HTTP-only cookie)
-     *     - Session must contain valid justification
-     *     - Justification stored server-side (Redis) - never in URLs
-     *
-     *     Access Control:
-     *     - Admins only: View all actions in their tenant
-     *
-     *     Requires: Authentication (JWT token or API key)
-     *     Requires: Admin permissions
-     *     Requires: Active audit access session with justification
      */
     get: operations["list_audit_logs_api_v1_audit_logs_get"];
     put?: never;
@@ -5027,13 +5027,7 @@ export interface paths {
     };
     /**
      * Get User Logs
-     * @description Get all logs where user is actor OR target (GDPR Article 15 export).
-     *
-     *     Returns audit logs involving the user in any capacity.
-     *
-     *     Requires: Authentication (JWT token or API key via X-API-Key header)
-     *     Requires: Admin permissions
-     *     Security: Only returns logs for the authenticated user's tenant
+     * @description Get all audit logs where the user is actor or target (GDPR Article 15 export).
      */
     get: operations["get_user_logs_api_v1_audit_logs_user__user_id__get"];
     put?: never;
@@ -5054,21 +5048,6 @@ export interface paths {
     /**
      * Export Audit Logs
      * @description Export audit logs to CSV or JSON Lines format.
-     *
-     *     Supported formats:
-     *     - csv: Comma-separated values (default, Excel-compatible)
-     *     - json: JSON Lines format (one JSON object per line, for large exports)
-     *
-     *     Use user_id for GDPR Article 15 data subject access requests.
-     *
-     *     Memory Protection:
-     *     - Default limit: 50,000 records (configurable via max_records parameter)
-     *     - Response includes X-Records-Truncated header if limit was hit
-     *     - Response includes X-Total-Records header with total matching count
-     *
-     *     Requires: Authentication (JWT token or API key via X-API-Key header)
-     *     Requires: Admin permissions
-     *     Security: Only exports logs for the authenticated user's tenant
      */
     get: operations["export_audit_logs_api_v1_audit_logs_export_get"];
     put?: never;
@@ -5090,23 +5069,7 @@ export interface paths {
     put?: never;
     /**
      * Request Async Export
-     * @description Request async export of audit logs.
-     *
-     *     Returns immediately with a job_id. Poll /logs/export/{job_id}/status for progress.
-     *     Download via /logs/export/{job_id}/download when complete.
-     *
-     *     Advantages over sync export:
-     *     - Handles 1M-10M+ records without timeout
-     *     - Progress tracking for long exports
-     *     - Cancellation support
-     *     - Constant memory usage (~50MB)
-     *
-     *     Limitations:
-     *     - Max 2 concurrent exports per tenant
-     *     - Files auto-deleted after 24 hours
-     *
-     *     Requires: Authentication (JWT token or API key via X-API-Key header)
-     *     Requires: Admin permissions
+     * @description Request an async background export of audit logs and receive a job ID.
      */
     post: operations["request_async_export_api_v1_audit_logs_export_async_post"];
     delete?: never;
@@ -5124,13 +5087,7 @@ export interface paths {
     };
     /**
      * Get Export Status
-     * @description Get export job status with progress.
-     *
-     *     Poll this endpoint to track export progress.
-     *     When status is 'completed', use the download_url to get the file.
-     *
-     *     Requires: Authentication (JWT token or API key via X-API-Key header)
-     *     Requires: Admin permissions
+     * @description Get the status and progress of an async export job.
      */
     get: operations["get_export_status_api_v1_audit_logs_export__job_id__status_get"];
     put?: never;
@@ -5150,13 +5107,7 @@ export interface paths {
     };
     /**
      * Download Export
-     * @description Download completed export file.
-     *
-     *     Only available when job status is 'completed'.
-     *     Files are auto-deleted after 24 hours.
-     *
-     *     Requires: Authentication (JWT token or API key via X-API-Key header)
-     *     Requires: Admin permissions
+     * @description Download the completed export file for an async export job.
      */
     get: operations["download_export_api_v1_audit_logs_export__job_id__download_get"];
     put?: never;
@@ -5178,13 +5129,7 @@ export interface paths {
     put?: never;
     /**
      * Cancel Export
-     * @description Cancel an in-progress export.
-     *
-     *     Only works for jobs in 'pending' or 'processing' state.
-     *     The worker will stop processing and clean up the partial file.
-     *
-     *     Requires: Authentication (JWT token or API key via X-API-Key header)
-     *     Requires: Admin permissions
+     * @description Cancel an in-progress async export job.
      */
     post: operations["cancel_export_api_v1_audit_logs_export__job_id__cancel_post"];
     delete?: never;
@@ -5202,33 +5147,12 @@ export interface paths {
     };
     /**
      * Get Retention Policy
-     * @description Get the current retention policy for your tenant.
-     *
-     *     Returns audit log retention policy configuration.
-     *
-     *     Requires: Authentication (JWT token or API key via X-API-Key header)
-     *     Requires: Admin permissions
+     * @description Get the current audit log retention policy for the tenant.
      */
     get: operations["get_retention_policy_api_v1_audit_retention_policy_get"];
     /**
      * Update Retention Policy
-     * @description Update the audit log retention policy for your tenant.
-     *
-     *     Configure audit log retention for compliance and security tracking.
-     *
-     *     Audit Log Retention:
-     *     - Minimum: 1 day (Recommended: 90+ days for compliance)
-     *     - Maximum: 2555 days (~7 years, Swedish statute of limitations)
-     *     - Default: 365 days (Swedish Arkivlagen)
-     *
-     *     Note: Conversation retention is configured at the Assistant, App, or Space level.
-     *     Tenant-level conversation retention has been removed to prevent accidental data loss.
-     *
-     *     The system automatically runs a daily job to delete audit logs older than
-     *     the retention period.
-     *
-     *     Requires: Authentication (JWT token or API key via X-API-Key header)
-     *     Requires: Admin permissions
+     * @description Update the audit log retention policy for the tenant.
      */
     put: operations["update_retention_policy_api_v1_audit_retention_policy_put"];
     post?: never;
@@ -5466,8 +5390,6 @@ export interface paths {
     /**
      * Create Mcp Server
      * @description Create a new MCP server in global catalog (admin only).
-     *
-     *     Validates connection before saving. Returns 400 if connection fails.
      */
     post: operations["create_mcp_server_api_v1_mcp_servers__post"];
     delete?: never;
@@ -5604,12 +5526,6 @@ export interface paths {
     /**
      * Sync Mcp Server Tools
      * @description Sync tools from remote MCP server (admin only).
-     *
-     *     Detects new, changed, and removed tools. Changes are stored as pending
-     *     and require explicit approval before becoming active. This prevents a
-     *     compromised MCP server from injecting malicious tool definitions.
-     *
-     *     Returns 400 if connection to the MCP server fails.
      */
     post: operations["sync_mcp_server_tools_api_v1_mcp_servers__id__tools_sync__post"];
     delete?: never;
@@ -5630,9 +5546,6 @@ export interface paths {
     /**
      * Approve Tool Changes
      * @description Approve pending tool changes (admin only).
-     *
-     *     For new/changed tools: pending values become active.
-     *     For removed tools: tool is deleted from database.
      */
     post: operations["approve_tool_changes_api_v1_mcp_servers__id__tools_review_approve__post"];
     delete?: never;
@@ -5653,10 +5566,6 @@ export interface paths {
     /**
      * Reject Tool Changes
      * @description Reject pending tool changes (admin only).
-     *
-     *     For new tools: tool is deleted (never activated).
-     *     For changed tools: pending values are cleared, active values kept.
-     *     For removed tools: removed flag is cleared, tool stays active.
      */
     post: operations["reject_tool_changes_api_v1_mcp_servers__id__tools_review_reject__post"];
     delete?: never;
@@ -6753,7 +6662,10 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Role Templates */
+    /**
+     * Get Role Templates
+     * @description List the predefined role templates available for creating roles.
+     */
     get: operations["get_role_templates_api_v1_roles_templates__get"];
     put?: never;
     post?: never;
@@ -6770,10 +6682,16 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    /** Get Roles */
+    /**
+     * Get Roles
+     * @description List all roles for the current tenant.
+     */
     get: operations["get_roles_api_v1_roles__get"];
     put?: never;
-    /** Create Role */
+    /**
+     * Create Role
+     * @description Create a new role for the current tenant.
+     */
     post: operations["create_role_api_v1_roles__post"];
     delete?: never;
     options?: never;
@@ -6791,9 +6709,15 @@ export interface paths {
     /** Get Role By Id */
     get: operations["get_role_by_id_api_v1_roles__role_id___get"];
     put?: never;
-    /** Update Role */
+    /**
+     * Update Role
+     * @description Update an existing role by id.
+     */
     post: operations["update_role_api_v1_roles__role_id___post"];
-    /** Delete Role By Id */
+    /**
+     * Delete Role By Id
+     * @description Delete a role by id.
+     */
     delete: operations["delete_role_by_id_api_v1_roles__role_id___delete"];
     options?: never;
     head?: never;
@@ -6809,7 +6733,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Reset Role To Default */
+    /**
+     * Reset Role To Default
+     * @description Reset a role's permissions to its default template.
+     */
     post: operations["reset_role_to_default_api_v1_roles__role_id__reset__post"];
     delete?: never;
     options?: never;
@@ -6826,7 +6753,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Set Default Role */
+    /**
+     * Set Default Role
+     * @description Set the given role as the tenant's default role.
+     */
     post: operations["set_default_role_api_v1_roles__role_id__set_default__post"];
     delete?: never;
     options?: never;
@@ -6843,7 +6773,10 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** Clear Default Role */
+    /**
+     * Clear Default Role
+     * @description Clear the tenant's default role.
+     */
     post: operations["clear_default_role_api_v1_roles_clear_default__post"];
     delete?: never;
     options?: never;
@@ -20324,6 +20257,15 @@ export interface operations {
           "application/json": components["schemas"]["PaginatedResponse_SemanticSearchResponse_"];
         };
       };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -20356,6 +20298,15 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
       };
       /** @description Validation Error */
       422: {
@@ -20408,6 +20359,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["SettingsPublic"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -20483,6 +20443,15 @@ export interface operations {
           "application/json": components["schemas"]["SettingsPublic"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -20514,6 +20483,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["SettingsPublic"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -20549,6 +20527,15 @@ export interface operations {
           "application/json": components["schemas"]["SettingsPublic"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -20580,6 +20567,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["SettingsPublic"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -23319,6 +23315,24 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
       };
       /** @description Validation Error */
       422: {
@@ -32294,6 +32308,24 @@ export interface operations {
         };
         content?: never;
       };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Service Unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   create_access_session_api_v1_audit_access_session_post: {
@@ -32318,6 +32350,24 @@ export interface operations {
           "application/json": components["schemas"]["AccessJustificationResponse"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -32325,6 +32375,24 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Service Unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
     };
@@ -32362,6 +32430,24 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["AuditLogListResponse"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -32403,6 +32489,24 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["AuditLogListResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -32449,6 +32553,24 @@ export interface operations {
           "application/json": unknown;
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Request Entity Too Large */
+      413: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -32482,13 +32604,31 @@ export interface operations {
           "application/json": components["schemas"]["ExportJobResponse"];
         };
       };
-      /** @description Validation Error */
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Unprocessable Entity */
       422: {
         headers: {
           [name: string]: unknown;
         };
         content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Too Many Requests */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
     };
@@ -32512,6 +32652,24 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["ExportJobStatusResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -32546,6 +32704,33 @@ export interface operations {
           "application/json": unknown;
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -32578,6 +32763,33 @@ export interface operations {
           "application/json": unknown;
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -32607,6 +32819,15 @@ export interface operations {
           "application/json": components["schemas"]["RetentionPolicyResponse"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   update_retention_policy_api_v1_audit_retention_policy_put: {
@@ -32629,6 +32850,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["RetentionPolicyResponse"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */
@@ -36408,6 +36638,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["RolePublic"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Validation Error */

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -5047,7 +5047,7 @@ export interface paths {
     };
     /**
      * Export Audit Logs
-     * @description Export audit logs to CSV or JSON Lines format.
+     * @description Export audit logs to CSV or JSON Lines format. Default limit is 50,000 records (configurable via max_records, max 100,000); the response includes an X-Records-Truncated header when the limit is hit.
      */
     get: operations["export_audit_logs_api_v1_audit_logs_export_get"];
     put?: never;
@@ -5069,7 +5069,7 @@ export interface paths {
     put?: never;
     /**
      * Request Async Export
-     * @description Request an async background export of audit logs and receive a job ID.
+     * @description Request an async background export of audit logs and receive a job ID. Limited to 2 concurrent exports per tenant; generated files are auto-deleted after 24 hours.
      */
     post: operations["request_async_export_api_v1_audit_logs_export_async_post"];
     delete?: never;
@@ -5107,7 +5107,7 @@ export interface paths {
     };
     /**
      * Download Export
-     * @description Download the completed export file for an async export job.
+     * @description Download the completed export file for an async export job. Files are auto-deleted after 24 hours.
      */
     get: operations["download_export_api_v1_audit_logs_export__job_id__download_get"];
     put?: never;
@@ -27137,6 +27137,24 @@ export interface operations {
           "application/json": components["schemas"]["UserGroupPublic"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Validation Error */
       422: {
         headers: {
@@ -27212,6 +27230,33 @@ export interface operations {
           "application/json": components["schemas"]["UserGroupPublic"];
         };
       };
+      /** @description Bad Request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -27250,6 +27295,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["UserGroupPublic"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -27293,6 +27347,24 @@ export interface operations {
           "application/json": components["schemas"]["UserGroupPublic"];
         };
       };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {
@@ -27332,6 +27404,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["UserGroupPublic"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
       /** @description Not Found */
@@ -32613,13 +32694,13 @@ export interface operations {
           "application/json": components["schemas"]["GeneralError"];
         };
       };
-      /** @description Unprocessable Entity */
+      /** @description Validation Error */
       422: {
         headers: {
           [name: string]: unknown;
         };
         content: {
-          "application/json": components["schemas"]["GeneralError"];
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
       /** @description Too Many Requests */


### PR DESCRIPTION
## What

Sixth phased slice of the repo-wide route-metadata debt (after #473–#477). Backfills OpenAPI metadata on the **59 routes** flagged by `scripts/check_route_metadata.py` across the admin / config domain:

| Router | routes |
|---|---|
| `mcp_servers/mcp_server_router.py` | 12 |
| `api/audit/routes.py` | 11 |
| `settings/settings_router.py` | 8 |
| `roles/roles_router.py` | 8 |
| `groups_legacy/api/group_router.py` | 8 |
| `services/service_router.py` | 6 |
| `user_groups/user_groups_router.py` | 6 |

## Scope / safety

- **Pure metadata — no behaviour or response-model contract changes.** `response_model` additions mirror existing return annotations; `status_code` untouched (transfer/delete 204 routes reformatted, not changed).
- **Export/stream routes** (audit log CSV/JSON export, file download): used `response_model=None` to satisfy the guardrail without injecting a schema.
- Error codes derived per-handler from actual raised exceptions (e.g. audit routes: 403 admin-gate, 404 job lookup, 413 export-too-large, 429 rate-limit, 503 Redis/service unavailable) — not invented.
- `schema.d.ts` regenerated via the same pipeline the pre-push hook uses.

## Verification

- `scripts/check_route_metadata.py` — clean on all 7 files
- `ruff check` / `ruff format --check` — clean
- `pyright` — 0 errors
- `app.openapi()` generates successfully (303 paths); `schema.d.ts` in sync

## Follow-up

Remaining ~36 non-compliant routes (tenants, authentication, security_classifications, token_usage, modules, admin, limits, logging, allowed_origins) stay ratchet-tracked — one final slice.