### PR TITLE
Expand and enforce frontend E2E coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -635,6 +635,7 @@ jobs:
       - script-tests
       - route-metadata
       - frontend
+      - frontend-e2e
       - schema-drift
       - docker-builds
 
@@ -647,6 +648,7 @@ jobs:
           SCRIPT_TESTS_RESULT: ${{ needs.script-tests.result }}
           ROUTE_METADATA_RESULT: ${{ needs.route-metadata.result }}
           FRONTEND_RESULT: ${{ needs.frontend.result }}
+          FRONTEND_E2E_RESULT: ${{ needs.frontend-e2e.result }}
           SCHEMA_DRIFT_RESULT: ${{ needs.schema-drift.result }}
           DOCKER_BUILDS_RESULT: ${{ needs.docker-builds.result }}
         run: |
@@ -673,6 +675,7 @@ jobs:
           check_result "Script tests" "$SCRIPT_TESTS_RESULT"
           check_result "Route metadata" "$ROUTE_METADATA_RESULT"
           check_result "Frontend" "$FRONTEND_RESULT"
+          check_result "Frontend E2E" "$FRONTEND_E2E_RESULT"
           check_result "Schema drift" "$SCHEMA_DRIFT_RESULT"
           check_result "Docker builds" "$DOCKER_BUILDS_RESULT"
 

