### PR TITLE
ci(@review): fix 👀 reaction 403 — pull-requests:write + continue-on-error

### DIFF
--- a/.github/workflows/ai-review-request.yml
+++ b/.github/workflows/ai-review-request.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 concurrency:
   group: eneo-ai-review-${{ github.event.repository.full_name }}-${{ github.event.issue.number }}
@@ -110,6 +111,7 @@ jobs:
 
       - name: Acknowledge receipt with an eyes reaction
         if: steps.dispatch.outputs.dispatched == 'true'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}


### PR DESCRIPTION
Fixes the reaction failure observed live (HTTP 403 'Resource not accessible by integration').

**Root cause:** reacting to a comment **on a PR** requires `pull-requests: write`, not just `issues: write` (a PR conversation comment is governed by the pull-requests permission despite the `/issues/comments/` URL). The review itself dispatched fine — only the reaction step failed, which (wrongly) marked the whole run failed.

**Fix:**
- Add `pull-requests: write` (keep `issues: write`).
- `continue-on-error: true` on the reaction step, so a reaction hiccup never fails the run or blocks the review (the 👀 is a cosmetic acknowledgement; the review is dispatched independently).

No new behavior; still model-stays-GitHub-read-only (the Action reacts).