### PR TITLE
fix(files): handle WebP/AVIF uploads instead of crashing

### DIFF
--- a/backend/src/intric/files/extensions.py
+++ b/backend/src/intric/files/extensions.py
@@ -29,4 +29,6 @@ MIMETYPE_EXTENSIONS_MAPPER = {
     # IMAGE
     ImageMimeTypes.PNG.value: [".png"],
     ImageMimeTypes.JPEG.value: [".jpeg", ".jpg", ".jpe"],
+    ImageMimeTypes.WEBP.value: [".webp"],
+    ImageMimeTypes.AVIF.value: [".avif"],
 }

--- a/backend/src/intric/files/image.py
+++ b/backend/src/intric/files/image.py
@@ -7,6 +7,8 @@ from intric.main.exceptions import FileNotSupportedException
 class ImageMimeTypes(MimeTypesBase):
     PNG = "image/png"
     JPEG = "image/jpeg"
+    WEBP = "image/webp"
+    AVIF = "image/avif"
 
 
 class ImageExtractor:

--- a/backend/src/intric/files/text.py
+++ b/backend/src/intric/files/text.py
@@ -104,6 +104,16 @@ class TextSanitizer:
 
 class TextExtractor:
     @staticmethod
+    def _looks_binary(filepath: Path) -> bool:
+        # A NUL byte in the leading chunk reliably marks binary content
+        # (images, video, archives); UTF-8/cp1252 text never contains it.
+        try:
+            with open(filepath, "rb") as f:
+                return b"\x00" in f.read(8192)
+        except (PermissionError, OSError):
+            return False
+
+    @staticmethod
     def extract_from_plain_text(filepath: Path, filename: str | None = None) -> str:
         display_name = filename or filepath.name
         # Try UTF-8 first, then cp1252 (Windows), then UTF-8 with replacement
@@ -312,7 +322,11 @@ class TextExtractor:
             case TextMimeTypes.XLSX | TextMimeTypes.XLS:
                 extracted_text = self.extract_from_xlsx(filepath, display_name)
             case _:
-                # Fallback to plain text
+                # Unknown mimetype: only treat as text if it is not binary.
+                # Guards against binary uploads (e.g. unsupported image formats)
+                # being decoded into garbage and written to the TEXT column.
+                if self._looks_binary(filepath):
+                    raise UnsupportedFormatError(display_name, mimetype or "binary")
                 extracted_text = self.extract_from_plain_text(filepath, display_name)
 
         return extracted_text.strip()

--- a/backend/tests/unittests/files/test_file_protocol.py
+++ b/backend/tests/unittests/files/test_file_protocol.py
@@ -186,13 +186,16 @@ async def test_to_domain_routes_audio_mime_types(protocol):
 @pytest.mark.asyncio
 async def test_to_domain_routes_image_mime_types(protocol):
     """Image MIME types should route through image_to_domain."""
-    for mime in ["image/png", "image/jpeg"]:
+    for mime in ["image/png", "image/jpeg", "image/webp", "image/avif"]:
         upload, size = _make_upload(mime, 1000)
         protocol.file_size_service.get_file_size.return_value = size
 
         result = await protocol.to_domain(upload)
 
         assert result.file_type.value == "image", f"MIME {mime} should route to image"
+        # Image data is stored as a blob, never decoded into the text column.
+        assert result.blob == b"image-bytes"
+        assert result.text is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unittests/files/test_text_extractor.py
+++ b/backend/tests/unittests/files/test_text_extractor.py
@@ -444,6 +444,22 @@ class TestTextExtractorExtractMethod:
         result = extractor.extract(test_file, "application/octet-stream")
         assert result == "Unknown format content"
 
+    def test_extract_rejects_binary_fallthrough(self, tmp_path):
+        """Binary data routed to the text fallback must be rejected, not decoded.
+
+        Regression for issue #431: WebP/AVIF (and any binary) reaching the
+        unknown-mimetype fallback used to be cp1252-decoded into garbage and
+        written to the TEXT column, crashing Postgres. It must raise instead.
+        """
+        extractor = TextExtractor()
+
+        test_file = tmp_path / "image.webp"
+        # NUL byte marks the content as binary.
+        test_file.write_bytes(b"RIFF\x00\x00\x00\x00WEBPVP8 ")
+
+        with pytest.raises(UnsupportedFormatError):
+            extractor.extract(test_file, "image/webp")
+
     def test_extract_strips_whitespace(self, tmp_path):
         """Should strip leading/trailing whitespace from result."""
         extractor = TextExtractor()


### PR DESCRIPTION
## Problem

Uploading a `.webp` or `.avif` image via `POST /api/v1/files/` returned **HTTP 500** with `CharacterNotInRepertoireError` (`invalid byte sequence for encoding "UTF8"`).

Root cause: `image/webp` and `image/avif` were missing from `ImageMimeTypes`, so `FileProtocol.to_domain()` fell through to the **text** path. The binary image bytes were cp1252/replacement-decoded into a garbage string and written to the `files.text` (Postgres `TEXT`) column, which rejected the invalid UTF-8.

This was also an inconsistency: the icon service already accepted `image/webp`.

Fixes #431.

## Changes

- **Add `image/webp` and `image/avif` to `ImageMimeTypes`** (+ `.webp`/`.avif` extension mappings). This one enum change flows automatically to routing, the supported-formats endpoint, vision format-limits, and app input validation (all read `ImageMimeTypes.values()` / `.has_value()`). WebP/AVIF now route to the image path and store as `blob` (BYTEA).
- **Defense-in-depth guard** in the text extractor's unknown-mimetype fallback: detect binary content (NUL-byte heuristic) and raise `UnsupportedFormatError` (**HTTP 415**) instead of decoding it into the TEXT column. Any future unhandled binary format now fails cleanly rather than 500ing.

## Notes

- OpenAI/Anthropic vision APIs accept WebP but **not** AVIF, so an AVIF image may be rejected by the provider at chat time. That is a documented provider limitation and out of scope here; the goal of this PR is that the **upload** no longer crashes.
- The icon service keeps its own separate hardcoded allow-list; unifying the two is left as a separate cleanup.

## Testing

- Extended the routing test to assert webp/avif route to image and store as `blob` (not `text`).
- Added a binary-fallthrough rejection test; existing `test_extract_fallback_to_plain_text` already covers "don't over-reject legitimate text".
- `uv run pytest tests/unittests/files` — 60 passed. ruff check + format clean.