--- a/frontend/E2E_FLOW_PLAN.md
+++ b/frontend/E2E_FLOW_PLAN.md
@@ -1,0 +1,311 @@
+# Frontend E2E flow plan
+
+## Purpose
+
+The E2E suite should prove that important backend capabilities are consumed
+correctly through the frontend and other supported consumers.
+
+An E2E flow is valuable when it verifies the complete contract:
+
+1. The UI sends the intended command.
+2. The backend accepts or rejects it according to domain rules and permissions.
+3. The resulting state is persisted.
+4. The frontend renders that state correctly after a reload or in a new session.
+5. A user or API consumer can use the result as intended.
+
+The suite should not repeat every backend validation or component rendering
+variant. Those remain cheaper and easier to diagnose in backend, unit, and
+component tests.
+
+## Current baseline
+
+The mandatory Playwright suite currently covers:
+
+- successful and rejected username/password login;
+- redirect from protected routes;
+- authenticated landing and primary navigation;
+- account information;
+- logout and session invalidation;
+- sending a deterministic chat message;
+- streaming and persisting the answer;
+- reopening the conversation from history and after a reload.
+
+This gives us a useful smoke test, but it does not yet prove the main authoring,
+permission, publishing, administration, or asynchronous processing workflows.
+Backend tests cover much of their domain logic in isolation; the E2E gaps are
+primarily in the contracts between UI state, API payloads, permissions, persisted
+state, and consumer-facing results.
+
+## Test selection rules
+
+Add an E2E flow when at least one of these is true:
+
+- a failure would block a core user journey;
+- the flow crosses several boundaries, such as UI, API, database, worker, or
+  websocket/SSE;
+- permissions change both the available UI and the backend outcome;
+- frontend form state is translated into a complex backend command;
+- an authored resource is later consumed from another page, session, role, or
+  API client;
+- the frontend has meaningful recovery behavior for a backend or streaming
+  failure.
+
+Do not add an E2E test only to cover:
+
+- every field validation or visual variant;
+- pure formatting or transformation logic;
+- every backend permission combination;
+- implementation details that are already covered by a smaller test;
+- third-party availability in the pull-request suite.
+
+For each major workflow, prefer one representative success journey and one
+high-risk permission or failure journey.
+
+## Mandatory pull-request suite
+
+These flows should be deterministic, isolated from external services, and remain
+part of the blocking `Frontend E2E` CI job.
+
+### 1. Authentication and session lifecycle
+
+**Status:** covered.
+
+**Journey**
+
+1. An anonymous user is redirected from a protected route.
+2. Invalid credentials produce an accessible error without creating a session.
+3. Valid credentials create a session and open the application.
+4. Logout invalidates the session and protects previously accessible routes.
+
+**Contract proved:** browser cookies, frontend guards, authentication API, error
+presentation, and session invalidation agree.
+
+### 2. Personal chat lifecycle
+
+**Status:** covered.
+
+**Journey**
+
+1. The user sends a message through the editor.
+2. The answer is streamed from the deterministic model service.
+3. Both messages are rendered and persisted.
+4. The conversation can be reopened from history.
+5. The same state remains after a full reload.
+
+**Contract proved:** chat input, conversation API, SSE streaming, persistence, and
+history rendering work together.
+
+### 3. Assistant authoring to consumption
+
+**Priority:** next.
+
+**Journey**
+
+1. Create an assistant from the UI with a unique name.
+2. Configure its prompt and completion model.
+3. Save it and reload the edit page.
+4. Verify that the persisted configuration is shown.
+5. Publish it.
+6. Open it from the dashboard and send a message.
+7. Verify the deterministic answer and persisted conversation.
+8. Unpublish it and verify that it is no longer offered as a published resource.
+
+**Contract proved:** editor form state, assistant API payloads, persistence,
+publishing, dashboard discovery, and runtime chat use the same resource
+correctly.
+
+**Avoid:** asserting every editor control. Detailed editor behavior belongs in
+component tests.
+
+### 4. Shared space and permission enforcement
+
+**Priority:** next.
+
+**Journey**
+
+1. An owner creates a restricted role, a user, and a shared space.
+2. The owner adds the user to the space with that role.
+3. The restricted user signs in using a separate browser context.
+4. The user can discover and use the allowed shared resource.
+5. Edit, publish, member-management, and other denied actions are absent.
+6. Direct navigation or an API request for a denied action is also rejected.
+7. A permitted change made by the owner becomes visible to the restricted user.
+
+**Contract proved:** role configuration, space membership, frontend capability
+rendering, backend authorization, and cross-session state agree.
+
+Use one representative restricted role. The backend suite should continue to
+cover the full permission matrix.
+
+### 5. API key from administration to real consumer
+
+**Priority:** next.
+
+**Journey**
+
+1. An owner creates a scoped API key through the admin UI.
+2. The one-time secret is shown and captured.
+3. Playwright's request client uses the secret against a stable endpoint allowed
+   by the selected scope.
+4. The response proves that the key is usable by an actual API consumer.
+5. The owner revokes the key in the UI.
+6. Repeating the same request is rejected.
+7. The UI shows the revoked state after a reload.
+
+**Contract proved:** admin form payload, secret presentation, authentication
+middleware, scope enforcement, revocation, and persisted status.
+
+This gives broader value than duplicating the backend's extensive API-key unit
+and integration test matrix.
+
+### 6. Model or stream failure recovery
+
+**Priority:** next.
+
+**Journey**
+
+1. Send a marker message that makes the local model mock return a deterministic
+   HTTP or stream error.
+2. Verify that the frontend presents an understandable error.
+3. Verify that no successful assistant answer is falsely persisted.
+4. Confirm that the user's input or conversation remains recoverable.
+5. Retry with a successful marker and verify that the conversation can continue.
+
+**Contract proved:** backend error translation, SSE termination, frontend state
+cleanup, persistence, and retry behavior.
+
+This requires extending the model mock with request-controlled success and error
+responses.
+
+## Mandatory after test infrastructure expansion
+
+These are core flows, but should only become blocking after their local
+dependencies are deterministic and stable.
+
+### 7. App authoring and asynchronous run
+
+**Journey**
+
+1. Create and configure an app in the UI.
+2. Save, reload, and publish it.
+3. Run it from the dashboard with known input.
+4. Observe the queued/running state.
+5. Receive the websocket update and open the completed result.
+6. Reload and verify that the result remains available.
+
+**Infrastructure required**
+
+- an ARQ worker in the E2E Docker Compose stack;
+- seeded completion and transcription model capabilities;
+- deterministic local model responses.
+
+**Contract proved:** app editor, publishing, job queue, worker, websocket updates,
+result persistence, and dashboard rendering.
+
+### 8. Knowledge upload to grounded answer
+
+**Journey**
+
+1. Create a collection.
+2. Upload a small document containing a unique known fact.
+3. Wait for indexing to complete and verify the document state.
+4. Attach the collection to an assistant.
+5. Ask a question whose answer exists only in that document.
+6. Verify the expected grounded answer and its source/reference.
+7. Reload the conversation and verify that the answer remains.
+
+**Infrastructure required**
+
+- an ARQ worker;
+- a deterministic local embeddings endpoint and seeded embedding model;
+- a small fixture document;
+- deterministic model behavior that can respond from the supplied context.
+
+**Contract proved:** upload, background processing, embeddings, collection
+selection, assistant configuration, retrieval, generation, citations, and
+frontend presentation.
+
+This is the strongest whole-product E2E candidate and should become mandatory
+once it is reliable.
+
+### 9. Auditable administration action
+
+Extend one existing mutation flow rather than creating a broad audit-log test:
+
+1. Perform a distinctive action such as publishing an assistant, creating an API
+   key, or changing a user.
+2. Open the audit log.
+3. Verify the action, actor, target, and timestamp are presented correctly.
+
+**Contract proved:** domain event creation, audit persistence, API serialization,
+label mapping, and admin rendering.
+
+## Nightly or provider-contract suite
+
+Keep these out of the blocking pull-request path until they use reliable local
+provider mocks:
+
+- OIDC/federation login and callback failures using a mock identity provider;
+- website crawling against a local fixture site;
+- SharePoint and other integration authorization/synchronization;
+- SCIM provisioning;
+- multi-tenant isolation journeys;
+- provider-specific completion, transcription, or embedding contracts;
+- browser and mobile-layout coverage beyond the primary Chromium desktop path.
+
+These tests are still valuable, but external availability and provider behavior
+must not make ordinary pull requests flaky.
+
+## Implementation order
+
+### Phase 1: Strengthen the current blocking suite
+
+1. Assistant authoring to consumption.
+2. Shared-space permission enforcement.
+3. API-key consumer lifecycle.
+4. Model/stream failure recovery.
+
+Keep these flows independent and use unique resource names. Use API or seed
+helpers for prerequisite data when setup itself is not the behavior being tested.
+
+### Phase 2: Add deterministic asynchronous infrastructure
+
+1. Add the worker service to local and CI E2E Compose files.
+2. Seed all model capabilities required by apps and knowledge.
+3. Extend the mock model service with completion, error, transcription, and
+   embedding behavior as needed.
+4. Add app execution and knowledge-to-answer flows.
+5. Make the new flows blocking only after repeated stable CI runs.
+
+### Phase 3: Expand consumer and provider confidence
+
+1. Add the audit assertion to an existing administration journey.
+2. Add mock-provider flows for OIDC, crawling, and integrations.
+3. Run provider-heavy and broader browser coverage on a nightly schedule.
+
+## Test design and CI guardrails
+
+- Use the UI for the behavior under test; use seed/API helpers for unrelated
+  setup and cleanup.
+- Give each test its own data and never rely on test order.
+- Prefer role, label, and semantic locators over CSS structure or translated
+  display text.
+- Assert durable outcomes after reload, a new page, or a second browser context.
+- Assert backend denial as well as hidden controls for permission tests.
+- Keep third-party network access disabled in the mandatory suite.
+- Capture Playwright traces, screenshots, and the HTML report on failure.
+- Retry only in CI and investigate repeated first-attempt failures as flakes.
+- Keep the mandatory browser journeys few enough to remain understandable and
+  fast; add lower-level tests when a flow starts branching into many variants.
+
+## Definition of done for a new mandatory flow
+
+A flow is ready to block pull requests when:
+
+- it runs against the isolated E2E stack with no production credentials;
+- all external responses are deterministic;
+- it owns its test data and passes when run alone;
+- it verifies a persisted or cross-consumer outcome, not only a toast;
+- it has failed for an intentional product regression during development;
+- failure artifacts make the broken boundary diagnosable;
+- repeated CI runs show no unexplained retries or timing dependence.

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -107,9 +107,35 @@ string (`E2E mock completion: pong`) — fast, free, and identical every run. No
 real provider is ever called. To keep credentials simple the stack runs with
 encryption off, so the seeded api-key is plaintext (and meaningless).
 
