### PR TITLE
fix(review): restore review request acknowledgement

### DIFF
--- a/.github/workflows/ai-review-request.yml
+++ b/.github/workflows/ai-review-request.yml
@@ -4,7 +4,8 @@ on:
   issue_comment:
     types: [created]
 
-permissions: {}
+permissions:
+  issues: write
 
 concurrency:
   group: eneo-ai-review-${{ github.event.repository.full_name }}-${{ github.event.issue.number }}
@@ -31,6 +32,7 @@ jobs:
 
     steps:
       - name: Authorize requester and send signed review request
+        id: dispatch
         shell: python
         run: |
           import hashlib
@@ -130,3 +132,15 @@ jobs:
               raise SystemExit(f"Eneo {mode} webhook rejected the request: HTTP {error.code} {detail}")
           except urllib.error.URLError as error:
               raise SystemExit(f"Eneo {mode} webhook could not be reached: {error.reason}")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write("dispatched=true\n")
+
+      - name: Acknowledge receipt with an eyes reaction
+        if: steps.dispatch.outputs.dispatched == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+        run: gh api --method POST "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content=eyes


### PR DESCRIPTION
## Summary
- Restores the eyes reaction on accepted `/review` and `/review ...` comments.
- Gates the reaction on successful webhook dispatch so ignored comments are not acknowledged.
- Grants only `issues: write`, which is the minimal GitHub token permission needed for issue-comment reactions.

## Why
PR #523 routed feedback comments to the bridge but also removed the acknowledgement step and reset workflow permissions to `{}`. The review trigger still dispatched, but developers lost the immediate GitHub receipt that the command was accepted.

## What changed
- `.github/workflows/ai-review-request.yml` owns the request relay and acknowledgement behavior.
- The dispatch step now exposes a `dispatched=true` output only after the webhook returns successfully.
- A separate non-blocking `gh api ... /reactions` step adds the eyes reaction using the built-in `GITHUB_TOKEN`.

## What was deliberately not changed
- No review command parsing changes.
- No feedback bridge routing changes.
- No bot, Hermes, memory, or review-agent code changes.
- No `pull-requests: write` permission because this workflow uses the issue-comment reactions endpoint.

## Deletion / consolidation
No code was deleted. This is a precise restoration of the lost acknowledgement path, with the permission narrowed to the endpoint actually used.

## Risk and rollback
Risk is limited to the GitHub Actions workflow that relays review comments. If reactions fail, the step is `continue-on-error: true`, so an accepted review request is not blocked. Rollback is reverting this commit, which removes the acknowledgement again.

Post-merge smoke test:
- An allowlisted maintainer comments `/review` on a PR: eyes reaction appears and the review dispatch starts.
- An ignored comment or non-allowlisted user: no eyes reaction is added.

## Validation
- `git diff --check` passed.
- Ruby stdlib YAML parser loaded `.github/workflows/ai-review-request.yml` and confirmed the workflow name, `issues: write` permission, and both workflow steps.
- Commit hooks passed: large-file check, merge-conflict check, private-key detection, commit-preflight, commit-msg-check; code linters/type checks skipped because no relevant code files changed.
- Push hooks passed: pre-push-check.
- Claude peer loop: iteration 1 requested least-privilege `issues: write`; iteration 2 returned green, MIN_SCORE 8.
