### PR TITLE
fix(models): require tenant-owned AI model rows

### DIFF
--- a/backend/alembic/versions/20260618_model_tenant_required.py
+++ b/backend/alembic/versions/20260618_model_tenant_required.py
@@ -1,0 +1,1382 @@
+"""repair residual global models and require tenant ownership.
+
+Revision ID: 20260618_model_tenant_required
+Revises: 202605251000
+Create Date: 2026-06-18
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, NamedTuple
+from urllib.parse import urlparse
+from uuid import UUID, uuid4
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "20260618_model_tenant_required"
+down_revision = "202605251000"
+branch_labels = None
+depends_on = None
+
+
+class ProviderDescriptor(NamedTuple):
+    provider_type: str
+    name: str
+    config: dict[str, object]
+
+
+class ProviderSelection(NamedTuple):
+    id: UUID
+    is_active: bool
+    was_created: bool
+
+
+class ModelSpec(NamedTuple):
+    kind: str
+    table: str
+    key_columns: tuple[str, ...]
+
+
+MODEL_SPECS = (
+    ModelSpec(
+        kind="completion",
+        table="completion_models",
+        key_columns=("name", "litellm_model_name", "deployment_name"),
+    ),
+    ModelSpec(
+        kind="embedding",
+        table="embedding_models",
+        key_columns=("name", "litellm_model_name"),
+    ),
+    ModelSpec(
+        kind="transcription",
+        table="transcription_models",
+        key_columns=("model_name",),
+    ),
+)
+
+
+PROVIDER_TYPES: dict[str, tuple[str, str]] = {
+    "anthropic": ("anthropic", "Anthropic"),
+    "azure": ("azure", "Azure OpenAI"),
+    "claude": ("anthropic", "Anthropic"),
+    "cohere": ("cohere", "Cohere"),
+    "gemini": ("gemini", "Google Gemini"),
+    "mistral": ("mistral", "Mistral AI"),
+    "openai": ("openai", "OpenAI"),
+    "ovhcloud": ("ovhcloud", "OVHcloud"),
+}
+
+
+def _execute(conn: sa.Connection, sql: str, params: dict[str, object] | None = None):
+    return conn.execute(sa.text(sql), params or {})
+
+
+def _lower(value: object | None) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text.lower() if text else None
+
+
+def _normalize_endpoint(endpoint: object | None) -> str | None:
+    if endpoint is None:
+        return None
+    value = str(endpoint).strip().rstrip("/")
+    return value.lower() if value else None
+
+
+def _endpoint_config(endpoint: str | None) -> dict[str, object]:
+    return {"endpoint": endpoint} if endpoint else {}
+
+
+def _provider_name_from_endpoint(endpoint: str | None) -> str:
+    if not endpoint:
+        return "Hosted vLLM"
+    parsed = urlparse(endpoint)
+    host = parsed.netloc or parsed.path
+    return host or "Hosted vLLM"
+
+
+def _combined_provider_hints(row: Any) -> str:
+    values = [
+        getattr(row, "family", None),
+        getattr(row, "org", None),
+        getattr(row, "base_url", None),
+        getattr(row, "litellm_model_name", None),
+        getattr(row, "name", None),
+        getattr(row, "model_name", None),
+    ]
+    return " ".join(str(value).lower() for value in values if value is not None)
+
+
+def _descriptor_for_row(kind: str, row: Any) -> ProviderDescriptor:
+    family = _lower(getattr(row, "family", None))
+    hints = _combined_provider_hints(row)
+    base_url = _normalize_endpoint(getattr(row, "base_url", None))
+
+    if "berget" in hints or family in {"berget", "e5"}:
+        endpoint = "https://api.berget.ai/v1"
+        return ProviderDescriptor(
+            provider_type="hosted_vllm",
+            name="Berget.ai",
+            config=_endpoint_config(endpoint),
+        )
+
+    if "gdm" in hints:
+        endpoint = "https://ai.gdm.se/api/v1"
+        return ProviderDescriptor(
+            provider_type="hosted_vllm",
+            name="GDM",
+            config=_endpoint_config(endpoint),
+        )
+
+    if family == "vllm":
+        return ProviderDescriptor(
+            provider_type="hosted_vllm",
+            name=getattr(row, "org", None) or _provider_name_from_endpoint(base_url),
+            config=_endpoint_config(base_url),
+        )
+
+    if family == "azure":
+        config = {
+            "endpoint": base_url or "",
+            "api_version": "",
+            "deployment_name": getattr(row, "deployment_name", None) or "",
+        }
+        return ProviderDescriptor(
+            provider_type="azure",
+            name="Azure OpenAI",
+            config=config,
+        )
+
+    if family in PROVIDER_TYPES:
+        provider_type, name = PROVIDER_TYPES[family]
+        return ProviderDescriptor(provider_type=provider_type, name=name, config={})
+
+    if base_url:
+        return ProviderDescriptor(
+            provider_type="hosted_vllm",
+            name=getattr(row, "org", None) or _provider_name_from_endpoint(base_url),
+            config=_endpoint_config(base_url),
+        )
+
+    raise RuntimeError(
+        f"Cannot map {kind} model {row.id} ({getattr(row, 'name', None)!r}) "
+        f"with family={getattr(row, 'family', None)!r} to a tenant provider."
+    )
+
+
+def _all_tenant_ids(conn: sa.Connection) -> list[UUID]:
+    return [
+        row.id
+        for row in _execute(
+            conn,
+            """
+            SELECT id
+            FROM tenants
+            ORDER BY created_at, id
+            """,
+        ).fetchall()
+    ]
+
+
+def _referencing_tenant_ids(conn: sa.Connection, kind: str, model_id: UUID) -> set[UUID]:
+    queries = {
+        "completion": """
+            SELECT DISTINCT tenant_id FROM (
+                SELECT u.tenant_id
+                FROM assistants a
+                JOIN users u ON u.id = a.user_id
+                WHERE a.completion_model_id = :id
+                UNION
+                SELECT tenant_id FROM apps WHERE completion_model_id = :id
+                UNION
+                SELECT tenant_id FROM app_runs WHERE completion_model_id = :id
+                UNION
+                SELECT u.tenant_id
+                FROM services s
+                JOIN users u ON u.id = s.user_id
+                WHERE s.completion_model_id = :id
+                UNION
+                SELECT tenant_id FROM questions WHERE completion_model_id = :id
+                UNION
+                SELECT tenant_id FROM app_templates
+                WHERE completion_model_id = :id AND tenant_id IS NOT NULL
+                UNION
+                SELECT tenant_id FROM assistant_templates
+                WHERE completion_model_id = :id AND tenant_id IS NOT NULL
+                UNION
+                SELECT s.tenant_id
+                FROM spaces_completion_models scm
+                JOIN spaces s ON s.id = scm.space_id
+                WHERE scm.completion_model_id = :id
+                UNION
+                SELECT gp.tenant_id
+                FROM governance_policy_completion_models gpcm
+                JOIN governance_policies gp ON gp.id = gpcm.policy_id
+                WHERE gpcm.completion_model_id = :id
+                UNION
+                SELECT tenant_id FROM completion_model_migration_history
+                WHERE from_model_id = :id OR to_model_id = :id
+                UNION
+                SELECT tenant_id FROM completion_models
+                WHERE migrated_to_model_id = :id AND tenant_id IS NOT NULL
+            ) tenants
+            """,
+        "embedding": """
+            SELECT DISTINCT tenant_id FROM (
+                SELECT tenant_id FROM groups WHERE embedding_model_id = :id
+                UNION
+                SELECT tenant_id FROM info_blobs WHERE embedding_model_id = :id
+                UNION
+                SELECT tenant_id FROM websites WHERE embedding_model_id = :id
+                UNION
+                SELECT tenant_id FROM integration_knowledge WHERE embedding_model_id = :id
+                UNION
+                SELECT s.tenant_id
+                FROM spaces_embedding_models sem
+                JOIN spaces s ON s.id = sem.space_id
+                WHERE sem.embedding_model_id = :id
+            ) tenants
+            """,
+        "transcription": """
+            SELECT DISTINCT tenant_id FROM (
+                SELECT tenant_id FROM apps WHERE transcription_model_id = :id
+                UNION
+                SELECT s.tenant_id
+                FROM spaces_transcription_models stm
+                JOIN spaces s ON s.id = stm.space_id
+                WHERE stm.transcription_model_id = :id
+                UNION
+                SELECT tenant_id FROM transcription_model_migration_history
+                WHERE from_model_id = :id OR to_model_id = :id
+                UNION
+                SELECT tenant_id FROM transcription_models
+                WHERE migrated_to_model_id = :id AND tenant_id IS NOT NULL
+            ) tenants
+            """,
+    }
+    return {
+        row.tenant_id
+        for row in _execute(conn, queries[kind], {"id": model_id}).fetchall()
+        if row.tenant_id is not None
+    }
+
+
+def _provider_endpoint_clause(descriptor: ProviderDescriptor) -> tuple[str, dict[str, object]]:
+    endpoint = _normalize_endpoint(descriptor.config.get("endpoint"))
+    if endpoint is None:
+        return "", {}
+    return (
+        "AND lower(trim(trailing '/' from COALESCE(config->>'endpoint', ''))) = :endpoint",
+        {"endpoint": endpoint},
+    )
+
+
+def _provider_by_name(
+    conn: sa.Connection, tenant_id: UUID, descriptor: ProviderDescriptor
+) -> ProviderSelection | None:
+    row = _execute(
+        conn,
+        """
+        SELECT id, is_active
+        FROM model_providers
+        WHERE tenant_id = :tenant_id
+          AND provider_type = :provider_type
+          AND lower(name) = lower(:name)
+        ORDER BY is_active DESC, created_at, id
+        LIMIT 1
+        """,
+        {
+            "tenant_id": tenant_id,
+            "provider_type": descriptor.provider_type,
+            "name": descriptor.name,
+        },
+    ).first()
+    if row is None:
+        return None
+    return ProviderSelection(id=row.id, is_active=row.is_active, was_created=False)
+
+
+def _provider_by_endpoint(
+    conn: sa.Connection, tenant_id: UUID, descriptor: ProviderDescriptor
+) -> ProviderSelection | None:
+    endpoint_clause, params = _provider_endpoint_clause(descriptor)
+    if not endpoint_clause:
+        return None
+    row = _execute(
+        conn,
+        f"""
+        SELECT id, is_active
+        FROM model_providers
+        WHERE tenant_id = :tenant_id
+          AND provider_type = :provider_type
+          {endpoint_clause}
+        ORDER BY is_active DESC, created_at, id
+        LIMIT 1
+        """,
+        {
+            "tenant_id": tenant_id,
+            "provider_type": descriptor.provider_type,
+            **params,
+        },
+    ).first()
+    if row is None:
+        return None
+    return ProviderSelection(id=row.id, is_active=row.is_active, was_created=False)
+
+
+def _single_provider_by_type(
+    conn: sa.Connection, tenant_id: UUID, descriptor: ProviderDescriptor
+) -> ProviderSelection | None:
+    rows = _execute(
+        conn,
+        """
+        SELECT id, is_active
+        FROM model_providers
+        WHERE tenant_id = :tenant_id
+          AND provider_type = :provider_type
+        ORDER BY is_active DESC, created_at, id
+        """,
+        {"tenant_id": tenant_id, "provider_type": descriptor.provider_type},
+    ).fetchall()
+    if len(rows) != 1:
+        return None
+    return ProviderSelection(id=rows[0].id, is_active=rows[0].is_active, was_created=False)
+
+
+def _unique_provider_name(conn: sa.Connection, tenant_id: UUID, base_name: str) -> str:
+    candidate = base_name
+    suffix = 2
+    while _execute(
+        conn,
+        """
+        SELECT 1
+        FROM model_providers
+        WHERE tenant_id = :tenant_id
+          AND lower(name) = lower(:name)
+        LIMIT 1
+        """,
+        {"tenant_id": tenant_id, "name": candidate},
+    ).first():
+        candidate = f"{base_name} ({suffix})"
+        suffix += 1
+    return candidate
+
+
+def _create_inactive_provider(
+    conn: sa.Connection, tenant_id: UUID, descriptor: ProviderDescriptor
+) -> ProviderSelection:
+    provider_id = uuid4()
+    provider_name = _unique_provider_name(conn, tenant_id, descriptor.name)
+    _execute(
+        conn,
+        """
+        INSERT INTO model_providers (
+            id, tenant_id, name, provider_type, credentials, config, is_active,
+            created_at, updated_at
+        )
+        VALUES (
+            :id, :tenant_id, :name, :provider_type,
+            CAST(:credentials AS jsonb), CAST(:config AS jsonb), false,
+            now(), now()
+        )
+        """,
+        {
+            "id": provider_id,
+            "tenant_id": tenant_id,
+            "name": provider_name,
+            "provider_type": descriptor.provider_type,
+            "credentials": json.dumps({}),
+            "config": json.dumps(descriptor.config),
+        },
+    )
+    return ProviderSelection(id=provider_id, is_active=False, was_created=True)
+
+
+def _find_or_create_provider(
+    conn: sa.Connection, tenant_id: UUID, descriptor: ProviderDescriptor
+) -> ProviderSelection:
+    endpoint_match = _provider_by_endpoint(conn, tenant_id, descriptor)
+    if endpoint_match is not None:
+        return endpoint_match
+
+    if "endpoint" in descriptor.config:
+        return _create_inactive_provider(conn, tenant_id, descriptor)
+
+    name_match = _provider_by_name(conn, tenant_id, descriptor)
+    if name_match is not None:
+        return name_match
+
+    single_type_match = _single_provider_by_type(conn, tenant_id, descriptor)
+    if single_type_match is not None:
+        return single_type_match
+
+    return _create_inactive_provider(conn, tenant_id, descriptor)
+
+
+def _provider_selection_by_id(
+    conn: sa.Connection, tenant_id: UUID, provider_id: UUID
+) -> ProviderSelection | None:
+    row = _execute(
+        conn,
+        """
+        SELECT id, is_active
+        FROM model_providers
+        WHERE id = :provider_id
+          AND tenant_id = :tenant_id
+        """,
+        {"provider_id": provider_id, "tenant_id": tenant_id},
+    ).first()
+    if row is None:
+        return None
+    return ProviderSelection(id=row.id, is_active=row.is_active, was_created=False)
+
+
+def _provider_tenant_id(conn: sa.Connection, provider_id: UUID) -> UUID | None:
+    row = _execute(
+        conn,
+        "SELECT tenant_id FROM model_providers WHERE id = :provider_id",
+        {"provider_id": provider_id},
+    ).first()
+    return row.tenant_id if row is not None else None
+
+
+def _active_default_exists(conn: sa.Connection, table: str, tenant_id: UUID) -> bool:
+    return (
+        _execute(
+            conn,
+            f"""
+            SELECT 1
+            FROM {table}
+            WHERE tenant_id = :tenant_id
+              AND is_default = true
+              AND is_deprecated = false
+              AND deleted_at IS NULL
+            LIMIT 1
+            """,
+            {"tenant_id": tenant_id},
+        ).first()
+        is not None
+    )
+
+
+def _value_lower(row: Any, column: str) -> str | None:
+    return _lower(getattr(row, column, None))
+
+
+def _find_existing_model(
+    conn: sa.Connection,
+    spec: ModelSpec,
+    tenant_id: UUID,
+    provider_id: UUID,
+    source_row: Any,
+) -> UUID | None:
+    params: dict[str, object] = {
+        "tenant_id": tenant_id,
+        "provider_id": provider_id,
+    }
+    comparisons: list[str] = []
+    for index, column in enumerate(spec.key_columns):
+        value = _value_lower(source_row, column)
+        if value is None:
+            continue
+        param_name = f"key_{index}"
+        params[param_name] = value
+        comparisons.append(f"lower({column}) = :{param_name}")
+
+    if not comparisons:
+        raise RuntimeError(f"Cannot derive model identity for {spec.kind} row {source_row.id}")
+
+    row = _execute(
+        conn,
+        f"""
+        SELECT id
+        FROM {spec.table}
+        WHERE tenant_id = :tenant_id
+          AND provider_id = :provider_id
+          AND deleted_at IS NULL
+          AND ({' OR '.join(comparisons)})
+        ORDER BY is_deprecated, created_at, id
+        LIMIT 1
+        """,
+        params,
+    ).first()
+    return row.id if row is not None else None
+
+
+def _unique_nickname(
+    conn: sa.Connection,
+    table: str,
+    tenant_id: UUID,
+    provider_id: UUID,
+    nickname: str | None,
+) -> str | None:
+    if nickname is None:
+        return None
+
+    candidate = nickname
+    suffix = 2
+    while _execute(
+        conn,
+        f"""
+        SELECT 1
+        FROM {table}
+        WHERE tenant_id = :tenant_id
+          AND provider_id = :provider_id
+          AND deleted_at IS NULL
+          AND is_deprecated = false
+          AND nickname IS NOT NULL
+          AND lower(nickname) = lower(:nickname)
+        LIMIT 1
+        """,
+        {
+            "tenant_id": tenant_id,
+            "provider_id": provider_id,
+            "nickname": candidate,
+        },
+    ).first():
+        candidate = f"{nickname} ({suffix})"
+        suffix += 1
+    return candidate
+
+
+def _copy_is_enabled(source_row: Any, provider: ProviderSelection) -> bool:
+    return bool(
+        getattr(source_row, "is_enabled", False)
+        and provider.is_active
+        and getattr(source_row, "deleted_at", None) is None
+    )
+
+
+def _copy_is_default(
+    conn: sa.Connection,
+    spec: ModelSpec,
+    tenant_id: UUID,
+    source_row: Any,
+    provider: ProviderSelection,
+) -> bool:
+    if not _copy_is_enabled(source_row, provider):
+        return False
+    if not bool(getattr(source_row, "is_default", False)):
+        return False
+    if bool(getattr(source_row, "is_deprecated", False)):
+        return False
+    return not _active_default_exists(conn, spec.table, tenant_id)
+
+
+def _promote_existing_default_if_needed(
+    conn: sa.Connection,
+    spec: ModelSpec,
+    tenant_id: UUID,
+    model_id: UUID,
+    source_row: Any,
+) -> None:
+    if not bool(getattr(source_row, "is_default", False)):
+        return
+    if bool(getattr(source_row, "is_deprecated", False)):
+        return
+    if _active_default_exists(conn, spec.table, tenant_id):
+        return
+    _execute(
+        conn,
+        f"""
+        UPDATE {spec.table}
+        SET is_default = true
+        WHERE id = :model_id
+          AND tenant_id = :tenant_id
+          AND deleted_at IS NULL
+          AND is_deprecated = false
+          AND is_enabled = true
+        """,
+        {"model_id": model_id, "tenant_id": tenant_id},
+    )
+
+
+def _insert_completion_copy(
+    conn: sa.Connection,
+    tenant_id: UUID,
+    provider_id: UUID,
+    source_id: UUID,
+    nickname: str | None,
+    is_enabled: bool,
+    is_default: bool,
+) -> UUID:
+    new_id = uuid4()
+    _execute(
+        conn,
+        """
+        INSERT INTO completion_models (
+            id, created_at, updated_at, name, nickname, open_source,
+            max_input_tokens, max_output_tokens, is_deprecated,
+            nr_billion_parameters, hf_link, family, stability, hosting,
+            description, deployment_name, org, vision, reasoning,
+            supports_tool_calling, base_url, litellm_model_name,
+            model_kwargs_capabilities, input_cost_per_token, output_cost_per_token,
+            tenant_id, provider_id, is_enabled, is_default,
+            security_classification_id, migrated_to_model_id, deleted_at
+        )
+        SELECT
+            :new_id, created_at, now(), name, :nickname, open_source,
+            max_input_tokens, max_output_tokens, is_deprecated,
+            nr_billion_parameters, hf_link, family, stability, hosting,
+            description, deployment_name, org, vision, reasoning,
+            supports_tool_calling, base_url, litellm_model_name,
+            model_kwargs_capabilities, input_cost_per_token, output_cost_per_token,
+            :tenant_id, :provider_id, :is_enabled, :is_default,
+            NULL, NULL, deleted_at
+        FROM completion_models
+        WHERE id = :source_id
+        """,
+        {
+            "new_id": new_id,
+            "tenant_id": tenant_id,
+            "provider_id": provider_id,
+            "source_id": source_id,
+            "nickname": nickname,
+            "is_enabled": is_enabled,
+            "is_default": is_default,
+        },
+    )
+    return new_id
+
+
+def _insert_embedding_copy(
+    conn: sa.Connection,
+    tenant_id: UUID,
+    provider_id: UUID,
+    source_id: UUID,
+    nickname: str | None,
+    is_enabled: bool,
+    is_default: bool,
+) -> UUID:
+    new_id = uuid4()
+    _execute(
+        conn,
+        """
+        INSERT INTO embedding_models (
+            id, created_at, updated_at, name, nickname, open_source,
+            dimensions, max_input, max_batch_size, is_deprecated, hf_link,
+            family, stability, hosting, description, org, litellm_model_name,
+            input_cost_per_token, output_cost_per_token, tenant_id, provider_id,
+            is_enabled, is_default, security_classification_id, deleted_at
+        )
+        SELECT
+            :new_id, created_at, now(), name, :nickname, open_source,
+            dimensions, max_input, max_batch_size, is_deprecated, hf_link,
+            family, stability, hosting, description, org, litellm_model_name,
+            input_cost_per_token, output_cost_per_token, :tenant_id, :provider_id,
+            :is_enabled, :is_default, NULL, deleted_at
+        FROM embedding_models
+        WHERE id = :source_id
+        """,
+        {
+            "new_id": new_id,
+            "tenant_id": tenant_id,
+            "provider_id": provider_id,
+            "source_id": source_id,
+            "nickname": nickname,
+            "is_enabled": is_enabled,
+            "is_default": is_default,
+        },
+    )
+    return new_id
+
+
+def _insert_transcription_copy(
+    conn: sa.Connection,
+    tenant_id: UUID,
+    provider_id: UUID,
+    source_id: UUID,
+    nickname: str | None,
+    is_enabled: bool,
+    is_default: bool,
+) -> UUID:
+    new_id = uuid4()
+    _execute(
+        conn,
+        """
+        INSERT INTO transcription_models (
+            id, created_at, updated_at, name, model_name, nickname, open_source,
+            is_deprecated, hf_link, family, stability, hosting, description,
+            org, base_url, cost_per_minute, tenant_id, provider_id, is_enabled,
+            is_default, security_classification_id, migrated_to_model_id, deleted_at
+        )
+        SELECT
+            :new_id, created_at, now(), name, model_name, :nickname, open_source,
+            is_deprecated, hf_link, family, stability, hosting, description,
+            org, base_url, cost_per_minute, :tenant_id, :provider_id, :is_enabled,
+            :is_default, NULL, NULL, deleted_at
+        FROM transcription_models
+        WHERE id = :source_id
+        """,
+        {
+            "new_id": new_id,
+            "tenant_id": tenant_id,
+            "provider_id": provider_id,
+            "source_id": source_id,
+            "nickname": nickname,
+            "is_enabled": is_enabled,
+            "is_default": is_default,
+        },
+    )
+    return new_id
+
+
+def _insert_copy(
+    conn: sa.Connection,
+    spec: ModelSpec,
+    tenant_id: UUID,
+    provider: ProviderSelection,
+    source_row: Any,
+) -> UUID:
+    nickname = _unique_nickname(
+        conn,
+        spec.table,
+        tenant_id,
+        provider.id,
+        getattr(source_row, "nickname", None) or getattr(source_row, "name", None),
+    )
+    is_enabled = _copy_is_enabled(source_row, provider)
+    is_default = _copy_is_default(conn, spec, tenant_id, source_row, provider)
+    if spec.kind == "completion":
+        return _insert_completion_copy(
+            conn, tenant_id, provider.id, source_row.id, nickname, is_enabled, is_default
+        )
+    if spec.kind == "embedding":
+        return _insert_embedding_copy(
+            conn, tenant_id, provider.id, source_row.id, nickname, is_enabled, is_default
+        )
+    if spec.kind == "transcription":
+        return _insert_transcription_copy(
+            conn, tenant_id, provider.id, source_row.id, nickname, is_enabled, is_default
+        )
+    raise AssertionError(f"Unexpected model kind {spec.kind}")
+
+
+def _record_mapping(
+    conn: sa.Connection, kind: str, old_id: UUID, tenant_id: UUID, new_id: UUID
+) -> None:
+    _execute(
+        conn,
+        """
+        INSERT INTO model_tenant_repair_map (kind, old_id, tenant_id, new_id)
+        VALUES (:kind, :old_id, :tenant_id, :new_id)
+        ON CONFLICT (kind, old_id, tenant_id) DO UPDATE
+        SET new_id = EXCLUDED.new_id
+        """,
+        {
+            "kind": kind,
+            "old_id": old_id,
+            "tenant_id": tenant_id,
+            "new_id": new_id,
+        },
+    )
+
+
+def _map_global_models(conn: sa.Connection) -> None:
+    all_tenant_ids = _all_tenant_ids(conn)
+    for spec in MODEL_SPECS:
+        global_rows = _execute(
+            conn,
+            f"""
+            SELECT *
+            FROM {spec.table}
+            WHERE tenant_id IS NULL OR provider_id IS NULL
+            ORDER BY created_at, id
+            """,
+        ).fetchall()
+
+        for source_row in global_rows:
+            if source_row.tenant_id is not None:
+                target_tenants = {source_row.tenant_id}
+            elif source_row.provider_id is not None:
+                provider_tenant_id = _provider_tenant_id(conn, source_row.provider_id)
+                target_tenants = {provider_tenant_id} if provider_tenant_id else set()
+            elif source_row.deleted_at is None:
+                target_tenants = set(all_tenant_ids)
+            else:
+                target_tenants = _referencing_tenant_ids(conn, spec.kind, source_row.id)
+
+            if not target_tenants:
+                continue
+
+            descriptor: ProviderDescriptor | None = None
+            for tenant_id in sorted(target_tenants, key=str):
+                provider = None
+                if source_row.provider_id is not None:
+                    provider = _provider_selection_by_id(
+                        conn, tenant_id, source_row.provider_id
+                    )
+                if provider is None:
+                    if descriptor is None:
+                        descriptor = _descriptor_for_row(spec.kind, source_row)
+                    provider = _find_or_create_provider(conn, tenant_id, descriptor)
+                existing_id = _find_existing_model(
+                    conn, spec, tenant_id, provider.id, source_row
+                )
+                if existing_id is not None:
+                    _promote_existing_default_if_needed(
+                        conn, spec, tenant_id, existing_id, source_row
+                    )
+                    _record_mapping(conn, spec.kind, source_row.id, tenant_id, existing_id)
+                    continue
+
+                new_id = _insert_copy(conn, spec, tenant_id, provider, source_row)
+                _record_mapping(conn, spec.kind, source_row.id, tenant_id, new_id)
+
+
+def _rewrite_completion_references(conn: sa.Connection) -> None:
+    for table, tenant_expr in (
+        ("apps", "apps.tenant_id"),
+        ("app_runs", "app_runs.tenant_id"),
+        ("questions", "questions.tenant_id"),
+    ):
+        _execute(
+            conn,
+            f"""
+            UPDATE {table}
+            SET completion_model_id = m.new_id
+            FROM model_tenant_repair_map m
+            WHERE m.kind = 'completion'
+              AND {table}.completion_model_id = m.old_id
+              AND {tenant_expr} = m.tenant_id
+            """,
+        )
+
+    for table in ("assistants", "services"):
+        _execute(
+            conn,
+            f"""
+            UPDATE {table}
+            SET completion_model_id = m.new_id
+            FROM users u, model_tenant_repair_map m
+            WHERE m.kind = 'completion'
+              AND {table}.user_id = u.id
+              AND {table}.completion_model_id = m.old_id
+              AND u.tenant_id = m.tenant_id
+            """,
+        )
+
+    for table in ("app_templates", "assistant_templates"):
+        _execute(
+            conn,
+            f"""
+            UPDATE {table}
+            SET completion_model_id = m.new_id
+            FROM model_tenant_repair_map m
+            WHERE m.kind = 'completion'
+              AND {table}.completion_model_id = m.old_id
+              AND {table}.tenant_id = m.tenant_id
+            """,
+        )
+        _execute(
+            conn,
+            f"""
+            UPDATE {table}
+            SET completion_model_id = NULL
+            WHERE tenant_id IS NULL
+              AND completion_model_id IN (
+                  SELECT old_id FROM model_tenant_repair_map WHERE kind = 'completion'
+              )
+            """,
+        )
+
+    _execute(
+        conn,
+        """
+        INSERT INTO spaces_completion_models (
+            space_id, completion_model_id, created_at, updated_at
+        )
+        SELECT scm.space_id, m.new_id, scm.created_at, scm.updated_at
+        FROM spaces_completion_models scm
+        JOIN spaces s ON s.id = scm.space_id
+        JOIN model_tenant_repair_map m
+          ON m.kind = 'completion'
+         AND m.old_id = scm.completion_model_id
+         AND m.tenant_id = s.tenant_id
+        ON CONFLICT (space_id, completion_model_id) DO NOTHING
+        """,
+    )
+    _execute(
+        conn,
+        """
+        DELETE FROM spaces_completion_models scm
+        USING spaces s, model_tenant_repair_map m
+        WHERE m.kind = 'completion'
+          AND scm.space_id = s.id
+          AND scm.completion_model_id = m.old_id
+          AND s.tenant_id = m.tenant_id
+        """,
+    )
+
+    _execute(
+        conn,
+        """
+        INSERT INTO governance_policy_completion_models (
+            policy_id, completion_model_id, is_default, created_at, updated_at
+        )
+        SELECT gpcm.policy_id, m.new_id, false, gpcm.created_at, gpcm.updated_at
+        FROM governance_policy_completion_models gpcm
+        JOIN governance_policies gp ON gp.id = gpcm.policy_id
+        JOIN model_tenant_repair_map m
+          ON m.kind = 'completion'
+         AND m.old_id = gpcm.completion_model_id
+         AND m.tenant_id = gp.tenant_id
+        ON CONFLICT (policy_id, completion_model_id) DO NOTHING
+        """,
+    )
+    _execute(
+        conn,
+        """
+        UPDATE governance_policy_completion_models target
+        SET is_default = true
+        FROM governance_policy_completion_models old_link
+        JOIN governance_policies gp ON gp.id = old_link.policy_id
+        JOIN model_tenant_repair_map m
+          ON m.kind = 'completion'
+         AND m.old_id = old_link.completion_model_id
+         AND m.tenant_id = gp.tenant_id
+        WHERE target.policy_id = old_link.policy_id
+          AND target.completion_model_id = m.new_id
+          AND old_link.is_default = true
+          AND NOT EXISTS (
+              SELECT 1
+              FROM governance_policy_completion_models other
+              WHERE other.policy_id = old_link.policy_id
+                AND other.is_default = true
+                AND other.completion_model_id NOT IN (old_link.completion_model_id, m.new_id)
+          )
+        """,
+    )
+    _execute(
+        conn,
+        """
+        DELETE FROM governance_policy_completion_models gpcm
+        USING governance_policies gp, model_tenant_repair_map m
+        WHERE m.kind = 'completion'
+          AND gpcm.policy_id = gp.id
+          AND gpcm.completion_model_id = m.old_id
+          AND gp.tenant_id = m.tenant_id
+        """,
+    )
+
+    _execute(
+        conn,
+        """
+        UPDATE completion_model_migration_history h
+        SET from_model_id = m.new_id
+        FROM model_tenant_repair_map m
+        WHERE m.kind = 'completion'
+          AND h.from_model_id = m.old_id
+          AND h.tenant_id = m.tenant_id
+        """,
+    )
+    _execute(
+        conn,
+        """
+        UPDATE completion_model_migration_history h
+        SET to_model_id = m.new_id
+        FROM model_tenant_repair_map m
+        WHERE m.kind = 'completion'
+          AND h.to_model_id = m.old_id
+          AND h.tenant_id = m.tenant_id
+        """,
+    )
+
+
+def _rewrite_embedding_references(conn: sa.Connection) -> None:
+    for table in ("groups", "info_blobs", "websites", "integration_knowledge"):
+        _execute(
+            conn,
+            f"""
+            UPDATE {table}
+            SET embedding_model_id = m.new_id
+            FROM model_tenant_repair_map m
+            WHERE m.kind = 'embedding'
+              AND {table}.embedding_model_id = m.old_id
+              AND {table}.tenant_id = m.tenant_id
+            """,
+        )
+
+    _execute(
+        conn,
+        """
+        INSERT INTO spaces_embedding_models (
+            space_id, embedding_model_id, created_at, updated_at
+        )
+        SELECT sem.space_id, m.new_id, sem.created_at, sem.updated_at
+        FROM spaces_embedding_models sem
+        JOIN spaces s ON s.id = sem.space_id
+        JOIN model_tenant_repair_map m
+          ON m.kind = 'embedding'
+         AND m.old_id = sem.embedding_model_id
+         AND m.tenant_id = s.tenant_id
+        ON CONFLICT (space_id, embedding_model_id) DO NOTHING
+        """,
+    )
+    _execute(
+        conn,
+        """
+        DELETE FROM spaces_embedding_models sem
+        USING spaces s, model_tenant_repair_map m
+        WHERE m.kind = 'embedding'
+          AND sem.space_id = s.id
+          AND sem.embedding_model_id = m.old_id
+          AND s.tenant_id = m.tenant_id
+        """,
+    )
+
+
+def _rewrite_transcription_references(conn: sa.Connection) -> None:
+    _execute(
+        conn,
+        """
+        UPDATE apps
+        SET transcription_model_id = m.new_id
+        FROM model_tenant_repair_map m
+        WHERE m.kind = 'transcription'
+          AND apps.transcription_model_id = m.old_id
+          AND apps.tenant_id = m.tenant_id
+        """,
+    )
+
+    _execute(
+        conn,
+        """
+        INSERT INTO spaces_transcription_models (
+            space_id, transcription_model_id, created_at, updated_at
+        )
+        SELECT stm.space_id, m.new_id, stm.created_at, stm.updated_at
+        FROM spaces_transcription_models stm
+        JOIN spaces s ON s.id = stm.space_id
+        JOIN model_tenant_repair_map m
+          ON m.kind = 'transcription'
+         AND m.old_id = stm.transcription_model_id
+         AND m.tenant_id = s.tenant_id
+        ON CONFLICT (space_id, transcription_model_id) DO NOTHING
+        """,
+    )
+    _execute(
+        conn,
+        """
+        DELETE FROM spaces_transcription_models stm
+        USING spaces s, model_tenant_repair_map m
+        WHERE m.kind = 'transcription'
+          AND stm.space_id = s.id
+          AND stm.transcription_model_id = m.old_id
+          AND s.tenant_id = m.tenant_id
+        """,
+    )
+
+    _execute(
+        conn,
+        """
+        UPDATE transcription_model_migration_history h
+        SET from_model_id = m.new_id
+        FROM model_tenant_repair_map m
+        WHERE m.kind = 'transcription'
+          AND h.from_model_id = m.old_id
+          AND h.tenant_id = m.tenant_id
+        """,
+    )
+    _execute(
+        conn,
+        """
+        UPDATE transcription_model_migration_history h
+        SET to_model_id = m.new_id
+        FROM model_tenant_repair_map m
+        WHERE m.kind = 'transcription'
+          AND h.to_model_id = m.old_id
+          AND h.tenant_id = m.tenant_id
+        """,
+    )
+
+
+def _rewrite_migrated_to_links(conn: sa.Connection) -> None:
+    for kind, table in (
+        ("completion", "completion_models"),
+        ("transcription", "transcription_models"),
+    ):
+        _execute(
+            conn,
+            f"""
+            UPDATE {table} tenant_copy
+            SET migrated_to_model_id = target_map.new_id
+            FROM model_tenant_repair_map source_map
+            JOIN {table} source_global ON source_global.id = source_map.old_id
+            JOIN model_tenant_repair_map target_map
+              ON target_map.kind = :kind
+             AND target_map.old_id = source_global.migrated_to_model_id
+             AND target_map.tenant_id = source_map.tenant_id
+            WHERE source_map.kind = :kind
+              AND tenant_copy.id = source_map.new_id
+            """,
+            {"kind": kind},
+        )
+        _execute(
+            conn,
+            f"""
+            UPDATE {table} tenant_model
+            SET migrated_to_model_id = m.new_id
+            FROM model_tenant_repair_map m
+            WHERE m.kind = :kind
+              AND tenant_model.migrated_to_model_id = m.old_id
+              AND tenant_model.tenant_id = m.tenant_id
+            """,
+            {"kind": kind},
+        )
+        _execute(
+            conn,
+            f"""
+            UPDATE {table}
+            SET migrated_to_model_id = NULL
+            WHERE migrated_to_model_id IN (
+                SELECT id FROM {table} WHERE tenant_id IS NULL OR provider_id IS NULL
+            )
+            """,
+        )
+
+
+def _remaining_global_reference_count(conn: sa.Connection) -> int:
+    queries = (
+        """
+        SELECT count(*)
+        FROM assistants a
+        JOIN completion_models cm ON cm.id = a.completion_model_id
+        WHERE cm.tenant_id IS NULL OR cm.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM services s
+        JOIN completion_models cm ON cm.id = s.completion_model_id
+        WHERE cm.tenant_id IS NULL OR cm.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM apps a
+        LEFT JOIN completion_models cm ON cm.id = a.completion_model_id
+        LEFT JOIN transcription_models tm ON tm.id = a.transcription_model_id
+        WHERE (
+              a.completion_model_id IS NOT NULL
+          AND (cm.tenant_id IS NULL OR cm.provider_id IS NULL)
+        )
+           OR (
+              a.transcription_model_id IS NOT NULL
+          AND (tm.tenant_id IS NULL OR tm.provider_id IS NULL)
+        )
+        """,
+        """
+        SELECT count(*)
+        FROM app_runs ar
+        JOIN completion_models cm ON cm.id = ar.completion_model_id
+        WHERE cm.tenant_id IS NULL OR cm.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM questions q
+        JOIN completion_models cm ON cm.id = q.completion_model_id
+        WHERE cm.tenant_id IS NULL OR cm.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM app_templates t
+        JOIN completion_models cm ON cm.id = t.completion_model_id
+        WHERE cm.tenant_id IS NULL OR cm.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM assistant_templates t
+        JOIN completion_models cm ON cm.id = t.completion_model_id
+        WHERE cm.tenant_id IS NULL OR cm.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM spaces_completion_models scm
+        JOIN completion_models cm ON cm.id = scm.completion_model_id
+        WHERE cm.tenant_id IS NULL OR cm.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM governance_policy_completion_models gpcm
+        JOIN completion_models cm ON cm.id = gpcm.completion_model_id
+        WHERE cm.tenant_id IS NULL OR cm.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM groups g
+        JOIN embedding_models em ON em.id = g.embedding_model_id
+        WHERE em.tenant_id IS NULL OR em.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM info_blobs ib
+        JOIN embedding_models em ON em.id = ib.embedding_model_id
+        WHERE em.tenant_id IS NULL OR em.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM websites w
+        JOIN embedding_models em ON em.id = w.embedding_model_id
+        WHERE em.tenant_id IS NULL OR em.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM integration_knowledge ik
+        JOIN embedding_models em ON em.id = ik.embedding_model_id
+        WHERE em.tenant_id IS NULL OR em.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM spaces_embedding_models sem
+        JOIN embedding_models em ON em.id = sem.embedding_model_id
+        WHERE em.tenant_id IS NULL OR em.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM spaces_transcription_models stm
+        JOIN transcription_models tm ON tm.id = stm.transcription_model_id
+        WHERE tm.tenant_id IS NULL OR tm.provider_id IS NULL
+        """,
+        """
+        SELECT count(*)
+        FROM completion_model_migration_history h
+        LEFT JOIN completion_models from_model ON from_model.id = h.from_model_id
+        LEFT JOIN completion_models to_model ON to_model.id = h.to_model_id
+        WHERE (
+              h.from_model_id IS NOT NULL
+          AND (from_model.tenant_id IS NULL OR from_model.provider_id IS NULL)
+        )
+           OR (
+              h.to_model_id IS NOT NULL
+          AND (to_model.tenant_id IS NULL OR to_model.provider_id IS NULL)
+        )
+        """,
+        """
+        SELECT count(*)
+        FROM transcription_model_migration_history h
+        LEFT JOIN transcription_models from_model ON from_model.id = h.from_model_id
+        LEFT JOIN transcription_models to_model ON to_model.id = h.to_model_id
+        WHERE (
+              h.from_model_id IS NOT NULL
+          AND (from_model.tenant_id IS NULL OR from_model.provider_id IS NULL)
+        )
+           OR (
+              h.to_model_id IS NOT NULL
+          AND (to_model.tenant_id IS NULL OR to_model.provider_id IS NULL)
+        )
+        """,
+    )
+    total = 0
+    for query in queries:
+        total += int(_execute(conn, query).scalar() or 0)
+    return total
+
+
+def _delete_global_rows(conn: sa.Connection) -> None:
+    remaining_refs = _remaining_global_reference_count(conn)
+    if remaining_refs:
+        raise RuntimeError(
+            f"Cannot delete residual global models; {remaining_refs} references still point at them."
+        )
+
+    for table in ("completion_models", "transcription_models", "embedding_models"):
+        _execute(
+            conn,
+            f"""
+            DELETE FROM {table}
+            WHERE tenant_id IS NULL OR provider_id IS NULL
+            """,
+        )
+
+
+def _enforce_tenant_provider_required(table: str, old_constraint: str, new_constraint: str) -> None:
+    op.execute(
+        f"""
+        ALTER TABLE {table}
+        ADD CONSTRAINT {new_constraint}
+        CHECK (tenant_id IS NOT NULL AND provider_id IS NOT NULL)
+        NOT VALID
+        """
+    )
+    op.execute(f"ALTER TABLE {table} VALIDATE CONSTRAINT {new_constraint}")
+    op.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {old_constraint}")
+    op.alter_column(
+        table,
+        "tenant_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=False,
+    )
+    op.alter_column(
+        table,
+        "provider_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=False,
+    )
+
+
+def _recreate_active_nickname_index(table: str) -> None:
+    op.execute(f"DROP INDEX IF EXISTS uq_{table}_active_nickname")
+    op.execute(
+        f"""
+        CREATE UNIQUE INDEX uq_{table}_active_nickname
+        ON {table} (tenant_id, provider_id, lower(nickname))
+        WHERE deleted_at IS NULL
+          AND is_deprecated = false
+          AND nickname IS NOT NULL
+        """
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    _execute(
+        conn,
+        """
+        CREATE TEMPORARY TABLE model_tenant_repair_map (
+            kind text NOT NULL,
+            old_id uuid NOT NULL,
+            tenant_id uuid NOT NULL,
+            new_id uuid NOT NULL,
+            PRIMARY KEY (kind, old_id, tenant_id)
+        ) ON COMMIT DROP
+        """,
+    )
+
+    _map_global_models(conn)
+    _rewrite_completion_references(conn)
+    _rewrite_embedding_references(conn)
+    _rewrite_transcription_references(conn)
+    _rewrite_migrated_to_links(conn)
+    _delete_global_rows(conn)
+
+    for table in ("completion_models", "embedding_models", "transcription_models"):
+        _recreate_active_nickname_index(table)
+
+    _enforce_tenant_provider_required(
+        "completion_models",
+        "ck_completion_models_tenant_provider",
+        "ck_completion_models_tenant_provider_required",
+    )
+    _enforce_tenant_provider_required(
+        "embedding_models",
+        "ck_embedding_models_tenant_provider",
+        "ck_embedding_models_tenant_provider_required",
+    )
+    _enforce_tenant_provider_required(
+        "transcription_models",
+        "ck_transcription_models_tenant_provider",
+        "ck_transcription_models_tenant_provider_required",
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "20260618_model_tenant_required deletes legacy global model rows after "
+        "rewriting tenant references. Restore from backup to downgrade."
+    )

--- a/backend/src/intric/ai_models/ai_models_service.py
+++ b/backend/src/intric/ai_models/ai_models_service.py
@@ -17,7 +17,6 @@ from intric.ai_models.embedding_models.embedding_model import (
 from intric.ai_models.embedding_models.embedding_models_repo import (
     AdminEmbeddingModelsService,
 )
-from intric.main.config import get_settings
 from intric.main.datetime_utils import datetime_or_utc_min
 from intric.main.exceptions import BadRequestException, UnauthorizedException
 from intric.roles.permissions import Permission, validate_permissions
@@ -145,16 +144,6 @@ class AIModelsService:
 
         models: list[CompletionModelPublic] = []
         for model in completion_models:
-            # See completion_model_crud_service: only the predefined global
-            # Azure models (tenant_id is None) are gated by this flag. Tenant-
-            # configured Azure models are explicit config and always shown.
-            if (
-                model.family == "azure"
-                and model.tenant_id is None
-                and not get_settings().using_azure_models
-            ):
-                continue
-
             models.append(
                 CompletionModelPublic(
                     **model.model_dump(exclude={"is_deprecated"}),

--- a/backend/src/intric/ai_models/completion_models/completion_models_repo.py
+++ b/backend/src/intric/ai_models/completion_models/completion_models_repo.py
@@ -5,8 +5,6 @@ from sqlalchemy.exc import IntegrityError
 
 from intric.ai_models.completion_models.completion_model import (
     CompletionModel,
-    CompletionModelCreate,
-    CompletionModelUpdate,
 )
 from intric.database.database import AsyncSession
 from intric.database.repositories.base import BaseRepositoryDelegate
@@ -37,16 +35,11 @@ class CompletionModelsRepository:
         # Query the model with tenant filtering
         stmt = (
             sa.select(CompletionModels, ModelProviders.provider_type)
-            .outerjoin(
-                ModelProviders, CompletionModels.provider_id == ModelProviders.id
-            )
+            .join(ModelProviders, CompletionModels.provider_id == ModelProviders.id)
             .where(
                 CompletionModels.id == id,
                 CompletionModels.deleted_at.is_(None),
-                sa.or_(
-                    CompletionModels.tenant_id.is_(None),
-                    CompletionModels.tenant_id == tenant_id,
-                ),
+                CompletionModels.tenant_id == tenant_id,
             )
         )
         result = await self.session.execute(stmt)
@@ -65,9 +58,6 @@ class CompletionModelsRepository:
 
     async def get_model_by_name(self, name: str) -> CompletionModel | None:
         return await self.delegate.get_by(conditions={CompletionModels.name: name})
-
-    async def create_model(self, model: CompletionModelCreate) -> CompletionModel:
-        return await self.delegate.add(model, exclude=COMPLETION_MODEL_DB_WRITE_EXCLUDE)
 
     async def enable_completion_model(
         self,
@@ -89,13 +79,6 @@ class CompletionModelsRepository:
             return await self.session.scalar(query)
         except IntegrityError as e:
             raise UniqueException("Default completion model already exists.") from e
-
-    async def update_model(
-        self, model: CompletionModelUpdate
-    ) -> CompletionModel | None:
-        return await self.delegate.update(
-            model, exclude=COMPLETION_MODEL_DB_WRITE_EXCLUDE
-        )
 
     async def delete_model(self, id: UUID) -> None:
         # Spaces are containers — a model "enabled" on a space without any
@@ -124,9 +107,7 @@ class CompletionModelsRepository:
     ) -> list[CompletionModel]:
         query = (
             sa.select(CompletionModels, ModelProviders.provider_type)
-            .outerjoin(
-                ModelProviders, CompletionModels.provider_id == ModelProviders.id
-            )
+            .join(ModelProviders, CompletionModels.provider_id == ModelProviders.id)
             .where(CompletionModels.is_deprecated == is_deprecated)
             .where(CompletionModels.deleted_at.is_(None))
             .order_by(CompletionModels.created_at)
@@ -135,14 +116,8 @@ class CompletionModelsRepository:
         if id_list is not None:
             query = query.where(CompletionModels.id.in_(id_list))
 
-        # Filter to tenant's models
         if tenant_id is not None:
-            query = query.where(
-                sa.or_(
-                    CompletionModels.tenant_id.is_(None),
-                    CompletionModels.tenant_id == tenant_id,
-                )
-            )
+            query = query.where(CompletionModels.tenant_id == tenant_id)
 
         result = await self.session.execute(query)
         rows = result.all()

--- a/backend/src/intric/ai_models/display_name_validation.py
+++ b/backend/src/intric/ai_models/display_name_validation.py
@@ -8,12 +8,10 @@ tell apart. This mirrors the partial unique indexes added in the
 `20260602_unique_display_names` migration so the service layer raises a clean
 409 instead of letting the DB throw a raw 500 on insert.
 
-Used by both the tenant model service (AddWizard path) and the sysadmin
-global-model endpoints — same rule everywhere. The predicate must stay in lockstep
-with that migration's index: active = `deleted_at IS NULL AND is_deprecated = false`,
-case-insensitive via SQL `lower()`, scoped per (tenant, provider). Global models
-always carry `provider_id IS NULL`, so they share one provider scope and stay
-unique per name; the same name may repeat across a tenant's providers.
+Used by the tenant model service (AddWizard path). The predicate must stay in
+lockstep with the active-nickname index: active = `deleted_at IS NULL AND
+is_deprecated = false`, case-insensitive via SQL `lower()`, scoped per concrete
+(tenant, provider). The same name may repeat across a tenant's providers.
 """
 
 from __future__ import annotations