-> **Status:** the full suite (login, unauthenticated redirect, authenticated
-> landing, and the deterministic chat stream) runs green in CI on every PR via the
-> `Frontend E2E` job, and locally with `bun run test:all` (or `bun run test:e2e`).
+> **Status:** the suite covers login, rejected credentials, unauthenticated
+> redirects, authenticated landing, primary navigation, account data, logout,
+> deterministic chat streaming, and reopening persisted chat history. It runs in
+> CI on every PR via the `Frontend E2E` job, and locally with `bun run test:all`
+> (or `bun run test:e2e`).
+
+### E2E coverage strategy
+
+Keep the E2E layer focused on high-value user journeys that cross the browser,
+SvelteKit, and backend boundary. Rendering variants and pure business logic
+belong in component or unit tests.
+
+The prioritized flow plan, including mandatory CI candidates and required test
+infrastructure, is documented in
+[`E2E_FLOW_PLAN.md`](./E2E_FLOW_PLAN.md).
+
+| Area                | Covered now                                                                                   | Next high-value coverage                                                              |
+| ------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Authentication      | Successful login, rejected credentials, protected-route redirect, logout/session invalidation | Expired sessions, OIDC callback failures, tenant switching                            |
+| App shell           | Authenticated landing, primary navigation, admin access, account details                      | Mobile navigation, permission-restricted navigation                                   |
+| Chat                | Send, stream, persist, reopen, reload                                                         | New conversation, rename/delete history, attachments, model switching, error recovery |
+| Spaces              | Navigation to the space list                                                                  | Create/edit/delete a shared space, member permissions                                 |
+| Assistants and apps | Route loading only through shared navigation                                                  | Create, configure, publish, run, and delete                                           |
+| Knowledge           | Not covered end-to-end                                                                        | Upload/index/delete a document, collection and website lifecycle                      |
+| Administration      | Admin shell loads                                                                             | User lifecycle, roles, model/provider configuration, audit logs                       |
+
+Prioritize one happy path and one failure or permission path for each critical
+workflow. Seed deterministic fixtures in `e2e/seed.py` instead of relying on test
+ordering, production data, or third-party services.
 
 ## Writing tests
 
