### PR TITLE
fix(admin/users): refresh list after editing a user

### DIFF
--- a/frontend/apps/web/src/routes/(app)/admin/users/editor/UserEditor.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/users/editor/UserEditor.svelte
@@ -80,7 +80,7 @@
         user: { username: user.username },
         update
       });
-      invalidate("admin:users:load");
+      await invalidate("admin:users");
       // Invalidate does not update the user and userPassword values in this component, so we need to update
       user = editableUser;
       userPassword = "";
@@ -104,7 +104,7 @@
       await intric.users.create(newUser);
       editableUser.updateWithValue(createEmptyUser());
       userPassword = "";
-      invalidate("admin:users:load");
+      await invalidate("admin:users");
       showDialog?.set(false);
     } catch (e) {
       toastError(e);


### PR DESCRIPTION
## Problem

Closes #425.

On `/admin/users`, editing a user (e.g. changing their role) and saving did not update the list. The old value kept showing until a hard page refresh.

## Cause

A SvelteKit dependency-key mismatch. The loader declares `event.depends("admin:users")` (and `UserActions.svelte` already invalidates that same key), but `UserEditor.svelte` invalidated `"admin:users:load"` after both update and create. The non-matching key was silently ignored, so the loader never re-ran and `data.users` stayed stale.

## Fix

Invalidate the canonical `"admin:users"` key (awaited, so the loader completes before the dialog closes) after both `updateUser()` and `createUser()`. Edits and newly created users now appear immediately.

## Testing

- Edit a user's role/email/username → row updates without a hard refresh.
- Create a user → appears in the list.
- Deactivate/reactivate/delete continue to work (already used the correct key).