@@ -33,9 +31,9 @@ async def validate_unique_display_name(
     session: "AsyncSession",
     table: Any,
     *,
-    tenant_id: UUID | None,
+    tenant_id: UUID,
     nickname: str | None,
-    provider_id: UUID | None = None,
+    provider_id: UUID,
     exclude_id: UUID | None = None,
 ) -> None:
     """Raise `NameCollisionException` if another active model in the same
@@ -43,11 +41,8 @@ async def validate_unique_display_name(
     None.
 
     `table` is one of the three model ORM tables (all carry `nickname`,
-    `deleted_at`, `is_deprecated`, `tenant_id`, `provider_id` after the
-    model-table alignment). `provider_id` is None for global models (which also
-    have no provider) and otherwise scopes the check to one provider, so a name
-    may repeat across a tenant's providers. Pass `exclude_id` on updates so a row
-    never collides with itself.
+    `deleted_at`, `is_deprecated`, `tenant_id`, `provider_id`). Pass
+    `exclude_id` on updates so a row never collides with itself.
     """
     if nickname is None:
         return
@@ -57,14 +52,8 @@ async def validate_unique_display_name(
         table.deleted_at.is_(None),
         table.is_deprecated.is_(False),
     ]
-    if tenant_id is None:
-        conditions.append(table.tenant_id.is_(None))
-    else:
-        conditions.append(table.tenant_id == tenant_id)
-    if provider_id is None:
-        conditions.append(table.provider_id.is_(None))
-    else:
-        conditions.append(table.provider_id == provider_id)
+    conditions.append(table.tenant_id == tenant_id)
+    conditions.append(table.provider_id == provider_id)
     if exclude_id is not None:
         conditions.append(table.id != exclude_id)
 

