### PR TITLE
feat(chat): adopt AI Elements composition for prompt input and model selector

### DIFF
--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -1026,6 +1026,7 @@
   "no_model_found": "No model found",
   "select_completion_model": "Select a completion model",
   "model_group_system": "System models",
+  "model_group_other": "Other models",
   "model_info_for": "Model info for",
   "basic": "Basic",
   "yes": "Yes",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -1193,6 +1193,7 @@
   "no_model_found": "Ingen modell hittades",
   "select_completion_model": "Välj en completion modell",
   "model_group_system": "Systemmodeller",
+  "model_group_other": "Övriga modeller",
   "model_info_for": "Modellinformation för",
   "basic": "Grundläggande",
   "creative": "Kreativ",

--- a/frontend/apps/web/src/lib/components/ai-elements/model-selector/context.ts
+++ b/frontend/apps/web/src/lib/components/ai-elements/model-selector/context.ts
@@ -1,0 +1,19 @@
+import { getContext, setContext } from "svelte";
+
+export type ModelSelectorContext = {
+  close: () => void;
+};
+
+const CONTEXT_KEY = Symbol("model-selector");
+
+export function setModelSelectorContext(context: ModelSelectorContext): ModelSelectorContext {
+  return setContext(CONTEXT_KEY, context);
+}
+
+export function getModelSelectorContext(): ModelSelectorContext {
+  const context = getContext<ModelSelectorContext | undefined>(CONTEXT_KEY);
+  if (!context) {
+    throw new Error("ModelSelector sub-components must be rendered inside <ModelSelector>");
+  }
+  return context;
+}

--- a/frontend/apps/web/src/lib/components/ai-elements/model-selector/index.ts
+++ b/frontend/apps/web/src/lib/components/ai-elements/model-selector/index.ts
@@ -1,0 +1,34 @@
+import Root from "./model-selector.svelte";
+import Trigger from "./model-selector-trigger.svelte";
+import Content from "./model-selector-content.svelte";
+import Input from "./model-selector-input.svelte";
+import List from "./model-selector-list.svelte";
+import Empty from "./model-selector-empty.svelte";
+import Group from "./model-selector-group.svelte";
+import Item from "./model-selector-item.svelte";
+import Logo from "./model-selector-logo.svelte";
+import Name from "./model-selector-name.svelte";
+
+export {
+  Root,
+  Trigger,
+  Content,
+  Input,
+  List,
+  Empty,
+  Group,
+  Item,
+  Logo,
+  Name,
+  //
+  Root as ModelSelector,
+  Trigger as ModelSelectorTrigger,
+  Content as ModelSelectorContent,
+  Input as ModelSelectorInput,
+  List as ModelSelectorList,
+  Empty as ModelSelectorEmpty,
+  Group as ModelSelectorGroup,
+  Item as ModelSelectorItem,
+  Logo as ModelSelectorLogo,
+  Name as ModelSelectorName
+};

--- a/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-content.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-content.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import * as Popover from "$lib/components/ui/popover/index.js";
+  import * as Command from "$lib/components/ui/command/index.js";
+  import { cn } from "$lib/utils.js";
+
+  type Props = {
+    class?: string;
+    align?: "start" | "center" | "end";
+    children: Snippet;
+  };
+
+  let { class: className, align = "end", children }: Props = $props();
+</script>
+
+<Popover.Content data-slot="model-selector-content" {align} class={cn("w-[320px] p-0", className)}>
+  <Command.Root>
+    {@render children()}
+  </Command.Root>
+</Popover.Content>

--- a/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-empty.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-empty.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import * as Command from "$lib/components/ui/command/index.js";
+
+  type Props = { children: Snippet };
+
+  let { children }: Props = $props();
+</script>
+
+<Command.Empty data-slot="model-selector-empty">
+  {@render children()}
+</Command.Empty>

