### PR TITLE
feat: support JSON/XML attachments and decouple crawler MIME policy

### DIFF
--- a/backend/src/intric/crawler/parse_html.py
+++ b/backend/src/intric/crawler/parse_html.py
@@ -12,6 +12,31 @@ from intric.files.text import TextMimeTypes
 logger = logging.getLogger(__name__)
 
 
+# MIME types of linked documents worth downloading and ingesting during a crawl.
+# Deliberately kept separate from the upload/attachment allowlist (TextMimeTypes):
+# broadening what users may attach must never silently widen crawl scope. HTML is
+# excluded on purpose — pages are extracted via parse_response, not ingested as
+# standalone files — and legacy .doc/.ppt are excluded since the extractor rejects
+# them anyway. Values are sourced from TextMimeTypes so a removed format breaks at
+# import time rather than drifting silently.
+CRAWLABLE_DOCUMENT_MIMETYPES: frozenset[str] = frozenset(
+    {
+        TextMimeTypes.MD.value,
+        TextMimeTypes.TXT.value,
+        TextMimeTypes.PDF.value,
+        TextMimeTypes.DOCX.value,
+        TextMimeTypes.TEXT_CSV.value,
+        TextMimeTypes.APP_CSV.value,
+        TextMimeTypes.PPTX.value,
+        TextMimeTypes.XLSX.value,
+        TextMimeTypes.XLS.value,
+        TextMimeTypes.JSON.value,
+        TextMimeTypes.XML.value,
+        TextMimeTypes.XML_APP.value,
+    }
+)
+
+
 @dataclass
 class CrawledPage:
     url: str
@@ -62,7 +87,8 @@ def parse_file(response: Response) -> dict[str, list[str]] | None:
             )
             return None
 
-    if TextMimeTypes.has_value(content_type):
+    base_type = content_type.split(";")[0].strip()
+    if base_type in CRAWLABLE_DOCUMENT_MIMETYPES:
         return {"file_urls": [response.url]}
 
     return None

--- a/backend/src/intric/files/extensions.py
+++ b/backend/src/intric/files/extensions.py
@@ -13,6 +13,9 @@ MIMETYPE_EXTENSIONS_MAPPER = {
     TextMimeTypes.PPTX.value: [".pptx"],
     TextMimeTypes.XLSX.value: [".xlsx"],
     TextMimeTypes.XLS.value: [".xls"],
+    TextMimeTypes.JSON.value: [".json"],
+    TextMimeTypes.XML.value: [".xml"],
+    TextMimeTypes.XML_APP.value: [".xml"],
     # Legacy formats (for detection/rejection)
     TextMimeTypes.DOC.value: [".doc"],
     TextMimeTypes.PPT.value: [".ppt"],

--- a/backend/src/intric/files/text.py
+++ b/backend/src/intric/files/text.py
@@ -75,6 +75,10 @@ class MimeTypesBase(str, Enum):
 
 
 class TextMimeTypes(MimeTypesBase):
+    # Text formats the extractor can handle. Doubles as the upload/attachment
+    # allowlist (see limits.limit_service). The crawler maintains its own
+    # download policy in crawler.parse_html.CRAWLABLE_DOCUMENT_MIMETYPES — keep
+    # the two concerns separate so changing one never silently affects the other.
     # Supported formats
     MD = "text/markdown"
     TXT = "text/plain"
@@ -85,6 +89,10 @@ class TextMimeTypes(MimeTypesBase):
     PPTX = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
     XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     XLS = "application/vnd.ms-excel"
+    JSON = "application/json"
+    # Browsers and libmagic disagree on the XML mimetype, so accept both spellings
+    XML = "text/xml"
+    XML_APP = "application/xml"
 
     # Legacy formats (for detection/rejection only)
     DOC = "application/msword"
@@ -386,6 +394,9 @@ class TextExtractor:
                 | TextMimeTypes.MD
                 | TextMimeTypes.TEXT_CSV
                 | TextMimeTypes.APP_CSV
+                | TextMimeTypes.JSON
+                | TextMimeTypes.XML
+                | TextMimeTypes.XML_APP
             ):
                 extracted_text = self.extract_from_plain_text(filepath, display_name)
             case TextMimeTypes.PDF:

--- a/backend/tests/unittests/crawler/test_parse_html.py
+++ b/backend/tests/unittests/crawler/test_parse_html.py
@@ -1,0 +1,45 @@
+from types import SimpleNamespace
+
+from intric.crawler.parse_html import (
+    CRAWLABLE_DOCUMENT_MIMETYPES,
+    parse_file,
+)
+
+
+def _response(content_type: str, url: str = "https://example.com/doc"):
+    # parse_file only touches .headers.get(b"Content-Type") and .url
+    return SimpleNamespace(
+        headers={b"Content-Type": content_type.encode()},
+        url=url,
+    )
+
+
+class TestParseFileCrawlPolicy:
+    """parse_file decides which linked files a crawl ingests as documents."""
+
+    def test_ingests_supported_documents(self):
+        for ct in ["application/pdf", "application/json", "text/xml", "text/csv"]:
+            assert parse_file(_response(ct)) == {
+                "file_urls": ["https://example.com/doc"]
+            }, ct
+
+    def test_skips_html_pages(self):
+        # HTML is handled by parse_response as a page, never downloaded as a file.
+        assert parse_file(_response("text/html")) is None
+        assert "text/html" not in CRAWLABLE_DOCUMENT_MIMETYPES
+
+    def test_skips_legacy_office_formats(self):
+        # Legacy .doc/.ppt are rejected by the extractor, so don't waste a download.
+        assert parse_file(_response("application/msword")) is None
+        assert parse_file(_response("application/vnd.ms-powerpoint")) is None
+
+    def test_skips_unknown_types(self):
+        assert parse_file(_response("application/octet-stream")) is None
+        assert parse_file(_response("image/png")) is None
+
+    def test_handles_charset_suffix(self):
+        assert parse_file(_response("application/pdf; charset=binary")) is not None
+
+    def test_falls_back_to_extension_when_no_content_type(self):
+        resp = SimpleNamespace(headers={}, url="https://example.com/report.pdf")
+        assert parse_file(resp) == {"file_urls": ["https://example.com/report.pdf"]}

--- a/backend/tests/unittests/files/test_text_extractor.py
+++ b/backend/tests/unittests/files/test_text_extractor.py
@@ -67,6 +67,9 @@ class TestTextMimeTypes:
             is True
         )
         assert TextMimeTypes.has_value("application/vnd.ms-excel") is True
+        assert TextMimeTypes.has_value("application/json") is True
+        assert TextMimeTypes.has_value("text/xml") is True
+        assert TextMimeTypes.has_value("application/xml") is True
 
     def test_has_value_returns_false_for_invalid_mime(self):
         """has_value should return False for invalid MIME types."""
@@ -494,6 +497,27 @@ class TestTextExtractorExtractMethod:
 
         result = extractor.extract(test_file, "text/plain")
         assert result == "Plain text content"
+
+    def test_extract_routes_json_correctly(self, tmp_path):
+        """Should route JSON files through plain text extraction."""
+        extractor = TextExtractor()
+
+        test_file = tmp_path / "test.json"
+        test_file.write_text('{"key": "value"}')
+
+        result = extractor.extract(test_file, "application/json")
+        assert result == '{"key": "value"}'
+
+    def test_extract_routes_xml_correctly(self, tmp_path):
+        """Should route XML files through plain text extraction for both spellings."""
+        extractor = TextExtractor()
+
+        test_file = tmp_path / "test.xml"
+        content = "<root><a>1</a></root>"
+        test_file.write_text(content)
+
+        assert extractor.extract(test_file, "text/xml") == content
+        assert extractor.extract(test_file, "application/xml") == content
 
     def test_extract_routes_markdown_correctly(self, tmp_path):
         """Should route markdown files correctly."""


### PR DESCRIPTION
## Summary

Adds **JSON** and **XML** as supported attachment / knowledge-upload formats, and decouples the crawler's downloadable-document policy from the upload allowlist so the two concerns can evolve independently.

## What changed

**New attachment formats**
- `application/json`, `text/xml` and `application/xml` added to `TextMimeTypes` (XML uses two spellings, mirroring the existing `text/csv` + `application/csv` pattern, because browsers and libmagic disagree on the canonical type).
- Extraction reuses the existing plain-text path — no new parser needed.
- Extension entries added to `MIMETYPE_EXTENSIONS_MAPPER` (required, or `limit_service` raises `KeyError`).
- The frontend picks the new formats up automatically via `GET /settings/formats/`; no frontend change needed.

**Crawler / upload separation**
- `parse_file` previously used `TextMimeTypes.has_value()`, so the crawler's "download this linked file" decision was coupled to the upload allowlist. Broadening uploads would have silently widened crawl scope.
- Introduced an explicit `CRAWLABLE_DOCUMENT_MIMETYPES` frozenset in `crawler/parse_html.py`. Its values are sourced from `TextMimeTypes` so a removed format breaks at import time rather than drifting silently.
- This also fixes pre-existing edge cases: HTML is excluded (pages are handled by `parse_response`, never downloaded as files) and legacy `.doc/.ppt` are excluded (the extractor rejects them anyway, so downloading them was wasted work).

## Why not HTML / YAML?

- **HTML**: raw extraction would feed the model `<script>`/`<style>`/tag noise. Proper support needs a dedicated cleaner (reuse `parse_html`), so it's deliberately out of scope here.
- **YAML / source code**: libmagic detects these as `text/plain` (backend already accepts them), but browsers report an empty `file.type`, so the frontend's exact-MIME validation rejects them. Supporting them properly needs extension-based frontend validation — a separate, isolated change.

## Testing

- New `tests/unittests/crawler/test_parse_html.py` locks the crawl policy: HTML excluded, documents included, legacy/unknown excluded, charset suffix handled, extension fallback.
- New JSON/XML extraction + `has_value` cases in `test_text_extractor.py`.
- 61 unit tests pass (files + crawler); `pyright` clean; all pre-commit hooks green.
