### PR TITLE
fix(mcp): assign post-creation-enabled servers to personal assistants

### DIFF
--- a/backend/src/intric/assistants/assistant_service.py
+++ b/backend/src/intric/assistants/assistant_service.py
@@ -623,9 +623,6 @@ class AssistantService:
             from intric.database.tables.mcp_server_table import (
                 MCPServers as MCPServersTable,
             )
-            from intric.database.tables.mcp_server_table import (
-                SpacesMCPServers as SpacesMCPServersTable,
-            )
 
             mcp_servers_query = (
                 sa.select(MCPServersTable.id)
@@ -649,9 +646,6 @@ class AssistantService:
 
             # For a personal default assistant under an active MCP policy, the
             # governance whitelist (enforced just below) is the source of truth.
-            # Personal spaces are seeded with tenant MCP servers only at creation
-            # time and are not back-filled when a server is enabled later, so the
-            # space-assignment check would wrongly reject a policy-allowed server.
             if isinstance(mcp_effective_config, NotProvided):
                 mcp_effective_config = await self._resolve_effective_config(
                     space=space, assistant=assistant
@@ -660,20 +654,18 @@ class AssistantService:
                 mcp_effective_config is not None and mcp_effective_config.mcp_enforced
             )
             if not mcp_governed:
-                space_servers_query = sa.select(
-                    SpacesMCPServersTable.mcp_server_id
-                ).where(
-                    SpacesMCPServersTable.space_id == space.id,
-                    SpacesMCPServersTable.mcp_server_id.in_(mcp_server_ids),
-                )
-                space_servers_result = await self.repo.session.execute(
-                    space_servers_query
-                )
-                space_server_ids = {row[0] for row in space_servers_result.fetchall()}
+                # Validate space membership against the space read model — the
+                # same source the editor/UI uses to offer servers. For a personal
+                # space that is every tenant-enabled server (space_factory exposes
+                # them all); for a shared space it is the spaces_mcp_servers
+                # mapping. Do NOT query spaces_mcp_servers directly: that table is
+                # seeded once at space creation and never back-filled, so for a
+                # personal space it goes stale and wrongly rejects servers enabled
+                # after the space was created (#500).
                 missing_space_ids = [
                     str(server_id)
                     for server_id in mcp_server_ids
-                    if server_id not in space_server_ids
+                    if not space.is_mcp_server_in_space(server_id)
                 ]
                 if missing_space_ids:
                     raise BadRequestException(
@@ -1811,9 +1803,6 @@ class AssistantService:
         from intric.database.tables.mcp_server_table import (
             MCPServers as MCPServersTable,
         )
-        from intric.database.tables.mcp_server_table import (
-            SpacesMCPServers as SpacesMCPServersTable,
-        )
 
         # Validate tenant ownership + enablement
         mcp_server_query = sa.select(MCPServersTable).where(
@@ -1829,16 +1818,14 @@ class AssistantService:
             space=space, assistant=assistant
         )
         mcp_governed = effective_config is not None and effective_config.mcp_enforced
-        if not mcp_governed:
-            space_mapping_query = sa.select(SpacesMCPServersTable).where(
-                SpacesMCPServersTable.space_id == space.id,
-                SpacesMCPServersTable.mcp_server_id == mcp_server_id,
+        if not mcp_governed and not space.is_mcp_server_in_space(mcp_server_id):
+            # Validate against the space read model, not the stale
+            # spaces_mcp_servers table (seeded once at space creation, never
+            # back-filled), so a server enabled after a personal space was
+            # created is assignable. See update_assistant (#500).
+            raise BadRequestException(
+                "MCP server is not assigned to this assistant's space"
             )
-            space_mapping = await self.repo.session.scalar(space_mapping_query)
-            if space_mapping is None:
-                raise BadRequestException(
-                    "MCP server is not assigned to this assistant's space"
-                )
 
         await self._ensure_governance_policy_allows_update(
             space=space,

--- a/backend/tests/unit/test_assistant_mcp_validation.py
+++ b/backend/tests/unit/test_assistant_mcp_validation.py
@@ -11,14 +11,15 @@ from intric.assistants.assistant_service import AssistantService
 from intric.main.exceptions import BadRequestException
 
 
-def _build_assistant_service_with_mocks():
+def _build_assistant_service_with_mocks(*, is_personal=True, server_in_space=False):
     service = object.__new__(AssistantService)
     assistant_id = uuid4()
     assistant = SimpleNamespace(id=assistant_id, is_default=True, mcp_servers=[])
     space = SimpleNamespace(
         id=uuid4(),
         get_assistant=lambda **_: assistant,
-        is_personal=lambda: True,
+        is_personal=lambda: is_personal,
+        is_mcp_server_in_space=lambda _server_id: server_in_space,
     )
     actor = SimpleNamespace(
         can_edit_assistants=lambda: True,
@@ -58,12 +59,15 @@ async def test_add_mcp_to_assistant_rejects_server_not_enabled_for_tenant():
 
 
 @pytest.mark.asyncio
-async def test_add_mcp_to_assistant_rejects_server_not_assigned_to_space():
-    service, assistant_id, session = _build_assistant_service_with_mocks()
-    session.scalar.side_effect = [
-        SimpleNamespace(id=uuid4()),  # server exists and is enabled
-        None,  # missing space mapping
-    ]
+async def test_add_mcp_to_assistant_rejects_server_not_in_shared_space():
+    # Shared (non-personal) space: a tenant-enabled server that is not a member
+    # of the space is still rejected. Membership now comes from the space read
+    # model (space.is_mcp_server_in_space), so no spaces_mcp_servers round-trip
+    # is issued — only the tenant-enablement query hits the DB.
+    service, assistant_id, session = _build_assistant_service_with_mocks(
+        is_personal=False, server_in_space=False
+    )
+    session.scalar.return_value = SimpleNamespace(id=uuid4())  # server is enabled
 
     with pytest.raises(
         BadRequestException, match="not assigned to this assistant's space"
@@ -72,7 +76,38 @@ async def test_add_mcp_to_assistant_rejects_server_not_assigned_to_space():
             assistant_id=assistant_id, mcp_server_id=uuid4()
         )
 
+    assert session.scalar.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_add_mcp_to_assistant_allows_personal_space_server_enabled_after_creation():
+    # Regression for #500: a personal space exposes every tenant-enabled server
+    # via the read model (space.is_mcp_server_in_space -> True), even though the
+    # stale spaces_mcp_servers table holds no row for a server enabled after the
+    # space was created. The assignment must succeed, without a spaces_mcp_servers
+    # round-trip (server lookup + assistant row only).
+    service, assistant_id, session = _build_assistant_service_with_mocks(
+        is_personal=True, server_in_space=True
+    )
+    mcp_server_id = uuid4()
+    assistant_in_db = SimpleNamespace(id=assistant_id)
+    session.scalar.side_effect = [
+        SimpleNamespace(id=mcp_server_id),  # server exists and is enabled
+        assistant_in_db,  # assistant row for set_mcp_servers
+    ]
+    result = MagicMock()
+    result.scalars.return_value = []
+    session.execute.return_value = result
+
+    await service.add_mcp_to_assistant(
+        assistant_id=assistant_id,
+        mcp_server_id=mcp_server_id,
+    )
+
     assert session.scalar.await_count == 2
+    service.repo.set_mcp_servers.assert_awaited_once_with(
+        assistant_in_db, [mcp_server_id]
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Assigning a tenant-enabled MCP server to a **personal**-space assistant failed with `MCP server(s) are not assigned to this assistant's space`, even though the editor offered the server. Assignment validation queried the `spaces_mcp_servers` table directly, but that table is seeded once at space creation and never back-filled (the domain model forbids adding MCP servers to a personal space). Any server enabled *after* the personal space was created — i.e. essentially always, since personal spaces are created at onboarding — was wrongly rejected, while the read model / UI treats a personal space as containing all tenant-enabled servers.

## Fix

Validate space membership against the space read model (`space.is_mcp_server_in_space()`) in both `update_assistant` and `add_mcp_to_assistant` — the same source the editor uses to offer servers. For a personal space that is every tenant-enabled server; for a shared space it is the `spaces_mcp_servers` mapping, so **shared-space behavior is unchanged**. The tenant-enablement check and the two distinct error messages are preserved. This also removes the ad-hoc `spaces_mcp_servers` SQL and its import.

## Tests

- shared-space rejection path retained (`test_add_mcp_to_assistant_rejects_server_not_in_shared_space`)
- new regression: a personal-space server enabled after creation is assignable (`test_add_mcp_to_assistant_allows_personal_space_server_enabled_after_creation`)

Closes #500