--- a/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-group.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-group.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import * as Command from "$lib/components/ui/command/index.js";
+
+  type Props = { heading?: string; children: Snippet };
+
+  let { heading, children }: Props = $props();
+</script>
+
+<Command.Group data-slot="model-selector-group" {heading}>
+  {@render children()}
+</Command.Group>

--- a/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-input.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-input.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import * as Command from "$lib/components/ui/command/index.js";
+
+  type Props = { placeholder?: string };
+
+  let { placeholder }: Props = $props();
+</script>
+
+<Command.Input data-slot="model-selector-input" {placeholder} />

--- a/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-item.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-item.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import * as Command from "$lib/components/ui/command/index.js";
+  import { cn } from "$lib/utils.js";
+  import { getModelSelectorContext } from "./context";
+
+  type Props = {
+    /** Search/filter string for the command palette — include the model name and vendor. */
+    value: string;
+    selected?: boolean;
+    onSelect?: () => void;
+    class?: string;
+    children: Snippet;
+  };
+
+  let { value, selected = false, onSelect, class: className, children }: Props = $props();
+
+  const modelSelector = getModelSelectorContext();
+</script>
+
+<Command.Item
+  data-slot="model-selector-item"
+  {value}
+  data-checked={selected ? "true" : undefined}
+  onSelect={() => {
+    onSelect?.();
+    modelSelector.close();
+  }}
+  class={cn("gap-2", className)}
+>
+  {@render children()}
+</Command.Item>

--- a/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-list.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-list.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import * as Command from "$lib/components/ui/command/index.js";
+  import { cn } from "$lib/utils.js";
+
+  type Props = { class?: string; children: Snippet };
+
+  let { class: className, children }: Props = $props();
+</script>
+
+<Command.List data-slot="model-selector-list" class={cn("max-h-[320px]", className)}>
+  {@render children()}
+</Command.List>