--- a/backend/src/intric/ai_models/embedding_models/embedding_models_repo.py
+++ b/backend/src/intric/ai_models/embedding_models/embedding_models_repo.py
@@ -4,9 +4,7 @@ import sqlalchemy as sa
 from sqlalchemy.exc import IntegrityError
 
 from intric.ai_models.embedding_models.embedding_model import (
-    EmbeddingModelCreate,
     EmbeddingModelLegacy,
-    EmbeddingModelUpdate,
 )
 from intric.database.database import AsyncSession
 from intric.database.repositories.base import BaseRepositoryDelegate
@@ -27,10 +25,7 @@ class AdminEmbeddingModelsService:
         # Query the model with tenant filtering
         stmt = sa.select(EmbeddingModels).where(
             EmbeddingModels.id == id,
-            sa.or_(
-                EmbeddingModels.tenant_id.is_(None),
-                EmbeddingModels.tenant_id == tenant_id,
-            ),
+            EmbeddingModels.tenant_id == tenant_id,
             EmbeddingModels.deleted_at.is_(None),
         )
         result = await self.session.execute(stmt)
@@ -47,17 +42,6 @@ class AdminEmbeddingModelsService:
 
     async def get_model_by_name(self, name: str) -> EmbeddingModelLegacy | None:
         return await self.delegate.get_by(conditions={EmbeddingModels.name: name})