@@ -224,11 +250,9 @@ Two jobs in `.github/workflows/ci.yml` run on every PR:
   backend built from its Dockerfile) and runs the full Playwright suite, uploading
   the HTML report as an artifact.
 
-**`Frontend E2E` is currently non-blocking:** it is *not* in the aggregate `CI`
-job's `needs:` list, so a red E2E run does not fail the PR (it adds real CI time —
-backend image build + frontend build + browser run — and the suite is newer/more
-prone to flake). To make it blocking, add the `Frontend E2E` check to branch
-protection in repo settings.
+**`Frontend E2E` is blocking:** it is included in the aggregate `CI` job's
+`needs:` list and result check, so a failed E2E run makes the required `CI` status
+fail.
 
 ## Coverage
 

--- a/frontend/apps/web/eslint.config.js
+++ b/frontend/apps/web/eslint.config.js
@@ -33,7 +33,17 @@ export default ts.config(
     // `**/dev/**` routes are throwaway UI prototypes / previews (see their
     // READMEs); their demo copy is intentionally not translated, so exempt them
     // from the lint rules that would otherwise force paraglide messages.
-    ignores: ["build/", ".svelte-kit/", "dist/", "**/paraglide/", "**/dev/**"]
+    ignores: [
+      "build/",
+      ".svelte-kit/",
+      ".svelte-kit-e2e/",
+      "coverage/",
+      "playwright-report/",
+      "test-results/",
+      "dist/",
+      "**/paraglide/",
+      "**/dev/**"
+    ]
   },
   {
     // Block hardcoded human-facing text — every human-facing string must go

--- a/frontend/apps/web/src/routes/(public)/login/+page.svelte
+++ b/frontend/apps/web/src/routes/(public)/login/+page.svelte
@@ -687,7 +687,10 @@
           <input type="text" hidden value={page.url.searchParams.get("next") ?? ""} name="next" />
 
           {#if loginFailed}
-            <div class="label-negative bg-label-dimmer text-label-stronger rounded-lg p-4">
+            <div
+              role="alert"
+              class="label-negative bg-label-dimmer text-label-stronger rounded-lg p-4"
+            >
               <p>{m.incorrect_credentials()}</p>
 
               <!-- Correlation ID Section for Developer Debugging -->

--- a/frontend/apps/web/tests/chat.spec.ts
+++ b/frontend/apps/web/tests/chat.spec.ts
@@ -5,14 +5,31 @@ import { expect, test } from "@playwright/test";
 // at the deterministic mock server, so the reply is always the same fixed string —
 // this exercises the full chain (UI → conversations SSE → litellm → model) without
 // touching a real provider.
-test("sending a message streams the assistant's answer", async ({ page }) => {
+test("a streamed answer is saved and can be reopened from history", async ({ page }) => {
   await page.goto("/spaces/personal/chat");
 
+  const question = "e2e persistence ping";
   const input = page.locator('[contenteditable="true"]').first();
   await input.click();
-  await input.pressSequentially("ping");
+  await input.pressSequentially(question);
 
   await page.locator('button[name="ask"]').click();
 
+  await expect(page.getByText(question, { exact: true })).toBeVisible();
   await expect(page.getByText("E2E mock completion: pong")).toBeVisible({ timeout: 20_000 });
+
+  await page.getByRole("tablist").getByRole("tab").nth(1).click();
+
+  const savedConversation = page.locator("table tbody button").first();
+  await expect(savedConversation).toBeVisible();
+  await savedConversation.click();
+
+  const conversation = page.locator("#session-message-container");
+  await expect(conversation.getByText(question, { exact: true })).toBeVisible();
+  await expect(conversation.getByText("E2E mock completion: pong")).toBeVisible();
+
+  await page.reload();
+
+  await expect(conversation.getByText(question, { exact: true })).toBeVisible();
+  await expect(conversation.getByText("E2E mock completion: pong")).toBeVisible();
 });

--- a/frontend/apps/web/tests/navigation.spec.ts
+++ b/frontend/apps/web/tests/navigation.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/test";
+
+test("primary navigation and account menu reach their main destinations", async ({ page }) => {
+  await page.goto("/");
+
+  const primaryNavigation = page.locator("header nav");
+
+  await primaryNavigation.locator('a[href$="/spaces/list"]').click();
+  await expect(page).toHaveURL(/\/spaces\/list$/);
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+  await primaryNavigation.locator('a[href$="/admin"]').click();
+  await expect(page).toHaveURL(/\/admin$/);
+  await expect(page.getByRole("navigation").nth(1)).toBeVisible();
+
+  await page.locator('header nav button[aria-haspopup="menu"]').last().click();
+  await page.locator('a[href$="/account"]').click();
+
+  await expect(page).toHaveURL(/\/account$/);
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+  await expect(page.locator("main pre").filter({ hasText: /^e2e@example\.com$/ })).toBeVisible();
+});

--- a/frontend/apps/web/tests/session.spec.ts
+++ b/frontend/apps/web/tests/session.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test("logging out invalidates the authenticated session", async ({ page }) => {
+  await page.goto("/logout");
+
+  await expect(page).toHaveURL(/\/login\?.*message=logout/);
+  await expect(page.locator('input[name="email"]')).toBeVisible();
+
+  await page.goto("/");
+
+  await expect(page).toHaveURL(/\/login/);
+  await expect(page.locator('input[name="password"]')).toBeVisible();
+});

--- a/frontend/apps/web/tests/smoke.spec.ts
+++ b/frontend/apps/web/tests/smoke.spec.ts
@@ -10,3 +10,15 @@ test("unauthenticated visitor is redirected to login", async ({ page }) => {
   await expect(page).toHaveURL(/\/login/);
   await expect(page.locator('input[name="email"]')).toBeVisible();
 });
+
+test("invalid credentials keep the visitor on the login page", async ({ page }) => {
+  await page.goto("/login");
+
+  await page.locator('input[name="email"]').fill("e2e@example.com");
+  await page.locator('input[name="password"]').fill("not-the-password");
+  await page.locator('button[type="submit"]').click();
+
+  await expect(page).toHaveURL(/\/login/);
+  await expect(page.getByRole("alert")).toBeVisible();
+  await expect(page.locator('input[name="email"]')).toBeVisible();
+});


### PR DESCRIPTION
## Summary

- make the Frontend E2E job part of the aggregate required CI result
- cover rejected login, primary navigation, account data, logout, chat persistence, history reopening, and reload
- add an accessible alert role to the login failure message
- document the E2E selection strategy and prioritized product flows
- ignore generated test artifacts in frontend linting

## Why

The E2E job ran on pull requests but did not affect the aggregate CI status, and the suite covered only a narrow smoke path. Important browser/backend contracts could regress without blocking a merge.

## Developer impact

The deterministic E2E suite now blocks the aggregate CI check. The flow plan separates high-value cross-boundary journeys from behavior better covered by unit or component tests.

## Validation

- Svelte check passed with 0 errors and 0 warnings
- Playwright discovered 7 tests across 6 files
- frontend format and lint hooks passed
- full Docker-backed Playwright execution is delegated to CI