--- a/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-logo.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-logo.svelte
@@ -1,0 +1,72 @@
+<script lang="ts" module>
+  // Logos are auto-discovered from `$lib/assets/provider-logos/*` (same source as
+  // the admin ProviderGlyph). `provider` accepts either a model vendor/org
+  // ("OpenAI", "Anthropic", "Google") or a hosting provider_type ("azure",
+  // "bedrock_converse") — aliases map vendors without a logo of their own onto
+  // the closest asset.
+  const logoModules = import.meta.glob("$lib/assets/provider-logos/*.{svg,png,jpg,jpeg,webp}", {
+    eager: true,
+    query: "?url",
+    import: "default"
+  });
+
+  const logos: Record<string, string> = {};
+  for (const [path, url] of Object.entries(logoModules)) {
+    const filename = path.split("/").pop() ?? "";
+    const name = filename.replace(/\.\w+$/, "");
+    if (!logos[name]) logos[name] = url as string; // SVG takes priority (sorted first)
+  }
+
+  const aliases: Record<string, string> = {
+    google: "gemini",
+    meta: "meta_llama",
+    microsoft: "azure",
+    amazon: "bedrock",
+    bedrock_converse: "bedrock"
+  };
+
+  function resolveLogo(provider: string | null | undefined): string | undefined {
+    if (!provider) return undefined;
+    let key = provider.toLowerCase().trim().replace(/\s+/g, "_");
+    if (key.startsWith("vertex_ai")) key = "vertex_ai";
+    key = aliases[key] ?? key;
+    return logos[key];
+  }
+</script>
+
+<script lang="ts">
+  import { cn } from "$lib/utils.js";
+
+  type Props = { provider: string | null | undefined; class?: string };
+
+  let { provider, class: className }: Props = $props();
+
+  const logoUrl = $derived(resolveLogo(provider));
+</script>
+
+{#if logoUrl}
+  <img
+    data-slot="model-selector-logo"
+    src={logoUrl}
+    alt=""
+    aria-hidden="true"
+    class={cn("size-4 shrink-0 object-contain", className)}
+  />
+{:else}
+  <svg
+    data-slot="model-selector-logo"
+    class={cn("text-muted-foreground size-4 shrink-0", className)}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="4" y="4" width="6" height="6" rx="1" />
+    <rect x="14" y="4" width="6" height="6" rx="1" />
+    <rect x="4" y="14" width="6" height="6" rx="1" />
+    <rect x="14" y="14" width="6" height="6" rx="1" />
+  </svg>
+{/if}

--- a/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-name.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-name.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import { cn } from "$lib/utils.js";
+
+  type Props = { class?: string; children: Snippet };
+
+  let { class: className, children }: Props = $props();
+</script>
+
+<span data-slot="model-selector-name" class={cn("truncate", className)}>
+  {@render children()}
+</span>

--- a/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-trigger.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector-trigger.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import { ChevronDown } from "lucide-svelte";
+  import * as Popover from "$lib/components/ui/popover/index.js";
+  import { cn } from "$lib/utils.js";
+
+  type Props = {
+    class?: string;
+    children: Snippet;
+    [key: string]: unknown;
+  };
+
+  let { class: className, children, ...restProps }: Props = $props();
+</script>
+
+<Popover.Trigger
+  data-slot="model-selector-trigger"
+  class={cn(
+    "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground flex h-9 max-w-[15rem] items-center gap-1.5 rounded-lg px-2.5 text-sm font-medium transition-colors outline-none focus-visible:ring-2",
+    className
+  )}
+  {...restProps}
+>
+  {@render children()}
+  <ChevronDown class="size-3.5 shrink-0 opacity-50" aria-hidden="true" />
+</Popover.Trigger>

--- a/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/model-selector/model-selector.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import * as Popover from "$lib/components/ui/popover/index.js";
+  import { setModelSelectorContext } from "./context";
+
+  type Props = { open?: boolean; children: Snippet };
+
+  let { open = $bindable(false), children }: Props = $props();
+
+  setModelSelectorContext({
+    close: () => (open = false)
+  });
+</script>
+
+<Popover.Root bind:open>
+  {@render children()}
+</Popover.Root>

--- a/frontend/apps/web/src/lib/components/ai-elements/prompt-input/context.ts
+++ b/frontend/apps/web/src/lib/components/ai-elements/prompt-input/context.ts
@@ -1,0 +1,23 @@
+import { getContext, setContext } from "svelte";
+
+/** Mirrors the AI SDK chat status union that AI Elements components key off. */
+export type PromptInputStatus = "ready" | "submitted" | "streaming" | "error";
+
+export type PromptInputContext = {
+  readonly status: PromptInputStatus;
+  stop: () => void;
+};
+
+const CONTEXT_KEY = Symbol("prompt-input");
+
+export function setPromptInputContext(context: PromptInputContext): PromptInputContext {
+  return setContext(CONTEXT_KEY, context);
+}
+
+export function getPromptInputContext(): PromptInputContext {
+  const context = getContext<PromptInputContext | undefined>(CONTEXT_KEY);
+  if (!context) {
+    throw new Error("PromptInput sub-components must be rendered inside <PromptInput>");
+  }
+  return context;
+}

--- a/frontend/apps/web/src/lib/components/ai-elements/prompt-input/index.ts
+++ b/frontend/apps/web/src/lib/components/ai-elements/prompt-input/index.ts
@@ -1,0 +1,24 @@
+import Root from "./prompt-input.svelte";
+import Body from "./prompt-input-body.svelte";
+import Footer from "./prompt-input-footer.svelte";
+import Tools from "./prompt-input-tools.svelte";
+import Button from "./prompt-input-button.svelte";
+import Submit from "./prompt-input-submit.svelte";
+
+export type { PromptInputStatus } from "./context";
+
+export {
+  Root,
+  Body,
+  Footer,
+  Tools,
+  Button,
+  Submit,
+  //
+  Root as PromptInput,
+  Body as PromptInputBody,
+  Footer as PromptInputFooter,
+  Tools as PromptInputTools,
+  Button as PromptInputButton,
+  Submit as PromptInputSubmit
+};

--- a/frontend/apps/web/src/lib/components/ai-elements/prompt-input/prompt-input-body.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/prompt-input/prompt-input-body.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import type { HTMLAttributes } from "svelte/elements";
+  import { cn } from "$lib/utils.js";
+
+  type Props = HTMLAttributes<HTMLDivElement> & { children: Snippet };
+
+  let { class: className, children, ...restProps }: Props = $props();
+</script>
+
+<div data-slot="prompt-input-body" class={cn("relative px-1.5 pt-1", className)} {...restProps}>
+  {@render children()}
+</div>

--- a/frontend/apps/web/src/lib/components/ai-elements/prompt-input/prompt-input-button.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/prompt-input/prompt-input-button.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { Button, type ButtonProps } from "$lib/components/ui/button/index.js";
+  import { cn } from "$lib/utils.js";
+
+  let {
+    variant = "ghost",
+    size = "sm",
+    type = "button",
+    class: className,
+    children,
+    ...restProps
+  }: ButtonProps = $props();
+</script>
+
+<Button
+  data-slot="prompt-input-button"
+  {variant}
+  {size}
+  {type}
+  class={cn("h-9 gap-1.5 rounded-lg", className)}
+  {...restProps}
+>
+  {@render children?.()}
+</Button>

--- a/frontend/apps/web/src/lib/components/ai-elements/prompt-input/prompt-input-footer.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/prompt-input/prompt-input-footer.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import type { HTMLAttributes } from "svelte/elements";
+  import { cn } from "$lib/utils.js";
+
+  type Props = HTMLAttributes<HTMLDivElement> & { children: Snippet };
+
+  let { class: className, children, ...restProps }: Props = $props();
+</script>
+
+<div
+  data-slot="prompt-input-footer"
+  class={cn("flex items-center justify-between gap-2 px-2 pt-1 pb-2", className)}
+  {...restProps}
+>
+  {@render children()}
+</div>

--- a/frontend/apps/web/src/lib/components/ai-elements/prompt-input/prompt-input-submit.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/prompt-input/prompt-input-submit.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { ArrowUp, Square } from "lucide-svelte";
+  import { Button, type ButtonProps } from "$lib/components/ui/button/index.js";
+  import { cn } from "$lib/utils.js";
+  import { m } from "$lib/paraglide/messages";
+  import { getPromptInputContext } from "./context";
+
+  let { disabled, class: className, ...restProps }: ButtonProps = $props();
+
+  const promptInput = getPromptInputContext();
+  const isBusy = $derived(promptInput.status === "streaming" || promptInput.status === "submitted");
+</script>
+
+{#if isBusy}
+  <Button
+    data-slot="prompt-input-submit"
+    size="icon"
+    variant="secondary"
+    type="button"
+    aria-label={m.cancel_your_request()}
+    title={m.stop_answer()}
+    onclick={() => promptInput.stop()}
+    class={cn("size-9 rounded-lg", className)}
+    {...restProps}
+  >
+    <Square class="size-4" />
+  </Button>
+{:else}
+  <Button
+    data-slot="prompt-input-submit"
+    size="icon"
+    type="submit"
+    {disabled}
+    aria-label={m.submit_your_question()}
+    title={m.send()}
+    class={cn("size-9 rounded-lg", className)}
+    {...restProps}
+  >
+    <ArrowUp class="size-5" />
+  </Button>
+{/if}

--- a/frontend/apps/web/src/lib/components/ai-elements/prompt-input/prompt-input-tools.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/prompt-input/prompt-input-tools.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import type { HTMLAttributes } from "svelte/elements";
+  import { cn } from "$lib/utils.js";
+
+  type Props = HTMLAttributes<HTMLDivElement> & { children: Snippet };
+
+  let { class: className, children, ...restProps }: Props = $props();
+</script>
+
+<div data-slot="prompt-input-tools" class={cn("flex items-center gap-1", className)} {...restProps}>
+  {@render children()}
+</div>

--- a/frontend/apps/web/src/lib/components/ai-elements/prompt-input/prompt-input.svelte
+++ b/frontend/apps/web/src/lib/components/ai-elements/prompt-input/prompt-input.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import type { HTMLFormAttributes } from "svelte/elements";
+  import { cn } from "$lib/utils.js";
+  import { setPromptInputContext, type PromptInputStatus } from "./context";
+
+  type Props = HTMLFormAttributes & {
+    status?: PromptInputStatus;
+    onSubmit: () => void | Promise<void>;
+    onStop?: () => void;
+    children: Snippet;
+  };
+
+  let {
+    status = "ready",
+    onSubmit,
+    onStop,
+    class: className,
+    children,
+    ...restProps
+  }: Props = $props();
+
+  setPromptInputContext({
+    get status() {
+      return status;
+    },
+    stop: () => onStop?.()
+  });
+</script>
+
+<form
+  data-slot="prompt-input"
+  onsubmit={async (event) => {
+    event.preventDefault();
+    await onSubmit();
+  }}
+  class={cn(
+    "bg-card border-input focus-within:border-ring focus-within:ring-ring/40 relative flex w-full flex-col rounded-2xl border shadow-sm transition-colors focus-within:ring-[3px]",
+    className
+  )}
+  {...restProps}
+>
+  {@render children()}
+</form>

--- a/frontend/apps/web/src/lib/features/chat/components/conversation/ConversationInput.svelte
+++ b/frontend/apps/web/src/lib/features/chat/components/conversation/ConversationInput.svelte
@@ -3,6 +3,7 @@
   import { browser } from "$app/environment";
   import AttachmentUploadIconButton from "$lib/features/attachments/components/AttachmentUploadIconButton.svelte";
   import { Button } from "$lib/components/ui/button/index.js";
+  import * as PromptInput from "$lib/components/ai-elements/prompt-input/index.js";
   import { getAttachmentManager } from "$lib/features/attachments/AttachmentManager";
   import MentionInput from "../mentions/MentionInput.svelte";
   import { initMentionInput } from "../mentions/MentionInput";
@@ -15,7 +16,7 @@
   import { getAppContext } from "$lib/core/AppContext";
   import { m } from "$lib/paraglide/messages";
   import { SvelteSet } from "svelte/reactivity";
-  import { ArrowUp, Square, Globe, AlertTriangle } from "lucide-svelte";
+  import { Globe, AlertTriangle } from "lucide-svelte";
   import { getErrorMessage } from "$lib/core/errors/getErrorMessage";
 
   type McpServerSummary = {
@@ -308,12 +309,11 @@
   );
 </script>
 
-<form
-  onsubmit={async (e) => {
-    e.preventDefault();
-    await ask();
-  }}
-  class="bg-card border-input focus-within:border-ring focus-within:ring-ring/40 relative flex w-full max-w-[74ch] flex-col rounded-2xl border shadow-sm transition-colors focus-within:ring-[3px] md:w-full"
+<PromptInput.Root
+  status={chat.askQuestion.isLoading ? "streaming" : "ready"}
+  onSubmit={ask}
+  onStop={() => abortController?.abort("User cancelled")}
+  class="max-w-[74ch] md:w-full"
 >
   {#if !chat.hasCompletionModel}
     <div
@@ -326,7 +326,7 @@
     </div>
   {/if}
 
-  <div class="relative px-1.5 pt-1">
+  <PromptInput.Body>
     <MentionInput onpaste={queueUploadsFromClipboard}></MentionInput>
     {#if chat.askQuestion.isLoading}
       <div
@@ -346,7 +346,7 @@
         </div>
       </div>
     {/if}
-  </div>
+  </PromptInput.Body>
 
   {#if inputError}
     <div
@@ -375,12 +375,9 @@
     </div>
   {/if}
 
-  <div class="flex items-center justify-between gap-2 px-2 pt-1 pb-2">
-    <!-- Left cluster -->
-    <div
-      class="flex items-center gap-1 {chat.askQuestion.isLoading
-        ? 'pointer-events-none opacity-40'
-        : ''}"
+  <PromptInput.Footer>
+    <PromptInput.Tools
+      class={chat.askQuestion.isLoading ? "pointer-events-none opacity-40" : undefined}
     >
       <AttachmentUploadIconButton label={m.upload_documents_to_conversation()} />
       {#if shouldShowMentionButton}
@@ -396,19 +393,16 @@
       {/if}
 
       {#if showWebSearch}
-        <Button
+        <PromptInput.Button
           variant={useWebSearch ? "secondary" : "ghost"}
-          size="sm"
-          type="button"
-          class="h-9 gap-1.5 rounded-lg"
           onclick={() => (useWebSearch = !useWebSearch)}
           title={m.search()}
         >
           <Globe class="size-4" />
           <span class="hidden sm:inline">{m.search()}</span>
-        </Button>
+        </PromptInput.Button>
       {/if}
-    </div>
+    </PromptInput.Tools>
 
     <!-- Right cluster: model + send/stop -->
     <div class="flex items-center gap-2">
@@ -416,32 +410,7 @@
         <ChatModelSelect />
       {/if}
 
-      {#if chat.askQuestion.isLoading}
-        <Button
-          size="icon"
-          variant="secondary"
-          aria-label={m.cancel_your_request()}
-          type="button"
-          name="ask"
-          onclick={() => abortController?.abort("User cancelled")}
-          class="size-9 rounded-lg"
-          title={m.stop_answer()}
-        >
-          <Square class="size-4" />
-        </Button>
-      {:else}
-        <Button
-          size="icon"
-          disabled={isAskingDisabled}
-          aria-label={m.submit_your_question()}
-          type="submit"
-          name="ask"
-          class="size-9 rounded-lg"
-          title={m.send()}
-        >
-          <ArrowUp class="size-5" />
-        </Button>
-      {/if}
+      <PromptInput.Submit disabled={isAskingDisabled} name="ask" />
     </div>
-  </div>
-</form>
+  </PromptInput.Footer>
+</PromptInput.Root>

--- a/frontend/apps/web/src/lib/features/chat/components/switcher/ChatModelSelect.svelte
+++ b/frontend/apps/web/src/lib/features/chat/components/switcher/ChatModelSelect.svelte
@@ -3,18 +3,20 @@
 
     Licensed under the MIT License.
 
-    shadcn model selector for the chat input toolbar: policy-filtered models,
-    a locked label when the policy pins a single model, and a plain label when
-    only one model is available. Switching updates the personal space's default
-    assistant. Only meaningful for the default assistant — callers gate on
-    partner.type.
+    AI Elements-style model selector for the chat input toolbar: a command
+    palette grouped by model vendor with provider logos and text search.
+    Policy-filtered models, a locked label when the policy pins a single model,
+    and a plain label when only one model is available. Switching updates the
+    personal space's default assistant. Only meaningful for the default
+    assistant — callers gate on partner.type.
 -->
 <script lang="ts">
-  import * as Select from "$lib/components/ui/select/index.js";
+  import * as ModelSelector from "$lib/components/ai-elements/model-selector/index.js";
   import { getSpacesManager } from "$lib/features/spaces/SpacesManager";
   import { sortModels } from "$lib/features/ai-models/sortModels";
   import { m } from "$lib/paraglide/messages";
   import { Lock } from "lucide-svelte";
+  import { SvelteMap } from "svelte/reactivity";
 
   const {
     state: { currentSpace },
@@ -59,6 +61,35 @@
   const selectedId = $derived(selectedModel?.id ?? "");
   const selectedLabel = $derived(selectedModel?.nickname ?? m.select_a_model());
 
+  function prettifyProviderType(type: string | null | undefined): string | null {
+    if (!type) return null;
+    return type
+      .split("_")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
+  }
+
+  // Group by model vendor (org), falling back to the configured provider for
+  // models without one. Groups sorted alphabetically, models within a group
+  // keep sortModels' nickname order.
+  const modelGroups = $derived.by(() => {
+    const groups = new SvelteMap<string, { label: string; models: typeof visibleModels }>();
+    for (const model of visibleModels) {
+      const label =
+        model.org?.trim() ||
+        model.provider_name?.trim() ||
+        prettifyProviderType(model.provider_type) ||
+        m.model_group_other();
+      let group = groups.get(label);
+      if (!group) {
+        group = { label, models: [] };
+        groups.set(label, group);
+      }
+      group.models.push(model);
+    }
+    return Array.from(groups.values()).sort((a, b) => a.label.localeCompare(b.label));
+  });
+
   function selectModel(id: string) {
     if (!id || id === selectedId) return;
     // Persist the model on the personal default assistant. The chat page keeps
@@ -81,19 +112,32 @@
     <span class="max-w-[12rem] truncate font-medium">{selectedLabel}</span>
   </div>
 {:else}
-  <Select.Root type="single" value={selectedId} onValueChange={selectModel}>
-    <Select.Trigger
-      class="h-9 max-w-[13rem] gap-1.5 rounded-lg border-0 shadow-none"
-      aria-label={m.choose_a_completion_model()}
-    >
-      <span class="truncate">{selectedLabel}</span>
-    </Select.Trigger>
-    <Select.Content align="end">
-      {#each visibleModels as model (model.id)}
-        <Select.Item value={model.id ?? ""} label={model.nickname ?? ""}>
-          {model.nickname}
-        </Select.Item>
-      {/each}
-    </Select.Content>
-  </Select.Root>
+  <ModelSelector.Root>
+    <ModelSelector.Trigger aria-label={m.choose_a_completion_model()}>
+      {#if selectedModel}
+        <ModelSelector.Logo provider={selectedModel.org ?? selectedModel.provider_type} />
+      {/if}
+      <ModelSelector.Name>{selectedLabel}</ModelSelector.Name>
+    </ModelSelector.Trigger>
+    <ModelSelector.Content>
+      <ModelSelector.Input placeholder={m.search_models()} />
+      <ModelSelector.List>
+        <ModelSelector.Empty>{m.no_models_found()}</ModelSelector.Empty>
+        {#each modelGroups as group (group.label)}
+          <ModelSelector.Group heading={group.label}>
+            {#each group.models as model (model.id)}
+              <ModelSelector.Item
+                value={`${model.nickname ?? model.name} ${group.label}`}
+                selected={model.id === selectedId}
+                onSelect={() => selectModel(model.id)}
+              >
+                <ModelSelector.Logo provider={model.org ?? model.provider_type} />
+                <ModelSelector.Name>{model.nickname}</ModelSelector.Name>
+              </ModelSelector.Item>
+            {/each}
+          </ModelSelector.Group>
+        {/each}
+      </ModelSelector.List>
+    </ModelSelector.Content>
+  </ModelSelector.Root>
 {/if}


### PR DESCRIPTION
## Summary

Introduces an `ai-elements` component layer in the web app that follows the Vercel AI Elements naming and compound-component patterns, built on top of the existing shadcn primitives. Replaces the hand-rolled chat composer and the flat model `Select` with composable families.

### Prompt input
- New `prompt-input` family (`Root` / `Body` / `Footer` / `Tools` / `Button` / `Submit`) replaces the hand-rolled form markup in `ConversationInput`.
- The submit/stop button derives its state from a shared status context.

### Model selector
- New `model-selector` family (`Trigger` / `Content` / `Input` / `List` / `Group` / `Item` / `Logo` / `Name`) built on Popover + Command replaces the flat `Select` in `ChatModelSelect`.
- Searchable command palette grouped by model vendor, with provider logos and a check on the selected model.
- Vendor grouping falls back `org` → `provider_name` → `provider_type`; locked-model and single-model states are unchanged.

## Base branch

Targets `feature/personal-chat-governance-plan` rather than `develop`, since this work builds directly on top of that branch's composer/governance changes. Contains a single commit.

## Notes
- New strings added to both `en.json` and `sv.json`.
- No backend changes.