### PR TITLE
Standardize local worker and cache commands

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -10,7 +10,7 @@ tasks:
 
   worker:
     cmds:
-      - uv run arq src.intric.worker.arq.WorkerSettings
+      - uv run worker
     dir: ./backend
 
   frontend:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -61,6 +61,7 @@ dependencies = [
 
 [project.scripts]
 start = "intric.server.main:start"
+worker = "intric.worker.cli:start"
 
 [dependency-groups]
 dev = [

--- a/backend/src/intric/worker/cli.py
+++ b/backend/src/intric/worker/cli.py
@@ -1,0 +1,9 @@
+import sys
+
+from arq.cli import cli
+
+WORKER_SETTINGS = "src.intric.worker.arq.WorkerSettings"
+
+
+def start() -> None:
+    cli(args=[WORKER_SETTINGS, *sys.argv[1:]], prog_name="worker")

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -41,7 +41,7 @@ cd backend && uv run python init_db.py
 # Start development servers (3 terminals)
 cd backend && uv run start              # Terminal 1
 cd frontend && bun run dev                 # Terminal 2
-cd backend && uv run arq src.intric.worker.arq.WorkerSettings  # Terminal 3
+cd backend && uv run worker             # Terminal 3
 ```
 
 ### 2. Make Your First Contribution

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -80,7 +80,7 @@ bun run dev
 **Terminal 3 - Worker (Optional, for document processing and for the crawler & apps to work):**
 ```bash
 cd backend
-uv run arq src.intric.worker.arq.WorkerSettings
+uv run worker
 ```
 
 ## Verify Installation

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,8 @@
   "scripts": {
     "build": "NODE_ENV=production FORCE_COLOR=1 bun run --filter @intric/ui build && NODE_ENV=production FORCE_COLOR=1 bun run --filter @intric/web build",
     "dev": "NODE_ENV=development FORCE_COLOR=1 bun run --elide-lines=0 --filter @intric/web --filter @intric/ui dev",
+    "dev:clean": "bun run clean:cache && bun run dev",
+    "clean:cache": "rm -rf apps/web/node_modules/.vite apps/web/.svelte-kit packages/ui/.svelte-kit",
     "lint": "FORCE_COLOR=1 bun run --filter '*' lint",
     "check": "NODE_ENV=production FORCE_COLOR=1 bun run --filter '*' check",
     "format": "FORCE_COLOR=1 bun run --filter '*' format",


### PR DESCRIPTION
## Summary

- expose the ARQ worker as the project script `uv run worker`
- preserve additional CLI arguments through a small worker entry point
- update Taskfile and setup documentation to use the stable command
- add frontend cache cleanup and `dev:clean` scripts

## Why

The documented worker command depended on an internal module path, and clearing stale frontend build caches required remembering several directories. Stable project-level commands make local setup and recovery less error-prone.

## Developer impact

Local development can start the worker through `task worker` or `uv run worker`, and can clear generated frontend caches with `bun run clean:cache` or restart cleanly with `bun run dev:clean`.

## Validation

- Ruff passed
- worker entry-point import smoke test passed
- commit hooks including Pyright passed
- pre-push schema drift check passed