-
-    async def create_model(self, model: EmbeddingModelCreate) -> EmbeddingModelLegacy:
-        return await self.delegate.add(model)
-
-    async def update_model(
-        self, model: EmbeddingModelUpdate
-    ) -> EmbeddingModelLegacy | None:
-        return await self.delegate.update(model)
-
-    async def delete_model(self, id: UUID) -> EmbeddingModelLegacy | None:
-        return await self.delegate.delete(id)
 
     async def get_models(
         self,
@@ -77,14 +61,8 @@ class AdminEmbeddingModelsService:
         if id_list is not None:
             stmt = stmt.where(EmbeddingModels.id.in_(id_list))
 
-        # Filter to tenant's models
         if tenant_id is not None:
-            stmt = stmt.where(
-                sa.or_(
-                    EmbeddingModels.tenant_id.is_(None),
-                    EmbeddingModels.tenant_id == tenant_id,
-                )
-            )
+            stmt = stmt.where(EmbeddingModels.tenant_id == tenant_id)
 
         result = await self.session.execute(stmt)
         db_models = result.scalars().all()

--- a/backend/src/intric/completion_models/application/completion_model_crud_service.py
+++ b/backend/src/intric/completion_models/application/completion_model_crud_service.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, Optional, Union
 
-from intric.main.config import get_settings
 from intric.main.datetime_utils import datetime_or_utc_min
 from intric.main.exceptions import UnauthorizedException
 from intric.main.models import NOT_PROVIDED, ModelId, NotProvided, is_provided
@@ -32,25 +31,7 @@ class CompletionModelCRUDService:
         self.security_classification_repo = security_classification_repo
 
     async def get_completion_models(self) -> list["CompletionModel"]:
-        models = await self.completion_model_repo.all()
-
-        available_models: list["CompletionModel"] = []
-        for model in models:
-            # `using_azure_models` gates the *predefined global* Azure models
-            # (tenant_id is None) that ship with Eneo. A tenant that explicitly
-            # configures an Azure provider gets family="azure" too, but those
-            # models are deliberate config and must never be hidden by a global
-            # deployment flag — otherwise they 200 on create yet vanish here.
-            if (
-                model.family == "azure"
-                and model.tenant_id is None
-                and not get_settings().using_azure_models
-            ):
-                continue
-
-            available_models.append(model)
-
-        return available_models
+        return await self.completion_model_repo.all()
 
     async def get_completion_model(self, model_id: "UUID") -> "CompletionModel":
         completion_model = await self.completion_model_repo.one(model_id=model_id)

--- a/backend/src/intric/completion_models/domain/completion_model_repo.py
+++ b/backend/src/intric/completion_models/domain/completion_model_repo.py
@@ -29,24 +29,14 @@ class CompletionModelRepository:
             sa.select(
                 CompletionModels, ModelProviders.name, ModelProviders.provider_type
             )
-            .outerjoin(
-                ModelProviders, CompletionModels.provider_id == ModelProviders.id
-            )
+            .join(ModelProviders, CompletionModels.provider_id == ModelProviders.id)
             .options(
                 selectinload(CompletionModels.security_classification),
                 selectinload(CompletionModels.security_classification).options(
                     selectinload(SecurityClassificationDBModel.tenant)
                 ),
             )
-            .where(
-                # Return both global and tenant models
-                # This allows existing assistants with global models to continue working
-                # UI filtering happens at the presentation layer
-                sa.or_(
-                    CompletionModels.tenant_id.is_(None),
-                    CompletionModels.tenant_id == self.user.tenant_id,
-                )
-            )
+            .where(CompletionModels.tenant_id == self.user.tenant_id)
             .order_by(
                 CompletionModels.org,
                 CompletionModels.created_at,
@@ -74,14 +64,11 @@ class CompletionModelRepository:
         ]
 
     async def one_or_none(self, model_id: "UUID") -> Optional["CompletionModel"]:
-        # When fetching by ID, return ANY model (global or tenant) that the user can access
         stmt = (
             sa.select(
                 CompletionModels, ModelProviders.name, ModelProviders.provider_type
             )
-            .outerjoin(
-                ModelProviders, CompletionModels.provider_id == ModelProviders.id
-            )
+            .join(ModelProviders, CompletionModels.provider_id == ModelProviders.id)
             .options(
                 selectinload(CompletionModels.security_classification),
                 selectinload(CompletionModels.security_classification).options(
@@ -91,11 +78,7 @@ class CompletionModelRepository:
             .where(
                 CompletionModels.id == model_id,
                 CompletionModels.deleted_at.is_(None),
-                # Allow both global models (tenant_id IS NULL) and tenant models (tenant_id = user.tenant_id)
-                sa.or_(
-                    CompletionModels.tenant_id.is_(None),
-                    CompletionModels.tenant_id == self.user.tenant_id,
-                ),
+                CompletionModels.tenant_id == self.user.tenant_id,
             )
         )
 

--- a/backend/src/intric/database/tables/ai_models_table.py
+++ b/backend/src/intric/database/tables/ai_models_table.py
@@ -62,12 +62,12 @@ class CompletionModels(BasePublic):
         Numeric(20, 12), nullable=True
     )
 
-    # Tenant model support: NULL = global model, NOT NULL = tenant-specific model
-    tenant_id: Mapped[Optional[UUID]] = mapped_column(
-        ForeignKey(Tenants.id, ondelete="CASCADE"), nullable=True, index=True
+    # Model rows are tenant-owned and backed by an explicit provider.
+    tenant_id: Mapped[UUID] = mapped_column(
+        ForeignKey(Tenants.id, ondelete="CASCADE"), nullable=False, index=True
     )
-    provider_id: Mapped[Optional[UUID]] = mapped_column(
-        ForeignKey("model_providers.id", ondelete="CASCADE"), nullable=True, index=True
+    provider_id: Mapped[UUID] = mapped_column(
+        ForeignKey("model_providers.id", ondelete="CASCADE"), nullable=False, index=True
     )
 
     # Settings (previously in separate completion_model_settings table)
@@ -79,7 +79,7 @@ class CompletionModels(BasePublic):
     security_classification: Mapped[Optional["SecurityClassificationsTable"]] = (
         relationship(back_populates="completion_models")
     )
-    provider: Mapped[Optional[ModelProviders]] = relationship()
+    provider: Mapped[ModelProviders] = relationship()
 
     # Lifecycle: migration tracking and soft-delete
     migrated_to_model_id: Mapped[Optional[UUID]] = mapped_column(
@@ -97,8 +97,8 @@ class CompletionModels(BasePublic):
 
     __table_args__ = (
         CheckConstraint(
-            "(tenant_id IS NULL AND provider_id IS NULL) OR (tenant_id IS NOT NULL AND provider_id IS NOT NULL)",
-            name="ck_completion_models_tenant_provider",
+            "tenant_id IS NOT NULL AND provider_id IS NOT NULL",
+            name="ck_completion_models_tenant_provider_required",
         ),
     )
 
@@ -129,12 +129,12 @@ class TranscriptionModels(BasePublic):
         Numeric(20, 6), nullable=True
     )
 
-    # Tenant model support: NULL = global model, NOT NULL = tenant-specific model
-    tenant_id: Mapped[Optional[UUID]] = mapped_column(
-        ForeignKey(Tenants.id, ondelete="CASCADE"), nullable=True, index=True
+    # Model rows are tenant-owned and backed by an explicit provider.
+    tenant_id: Mapped[UUID] = mapped_column(
+        ForeignKey(Tenants.id, ondelete="CASCADE"), nullable=False, index=True
     )
-    provider_id: Mapped[Optional[UUID]] = mapped_column(
-        ForeignKey("model_providers.id", ondelete="CASCADE"), nullable=True, index=True
+    provider_id: Mapped[UUID] = mapped_column(
+        ForeignKey("model_providers.id", ondelete="CASCADE"), nullable=False, index=True
     )
 
     # Settings (previously in separate transcription_model_settings table)
@@ -159,8 +159,8 @@ class TranscriptionModels(BasePublic):
 
     __table_args__ = (
         CheckConstraint(
-            "(tenant_id IS NULL AND provider_id IS NULL) OR (tenant_id IS NOT NULL AND provider_id IS NOT NULL)",
-            name="ck_transcription_models_tenant_provider",
+            "tenant_id IS NOT NULL AND provider_id IS NOT NULL",
+            name="ck_transcription_models_tenant_provider_required",
         ),
     )
 
@@ -192,12 +192,12 @@ class EmbeddingModels(BasePublic):
         Numeric(20, 12), nullable=True
     )
 
-    # Tenant model support: NULL = global model, NOT NULL = tenant-specific model
-    tenant_id: Mapped[Optional[UUID]] = mapped_column(
-        ForeignKey(Tenants.id, ondelete="CASCADE"), nullable=True, index=True
+    # Model rows are tenant-owned and backed by an explicit provider.
+    tenant_id: Mapped[UUID] = mapped_column(
+        ForeignKey(Tenants.id, ondelete="CASCADE"), nullable=False, index=True
     )
-    provider_id: Mapped[Optional[UUID]] = mapped_column(
-        ForeignKey("model_providers.id", ondelete="CASCADE"), nullable=True, index=True
+    provider_id: Mapped[UUID] = mapped_column(
+        ForeignKey("model_providers.id", ondelete="CASCADE"), nullable=False, index=True
     )
 
     # Settings (previously in separate embedding_model_settings table)
@@ -218,8 +218,8 @@ class EmbeddingModels(BasePublic):
 
     __table_args__ = (
         CheckConstraint(
-            "(tenant_id IS NULL AND provider_id IS NULL) OR (tenant_id IS NOT NULL AND provider_id IS NOT NULL)",
-            name="ck_embedding_models_tenant_provider",
+            "tenant_id IS NOT NULL AND provider_id IS NOT NULL",
+            name="ck_embedding_models_tenant_provider_required",
         ),
     )
 

--- a/backend/src/intric/embedding_models/domain/embedding_model_repo.py
+++ b/backend/src/intric/embedding_models/domain/embedding_model_repo.py
@@ -27,7 +27,7 @@ class EmbeddingModelRepository:
             sa.select(
                 EmbeddingModels, ModelProviders.name, ModelProviders.provider_type
             )
-            .outerjoin(ModelProviders, EmbeddingModels.provider_id == ModelProviders.id)
+            .join(ModelProviders, EmbeddingModels.provider_id == ModelProviders.id)
             .options(
                 selectinload(EmbeddingModels.security_classification),
                 selectinload(EmbeddingModels.security_classification).options(
@@ -35,13 +35,7 @@ class EmbeddingModelRepository:
                 ),
             )
             .where(
-                # Return both global and tenant models
-                # This allows existing collections with global models to continue working
-                # UI filtering happens at the presentation layer
-                sa.or_(
-                    EmbeddingModels.tenant_id.is_(None),
-                    EmbeddingModels.tenant_id == self.user.tenant_id,
-                ),
+                EmbeddingModels.tenant_id == self.user.tenant_id,
                 # Soft-deleted models are tombstones kept only so existing
                 # collections/websites still resolve; never surface them.
                 EmbeddingModels.deleted_at.is_(None),
@@ -70,12 +64,11 @@ class EmbeddingModelRepository:
         ]
 
     async def one_or_none(self, model_id: "UUID") -> Optional["EmbeddingModel"]:
-        # When fetching by ID, return ANY model (global or tenant) that the user can access
         stmt = (
             sa.select(
                 EmbeddingModels, ModelProviders.name, ModelProviders.provider_type
             )
-            .outerjoin(ModelProviders, EmbeddingModels.provider_id == ModelProviders.id)
+            .join(ModelProviders, EmbeddingModels.provider_id == ModelProviders.id)
             .options(
                 selectinload(EmbeddingModels.security_classification),
                 selectinload(EmbeddingModels.security_classification).options(
@@ -84,11 +77,7 @@ class EmbeddingModelRepository:
             )
             .where(
                 EmbeddingModels.id == model_id,
-                # Allow both global models (tenant_id IS NULL) and tenant models (tenant_id = user.tenant_id)
-                sa.or_(
-                    EmbeddingModels.tenant_id.is_(None),
-                    EmbeddingModels.tenant_id == self.user.tenant_id,
-                ),
+                EmbeddingModels.tenant_id == self.user.tenant_id,
                 # Soft-deleted models stay invisible to all callers.
                 EmbeddingModels.deleted_at.is_(None),
             )

--- a/backend/src/intric/sysadmin/sysadmin_router.py
+++ b/backend/src/intric/sysadmin/sysadmin_router.py
@@ -2,30 +2,21 @@ from datetime import datetime, timedelta
 from typing import Annotated, cast
 from uuid import UUID
 
-import sqlalchemy as sa
 from fastapi import APIRouter, Depends, HTTPException, Query, Security
 from pydantic import BaseModel, Field
 
 from intric.ai_models.completion_models.completion_model import (
-    CompletionModelCreate,
     CompletionModelPublic,
     CompletionModelSparse,
-    CompletionModelUpdate,
     CompletionModelUpdateFlags,
 )
 from intric.ai_models.completion_models.completion_models_repo import (
     CompletionModelsRepository,
 )
-from intric.ai_models.display_name_validation import validate_unique_display_name
 from intric.ai_models.embedding_models.embedding_model import (
-    EmbeddingModelCreate,
     EmbeddingModelLegacy,
     EmbeddingModelPublicLegacy,
-    EmbeddingModelSparse,
     EmbeddingModelUpdateFlags,
-)
-from intric.ai_models.embedding_models.embedding_model import (
-    EmbeddingModelUpdate as EmbeddingModelMetadataUpdate,
 )
 from intric.ai_models.embedding_models.embedding_models_repo import (
     AdminEmbeddingModelsService,
@@ -45,20 +36,10 @@ from intric.completion_models.presentation.completion_model_models import (
     ModelMigrationRequest,
 )
 from intric.database.database import AsyncSession
-from intric.database.tables.ai_models_table import (
-    CompletionModels,
-    EmbeddingModels,
-)
-from intric.database.tables.collections_table import CollectionsTable
-from intric.database.tables.info_blobs_table import InfoBlobs
-from intric.database.tables.integration_table import IntegrationKnowledge
-from intric.database.tables.spaces_table import SpacesEmbeddingModels
-from intric.database.tables.websites_table import Websites
 from intric.main.container.container import Container
 from intric.main.container.container_overrides import override_user
 from intric.main.exceptions import (
     BadRequestException,
-    ModelInUseException,
     ValidationException,
 )
 from intric.main.logging import get_logger
@@ -1290,13 +1271,14 @@ async def migrate_completion_model_for_all_tenants(
 
 
 # ============================================================================
-# AI Models CRUD Operations (System-Wide)
+# Legacy Global AI Model CRUD
 # ============================================================================
-# These endpoints allow system administrators to create, update, and delete
-# AI model metadata. They require ENEO_SUPER_API_KEY authentication.
-# Note: These endpoints manage global model metadata only, not tenant-specific
-# settings. To enable/disable models for specific tenants, use the tenant-scoped
-# endpoints in the completion_models and embedding_models routers.
+# Model ownership now lives exclusively in tenant-scoped model rows with a
+# concrete provider. The old sysadmin CRUD API created provider-less global rows,
+# which made tenant/admin model state diverge and allowed dirty databases to
+# recreate hidden global models. Keep these routes present long enough to give
+# old clients an explicit deprecation response instead of silently mutating the
+# wrong owner.
 # ============================================================================
 
 
@@ -1305,134 +1287,63 @@ async def migrate_completion_model_for_all_tenants(
 
 @router.post(
     "/completion-models/create",
-    response_model=CompletionModelSparse,
-    description="Create global completion model metadata (system-wide operation).",
-    responses=responses.get_responses([400, 401, 409]),
+    response_model=None,
+    description="Deprecated. Completion models must be created through tenant-scoped admin model routes.",
+    responses=responses.get_responses([401, 410]),
 )
 async def create_completion_model(
-    model_data: CompletionModelCreate,
     container: Annotated[Container, Depends(get_container_for_sysadmin())],
-) -> CompletionModelSparse:
-    """
-    Create a new completion model (system-wide operation).
-
-    Requires: X-API-Key header with ENEO_SUPER_API_KEY
-
-    This creates the model metadata only. To enable it for a tenant,
-    use POST /api/v1/completion-models/{id}/ with tenant credentials.
-    """
-    # AUDIT GAP: sysadmin model lifecycle does not emit audit_log rows.
-    # audit_logs.tenant_id is NOT NULL but a global model has no owning
-    # tenant at create time. The tenant-scoped /tenant-models/ routes
-    # already audit COMPLETION_MODEL_CREATED via tenant_model_service;
-    # this path is reachable only by ENEO_SUPER_API_KEY (cross-tenant
-    # operator), and observability lives in app logs for now. A clean
-    # fix needs either a system-tenant convention or a separate
-    # sysadmin_audit store; tracked as follow-up.
-    session = cast(AsyncSession, container.session())
-    async with session.begin():
-        await validate_unique_display_name(
-            session,
-            CompletionModels,
-            tenant_id=None,
-            nickname=getattr(model_data, "nickname", None),
-        )
-        repo = CompletionModelsRepository(session=session)
-        model = await repo.create_model(model_data)
-
-    return CompletionModelSparse.model_validate(model)
+):
+    _ = container
+    raise HTTPException(
+        status_code=410,
+        detail=(
+            "Global completion model CRUD has been removed. Create or update "
+            "tenant-owned models through /api/v1/admin/tenant-models/completion/ "
+            "with an explicit provider_id."
+        ),
+    )
 
 
 @router.put(
     "/completion-models/{id}/metadata",
-    response_model=CompletionModelSparse,
-    description="Update global completion model metadata (system-wide operation).",
-    responses=responses.get_responses([401, 404, 409]),
+    response_model=None,
+    description="Deprecated. Completion model metadata must be updated through tenant-scoped admin model routes.",
+    responses=responses.get_responses([401, 410]),
 )
 async def update_completion_model_metadata(
     id: UUID,
-    model_data: CompletionModelUpdate,
     container: Annotated[Container, Depends(get_container_for_sysadmin())],
-) -> CompletionModelSparse:
-    """
-    Update completion model metadata (system-wide operation).
-
-    Requires: X-API-Key header with ENEO_SUPER_API_KEY
-
-    Updates global model metadata. Does not affect tenant-specific settings.
-    """
-    from intric.main.exceptions import NotFoundException
-
-    session = cast(AsyncSession, container.session())
-    async with session.begin():
-        repo = CompletionModelsRepository(session=session)
-
-        await validate_unique_display_name(
-            session,
-            CompletionModels,
-            tenant_id=None,
-            nickname=getattr(model_data, "nickname", None),
-            exclude_id=id,
-        )
-
-        # Ensure model_data has the id
-        update_with_id = CompletionModelUpdate(
-            id=id, **model_data.model_dump(exclude={"id"}, exclude_unset=True)
-        )
-        model = await repo.update_model(update_with_id)
-
-        if model is None:
-            raise NotFoundException(f"Completion model with id {id} not found")
-
-    return CompletionModelSparse.model_validate(model)
+):
+    _ = (id, container)
+    raise HTTPException(
+        status_code=410,
+        detail=(
+            "Global completion model metadata cannot be updated. Update the "
+            "tenant-owned model row through /api/v1/admin/tenant-models/completion/."
+        ),
+    )
 
 
 @router.delete(
     "/completion-models/{id}",
     response_model=None,
-    description="Soft-delete global completion model metadata (system-wide operation).",
-    responses=responses.get_responses([404, 400, 401]),
+    description="Deprecated. Completion models must be deleted through tenant-scoped admin model routes.",
+    responses=responses.get_responses([401, 410]),
 )
 async def delete_completion_model(
     id: UUID,
     container: Annotated[Container, Depends(get_container_for_sysadmin())],
     force: Annotated[bool, Query(description="Force delete even if in use")] = False,
 ):
-    """
-    Soft-delete a completion model (system-wide operation).
-
-    Requires: X-API-Key header with ENEO_SUPER_API_KEY
-
-    WARNING: Affects all tenants. Use with caution.
-    Set force=true to hard-delete (may break references).
-    """
-    # AUDIT GAP: same constraint as create_completion_model — no tenant
-    # to attach the audit row to. App logs are the only trace today.
-    session = cast(AsyncSession, container.session())
-    async with session.begin():
-        repo = CompletionModelsRepository(session=session)
-        if force:
-            # Hard-delete: 20260402_lifecycle changed questions.completion_model_id
-            # from SET NULL → RESTRICT so historical attribution can't be silently
-            # erased. If any question references this model the DELETE will fail
-            # with IntegrityError; surface it as MODEL_IN_USE (400) so operators
-            # see a useful error instead of a 500.
-            import sqlalchemy as sa
-            from sqlalchemy.exc import IntegrityError
-
-            from intric.database.tables.ai_models_table import CompletionModels
-
-            stmt = sa.delete(CompletionModels).where(CompletionModels.id == id)
-            try:
-                await session.execute(stmt)
-            except IntegrityError as exc:
-                raise ModelInUseException() from exc
-        else:
-            if await repo.has_active_references(id):
-                raise ModelInUseException()
-            await repo.delete_model(id)
-
-    return {"success": True, "message": f"Model {id} deleted successfully"}
+    _ = (id, container, force)
+    raise HTTPException(
+        status_code=410,
+        detail=(
+            "Global completion model deletion has been removed. Delete the "
+            "tenant-owned model row through /api/v1/admin/tenant-models/completion/."
+        ),
+    )
 
 
 # Embedding Models CRUD
@@ -1440,171 +1351,63 @@ async def delete_completion_model(
 
 @router.post(
     "/embedding-models/create",
-    response_model=EmbeddingModelSparse,
-    description="Create global embedding model metadata (system-wide operation).",
-    responses=responses.get_responses([400, 401, 409]),
+    response_model=None,
+    description="Deprecated. Embedding models must be created through tenant-scoped admin model routes.",
+    responses=responses.get_responses([401, 410]),
 )
 async def create_embedding_model(
-    model_data: EmbeddingModelCreate,
     container: Annotated[Container, Depends(get_container_for_sysadmin())],
-) -> EmbeddingModelSparse:
-    """
-    Create a new embedding model (system-wide operation).
-
-    Requires: X-API-Key header with ENEO_SUPER_API_KEY
-
-    This creates the model metadata only. To enable it for a tenant,
-    use POST /api/v1/embedding-models/{id}/ with tenant credentials.
-    """
-    # AUDIT GAP: see create_completion_model — no owning tenant for a
-    # global model row, so no audit_log entry is emitted today.
-    session = cast(AsyncSession, container.session())
-    async with session.begin():
-        await validate_unique_display_name(
-            session,
-            EmbeddingModels,
-            tenant_id=None,
-            nickname=getattr(model_data, "nickname", None),
-        )
-        repo = AdminEmbeddingModelsService(session=session)
-        model = await repo.create_model(model_data)
-
-    return EmbeddingModelSparse.model_validate(model)
+):
+    _ = container
+    raise HTTPException(
+        status_code=410,
+        detail=(
+            "Global embedding model CRUD has been removed. Create or update "
+            "tenant-owned models through /api/v1/admin/tenant-models/embedding/ "
+            "with an explicit provider_id."
+        ),
+    )
 
 
 @router.put(
     "/embedding-models/{id}/metadata",
-    response_model=EmbeddingModelSparse,
-    description="Update global embedding model metadata (system-wide operation).",
-    responses=responses.get_responses([401, 404, 409]),
+    response_model=None,
+    description="Deprecated. Embedding model metadata must be updated through tenant-scoped admin model routes.",
+    responses=responses.get_responses([401, 410]),
 )
 async def update_embedding_model_metadata(
     id: UUID,
-    model_data: EmbeddingModelMetadataUpdate,
     container: Annotated[Container, Depends(get_container_for_sysadmin())],
-) -> EmbeddingModelSparse:
-    """
-    Update embedding model metadata (system-wide operation).
-
-    Requires: X-API-Key header with ENEO_SUPER_API_KEY
-
-    Updates global model metadata. Does not affect tenant-specific settings.
-    """
-    from intric.main.exceptions import NotFoundException
-
-    session = cast(AsyncSession, container.session())
-    async with session.begin():
-        repo = AdminEmbeddingModelsService(session=session)
-
-        await validate_unique_display_name(
-            session,
-            EmbeddingModels,
-            tenant_id=None,
-            nickname=getattr(model_data, "nickname", None),
-            exclude_id=id,
-        )
-
-        # Ensure model_data has the id
-        update_with_id = EmbeddingModelMetadataUpdate(
-            id=id, **model_data.model_dump(exclude={"id"}, exclude_unset=True)
-        )
-        model = await repo.update_model(update_with_id)
-
-        if model is None:
-            raise NotFoundException(f"Embedding model with id {id} not found")
-
-    return EmbeddingModelSparse.model_validate(model)
+):
+    _ = (id, container)
+    raise HTTPException(
+        status_code=410,
+        detail=(
+            "Global embedding model metadata cannot be updated. Update the "
+            "tenant-owned model row through /api/v1/admin/tenant-models/embedding/."
+        ),
+    )
 
 
 @router.delete(
     "/embedding-models/{id}",
     response_model=None,
-    description="Soft-delete global embedding model metadata (system-wide operation).",
-    responses=responses.get_responses([404, 400, 401]),
+    description="Deprecated. Embedding models must be deleted through tenant-scoped admin model routes.",
+    responses=responses.get_responses([401, 410]),
 )
 async def delete_embedding_model(
     id: UUID,
     container: Annotated[Container, Depends(get_container_for_sysadmin())],
     force: Annotated[bool, Query(description="Force delete even if in use")] = False,
 ):
-    """
-    Delete an embedding model (system-wide operation).
-
-    Requires: X-API-Key header with ENEO_SUPER_API_KEY
-
-    WARNING: Deletion affects all tenants. Use with caution.
-    Set force=true to hard-delete (may erase historical info_blob attribution).
-    """
-    # AUDIT GAP: see create_embedding_model — no owning tenant to attach
-    # the audit row to. App logs are the only trace today.
-    session = cast(AsyncSession, container.session())
-
-    async with session.begin():
-        if force:
-            # Hard-delete remains an explicit operator escape hatch. Historical
-            # info_blobs use ON DELETE SET NULL, so this can erase attribution;
-            # the normal path below soft-deletes instead.
-            from sqlalchemy.exc import IntegrityError
-
-            repo = AdminEmbeddingModelsService(session=session)
-            try:
-                await repo.delete_model(id)
-            except IntegrityError as exc:
-                raise ModelInUseException() from exc
-        else:
-            model = await session.scalar(
-                sa.select(EmbeddingModels).where(
-                    EmbeddingModels.id == id,
-                    EmbeddingModels.deleted_at.is_(None),
-                )
-            )
-            if model is None:
-                # Idempotent, matching delete_completion_model: a missing or
-                # already-soft-deleted model is a no-op success, not a 404.
-                return {
-                    "success": True,
-                    "message": f"Model {id} deleted successfully",
-                }
-
-            # Three separate counts — combining them in one SELECT pulls all three
-            # tables into the FROM clause, producing a cartesian product.
-            collections_count = await session.scalar(
-                sa.select(sa.func.count()).where(
-                    CollectionsTable.embedding_model_id == id
-                )
-            )
-            websites_count = await session.scalar(
-                sa.select(sa.func.count()).where(Websites.embedding_model_id == id)
-            )
-            integrations_count = await session.scalar(
-                sa.select(sa.func.count()).where(
-                    IntegrationKnowledge.embedding_model_id == id
-                )
-            )
-            if collections_count or websites_count or integrations_count:
-                raise ModelInUseException()
-
-            info_blobs_count = await session.scalar(
-                sa.select(sa.func.count()).where(InfoBlobs.embedding_model_id == id)
-            )
-            if info_blobs_count:
-                logger.info(
-                    "sysadmin.embedding_model.soft_deleted_with_info_blobs",
-                    extra={
-                        "embedding_model_id": str(id),
-                        "info_blobs_count": info_blobs_count,
-                    },
-                )
-
-            await session.execute(
-                sa.delete(SpacesEmbeddingModels).where(
-                    SpacesEmbeddingModels.embedding_model_id == id
-                )
-            )
-            model.deleted_at = sa.func.now()
-            await session.flush()
-
-    return {"success": True, "message": f"Model {id} deleted successfully"}
+    _ = (id, container, force)
+    raise HTTPException(
+        status_code=410,
+        detail=(
+            "Global embedding model deletion has been removed. Delete the "
+            "tenant-owned model row through /api/v1/admin/tenant-models/embedding/."
+        ),
+    )
 
 
 @router.post(

--- a/backend/src/intric/tenant_models/application/tenant_model_service.py
+++ b/backend/src/intric/tenant_models/application/tenant_model_service.py
@@ -144,12 +144,13 @@ def _snapshot_completion_capabilities(
 
 
 def _ensure_tenant_owned(model: Any) -> None:
-    """Block updates/deletes against rows that escaped the tenant_id filter
-    (e.g. global models surfaced through a shared table). The router's
-    SELECT already filters by tenant_id; this is the belt-and-braces
-    guard for the rare case the row's `tenant_id` itself is NULL."""
+    """Block updates/deletes against rows that escaped the tenant_id filter.
+
+    The SELECT already filters by tenant_id; this is the belt-and-braces guard
+    for legacy dirty rows that predate the tenant-owned model invariant.
+    """
     if model.tenant_id is None:
-        raise UnauthorizedException("Cannot modify global models")
+        raise UnauthorizedException("Cannot modify models without tenant ownership")
 
 
 async def _audit(
@@ -340,7 +341,8 @@ class TenantCompletionModelService:
         # re-discover with both fields settled. An explicit capability payload
         # below still wins over the refreshed snapshot.
         if payload.name is not None or payload.reasoning is not None:
-            if model.provider_id is None:
+            provider_id = getattr(model, "provider_id", None)
+            if provider_id is None:
                 raise BadRequestException(
                     "Tenant completion model is missing its provider"
                 )
@@ -348,7 +350,7 @@ class TenantCompletionModelService:
                 session=self.session,
                 tenant_id=self.user.tenant_id,
             )
-            provider = await provider_repo.get_by_id(model.provider_id)
+            provider = await provider_repo.get_by_id(provider_id)
             model.model_kwargs_capabilities = _snapshot_completion_capabilities(
                 provider.provider_type,
                 model.name,

--- a/backend/src/intric/transcription_models/domain/transcription_model_repo.py
+++ b/backend/src/intric/transcription_models/domain/transcription_model_repo.py
@@ -31,9 +31,7 @@ class TranscriptionModelRepository:
             sa.select(
                 TranscriptionModels, ModelProviders.name, ModelProviders.provider_type
             )
-            .outerjoin(
-                ModelProviders, TranscriptionModels.provider_id == ModelProviders.id
-            )
+            .join(ModelProviders, TranscriptionModels.provider_id == ModelProviders.id)
             .options(
                 selectinload(TranscriptionModels.security_classification),
                 selectinload(TranscriptionModels.security_classification).options(
@@ -41,13 +39,7 @@ class TranscriptionModelRepository:
                 ),
             )
             .where(
-                # Return both global and tenant models
-                # This allows existing apps with global models to continue working
-                # UI filtering happens at the presentation layer
-                sa.or_(
-                    TranscriptionModels.tenant_id.is_(None),
-                    TranscriptionModels.tenant_id == self.user.tenant_id,
-                ),
+                TranscriptionModels.tenant_id == self.user.tenant_id,
                 # Soft-deleted models are tombstones kept only so migration
                 # history and lingering app references resolve; never surface
                 # them to readers.
@@ -77,14 +69,11 @@ class TranscriptionModelRepository:
         ]
 
     async def one_or_none(self, model_id: "UUID") -> Optional["TranscriptionModel"]:
-        # When fetching by ID, return ANY model (global or tenant) that the user can access
         stmt = (
             sa.select(
                 TranscriptionModels, ModelProviders.name, ModelProviders.provider_type
             )
-            .outerjoin(
-                ModelProviders, TranscriptionModels.provider_id == ModelProviders.id
-            )
+            .join(ModelProviders, TranscriptionModels.provider_id == ModelProviders.id)
             .options(
                 selectinload(TranscriptionModels.security_classification),
                 selectinload(TranscriptionModels.security_classification).options(
@@ -93,11 +82,7 @@ class TranscriptionModelRepository:
             )
             .where(
                 TranscriptionModels.id == model_id,
-                # Allow both global models (tenant_id IS NULL) and tenant models (tenant_id = user.tenant_id)
-                sa.or_(
-                    TranscriptionModels.tenant_id.is_(None),
-                    TranscriptionModels.tenant_id == self.user.tenant_id,
-                ),
+                TranscriptionModels.tenant_id == self.user.tenant_id,
                 # Soft-deleted models are invisible to all callers (including the
                 # migration engine, which must not migrate from/to a tombstone).
                 TranscriptionModels.deleted_at.is_(None),

--- a/backend/tests/integration/embedding_models/test_embedding_model_lifecycle.py
+++ b/backend/tests/integration/embedding_models/test_embedding_model_lifecycle.py
@@ -110,7 +110,7 @@ class TestEmbeddingModelSoftDelete:
                     TenantEmbeddingModelUpdate(description="should not update"),
                 )
 
-    async def test_sysadmin_delete_soft_deletes_and_preserves_info_blob_model_link(
+    async def test_legacy_sysadmin_delete_does_not_mutate_tenant_embedding_model(
         self, client, super_admin_token, db_container, admin_user, space_factory
     ):
         async with db_container() as container:
@@ -136,7 +136,7 @@ class TestEmbeddingModelSoftDelete:
             f"/api/v1/sysadmin/embedding-models/{model_id}",
             headers={"X-API-Key": super_admin_token},
         )
-        assert response.status_code == 200
+        assert response.status_code == 410
 
         async with db_container() as container:
             session = container.session()
@@ -146,7 +146,7 @@ class TestEmbeddingModelSoftDelete:
                     select(EmbeddingModels).where(EmbeddingModels.id == model_id)
                 )
             ).scalar_one()
-            assert row.deleted_at is not None
+            assert row.deleted_at is None
 
             blob = (
                 await session.execute(
@@ -162,7 +162,7 @@ class TestEmbeddingModelSoftDelete:
                     )
                 )
             ).scalar_one_or_none()
-            assert link is None
+            assert link is not None
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/fixtures/organization_knowledge.py
+++ b/backend/tests/integration/fixtures/organization_knowledge.py
@@ -7,6 +7,7 @@ These fixtures support testing knowledge distribution across org space and child
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 
 from intric.database.tables.ai_models_table import EmbeddingModels
 from intric.database.tables.integration_table import (
@@ -14,6 +15,7 @@ from intric.database.tables.integration_table import (
     TenantIntegration,
     UserIntegration,
 )
+from intric.database.tables.model_providers_table import ModelProviders
 from intric.database.tables.tenant_table import Tenants
 from intric.database.tables.users_table import Users
 
@@ -199,20 +201,62 @@ def embedding_model_factory(admin_user):
         EmbeddingModels: The created embedding model
     """
 
+    _provider_cache = {}
+
+    async def _get_or_create_provider(session, tenant_id, provider_type: str):
+        cache_key = (tenant_id, provider_type)
+        if cache_key in _provider_cache:
+            return _provider_cache[cache_key]
+
+        result = await session.execute(
+            select(ModelProviders).where(
+                ModelProviders.tenant_id == tenant_id,
+                ModelProviders.provider_type == provider_type,
+            )
+        )
+        existing = result.scalar_one_or_none()
+        if existing:
+            _provider_cache[cache_key] = existing.id
+            return existing.id
+
+        provider = ModelProviders(
+            tenant_id=tenant_id,
+            name=provider_type.title(),
+            provider_type=provider_type,
+            credentials={"api_key": "test-key"},
+            config={},
+            is_active=True,
+        )
+        session.add(provider)
+        await session.flush()
+        _provider_cache[cache_key] = provider.id
+        return provider.id
+
     async def _create_embedding_model(
-        session, name: str = None, **extra
+        session,
+        name: str = None,
+        tenant_id=None,
+        provider: str = "openai",
+        provider_id=None,
+        **extra,
     ) -> EmbeddingModels:
         """Create an embedding model."""
         if name is None:
             name = f"embedding-model-{str(uuid4())[:8]}"
+        if tenant_id is None:
+            tenant_id = admin_user.tenant_id
+        if provider_id is None:
+            provider_id = await _get_or_create_provider(session, tenant_id, provider)
 
         model = EmbeddingModels(
+            tenant_id=tenant_id,
+            provider_id=provider_id,
             name=name,
             open_source=False,
-            family="test-family",
-            stability="stable",
-            hosting="cloud",
-            description=f"{name} embedding model",
+            family=extra.pop("family", "test-family"),
+            stability=extra.pop("stability", "stable"),
+            hosting=extra.pop("hosting", "cloud"),
+            description=extra.pop("description", f"{name} embedding model"),
             **extra,
         )
         session.add(model)

--- a/backend/tests/integration/migrations/test_model_tenant_required_migration.py
+++ b/backend/tests/integration/migrations/test_model_tenant_required_migration.py
@@ -1,0 +1,244 @@
+"""Focused coverage for residual global model repair.
+
+Run with:
+    pytest -m migration_isolation \
+        tests/integration/migrations/test_model_tenant_required_migration.py -v
+"""
+
+from pathlib import Path
+from uuid import uuid4
+
+import psycopg2
+import pytest
+
+from alembic import command
+from alembic.config import Config
+
+pytestmark = [pytest.mark.integration, pytest.mark.migration_isolation]
+
+
+def _alembic_cfg(database_url: str) -> Config:
+    backend_dir = Path(__file__).resolve().parents[3]
+    cfg = Config(str(backend_dir / "alembic.ini"))
+    cfg.set_main_option("script_location", str(backend_dir / "alembic"))
+    cfg.set_main_option("sqlalchemy.url", database_url)
+    return cfg
+
+
+@pytest.fixture(autouse=True)
+def cleanup_database():
+    yield
+
+
+@pytest.fixture(autouse=True)
+def seed_default_models():
+    yield
+
+
+@pytest.fixture
+def repaired_db(test_settings):
+    cfg = _alembic_cfg(test_settings.sync_database_url)
+    conn = psycopg2.connect(
+        host=test_settings.postgres_host,
+        port=test_settings.postgres_port,
+        dbname=test_settings.postgres_db,
+        user=test_settings.postgres_user,
+        password=test_settings.postgres_password,
+    )
+    conn.autocommit = True
+
+    tenant_a = uuid4()
+    tenant_b = uuid4()
+    user_a = uuid4()
+    space_a = uuid4()
+    app_a = uuid4()
+    global_transcription = uuid4()
+
+    try:
+        command.upgrade(cfg, "202605251000")
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                DO $$
+                DECLARE r RECORD;
+                BEGIN
+                    FOR r IN (
+                        SELECT tablename
+                        FROM pg_tables
+                        WHERE schemaname = 'public'
+                          AND tablename != 'alembic_version'
+                    ) LOOP
+                        EXECUTE 'TRUNCATE TABLE ' || quote_ident(r.tablename) || ' CASCADE';
+                    END LOOP;
+                END $$;
+                """
+            )
+            cur.execute(
+                """
+                INSERT INTO tenants (
+                    id, name, slug, quota_limit, state, api_credentials,
+                    federation_config, crawler_settings, api_key_policy,
+                    favorite_providers
+                )
+                VALUES
+                    (%s, 'tenant-a', 'tenant-a', 1000000, 'active', '{}', '{}', '{}', '{}', '[]'),
+                    (%s, 'tenant-b', 'tenant-b', 1000000, 'active', '{}', '{}', '{}', '{}', '[]')
+                """,
+                (tenant_a, tenant_b),
+            )
+            cur.execute(
+                """
+                INSERT INTO users (
+                    id, username, email, state, used_tokens, tenant_id
+                )
+                VALUES (%s, 'admin-a', 'admin-a@example.com', 'active', 0, %s)
+                """,
+                (user_a, tenant_a),
+            )
+            cur.execute(
+                """
+                INSERT INTO spaces (
+                    id, name, description, data_retention_days, tenant_id,
+                    user_id
+                )
+                VALUES (%s, 'Tenant A space', NULL, NULL, %s, NULL)
+                """,
+                (space_a, tenant_a),
+            )
+            cur.execute(
+                """
+                INSERT INTO transcription_models (
+                    id, name, model_name, nickname, open_source, is_deprecated,
+                    family, stability, hosting, description, org, base_url,
+                    cost_per_minute, tenant_id, provider_id, is_enabled,
+                    is_default, deleted_at
+                )
+                VALUES (
+                    %s, 'KB-Whisper', 'kb-whisper', 'KB-Whisper', false, false,
+                    'openai', 'stable', 'swe', 'Berget-hosted transcription',
+                    'Berget', 'https://api.berget.ai/v1', 0.006,
+                    NULL, NULL, true, true, NULL
+                )
+                """,
+                (global_transcription,),
+            )
+            cur.execute(
+                """
+                INSERT INTO apps (
+                    id, name, description, completion_model_kwargs, published,
+                    data_retention_days, tenant_id, user_id, space_id,
+                    transcription_model_id
+                )
+                VALUES (%s, 'App A', NULL, '{}', false, NULL, %s, %s, %s, %s)
+                """,
+                (app_a, tenant_a, user_a, space_a, global_transcription),
+            )
+            cur.execute(
+                """
+                INSERT INTO spaces_transcription_models (
+                    space_id, transcription_model_id
+                )
+                VALUES (%s, %s)
+                """,
+                (space_a, global_transcription),
+            )
+
+        command.upgrade(cfg, "head")
+        yield {
+            "conn": conn,
+            "tenant_a": tenant_a,
+            "tenant_b": tenant_b,
+            "app_a": app_a,
+            "space_a": space_a,
+            "global_transcription": global_transcription,
+        }
+    finally:
+        conn.close()
+
+
+def test_residual_global_transcription_models_are_repaired(repaired_db):
+    conn = repaired_db["conn"]
+    tenant_a = repaired_db["tenant_a"]
+    tenant_b = repaired_db["tenant_b"]
+    app_a = repaired_db["app_a"]
+    space_a = repaired_db["space_a"]
+    global_transcription = repaired_db["global_transcription"]
+
+    with conn.cursor() as cur:
+        for table in (
+            "completion_models",
+            "embedding_models",
+            "transcription_models",
+        ):
+            cur.execute(
+                f"""
+                SELECT count(*)
+                FROM {table}
+                WHERE tenant_id IS NULL OR provider_id IS NULL
+                """
+            )
+            assert cur.fetchone()[0] == 0
+
+        cur.execute(
+            """
+            SELECT tm.id, tm.tenant_id, tm.provider_id, tm.is_enabled, tm.is_default,
+                   mp.name, mp.provider_type, mp.is_active, mp.config->>'endpoint',
+                   mp.credentials
+            FROM transcription_models tm
+            JOIN model_providers mp ON mp.id = tm.provider_id
+            WHERE tm.model_name = 'kb-whisper'
+            ORDER BY tm.tenant_id
+            """
+        )
+        rows = cur.fetchall()
+        assert {row[1] for row in rows} == {str(tenant_a), str(tenant_b)}
+        assert all(row[2] is not None for row in rows)
+        assert all(row[3] is False for row in rows)
+        assert all(row[4] is False for row in rows)
+        assert all(row[5] == "Berget.ai" for row in rows)
+        assert all(row[6] == "hosted_vllm" for row in rows)
+        assert all(row[7] is False for row in rows)
+        assert all(row[8] == "https://api.berget.ai/v1" for row in rows)
+        assert all(row[9] == {} for row in rows)
+
+        tenant_a_model_id = next(row[0] for row in rows if row[1] == str(tenant_a))
+        cur.execute(
+            "SELECT transcription_model_id FROM apps WHERE id = %s",
+            (app_a,),
+        )
+        assert cur.fetchone()[0] == tenant_a_model_id
+
+        cur.execute(
+            """
+            SELECT transcription_model_id
+            FROM spaces_transcription_models
+            WHERE space_id = %s
+            """,
+            (space_a,),
+        )
+        assert cur.fetchone()[0] == tenant_a_model_id
+
+        cur.execute(
+            "SELECT 1 FROM transcription_models WHERE id = %s",
+            (global_transcription,),
+        )
+        assert cur.fetchone() is None
+
+
+def test_model_owner_columns_are_not_nullable(repaired_db):
+    conn = repaired_db["conn"]
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT table_name, column_name, is_nullable
+            FROM information_schema.columns
+            WHERE table_name IN (
+                'completion_models',
+                'embedding_models',
+                'transcription_models'
+            )
+              AND column_name IN ('tenant_id', 'provider_id')
+            """
+        )
+        assert {row[2] for row in cur.fetchall()} == {"NO"}

--- a/backend/tests/integration/sysadmin/test_ai_models_crud.py
+++ b/backend/tests/integration/sysadmin/test_ai_models_crud.py
@@ -1,812 +1,109 @@
-"""
-Integration tests for sysadmin AI models CRUD endpoints.
+"""Integration tests for deprecated sysadmin global model CRUD endpoints."""
 
-Tests the system-wide AI model management endpoints that require super admin API key:
-- POST /sysadmin/completion-models/create
-- POST /sysadmin/completion-models/{id}/metadata
-- DELETE /sysadmin/completion-models/{id}
-- POST /sysadmin/embedding-models/create
-- POST /sysadmin/embedding-models/{id}/metadata
-- DELETE /sysadmin/embedding-models/{id}
-"""
+from uuid import uuid4
 
 import pytest
-import sqlalchemy as sa
 
-from intric.database.tables.ai_models_table import CompletionModels, EmbeddingModels
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_duplicate_display_name_race_returns_409(
-    client, super_admin_token, monkeypatch
-):
-    """The display-name pre-check normally returns a 409 before the DB. If a
-    concurrent request slips past it (the validate-then-insert race), the active
-    nickname unique index fires at flush; that IntegrityError must surface as the
-    same clean 409 NAME_COLLISION, not a 500. Bypass the pre-check to reach it.
-    """
-
-    async def _noop(*args, **kwargs):
-        return None
-
-    monkeypatch.setattr(
-        "intric.sysadmin.sysadmin_router.validate_unique_display_name", _noop
-    )
-
-    payload = {
-        "name": "race-collision-model",
-        "nickname": "Race Collision Display Name",
-        "family": "openai",
-        "max_input_tokens": 8000,
-        "max_output_tokens": 4096,
-        "is_deprecated": False,
-        "stability": "stable",
-        "hosting": "usa",
-        "open_source": False,
-        "description": "Race test model",
-        "org": "OpenAI",
-        "vision": False,
-        "reasoning": False,
-        "base_url": "https://api.openai.com/v1",
-        "litellm_model_name": "gpt-4",
-    }
-
-    first = await client.post(
-        "/api/v1/sysadmin/completion-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=payload,
-    )
-    assert first.status_code == 200
-
-    second = await client.post(
-        "/api/v1/sysadmin/completion-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=payload,
-    )
-    assert second.status_code == 409
-    assert second.json().get("intric_error_code") == 9017
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
 
 
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_create_completion_model_success(client, super_admin_token, db_container):
-    """Test creating a new completion model with valid data."""
-    model_data = {
-        "name": "gpt-4-test",
-        "nickname": "GPT-4 Test",
-        "family": "openai",
-        "max_input_tokens": 8000,
-        "max_output_tokens": 4096,
-        "is_deprecated": False,
-        "stability": "stable",
-        "hosting": "usa",
-        "open_source": False,
-        "description": "Test model for integration testing",
-        "org": "OpenAI",
-        "vision": True,
-        "reasoning": False,
-        "base_url": "https://api.openai.com/v1",
-        "litellm_model_name": "gpt-4",
-    }
+COMPLETION_CREATE_PAYLOAD = {
+    "name": "gpt-4-test",
+    "nickname": "GPT-4 Test",
+    "family": "openai",
+    "max_input_tokens": 8000,
+    "max_output_tokens": 4096,
+    "is_deprecated": False,
+    "stability": "stable",
+    "hosting": "usa",
+    "open_source": False,
+    "description": "Test model for integration testing",
+    "org": "OpenAI",
+    "vision": True,
+    "reasoning": False,
+    "base_url": "https://api.openai.com/v1",
+    "litellm_model_name": "gpt-4",
+}
 
+EMBEDDING_CREATE_PAYLOAD = {
+    "name": "text-embedding-3-small-test",
+    "nickname": "Embedding Test",
+    "family": "openai",
+    "dimensions": 1536,
+    "max_input": 8191,
+    "is_deprecated": False,
+    "stability": "stable",
+    "hosting": "usa",
+    "open_source": False,
+    "description": "Test embedding model",
+    "org": "OpenAI",
+    "litellm_model_name": "text-embedding-3-small",
+}
+
+
+async def test_completion_model_create_requires_sysadmin_auth(client):
     response = await client.post(
         "/api/v1/sysadmin/completion-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=model_data,
-    )
-
-    assert response.status_code == 200
-    data = response.json()
-
-    # Verify response structure (CompletionModelSparse)
-    assert data["name"] == "gpt-4-test"
-    assert data["nickname"] == "GPT-4 Test"
-    assert data["family"] == "openai"
-    assert data["max_input_tokens"] == 8000
-    assert data["vision"] is True
-    assert data["reasoning"] is False
-    assert "id" in data
-    assert "created_at" in data
-    assert "updated_at" in data
-
-    # Verify tenant-specific fields are NOT in response (Sparse model)
-    assert "is_org_enabled" not in data
-    assert "is_org_default" not in data
-    assert "can_access" not in data
-    assert "is_locked" not in data
-    assert "security_classification" not in data
-
-    # Verify model was created in database
-    async with db_container() as container:
-        session = container.session()
-        stmt = sa.select(CompletionModels).where(CompletionModels.name == "gpt-4-test")
-        result = await session.execute(stmt)
-        db_model = result.scalar_one_or_none()
-
-        assert db_model is not None
-        assert db_model.name == "gpt-4-test"
-        assert db_model.nickname == "GPT-4 Test"
-        assert db_model.max_input_tokens == 8000
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_create_completion_model_without_auth(client):
-    """Test that creating a completion model without authentication fails."""
-    model_data = {
-        "name": "test-model",
-        "nickname": "Test Model",
-        "family": "openai",
-        "max_input_tokens": 8000,
-        "max_output_tokens": 4096,
-        "is_deprecated": False,
-        "stability": "stable",
-        "hosting": "usa",
-        "vision": False,
-        "reasoning": False,
-    }
-
-    response = await client.post(
-        "/api/v1/sysadmin/completion-models/create",
-        json=model_data,
+        json=COMPLETION_CREATE_PAYLOAD,
     )
 
     assert response.status_code == 401
 
 
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_create_completion_model_with_invalid_auth(client):
-    """Test that creating a completion model with invalid API key fails."""
-    model_data = {
-        "name": "test-model",
-        "nickname": "Test Model",
-        "family": "openai",
-        "max_input_tokens": 8000,
-        "max_output_tokens": 4096,
-        "is_deprecated": False,
-        "stability": "stable",
-        "hosting": "usa",
-        "vision": False,
-        "reasoning": False,
-    }
-
-    response = await client.post(
-        "/api/v1/sysadmin/completion-models/create",
-        headers={"X-API-Key": "invalid-key"},
-        json=model_data,
-    )
-
-    assert response.status_code == 401
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_update_completion_model_metadata(
-    client, super_admin_token, db_container
-):
-    """Test updating an existing completion model's metadata."""
-    # First create a model
-    create_data = {
-        "name": "gpt-3.5-turbo",
-        "nickname": "GPT-3.5 Turbo",
-        "family": "openai",
-        "max_input_tokens": 4000,
-        "max_output_tokens": 4096,
-        "is_deprecated": False,
-        "stability": "stable",
-        "hosting": "usa",
-        "vision": False,
-        "reasoning": False,
-    }
+async def test_legacy_completion_model_crud_returns_gone(client, super_admin_token):
+    model_id = uuid4()
+    headers = {"X-API-Key": super_admin_token}
 
     create_response = await client.post(
         "/api/v1/sysadmin/completion-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=create_data,
+        headers=headers,
+        json=COMPLETION_CREATE_PAYLOAD,
     )
-    assert create_response.status_code == 200
-    model_id = create_response.json()["id"]
-
-    # Update the model
-    update_data = {
-        "nickname": "GPT-3.5 Turbo Updated",
-        "description": "Updated description",
-        "is_deprecated": True,
-        "max_input_tokens": 16000,
-    }
-
-    response = await client.put(
+    update_response = await client.put(
         f"/api/v1/sysadmin/completion-models/{model_id}/metadata",
-        headers={"X-API-Key": super_admin_token},
-        json=update_data,
+        headers=headers,
+        json={"nickname": "Updated"},
     )
-
-    assert response.status_code == 200
-    data = response.json()
-
-    assert data["id"] == model_id
-    assert data["nickname"] == "GPT-3.5 Turbo Updated"
-    assert data["description"] == "Updated description"
-    assert data["is_deprecated"] is True
-    assert data["max_input_tokens"] == 16000
-
-    # Verify in database
-    async with db_container() as container:
-        session = container.session()
-        stmt = sa.select(CompletionModels).where(CompletionModels.id == model_id)
-        result = await session.execute(stmt)
-        db_model = result.scalar_one()
-
-        assert db_model.nickname == "GPT-3.5 Turbo Updated"
-        assert db_model.description == "Updated description"
-        assert db_model.is_deprecated is True
-        assert db_model.max_input_tokens == 16000
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_update_nonexistent_completion_model(client, super_admin_token):
-    """Test that updating a non-existent model returns 404."""
-    from uuid import uuid4
-
-    fake_id = str(uuid4())
-    update_data = {
-        "nickname": "Should Fail",
-        "description": "This should not work",
-    }
-
-    response = await client.put(
-        f"/api/v1/sysadmin/completion-models/{fake_id}/metadata",
-        headers={"X-API-Key": super_admin_token},
-        json=update_data,
-    )
-
-    assert response.status_code == 404
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_delete_completion_model(client, super_admin_token, db_container):
-    """Test soft-deleting a completion model."""
-    # First create a model
-    create_data = {
-        "name": "model-to-delete",
-        "nickname": "Model to Delete",
-        "family": "openai",
-        "max_input_tokens": 8000,
-        "max_output_tokens": 4096,
-        "is_deprecated": False,
-        "stability": "stable",
-        "hosting": "usa",
-        "vision": False,
-        "reasoning": False,
-    }
-
-    create_response = await client.post(
-        "/api/v1/sysadmin/completion-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=create_data,
-    )
-    assert create_response.status_code == 200
-    model_id = create_response.json()["id"]
-
-    # Delete the model
-    response = await client.delete(
+    delete_response = await client.delete(
         f"/api/v1/sysadmin/completion-models/{model_id}",
-        headers={"X-API-Key": super_admin_token},
+        headers=headers,
     )
 
-    assert response.status_code == 200
-
-    # Verify model was soft-deleted in database
-    async with db_container() as container:
-        session = container.session()
-        stmt = sa.select(CompletionModels).where(CompletionModels.id == model_id)
-        result = await session.execute(stmt)
-        db_model = result.scalar_one_or_none()
-
-        assert db_model is not None
-        assert db_model.deleted_at is not None
+    assert create_response.status_code == 410
+    assert update_response.status_code == 410
+    assert delete_response.status_code == 410
+    assert "tenant-owned models" in create_response.json()["detail"]
 
 
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_delete_nonexistent_completion_model(client, super_admin_token):
-    """Test that deleting a non-existent model succeeds (idempotent delete)."""
-    from uuid import uuid4
-
-    fake_id = str(uuid4())
-
-    response = await client.delete(
-        f"/api/v1/sysadmin/completion-models/{fake_id}",
-        headers={"X-API-Key": super_admin_token},
-    )
-
-    # Note: Current implementation returns 200 even for non-existent models (idempotent)
-    assert response.status_code == 200
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_force_delete_completion_model_without_history(
-    client, super_admin_token, db_container
-):
-    """force=true hard-deletes a model that has no historical attribution."""
-    create_data = {
-        "name": "model-to-force-delete",
-        "nickname": "Model to Force Delete",
-        "family": "openai",
-        "max_input_tokens": 8000,
-        "max_output_tokens": 4096,
-        "is_deprecated": False,
-        "stability": "stable",
-        "hosting": "usa",
-        "vision": False,
-        "reasoning": False,
-    }
-    create_response = await client.post(
-        "/api/v1/sysadmin/completion-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=create_data,
-    )
-    assert create_response.status_code == 200
-    model_id = create_response.json()["id"]
-
-    response = await client.delete(
-        f"/api/v1/sysadmin/completion-models/{model_id}?force=true",
-        headers={"X-API-Key": super_admin_token},
-    )
-    assert response.status_code == 200
-
-    # Hard-delete, not soft-delete — the row must be physically gone.
-    async with db_container() as container:
-        session = container.session()
-        result = await session.execute(
-            sa.select(CompletionModels).where(CompletionModels.id == model_id)
-        )
-        assert result.scalar_one_or_none() is None
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_force_delete_completion_model_with_history_returns_400(
-    client, super_admin_token, db_container
-):
-    """20260402_lifecycle switched questions.completion_model_id to RESTRICT,
-    so hard-deleting a model with question history must fail. The router
-    converts the IntegrityError into MODEL_IN_USE (400) instead of letting
-    it surface as a 500.
-    """
-    from intric.database.tables.questions_table import Questions
-
-    create_data = {
-        "name": "model-with-history",
-        "nickname": "Model With History",
-        "family": "openai",
-        "max_input_tokens": 8000,
-        "max_output_tokens": 4096,
-        "is_deprecated": False,
-        "stability": "stable",
-        "hosting": "usa",
-        "vision": False,
-        "reasoning": False,
-    }
-    create_response = await client.post(
-        "/api/v1/sysadmin/completion-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=create_data,
-    )
-    assert create_response.status_code == 200
-    model_id = create_response.json()["id"]
-
-    async with db_container() as container:
-        session = container.session()
-        tenant = container.tenant()
-        await session.execute(
-            sa.insert(Questions).values(
-                tenant_id=tenant.id,
-                question="hello",
-                answer="world",
-                num_tokens_question=1,
-                num_tokens_answer=1,
-                completion_model_id=model_id,
-            )
-        )
-
-    response = await client.delete(
-        f"/api/v1/sysadmin/completion-models/{model_id}?force=true",
-        headers={"X-API-Key": super_admin_token},
-    )
-    assert response.status_code == 400
-    body = response.json()
-    from intric.main.exceptions import ErrorCodes
-
-    assert body["intric_error_code"] == ErrorCodes.MODEL_IN_USE
-
-    # The model must still exist after the failed delete.
-    async with db_container() as container:
-        session = container.session()
-        result = await session.execute(
-            sa.select(CompletionModels).where(CompletionModels.id == model_id)
-        )
-        assert result.scalar_one_or_none() is not None
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_create_completion_model_with_duplicate_name(client, super_admin_token):
-    """Test that duplicate model names are allowed (unique constraint removed)."""
-    model_data = {
-        "name": "duplicate-name-test",
-        "nickname": "First Model",
-        "family": "openai",
-        "max_input_tokens": 8000,
-        "max_output_tokens": 4096,
-        "is_deprecated": False,
-        "stability": "stable",
-        "hosting": "usa",
-        "vision": False,
-        "reasoning": False,
-    }
-
-    # Create first model
-    response1 = await client.post(
-        "/api/v1/sysadmin/completion-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=model_data,
-    )
-    assert response1.status_code == 200
-
-    # Create second model with same name (should succeed)
-    model_data["nickname"] = "Second Model"
-    response2 = await client.post(
-        "/api/v1/sysadmin/completion-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=model_data,
-    )
-    assert response2.status_code == 200
-
-    # Verify they have different IDs
-    assert response1.json()["id"] != response2.json()["id"]
-
-
-# Embedding Models Tests
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_create_embedding_model_success(client, super_admin_token, db_container):
-    """Test creating a new embedding model with valid data."""
-    model_data = {
-        "name": "text-embedding-ada-002",
-        "family": "openai",
-        "is_deprecated": False,
-        "open_source": False,
-        "dimensions": 1536,
-        "max_input": 8191,
-        "max_batch_size": 100,
-        "stability": "stable",
-        "hosting": "usa",
-        "description": "Test embedding model",
-        "org": "OpenAI",
-        "litellm_model_name": "text-embedding-ada-002",
-    }
-
+async def test_embedding_model_create_requires_sysadmin_auth(client):
     response = await client.post(
         "/api/v1/sysadmin/embedding-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=model_data,
-    )
-
-    assert response.status_code == 200
-    data = response.json()
-
-    # Verify response structure (EmbeddingModelSparse)
-    assert data["name"] == "text-embedding-ada-002"
-    assert data["family"] == "openai"
-    assert data["dimensions"] == 1536
-    assert data["max_input"] == 8191
-    assert data["max_batch_size"] == 100
-    assert "id" in data
-    assert "created_at" in data
-    assert "updated_at" in data
-
-    # Verify tenant-specific fields are NOT in response (Sparse model)
-    assert "is_org_enabled" not in data
-    assert "can_access" not in data
-    assert "is_locked" not in data
-
-    # Verify model was created in database
-    async with db_container() as container:
-        session = container.session()
-        stmt = sa.select(EmbeddingModels).where(
-            EmbeddingModels.name == "text-embedding-ada-002"
-        )
-        result = await session.execute(stmt)
-        db_model = result.scalar_one_or_none()
-
-        assert db_model is not None
-        assert db_model.name == "text-embedding-ada-002"
-        assert db_model.dimensions == 1536
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_create_embedding_model_without_auth(client):
-    """Test that creating an embedding model without authentication fails."""
-    model_data = {
-        "name": "test-embedding",
-        "family": "openai",
-        "is_deprecated": False,
-        "open_source": False,
-        "stability": "stable",
-        "hosting": "usa",
-    }
-
-    response = await client.post(
-        "/api/v1/sysadmin/embedding-models/create",
-        json=model_data,
+        json=EMBEDDING_CREATE_PAYLOAD,
     )
 
     assert response.status_code == 401
 
 
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_update_embedding_model_metadata(client, super_admin_token, db_container):
-    """Test updating an existing embedding model's metadata."""
-    # First create a model
-    create_data = {
-        "name": "text-embedding-3-small",
-        "family": "openai",
-        "is_deprecated": False,
-        "open_source": False,
-        "dimensions": 1536,
-        "stability": "stable",
-        "hosting": "usa",
-    }
+async def test_legacy_embedding_model_crud_returns_gone(client, super_admin_token):
+    model_id = uuid4()
+    headers = {"X-API-Key": super_admin_token}
 
     create_response = await client.post(
         "/api/v1/sysadmin/embedding-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=create_data,
+        headers=headers,
+        json=EMBEDDING_CREATE_PAYLOAD,
     )
-    assert create_response.status_code == 200
-    model_id = create_response.json()["id"]
-
-    # Update the model
-    update_data = {
-        "description": "Updated embedding model description",
-        "is_deprecated": True,
-        "dimensions": 512,
-    }
-
-    response = await client.put(
+    update_response = await client.put(
         f"/api/v1/sysadmin/embedding-models/{model_id}/metadata",
-        headers={"X-API-Key": super_admin_token},
-        json=update_data,
+        headers=headers,
+        json={"nickname": "Updated"},
     )
-
-    assert response.status_code == 200
-    data = response.json()
-
-    assert data["id"] == model_id
-    assert data["description"] == "Updated embedding model description"
-    assert data["is_deprecated"] is True
-    assert data["dimensions"] == 512
-
-    # Verify in database
-    async with db_container() as container:
-        session = container.session()
-        stmt = sa.select(EmbeddingModels).where(EmbeddingModels.id == model_id)
-        result = await session.execute(stmt)
-        db_model = result.scalar_one()
-
-        assert db_model.description == "Updated embedding model description"
-        assert db_model.is_deprecated is True
-        assert db_model.dimensions == 512
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_update_nonexistent_embedding_model(client, super_admin_token):
-    """Test that updating a non-existent embedding model returns 404."""
-    from uuid import uuid4
-
-    fake_id = str(uuid4())
-    update_data = {
-        "description": "Should Fail",
-    }
-
-    response = await client.put(
-        f"/api/v1/sysadmin/embedding-models/{fake_id}/metadata",
-        headers={"X-API-Key": super_admin_token},
-        json=update_data,
-    )
-
-    assert response.status_code == 404
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_delete_embedding_model(client, super_admin_token, db_container):
-    """Test deleting an embedding model."""
-    # First create a model
-    create_data = {
-        "name": "embedding-to-delete",
-        "family": "openai",
-        "is_deprecated": False,
-        "open_source": False,
-        "stability": "stable",
-        "hosting": "usa",
-    }
-
-    create_response = await client.post(
-        "/api/v1/sysadmin/embedding-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=create_data,
-    )
-    assert create_response.status_code == 200
-    model_id = create_response.json()["id"]
-
-    # Delete the model
-    response = await client.delete(
+    delete_response = await client.delete(
         f"/api/v1/sysadmin/embedding-models/{model_id}",
-        headers={"X-API-Key": super_admin_token},
+        headers=headers,
     )
 
-    assert response.status_code == 200
-
-    # The normal sysadmin delete soft-deletes (parity with completion): the row
-    # is kept as a tombstone with deleted_at set so historical info_blob
-    # attribution survives. Use force=true for a hard delete.
-    async with db_container() as container:
-        session = container.session()
-        stmt = sa.select(EmbeddingModels).where(EmbeddingModels.id == model_id)
-        result = await session.execute(stmt)
-        db_model = result.scalar_one_or_none()
-
-        assert db_model is not None
-        assert db_model.deleted_at is not None
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_delete_nonexistent_embedding_model(client, super_admin_token):
-    """Test that deleting a non-existent embedding model succeeds (idempotent delete)."""
-    from uuid import uuid4
-
-    fake_id = str(uuid4())
-
-    response = await client.delete(
-        f"/api/v1/sysadmin/embedding-models/{fake_id}",
-        headers={"X-API-Key": super_admin_token},
-    )
-
-    # Note: Current implementation returns 200 even for non-existent models (idempotent)
-    assert response.status_code == 200
-
-
-# Validation Tests
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_create_completion_model_missing_required_fields(
-    client, super_admin_token
-):
-    """Test that creating a model with missing required fields fails."""
-    incomplete_data = {
-        "name": "incomplete-model",
-        # Missing many required fields like family, max_input_tokens, etc.
-    }
-
-    response = await client.post(
-        "/api/v1/sysadmin/completion-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=incomplete_data,
-    )
-
-    assert response.status_code == 422  # Unprocessable Entity
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_create_completion_model_accepts_custom_family(client, super_admin_token):
-    """Test that creating a model with custom family string is accepted.
-
-    With per-tenant model architecture, family is Union[CompletionModelFamily, str]
-    to allow tenant-specific models with custom family values.
-    """
-    custom_family_data = {
-        "name": "custom-family-model",
-        "nickname": "Custom Family",
-        "family": "custom_provider",  # Custom family string (now allowed)
-        "max_input_tokens": 8000,
-        "max_output_tokens": 4096,
-        "is_deprecated": False,
-        "stability": "stable",
-        "hosting": "usa",
-        "vision": False,
-        "reasoning": False,
-    }
-
-    response = await client.post(
-        "/api/v1/sysadmin/completion-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=custom_family_data,
-    )
-
-    assert response.status_code == 200  # Now accepts custom family strings
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_create_embedding_model_invalid_batch_size(client, super_admin_token):
-    """Test that creating an embedding model with invalid batch size fails."""
-    invalid_data = {
-        "name": "invalid-batch-size",
-        "family": "openai",
-        "is_deprecated": False,
-        "open_source": False,
-        "stability": "stable",
-        "hosting": "usa",
-        "max_batch_size": 500,  # Exceeds max of 256
-    }
-
-    response = await client.post(
-        "/api/v1/sysadmin/embedding-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=invalid_data,
-    )
-
-    assert response.status_code == 422  # Validation error
-
-
-@pytest.mark.integration
-@pytest.mark.asyncio
-async def test_partial_update_completion_model(client, super_admin_token):
-    """Test that partial updates work (only update specified fields)."""
-    # Create a model
-    create_data = {
-        "name": "partial-update-test",
-        "nickname": "Original Nickname",
-        "family": "openai",
-        "max_input_tokens": 8000,
-        "max_output_tokens": 4096,
-        "is_deprecated": False,
-        "stability": "stable",
-        "hosting": "usa",
-        "description": "Original description",
-        "vision": False,
-        "reasoning": False,
-    }
-
-    create_response = await client.post(
-        "/api/v1/sysadmin/completion-models/create",
-        headers={"X-API-Key": super_admin_token},
-        json=create_data,
-    )
-    assert create_response.status_code == 200
-    model_id = create_response.json()["id"]
-
-    # Update only the description
-    update_data = {
-        "description": "Updated description only",
-    }
-
-    response = await client.put(
-        f"/api/v1/sysadmin/completion-models/{model_id}/metadata",
-        headers={"X-API-Key": super_admin_token},
-        json=update_data,
-    )
-
-    assert response.status_code == 200
-    data = response.json()
-
-    # Verify only description changed, other fields unchanged
-    assert data["description"] == "Updated description only"
-    assert data["nickname"] == "Original Nickname"  # Unchanged
-    assert data["max_input_tokens"] == 8000  # Unchanged
+    assert create_response.status_code == 410
+    assert update_response.status_code == 410
+    assert delete_response.status_code == 410
+    assert "tenant-owned models" in create_response.json()["detail"]

--- a/backend/tests/integration/test_knowledge_distribution.py
+++ b/backend/tests/integration/test_knowledge_distribution.py
@@ -11,11 +11,11 @@ Tests cover:
 import pytest
 from sqlalchemy import select
 
-from intric.database.tables.spaces_table import Spaces
-from intric.database.tables.integration_table import IntegrationKnowledge
 from intric.database.tables.integration_knowledge_spaces_table import (
     IntegrationKnowledgesSpaces,
 )
+from intric.database.tables.integration_table import IntegrationKnowledge
+from intric.database.tables.spaces_table import Spaces
 
 
 class TestKnowledgeDistributionBasics:
@@ -57,7 +57,9 @@ class TestKnowledgeDistributionBasics:
             await session.flush()
 
             # Create embedding model and user integration
-            embedding_model = await embedding_model_factory(session)
+            embedding_model = await embedding_model_factory(
+                session, tenant_id=tenant.id
+            )
             user_integration = await user_integration_factory(
                 session, tenant_id=tenant.id
             )
@@ -129,7 +131,9 @@ class TestKnowledgeDistributionBasics:
             await session.flush()
 
             # Create embedding model and user integration
-            embedding_model = await embedding_model_factory(session)
+            embedding_model = await embedding_model_factory(
+                session, tenant_id=tenant.id
+            )
             user_integration = await user_integration_factory(
                 session, tenant_id=tenant.id
             )
@@ -210,7 +214,9 @@ class TestKnowledgeDistributionBasics:
             await session.flush()
 
             # Create embedding model and user integration
-            embedding_model = await embedding_model_factory(session)
+            embedding_model = await embedding_model_factory(
+                session, tenant_id=tenant.id
+            )
             user_integration = await user_integration_factory(
                 session, tenant_id=tenant.id
             )
@@ -272,7 +278,9 @@ class TestDistributionIdempotency:
             await session.flush()
 
             # Create knowledge
-            embedding_model = await embedding_model_factory(session)
+            embedding_model = await embedding_model_factory(
+                session, tenant_id=tenant.id
+            )
             user_integration = await user_integration_factory(
                 session, tenant_id=tenant.id
             )
@@ -334,7 +342,9 @@ class TestDistributionScope:
             await session.flush()
 
             # Create knowledge on org space
-            embedding_model = await embedding_model_factory(session)
+            embedding_model = await embedding_model_factory(
+                session, tenant_id=tenant.id
+            )
             user_integration = await user_integration_factory(
                 session, tenant_id=tenant.id
             )
@@ -444,7 +454,9 @@ class TestDistributionScope:
             await session.flush()
 
             # Create knowledge on tenant 1 org space
-            embedding_model = await embedding_model_factory(session)
+            embedding_model = await embedding_model_factory(
+                session, tenant_id=tenant_1.id
+            )
             user_integration = await user_integration_factory(
                 session, tenant_id=tenant_1.id
             )
@@ -515,7 +527,9 @@ class TestDistributionScope:
             await session.flush()
 
             # Create knowledge
-            embedding_model = await embedding_model_factory(session)
+            embedding_model = await embedding_model_factory(
+                session, tenant_id=tenant.id
+            )
             user_integration = await user_integration_factory(
                 session, tenant_id=tenant.id
             )

--- a/backend/tests/integration/test_knowledge_retrieval.py
+++ b/backend/tests/integration/test_knowledge_retrieval.py
@@ -9,11 +9,11 @@ Tests cover:
 
 from sqlalchemy import select
 
-from intric.database.tables.spaces_table import Spaces
-from intric.database.tables.integration_table import IntegrationKnowledge
 from intric.database.tables.integration_knowledge_spaces_table import (
     IntegrationKnowledgesSpaces,
 )
+from intric.database.tables.integration_table import IntegrationKnowledge
+from intric.database.tables.spaces_table import Spaces
 
 
 class TestKnowledgeRetrieval:
@@ -52,7 +52,9 @@ class TestKnowledgeRetrieval:
             await session.flush()
 
             # Create knowledge on org space
-            embedding_model = await embedding_model_factory(session)
+            embedding_model = await embedding_model_factory(
+                session, tenant_id=tenant.id
+            )
             user_integration = await user_integration_factory(
                 session, tenant_id=tenant.id
             )
@@ -127,7 +129,9 @@ class TestKnowledgeRetrieval:
             await session.flush()
 
             # Create embedding model and user integration
-            embedding_model = await embedding_model_factory(session)
+            embedding_model = await embedding_model_factory(
+                session, tenant_id=tenant.id
+            )
             user_integration = await user_integration_factory(
                 session, tenant_id=tenant.id
             )
@@ -216,7 +220,9 @@ class TestKnowledgeRetrieval:
             await session.flush()
 
             # Create embedding model and user integration
-            embedding_model = await embedding_model_factory(session)
+            embedding_model = await embedding_model_factory(
+                session, tenant_id=tenant.id
+            )
             user_integration = await user_integration_factory(
                 session, tenant_id=tenant.id
             )
@@ -297,7 +303,9 @@ class TestKnowledgeRetrieval:
             await session.flush()
 
             # Create embedding model and user integration
-            embedding_model = await embedding_model_factory(session)
+            embedding_model = await embedding_model_factory(
+                session, tenant_id=tenant.id
+            )
             user_integration = await user_integration_factory(
                 session, tenant_id=tenant.id
             )
@@ -363,7 +371,9 @@ class TestKnowledgeVisibilityBoundaries:
             await session.flush()
 
             # Create knowledge on org space
-            embedding_model = await embedding_model_factory(session)
+            embedding_model = await embedding_model_factory(
+                session, tenant_id=tenant.id
+            )
             user_integration = await user_integration_factory(
                 session, tenant_id=tenant.id
             )
@@ -422,7 +432,9 @@ class TestKnowledgeVisibilityBoundaries:
             await session.flush()
 
             # Create knowledge in tenant 1
-            embedding_model = await embedding_model_factory(session)
+            embedding_model = await embedding_model_factory(
+                session, tenant_id=tenant_1.id
+            )
             user_integration_1 = await user_integration_factory(
                 session, tenant_id=tenant_1.id
             )

--- a/backend/tests/unittests/ai_models/test_ai_models_service.py
+++ b/backend/tests/unittests/ai_models/test_ai_models_service.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 import pytest
 
 from intric.ai_models.ai_models_service import AIModelsService
-from intric.main.config import get_settings
 from intric.roles.permissions import Permission
 from intric.roles.role import RoleInDB
 from intric.user_groups.user_group import UserGroupInDB
@@ -180,8 +179,9 @@ async def test_embedding_models_flags_settings_not_exists(service: AIModelsServi
             assert not model.is_org_enabled
 
 
-async def test_azure_models_with_feature_flag_off(service: AIModelsService):
-    get_settings().using_azure_models = False
+async def test_completion_models_are_not_filtered_by_global_azure_flag(
+    service: AIModelsService,
+):
     service.completion_model_repo.get_models.return_value = [
         TEST_MODEL_GPT4,
         TEST_MODEL_CHATGPT,
@@ -190,12 +190,15 @@ async def test_azure_models_with_feature_flag_off(service: AIModelsService):
 
     models = await service.get_completion_models()
 
-    assert len(models) == 2
-    assert "azure" not in [model.family for model in models]
+    service.completion_model_repo.get_models.assert_awaited_once_with(
+        tenant_id=TEST_TENANT.id,
+        is_deprecated=False,
+        id_list=None,
+    )
+    assert [model.family for model in models] == ["openai", "openai", "azure"]
 
 
-async def test_azure_models_with_feature_flag_on(service: AIModelsService):
-    get_settings().using_azure_models = True
+async def test_completion_models_keep_repository_order(service: AIModelsService):
     service.completion_model_repo.get_models.return_value = [
         TEST_MODEL_GPT4,
         TEST_MODEL_CHATGPT,
@@ -204,30 +207,27 @@ async def test_azure_models_with_feature_flag_on(service: AIModelsService):
 
     models = await service.get_completion_models()
 
-    assert len(models) == 3
-    assert "azure" in [model.family for model in models]
+    assert [model.id for model in models] == [
+        TEST_MODEL_GPT4.id,
+        TEST_MODEL_CHATGPT.id,
+        TEST_MODEL_AZURE.id,
+    ]
 
 
-async def test_tenant_azure_models_shown_when_flag_off(service: AIModelsService):
-    # A tenant that explicitly configures an Azure provider gets family="azure"
-    # on its completion models. Those are deliberate config and must stay
-    # visible even when the global `using_azure_models` flag (which only gates
-    # the predefined global Azure models) is off. Regression for Azure
-    # completion models 200-ing on create yet never appearing in the admin
-    # list / chat picker.
-    get_settings().using_azure_models = False
+async def test_tenant_azure_models_shown_from_repository(service: AIModelsService):
+    # Azure is now just a tenant-owned provider/model combination. The global
+    # `using_azure_models` setting no longer filters read results; the repository
+    # owns tenant visibility and returns only rows for this tenant.
     tenant_azure = TEST_MODEL_AZURE.model_copy(update={"tenant_id": TEST_TENANT.id})
     service.completion_model_repo.get_models.return_value = [
         TEST_MODEL_GPT4,
-        TEST_MODEL_AZURE,  # global → hidden
-        tenant_azure,  # tenant-owned → shown
+        tenant_azure,
     ]
 
     models = await service.get_completion_models()
 
-    families = [model.family for model in models]
-    assert families.count("azure") == 1
-    assert any(model.tenant_id == TEST_TENANT.id for model in models)
+    assert [model.family for model in models] == ["openai", "azure"]
+    assert models[1].tenant_id == TEST_TENANT.id
 
 
 def test_get_latest_available_model_handles_missing_created_at(

--- a/backend/tests/unittests/ai_models/test_model_repository_tenant_scope.py
+++ b/backend/tests/unittests/ai_models/test_model_repository_tenant_scope.py
@@ -1,0 +1,90 @@
+from typing import Any
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from intric.ai_models.completion_models.completion_models_repo import (
+    CompletionModelsRepository as AdminCompletionModelsRepository,
+)
+from intric.ai_models.embedding_models.embedding_models_repo import (
+    AdminEmbeddingModelsService,
+)
+from intric.completion_models.domain.completion_model_repo import (
+    CompletionModelRepository,
+)
+from intric.embedding_models.domain.embedding_model_repo import EmbeddingModelRepository
+from intric.transcription_models.domain.transcription_model_repo import (
+    TranscriptionModelRepository,
+)
+from tests.fixtures import TEST_TENANT, TEST_USER
+
+
+class _EmptyResult:
+    def all(self) -> list[Any]:
+        return []
+
+    def scalars(self) -> "_EmptyResult":
+        return self
+
+
+class _CapturingSession:
+    def __init__(self) -> None:
+        self.statement: Any | None = None
+
+    async def execute(self, statement: Any) -> _EmptyResult:
+        self.statement = statement
+        return _EmptyResult()
+
+
+def _compiled_sql(statement: Any) -> str:
+    return str(
+        statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("repo_factory", "method_name"),
+    [
+        (CompletionModelRepository, "all"),
+        (EmbeddingModelRepository, "all"),
+        (TranscriptionModelRepository, "all"),
+    ],
+)
+async def test_domain_model_repositories_do_not_include_global_rows(
+    repo_factory, method_name
+):
+    session = _CapturingSession()
+    repo = repo_factory(session, TEST_USER)
+
+    await getattr(repo, method_name)()
+
+    sql = _compiled_sql(session.statement)
+    assert "tenant_id IS NULL" not in sql
+    assert f"tenant_id = '{TEST_USER.tenant_id}'" in sql
+    assert "JOIN model_providers" in sql
+
+
+async def test_admin_completion_model_repo_scopes_to_tenant_only():
+    session = _CapturingSession()
+    repo = AdminCompletionModelsRepository(session)
+
+    await repo.get_models(tenant_id=TEST_TENANT.id)
+
+    sql = _compiled_sql(session.statement)
+    assert "tenant_id IS NULL" not in sql
+    assert f"tenant_id = '{TEST_TENANT.id}'" in sql
+    assert "JOIN model_providers" in sql
+
+
+async def test_admin_embedding_model_repo_scopes_to_tenant_only():
+    session = _CapturingSession()
+    repo = AdminEmbeddingModelsService(session)
+
+    await repo.get_models(tenant_id=TEST_TENANT.id)
+
+    sql = _compiled_sql(session.statement)
+    assert "tenant_id IS NULL" not in sql
+    assert f"tenant_id = '{TEST_TENANT.id}'" in sql

--- a/backend/tests/unittests/completion_models/test_completion_model_crud_service.py
+++ b/backend/tests/unittests/completion_models/test_completion_model_crud_service.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 from intric.completion_models.application.completion_model_crud_service import (
     CompletionModelCRUDService,
 )
-from intric.main.config import get_settings
 
 
 def _build_service(repo: AsyncMock) -> CompletionModelCRUDService:
@@ -20,30 +19,14 @@ def _model(*, family: str, tenant_id=None):
     return SimpleNamespace(family=family, tenant_id=tenant_id)
 
 
-async def test_get_completion_models_hides_only_global_azure_when_flag_off(
-    monkeypatch,
-):
-    monkeypatch.setattr(get_settings(), "using_azure_models", False)
-    global_azure = _model(family="azure")
+async def test_get_completion_models_returns_repository_models_without_global_filter():
     tenant_azure = _model(family="azure", tenant_id=uuid4())
     openai = _model(family="openai")
     repo = AsyncMock()
-    repo.all.return_value = [global_azure, tenant_azure, openai]
+    repo.all.return_value = [tenant_azure, openai]
     service = _build_service(repo)
 
     models = await service.get_completion_models()
 
     assert models == [tenant_azure, openai]
-
-
-async def test_get_completion_models_shows_global_azure_when_flag_on(monkeypatch):
-    monkeypatch.setattr(get_settings(), "using_azure_models", True)
-    global_azure = _model(family="azure")
-    tenant_azure = _model(family="azure", tenant_id=uuid4())
-    repo = AsyncMock()
-    repo.all.return_value = [global_azure, tenant_azure]
-    service = _build_service(repo)
-
-    models = await service.get_completion_models()
-
-    assert models == [global_azure, tenant_azure]
+    repo.all.assert_awaited_once_with()

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -6535,7 +6535,7 @@ export interface paths {
     put?: never;
     /**
      * Create Completion Model
-     * @description Create global completion model metadata (system-wide operation).
+     * @description Deprecated. Completion models must be created through tenant-scoped admin model routes.
      */
     post: operations["create_completion_model_api_v1_sysadmin_completion_models_create_post"];
     delete?: never;
@@ -6554,7 +6554,7 @@ export interface paths {
     get?: never;
     /**
      * Update Completion Model Metadata
-     * @description Update global completion model metadata (system-wide operation).
+     * @description Deprecated. Completion model metadata must be updated through tenant-scoped admin model routes.
      */
     put: operations["update_completion_model_metadata_api_v1_sysadmin_completion_models__id__metadata_put"];
     post?: never;
@@ -6576,7 +6576,7 @@ export interface paths {
     post?: never;
     /**
      * Delete Completion Model
-     * @description Soft-delete global completion model metadata (system-wide operation).
+     * @description Deprecated. Completion models must be deleted through tenant-scoped admin model routes.
      */
     delete: operations["delete_completion_model_api_v1_sysadmin_completion_models__id__delete"];
     options?: never;
@@ -6595,7 +6595,7 @@ export interface paths {
     put?: never;
     /**
      * Create Embedding Model
-     * @description Create global embedding model metadata (system-wide operation).
+     * @description Deprecated. Embedding models must be created through tenant-scoped admin model routes.
      */
     post: operations["create_embedding_model_api_v1_sysadmin_embedding_models_create_post"];
     delete?: never;
@@ -6614,7 +6614,7 @@ export interface paths {
     get?: never;
     /**
      * Update Embedding Model Metadata
-     * @description Update global embedding model metadata (system-wide operation).
+     * @description Deprecated. Embedding model metadata must be updated through tenant-scoped admin model routes.
      */
     put: operations["update_embedding_model_metadata_api_v1_sysadmin_embedding_models__id__metadata_put"];
     post?: never;
@@ -6636,7 +6636,7 @@ export interface paths {
     post?: never;
     /**
      * Delete Embedding Model
-     * @description Soft-delete global embedding model metadata (system-wide operation).
+     * @description Deprecated. Embedding models must be deleted through tenant-scoped admin model routes.
      */
     delete: operations["delete_embedding_model_api_v1_sysadmin_embedding_models__id__delete"];
     options?: never;
@@ -9439,55 +9439,6 @@ export interface components {
       readonly token_limit: number;
       readonly supported_model_kwargs: components["schemas"]["SupportedModelKwargs"];
     };
-    /** CompletionModelCreate */
-    CompletionModelCreate: {
-      /** Name */
-      name: string;
-      /** Nickname */
-      nickname?: string | null;
-      /** Family */
-      family?: string | null;
-      /** Max Input Tokens */
-      max_input_tokens: number;
-      /** Max Output Tokens */
-      max_output_tokens: number;
-      /** Is Deprecated */
-      is_deprecated: boolean;
-      /** Nr Billion Parameters */
-      nr_billion_parameters?: number | null;
-      /** Hf Link */
-      hf_link?: string | null;
-      /** Stability */
-      stability?: string | null;
-      /** Hosting */
-      hosting?: string | null;
-      /** Open Source */
-      open_source?: boolean | null;
-      /** Description */
-      description?: string | null;
-      /** Deployment Name */
-      deployment_name?: string | null;
-      /** Org */
-      org?: string | null;
-      /** Vision */
-      vision: boolean;
-      /** Reasoning */
-      reasoning: boolean;
-      /**
-       * Supports Tool Calling
-       * @default false
-       */
-      supports_tool_calling?: boolean;
-      /** Base Url */
-      base_url?: string | null;
-      /** Litellm Model Name */
-      litellm_model_name?: string | null;
-      model_kwargs_capabilities?: components["schemas"]["SupportedModelKwargs"] | null;
-      /** Input Cost Per Token */
-      input_cost_per_token?: number | string | null;
-      /** Output Cost Per Token */
-      output_cost_per_token?: number | string | null;
-    };
     /** CompletionModelPublic */
     CompletionModelPublic: {
       /** Created At */
@@ -10558,39 +10509,6 @@ export interface components {
       /** Prompt Locked */
       prompt_locked: boolean;
     };
-    /** EmbeddingModelCreate */
-    EmbeddingModelCreate: {
-      /** Name */
-      name: string;
-      /** Family */
-      family?: string | null;
-      /** Is Deprecated */
-      is_deprecated: boolean;
-      /** Open Source */
-      open_source: boolean;
-      /** Dimensions */
-      dimensions?: number | null;
-      /** Max Input */
-      max_input?: number | null;
-      /** Max Batch Size */
-      max_batch_size?: number | null;
-      /** Hf Link */
-      hf_link?: string | null;
-      /** Stability */
-      stability?: string | null;
-      /** Hosting */
-      hosting?: string | null;
-      /** Description */
-      description?: string | null;
-      /** Org */
-      org?: string | null;
-      /** Litellm Model Name */
-      litellm_model_name?: string | null;
-      /** Input Cost Per Token */
-      input_cost_per_token?: number | string | null;
-      /** Output Cost Per Token */
-      output_cost_per_token?: number | string | null;
-    };
     /** EmbeddingModelLegacy */
     EmbeddingModelLegacy: {
       /** Created At */
@@ -10842,48 +10760,6 @@ export interface components {
       deprecation_date?: string | null;
       /** Meets Security Classification */
       meets_security_classification?: boolean | null;
-    };
-    /** EmbeddingModelSparse */
-    EmbeddingModelSparse: {
-      /** Created At */
-      created_at?: string | null;
-      /** Updated At */
-      updated_at?: string | null;
-      /**
-       * Id
-       * Format: uuid
-       */
-      id: string;
-      /** Name */
-      name: string;
-      /** Family */
-      family?: string | null;
-      /** Is Deprecated */
-      is_deprecated: boolean;
-      /** Open Source */
-      open_source: boolean;
-      /** Dimensions */
-      dimensions?: number | null;
-      /** Max Input */
-      max_input?: number | null;
-      /** Max Batch Size */
-      max_batch_size?: number | null;
-      /** Hf Link */
-      hf_link?: string | null;
-      /** Stability */
-      stability?: string | null;
-      /** Hosting */
-      hosting?: string | null;
-      /** Description */
-      description?: string | null;
-      /** Org */
-      org?: string | null;
-      /** Litellm Model Name */
-      litellm_model_name?: string | null;
-      /** Input Cost Per Token */
-      input_cost_per_token?: string | null;
-      /** Output Cost Per Token */
-      output_cost_per_token?: string | null;
     };
     /** EmbeddingModelUpdate */
     EmbeddingModelUpdate: {
@@ -13834,89 +13710,6 @@ export interface components {
        * @description Icon ID referencing an uploaded icon. Set to null to remove.
        */
       icon_id?: string | null;
-    };
-    /** PartialCompletionModelUpdate */
-    PartialCompletionModelUpdate: {
-      /** Name */
-      name?: string | null;
-      /** Nickname */
-      nickname?: string | null;
-      /** Family */
-      family?: string | null;
-      /** Max Input Tokens */
-      max_input_tokens?: number | null;
-      /** Max Output Tokens */
-      max_output_tokens?: number | null;
-      /** Is Deprecated */
-      is_deprecated?: boolean | null;
-      /** Nr Billion Parameters */
-      nr_billion_parameters?: number | null;
-      /** Hf Link */
-      hf_link?: string | null;
-      /** Stability */
-      stability?: string | null;
-      /** Hosting */
-      hosting?: string | null;
-      /** Open Source */
-      open_source?: boolean | null;
-      /** Description */
-      description?: string | null;
-      /** Deployment Name */
-      deployment_name?: string | null;
-      /** Org */
-      org?: string | null;
-      /** Vision */
-      vision?: boolean | null;
-      /** Reasoning */
-      reasoning?: boolean | null;
-      /** Supports Tool Calling */
-      supports_tool_calling?: boolean | null;
-      /** Base Url */
-      base_url?: string | null;
-      /** Litellm Model Name */
-      litellm_model_name?: string | null;
-      model_kwargs_capabilities?: components["schemas"]["SupportedModelKwargs"] | null;
-      /** Input Cost Per Token */
-      input_cost_per_token?: number | string | null;
-      /** Output Cost Per Token */
-      output_cost_per_token?: number | string | null;
-      /** Id */
-      id?: string | null;
-    };
-    /** PartialEmbeddingModelUpdate */
-    PartialEmbeddingModelUpdate: {
-      /** Name */
-      name?: string | null;
-      /** Family */
-      family?: string | null;
-      /** Is Deprecated */
-      is_deprecated?: boolean | null;
-      /** Open Source */
-      open_source?: boolean | null;
-      /** Dimensions */
-      dimensions?: number | null;
-      /** Max Input */
-      max_input?: number | null;
-      /** Max Batch Size */
-      max_batch_size?: number | null;
-      /** Hf Link */
-      hf_link?: string | null;
-      /** Stability */
-      stability?: string | null;
-      /** Hosting */
-      hosting?: string | null;
-      /** Description */
-      description?: string | null;
-      /** Org */
-      org?: string | null;
-      /** Litellm Model Name */
-      litellm_model_name?: string | null;
-      /** Input Cost Per Token */
-      input_cost_per_token?: number | string | null;
-      /** Output Cost Per Token */
-      output_cost_per_token?: number | string | null;
-      /** Id */
-      id?: string | null;
     };
     /** PartialPropUserUpdate */
     PartialPropUserUpdate: {
@@ -39969,11 +39762,7 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CompletionModelCreate"];
-      };
-    };
+    requestBody?: never;
     responses: {
       /** @description Successful Response */
       200: {
@@ -39981,16 +39770,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "application/json": components["schemas"]["CompletionModelSparse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
+          "application/json": unknown;
         };
       };
       /** @description Unauthorized */
@@ -40002,22 +39782,13 @@ export interface operations {
           "application/json": components["schemas"]["GeneralError"];
         };
       };
-      /** @description Conflict */
-      409: {
+      /** @description Gone */
+      410: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
     };
@@ -40031,11 +39802,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["PartialCompletionModelUpdate"];
-      };
-    };
+    requestBody?: never;
     responses: {
       /** @description Successful Response */
       200: {
@@ -40043,7 +39810,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "application/json": components["schemas"]["CompletionModelSparse"];
+          "application/json": unknown;
         };
       };
       /** @description Unauthorized */
@@ -40055,17 +39822,8 @@ export interface operations {
           "application/json": components["schemas"]["GeneralError"];
         };
       };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Conflict */
-      409: {
+      /** @description Gone */
+      410: {
         headers: {
           [name: string]: unknown;
         };
@@ -40107,15 +39865,6 @@ export interface operations {
           "application/json": unknown;
         };
       };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
       /** @description Unauthorized */
       401: {
         headers: {
@@ -40125,8 +39874,8 @@ export interface operations {
           "application/json": components["schemas"]["GeneralError"];
         };
       };
-      /** @description Not Found */
-      404: {
+      /** @description Gone */
+      410: {
         headers: {
           [name: string]: unknown;
         };
@@ -40152,11 +39901,7 @@ export interface operations {
       path?: never;
       cookie?: never;
     };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["EmbeddingModelCreate"];
-      };
-    };
+    requestBody?: never;
     responses: {
       /** @description Successful Response */
       200: {
@@ -40164,16 +39909,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "application/json": components["schemas"]["EmbeddingModelSparse"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
+          "application/json": unknown;
         };
       };
       /** @description Unauthorized */
@@ -40185,22 +39921,13 @@ export interface operations {
           "application/json": components["schemas"]["GeneralError"];
         };
       };
-      /** @description Conflict */
-      409: {
+      /** @description Gone */
+      410: {
         headers: {
           [name: string]: unknown;
         };
         content: {
           "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
     };
@@ -40214,11 +39941,7 @@ export interface operations {
       };
       cookie?: never;
     };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["PartialEmbeddingModelUpdate"];
-      };
-    };
+    requestBody?: never;
     responses: {
       /** @description Successful Response */
       200: {
@@ -40226,7 +39949,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          "application/json": components["schemas"]["EmbeddingModelSparse"];
+          "application/json": unknown;
         };
       };
       /** @description Unauthorized */
@@ -40238,17 +39961,8 @@ export interface operations {
           "application/json": components["schemas"]["GeneralError"];
         };
       };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Conflict */
-      409: {
+      /** @description Gone */
+      410: {
         headers: {
           [name: string]: unknown;
         };
@@ -40290,15 +40004,6 @@ export interface operations {
           "application/json": unknown;
         };
       };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
       /** @description Unauthorized */
       401: {
         headers: {
@@ -40308,8 +40013,8 @@ export interface operations {
           "application/json": components["schemas"]["GeneralError"];
         };
       };
-      /** @description Not Found */
-      404: {
+      /** @description Gone */
+      410: {
         headers: {
           [name: string]: unknown;
         };


### PR DESCRIPTION
## Summary

- Makes tenant-owned, provider-backed AI model rows the only supported ownership shape.
- Adds a forward repair migration for old or dirty databases that still contain global/providerless models.
- Removes backend read fallback to global model rows so model visibility is consistent across admin and space settings.
- Deprecates legacy sysadmin global model CRUD endpoints with explicit `410 Gone` responses.
- Updates generated API schema and tests for the new invariant.

## Why

The visible bug was that space settings could list transcription models such as `KB-Whisper` / `Whisper`, while the tenant admin Models page only showed tenant-owned models like `whisper-1`.

That mismatch was a backend ownership problem, not a frontend filtering problem. The schema still allowed legacy model rows with no tenant and no provider, and some repositories still treated those rows as shared fallback models. Other parts of the product only worked with tenant-owned rows. On a restored, stamped, or otherwise dirty database, two pages could therefore show different model truth for the same tenant.

This PR makes the source of truth explicit: every completion, embedding, and transcription model row belongs to one tenant and one provider.

## What changed

- Added `20260618_model_tenant_required.py` to repair residual global/providerless model rows.
- The migration maps or copies old model rows into tenant-owned rows, rewrites references, and deletes the invalid ownerless rows only after reference validation.
- Provider handling is reuse-first. If a supported provider is missing, the migration creates an inactive provider with empty credentials so an admin can configure it manually. Unknown provider mappings fail loudly instead of guessing.
- `KB-Whisper` / Berget is preserved by mapping it to a Berget hosted vLLM provider.
- Completion, embedding, and transcription repositories now return tenant-owned rows only.
- Legacy sysadmin completion/embedding create/update/delete routes now return `410 Gone` instead of recreating hidden global rows.
- Generated API schema was regenerated for the deprecated sysadmin route contracts.
- Tests were added or updated for migration repair, repository tenant scoping, service behavior, and legacy sysadmin route deprecation.

## What was deliberately not changed

- No frontend-only filter was added.
- No old applied migration was edited as the fix.
- No live application service is imported by the migration.
- No provider credentials are copied, decrypted, or re-encrypted by the migration.
- No fake downgrade recreates invalid global model state.

## Deletion / consolidation

- Removed the permanent global-model compatibility path from tenant-facing reads.
- Removed unused global-style repository create/update helpers that could recreate stale model rows.
- Removed stale global Azure filtering from model services; tenant visibility is now owned by the repository predicate.

## Risk and rollback

The main risk is migration correctness on old or dirty databases. The migration is intentionally conservative: it rewrites known references, preserves supported capabilities, creates missing supported providers inactive with empty credentials, and aborts for unknown provider mappings rather than silently dropping or misrouting model access.

Because the migration rewrites references and deletes invalid global rows, downgrade is intentionally irreversible. Rollback means restoring a database backup from before this migration and redeploying the previous application version if needed.

## Validation

- `uv run ruff check ...`
- `uv run pyright ...` on changed backend source files
- `uv run alembic heads`
- `uv run python -m py_compile alembic/versions/20260618_model_tenant_required.py`
- `uv run pytest tests/unittests/ai_models/test_ai_models_service.py tests/unittests/ai_models/test_model_repository_tenant_scope.py tests/unittests/completion_models/test_completion_model_crud_service.py -q`
- Generated API schema from the updated OpenAPI contract.
- Manual disposable Postgres migration smoke covering dirty `KB-Whisper` / Berget repair, reference rewrites, empty provider credentials, no ownerless model rows, and `NOT NULL` owner columns.
