### PR TITLE
fix(project): automate roadmap setup

### DIFF
--- a/.github/PROJECT_WORKFLOW.md
+++ b/.github/PROJECT_WORKFLOW.md
@@ -24,7 +24,7 @@ Use one source of truth for humans and keep fallback metadata only for automatio
 - Human UI/source of truth: GitHub issue type, Parent issue/sub-issues, GitHub Project fields, and GitHub Project views.
 - Automation/export fallback: `kind:*` labels and issue body sections.
 
-`kind:*` labels are maintained because they are simple, visible, and reliable for scripts. Do not require a separate Project `Kind` field until it is automatically populated. If Project #5 already has `Kind`, it can remain as an optional convenience field, but it must not become a second manual truth.
+Project `Kind` is the human-facing field for project views and draft items. `kind:*` labels remain the issue-template default and automation/export fallback. Keep them aligned where practical, and do not add another kind-like field.
 
 ## Item kinds
 
@@ -44,7 +44,7 @@ Epics carry a `Roadmap version` value in the issue body and/or Project field, fo
 
 `Roadmap version` is a release bucket for grouping, filtering, and export. It is not the timeline field for GitHub's Roadmap layout.
 
-Use the version string that is useful for planning. Adding `2.7` or `2.7 RC` should not require a code change; update the issue or Project field value. If Project #5 uses a single-select `Roadmap version` field, add the new option in GitHub Project settings. The issue body remains a free-form export fallback.
+Use the version string that is useful for planning. Adding `2.7` or `2.7 RC` should not require a code change; update the issue or Project field value. Project #5 should keep `Roadmap version` as a text field so new version buckets do not require Project option maintenance. The issue body remains a free-form export fallback.
 
 GitHub Releases and release-candidate tags are delivery artifacts, not the source of truth for roadmap planning. Use release names such as `2.7 RC` in `Roadmap version` only when the roadmap needs that planning bucket.
 
@@ -72,15 +72,60 @@ Configure this once after merge:
 
 - Organization project: `eneo-ai/5`.
 - Secret: `ADD_TO_PROJECT_PAT`.
-- PAT access: enough to add/read organization Project items and read repo issues/PRs used by the export.
+- Token access: enough to read/update organization Project #5 fields and items, plus read repo issues/PRs used by the export and intake workflows.
 - Required issue types: `task`, `bug`, `feature`.
 - Optional custom issue types later: `Epic`, `Finding`, `Initiative`.
-- Required Project fields: `Status`, `Roadmap version`, `Start date`, `Target date`, `Priority`, `Area`.
-- Recommended Project fields: `Owner / lead`, `Sponsor / municipality`, `Decision needed`, `Visibility`.
+- Required Project fields: `Kind`, `Status`, `Roadmap version`, `Start date`, `Target date`, `Priority`, `Area`, `Owner / lead`, `Sponsor / municipality`, `Decision needed`.
 - Enable hidden Project fields: `Parent issue`, `Sub-issue progress`.
-- Required views: `Committee Roadmap`, `Standup`, `Epics`, `Active work`, `Findings`, `Needs triage`, `Needs epic`, `Done since last committee`.
+- Recommended views: `Committee Roadmap`, `Standup`, `Epics`, `Active work`, `Findings`, `Needs triage`, `Needs epic`, `Done since last committee`.
 
 Issue forms also list `projects: ["eneo-ai/5"]` for convenience. If the issue creator lacks write access to the org project, the intake workflow and Project auto-add should still add the item.
+
+The workflows run `.github/scripts/ensure-project-fields.mjs` after validating `ADD_TO_PROJECT_PAT`. The script creates missing planning fields and adds missing standard options for `Status`, `Area`, `Priority`, and `Kind`. It does not delete team-specific options or change Project view layouts.
+
+Run the setup script manually after changing Project #5 fields:
+
+```bash
+GH_TOKEN=... node .github/scripts/ensure-project-fields.mjs
+```
+
+Run a local script check without touching GitHub:
+
+```bash
+node .github/scripts/ensure-project-fields.mjs --self-test
+```
+
+### `ADD_TO_PROJECT_PAT` setup
+
+`ADD_TO_PROJECT_PAT` must be an Actions secret, not an Actions variable. Variables are visible as plain configuration and must not contain tokens.
+
+Use a fine-grained personal access token when possible:
+
+- Resource owner: `eneo-ai`.
+- Repository access: `eneo-ai/eneo`.
+- Organization permission: Projects read/write.
+- Repository permissions: Issues read-only and Pull requests read-only.
+- Expiration: set a real expiry date and rotate the secret before it expires.
+
+If using a classic personal access token instead, use the narrowest token that can still access organization Projects and this repository. The local `gh` setup used for verification had `repo`, `read:org`, `project`, and `workflow` scopes; the `workflow` scope is only needed for local workflow inspection, not for the Actions secret itself.
+
+Create the repository secret in GitHub:
+
+1. Open `eneo-ai/eneo` -> `Settings`.
+2. Open `Secrets and variables` -> `Actions`.
+3. Stay on the `Secrets` tab.
+4. Click `New repository secret`.
+5. Name: `ADD_TO_PROJECT_PAT`.
+6. Secret: paste the token value.
+7. Save, then rerun `Export roadmap graph`.
+
+You can also set it with GitHub CLI:
+
+```bash
+gh secret set ADD_TO_PROJECT_PAT --repo eneo-ai/eneo
+```
+
+The CLI prompts for the token value. Do not put the token in chat, commit it, or store it as a repository variable.
 
 ## Adding new items
 
@@ -223,14 +268,18 @@ GH_TOKEN=... node scripts/export_github_roadmap.mjs --owner eneo-ai --project 5 
 
 The `Export roadmap graph` workflow can also be run manually in GitHub Actions. It uploads the generated roadmap as an artifact and lets the runner choose `default`, `committee`, or `standup` audience.
 
+If an epic appears under `Unscheduled`, set its `Roadmap version` Project field or fill in the `Roadmap version` section in the epic issue body. The export does not use GitHub Releases, tags, or milestones as the roadmap source of truth.
+
 ## Validation
 
 Run these checks after editing project workflow files:
 
 ```bash
+node --check .github/scripts/ensure-project-fields.mjs
 node --check .github/scripts/project-intake.mjs
 node --check .github/scripts/ensure-planning-labels.mjs
 node --check scripts/export_github_roadmap.mjs
+node .github/scripts/ensure-project-fields.mjs --self-test
 node .github/scripts/project-intake.mjs --self-test
 node scripts/export_github_roadmap.mjs --self-test
 ```

--- a/.github/scripts/ensure-project-fields.mjs
+++ b/.github/scripts/ensure-project-fields.mjs
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run");
+const selfTest = args.has("--self-test");
+const owner = process.env.PROJECT_OWNER || "eneo-ai";
+const projectNumber = process.env.PROJECT_NUMBER || "5";
+
+const textAndDateFields = [
+  { name: "Roadmap version", dataType: "TEXT" },
+  { name: "Sponsor / municipality", dataType: "TEXT" },
+  { name: "Owner / lead", dataType: "TEXT" },
+  { name: "Decision needed", dataType: "TEXT" },
+  { name: "Start date", dataType: "DATE" },
+  { name: "Target date", dataType: "DATE" },
+];
+
+const singleSelectFields = [
+  {
+    name: "Status",
+    options: [
+      option("Todo", "GRAY", "Planned or not started"),
+      option("In Progress", "BLUE", "Work has started"),
+      option("Done", "GREEN", "Delivered or closed"),
+    ],
+  },
+  {
+    name: "Area",
+    options: [
+      option("Backend", "BLUE", "Backend service or API work"),
+      option("Frontend", "GREEN", "Frontend user experience work"),
+      option("Infra", "ORANGE", "Infrastructure, CI, or deployment work"),
+      option("Docs", "GRAY", "Documentation work"),
+      option("Security", "RED", "Security or compliance work"),
+      option("Other", "GRAY", "Work that does not fit the standard areas"),
+    ],
+  },
+  {
+    name: "Priority",
+    options: [
+      option("P0", "RED", "Urgent or release-critical"),
+      option("P1", "ORANGE", "High priority"),
+      option("P2", "YELLOW", "Normal priority"),
+      option("P3", "GRAY", "Low priority"),
+    ],
+  },
+  {
+    name: "Kind",
+    options: [
+      option("Epic", "PURPLE", "Roadmap-level outcome that can own development tasks"),
+      option("Task", "BLUE", "Buildable development work item that belongs to an epic"),
+      option("Bug", "RED", "Reported product defect"),
+      option("Finding", "YELLOW", "Observed issue, risk, or improvement candidate before planning"),
+      option("Chore", "GRAY", "Maintenance work without direct product behavior"),
+    ],
+  },
+];
+
+if (selfTest) {
+  runSelfTest();
+  process.exit(0);
+}
+
+let project = readProject(owner, projectNumber);
+
+for (const field of textAndDateFields) {
+  ensureCustomField(project, field);
+  project = readProject(owner, projectNumber);
+}
+
+for (const field of singleSelectFields) {
+  ensureSingleSelectField(project, field);
+  project = readProject(owner, projectNumber);
+}
+
+console.log(`Project ${owner}/${projectNumber} has the required roadmap fields.`);
+
+function option(name, color, description) {
+  return { name, color, description };
+}
+
+function ensureCustomField(project, desired) {
+  const existing = findField(project, desired.name);
+
+  if (!existing) {
+    runGh([
+      "project",
+      "field-create",
+      projectNumber,
+      "--owner",
+      owner,
+      "--name",
+      desired.name,
+      "--data-type",
+      desired.dataType,
+      "--format",
+      "json",
+    ], { mutates: true });
+    console.log(`Created project field: ${desired.name}`);
+    return;
+  }
+
+  if (existing.dataType !== desired.dataType) {
+    throw new Error(
+      `Project field "${desired.name}" is ${existing.dataType}, expected ${desired.dataType}. Rename or remove the conflicting field in GitHub Project ${owner}/${projectNumber}.`,
+    );
+  }
+}
+
+function ensureSingleSelectField(project, desired) {
+  let existing = findField(project, desired.name);
+
+  if (!existing) {
+    runGh([
+      "project",
+      "field-create",
+      projectNumber,
+      "--owner",
+      owner,
+      "--name",
+      desired.name,
+      "--data-type",
+      "SINGLE_SELECT",
+      "--single-select-options",
+      desired.options.map((option) => option.name).join(","),
+      "--format",
+      "json",
+    ], { mutates: true });
+    console.log(`Created project field: ${desired.name}`);
+
+    if (dryRun) {
+      return;
+    }
+
+    existing = findField(readProject(owner, projectNumber), desired.name);
+    if (!existing) {
+      throw new Error(`Created project field "${desired.name}", but GitHub did not return it on re-read.`);
+    }
+  }
+
+  if (existing.dataType !== "SINGLE_SELECT") {
+    throw new Error(
+      `Project field "${desired.name}" is ${existing.dataType}, expected SINGLE_SELECT. Rename or remove the conflicting field in GitHub Project ${owner}/${projectNumber}.`,
+    );
+  }
+
+  const nextOptions = mergeSingleSelectOptions(existing.options || [], desired.options);
+  const changed = JSON.stringify(toComparableOptions(existing.options || []))
+    !== JSON.stringify(toComparableOptions(nextOptions));
+
+  if (!changed) {
+    return;
+  }
+
+  runGraphql({
+    query: `
+      mutation($fieldId: ID!, $options: [ProjectV2SingleSelectFieldOptionInput!]) {
+        updateProjectV2Field(input: { fieldId: $fieldId, singleSelectOptions: $options }) {
+          projectV2Field {
+            ... on ProjectV2SingleSelectField {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+    variables: {
+      fieldId: existing.id,
+      options: nextOptions,
+    },
+  }, { mutates: true });
+  console.log(`Updated project field options: ${desired.name}`);
+}
+
+function mergeSingleSelectOptions(existingOptions, desiredOptions) {
+  const existingByName = new Map(
+    existingOptions.map((existing) => [normalizeName(existing.name), existing]),
+  );
+  const desiredNames = new Set(desiredOptions.map((desired) => normalizeName(desired.name)));
+  const merged = [];
+
+  for (const desired of desiredOptions) {
+    const existing = existingByName.get(normalizeName(desired.name));
+    merged.push({
+      ...(existing?.id ? { id: existing.id } : {}),
+      name: desired.name,
+      color: existing?.color || desired.color,
+      description: existing?.description || desired.description,
+    });
+  }
+
+  for (const existing of existingOptions) {
+    if (!desiredNames.has(normalizeName(existing.name))) {
+      merged.push({
+        id: existing.id,
+        name: existing.name,
+        color: existing.color || "GRAY",
+        description: existing.description || "",
+      });
+    }
+  }
+
+  return merged;
+}
+
+function toComparableOptions(options) {
+  return options.map((option) => ({
+    id: option.id || "",
+    name: option.name,
+    color: option.color || "",
+    description: option.description || "",
+  }));
+}
+
+function findField(project, name) {
+  return project.fields.find((field) => field.name === name);
+}
+
+function readProject(projectOwner, number) {
+  const data = runGraphql({
+    query: `
+      query($owner: String!, $number: Int!) {
+        organization(login: $owner) {
+          projectV2(number: $number) {
+            id
+            fields(first: 100) {
+              nodes {
+                __typename
+                ... on ProjectV2Field {
+                  id
+                  name
+                  dataType
+                }
+                ... on ProjectV2SingleSelectField {
+                  id
+                  name
+                  dataType
+                  options {
+                    id
+                    name
+                    color
+                    description
+                  }
+                }
+                ... on ProjectV2IterationField {
+                  id
+                  name
+                  dataType
+                }
+              }
+            }
+          }
+        }
+      }
+    `,
+    variables: {
+      owner: projectOwner,
+      number: Number(number),
+    },
+  });
+
+  const project = data.organization?.projectV2;
+
+  if (!project) {
+    throw new Error(`GitHub Project ${projectOwner}/${number} was not found.`);
+  }
+
+  return {
+    id: project.id,
+    fields: project.fields.nodes.filter(Boolean),
+  };
+}
+
+function runGraphql(body, options = {}) {
+  const result = runGh(["api", "graphql", "--input", "-"], {
+    capture: true,
+    input: JSON.stringify(body),
+    mutates: options.mutates,
+  });
+  const parsed = JSON.parse(result.stdout);
+
+  if (parsed.errors?.length) {
+    throw new Error(parsed.errors.map((error) => error.message).join("\n"));
+  }
+
+  return parsed.data;
+}
+
+function runGh(args, options = {}) {
+  const printable = ["gh", ...args].join(" ");
+
+  if (dryRun && options.mutates) {
+    console.log(`[dry-run] ${printable}`);
+    return { status: 0, stdout: "{}" };
+  }
+
+  let result = spawnGh("gh", args, options);
+
+  if (result.error?.code === "ENOENT" && fs.existsSync("/opt/homebrew/bin/gh")) {
+    result = spawnGh("/opt/homebrew/bin/gh", args, options);
+  }
+
+  const status = result.status ?? 1;
+
+  if (status !== 0) {
+    if (result.error) {
+      process.stderr.write(`${result.error.message}\n`);
+    }
+    if (result.stderr) {
+      process.stderr.write(result.stderr);
+    }
+    throw new Error(`${printable} failed with exit code ${status}`);
+  }
+
+  return {
+    status,
+    stdout: result.stdout || "",
+  };
+}
+
+function spawnGh(command, args, options) {
+  return spawnSync(command, args, {
+    encoding: "utf8",
+    input: options.input,
+    stdio: options.capture ? ["pipe", "pipe", "pipe"] : ["pipe", "inherit", "pipe"],
+    env: process.env,
+  });
+}
+
+function normalizeName(value) {
+  return value.trim().toLowerCase();
+}
+
+function runSelfTest() {
+  const merged = mergeSingleSelectOptions(
+    [
+      { id: "todo-id", name: "Todo", color: "GRAY", description: "Existing todo" },
+      { id: "later-id", name: "Later", color: "PINK", description: "Team-specific option" },
+    ],
+    [
+      option("Todo", "GRAY", "Planned or not started"),
+      option("In Progress", "BLUE", "Work has started"),
+    ],
+  );
+
+  assert.deepEqual(merged, [
+    { id: "todo-id", name: "Todo", color: "GRAY", description: "Existing todo" },
+    { name: "In Progress", color: "BLUE", description: "Work has started" },
+    { id: "later-id", name: "Later", color: "PINK", description: "Team-specific option" },
+  ]);
+
+  assert.equal(normalizeName(" Roadmap version "), "roadmap version");
+  console.log("ensure-project-fields self-test passed");
+}

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -30,6 +30,28 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Validate project intake token
+        if: >-
+          (github.event_name == 'issues' && contains(fromJSON('["opened","reopened","labeled"]'), github.event.action)) ||
+          (github.event_name == 'pull_request_target' && contains(fromJSON('["opened","reopened","labeled"]'), github.event.action))
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error title=Missing ADD_TO_PROJECT_PAT::Create an Actions repository secret named ADD_TO_PROJECT_PAT. It must contain a GitHub token that can add items to organization project eneo-ai/5."
+            exit 1
+          fi
+
+          gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --limit 1 --format json >/dev/null
+
+      - name: Ensure project planning fields
+        if: >-
+          (github.event_name == 'issues' && contains(fromJSON('["opened","reopened","labeled"]'), github.event.action)) ||
+          (github.event_name == 'pull_request_target' && contains(fromJSON('["opened","reopened","labeled"]'), github.event.action))
+        run: node .github/scripts/ensure-project-fields.mjs
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+
       - name: Add to Eneo project
         if: >-
           (github.event_name == 'issues' && contains(fromJSON('["opened","reopened","labeled"]'), github.event.action)) ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
 
       - name: Run project workflow self-tests
         run: |
+          node .github/scripts/ensure-project-fields.mjs --self-test
           node .github/scripts/project-intake.mjs --self-test
           node scripts/export_github_roadmap.mjs --self-test
 

--- a/.github/workflows/export-roadmap.yml
+++ b/.github/workflows/export-roadmap.yml
@@ -47,6 +47,24 @@ jobs:
             *) echo "extension=md" >> "$GITHUB_OUTPUT" ;;
           esac
 
+      - name: Validate project export token
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error title=Missing ADD_TO_PROJECT_PAT::Create an Actions repository secret named ADD_TO_PROJECT_PAT. It must contain a GitHub token that can read and update organization project eneo-ai/5."
+            exit 1
+          fi
+
+          gh project item-list 5 --owner eneo-ai --limit 1 --format json >/dev/null
+
+      - name: Ensure roadmap project fields
+        run: node .github/scripts/ensure-project-fields.mjs
+        env:
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          PROJECT_OWNER: eneo-ai
+          PROJECT_NUMBER: "5"
+
       - name: Export roadmap
         run: |
           node scripts/export_github_roadmap.mjs \

--- a/frontend/apps/docs-site/package.json
+++ b/frontend/apps/docs-site/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@theguild/remark-mermaid": "^0.3.0",
     "classnames": "^2.5.1",
     "next": "15.3.8",
     "nextra": "^4.6.1",
@@ -19,6 +20,7 @@
   "devDependencies": {
     "pagefind": "^1.3.0",
     "@eslint/eslintrc": "^3",
+    "@next/eslint-plugin-next": "15.3.8",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/frontend/apps/docs-site/src/content/contributing/_meta.ts
+++ b/frontend/apps/docs-site/src/content/contributing/_meta.ts
@@ -1,8 +1,9 @@
-import type { MetaRecord } from 'nextra';
+import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {
-  index: 'Overview',
-  security: 'Security',
-}
+  index: "Overview",
+  "project-roadmap": "Project Roadmap",
+  security: "Security",
+};
 
 export default meta;

--- a/frontend/apps/docs-site/src/content/contributing/index.mdx
+++ b/frontend/apps/docs-site/src/content/contributing/index.mdx
@@ -68,6 +68,12 @@ All UI contributions must follow Eneo's established design system and use existi
 - **Follow existing conventions** — code style, project structure, commit message format
 - **Update documentation** if your change affects user-facing behavior
 
+## Roadmap Planning
+
+Eneo tracks roadmap epics, development tasks, findings, bugs, and chores in one GitHub Project. Epics use the `Roadmap version` field to appear in exported roadmap snapshots such as `2.0`, `2.1`, `2.2`, or `2.X`.
+
+See [Project Roadmap](/contributing/project-roadmap) for the project fields, version rules, task-to-epic relationship, and export workflow.
+
 ## Security Checks
 
 Pull requests run CI and Dependency Review before merge. These checks make dependency updates reviewable and prevent known high-severity vulnerable dependencies from entering `develop`. Code scanning is paused while maintainers evaluate a setup that gives developers useful feedback without high false-positive noise.

--- a/frontend/apps/docs-site/src/content/contributing/project-roadmap.mdx
+++ b/frontend/apps/docs-site/src/content/contributing/project-roadmap.mdx
@@ -1,0 +1,182 @@
+---
+title: Project Roadmap
+---
+
+import { Callout, Steps } from 'nextra/components'
+
+# Project Roadmap
+
+Eneo tracks product planning in one GitHub Project:
+
+- Project: [eneo-ai/5](https://github.com/orgs/eneo-ai/projects/5)
+- Repository: [eneo-ai/eneo](https://github.com/eneo-ai/eneo)
+- Main export workflow: `Export roadmap graph`
+
+Use the project for roadmap epics, active development tasks, findings, bugs, and chores. The roadmap export reads the same project data and turns epics into Markdown, Mermaid, or SVG snapshots.
+
+<Callout type="info">
+  Project #5 has the roadmap fields listed below. The Actions workflows also run a setup script that recreates missing fields when the project configuration drifts.
+</Callout>
+
+## Planning Model
+
+Use one item kind per issue or draft item.
+
+| Kind | Use it for | Roadmap export |
+| --- | --- | --- |
+| `Epic` | A roadmap outcome that can own several development tasks. | Exported as a roadmap card. |
+| `Task` | Buildable engineering work under an epic. | Kept out of the roadmap card view. |
+| `Bug` | A product defect. Triage decides whether it becomes planned work. | Kept out of the roadmap card view. |
+| `Finding` | An observed issue, risk, or improvement candidate. | Kept out until converted to an epic or task. |
+| `Chore` | Maintenance work without direct product behavior. | Kept out of the roadmap card view. |
+
+The SVG roadmap shows epics only. Tasks still matter because they show how developers deliver each epic.
+
+## Fields That Matter
+
+Project #5 uses these planning fields.
+
+| Field | Type | Who fills it in | Why it matters |
+| --- | --- | --- | --- |
+| `Kind` | Single select | Creator or triage | Classifies project items for views, draft cards, and roadmap export. |
+| `Roadmap version` | Text | Product or project lead | Places epics under `2.0`, `2.1`, `2.2`, `2.3`, `2.X`, or another export column. |
+| `Status` | Single select | Owner or assignee | Shows whether work is planned, active, or done. |
+| `Sponsor / municipality` | Text | Product or project lead | Shows the requester or sponsor, for example `Sundsvall`. |
+| `Owner / lead` | Text | Product or project lead | Shows the person or team driving the epic. Leave it empty until someone decides ownership. |
+| `Start date` | Date | Project lead | Drives GitHub's Roadmap timeline view. |
+| `Target date` | Date | Project lead | Drives GitHub's Roadmap timeline view. |
+| `Decision needed` | Text | Product, project, or architecture lead | Flags committee, product, or architecture decisions. |
+| `Parent issue` | GitHub relationship | Developer or maintainer | Connects tasks to their epic when sub-issues are available. |
+| `Sub-issues progress` | GitHub field | GitHub | Shows task progress under an epic. |
+
+`Roadmap version` controls the SVG export columns. `Start date` and `Target date` control GitHub's Roadmap timeline. Use both when you need both a release bucket and a calendar view.
+
+## Add An Epic
+
+<Steps>
+
+### Create the epic
+
+Create an issue with the `Epic` template, or create a draft item in Project #5 and set `Kind` to `Epic`.
+
+Use a short, readable title. The title appears on the exported roadmap card.
+
+### Set the roadmap version
+
+Set `Roadmap version` to the release bucket that should contain the epic:
+
+```text
+2.2
+```
+
+The export accepts free text. Use values such as `2.2`, `2.3`, `2.7 RC`, `2.X`, `Future`, or `Unscheduled`.
+
+### Fill in visible roadmap metadata
+
+Add these values when you know them:
+
+```text
+Sponsor / municipality: Sundsvall
+Owner / lead: Team Platform
+Status: Todo
+Decision needed: Need rollout decision
+```
+
+Leave `Owner / lead`, dates, and sponsor empty when nobody has made that decision. The exporter does not infer owners from labels, assignees, areas, or AI text.
+
+### Add dates for the GitHub Roadmap view
+
+Set `Start date` and `Target date` when the team wants the card on GitHub's timeline view. These dates do not decide the SVG version column.
+
+</Steps>
+
+## Add Development Tasks
+
+Create development tasks under an epic when the work is ready to build.
+
+Use the `Development task` issue template and fill in `Parent epic` with the epic issue number:
+
+```text
+#123
+```
+
+When GitHub sub-issues are available, add the task as a sub-issue of the epic too. Keep the `Parent epic` field in the issue body because automation and exports can read it.
+
+Tasks without a parent epic get the `needs:epic` label. That label means the task needs planning context before the team treats it as roadmap work.
+
+## Export The Roadmap
+
+Run the manual GitHub Actions workflow:
+
+```text
+Actions -> Export roadmap graph -> Run workflow
+```
+
+Choose:
+
+| Input | Recommended value | Meaning |
+| --- | --- | --- |
+| `format` | `svg` | Creates the slide-style roadmap. |
+| `audience` | `committee` | Uses stakeholder-oriented labels and layout. |
+| `versions` | `2.0,2.1,2.2,2.3` | Shows these columns even if some are empty. |
+
+The workflow uploads the result as an Actions artifact. It does not commit generated SVG files to the repository.
+
+## Version Rules
+
+The project does not hardcode future versions. Add the version string to the epic's `Roadmap version` field.
+Keep `Roadmap version` as a text field in Project #5. A single-select field would make every new version bucket require Project option maintenance.
+
+Examples:
+
+| Roadmap version | Export behavior |
+| --- | --- |
+| `2.2` | Places the epic in the `2.2` column. |
+| `2.7 RC` | Places the epic in a `2.7 RC` column when that column is requested or present in data. |
+| `2.X` | Places the epic in the future bucket. |
+| `Future` | Normalizes to `2.X` in the export. |
+| Empty | Places the epic in `Unscheduled`. |
+
+GitHub Releases, tags, release candidates, and milestones do not drive the roadmap export. Use them for delivery tracking. Use `Roadmap version` for planning.
+
+## Project Setup Automation
+
+The repo includes a setup script for Project #5:
+
+```bash
+GH_TOKEN=... node .github/scripts/ensure-project-fields.mjs
+```
+
+The script creates missing fields and adds missing standard options. It keeps team-specific options instead of deleting them.
+It does not change Project view layouts.
+
+It ensures these fields exist:
+
+```text
+Roadmap version
+Sponsor / municipality
+Owner / lead
+Decision needed
+Start date
+Target date
+Status
+Area
+Priority
+Kind
+```
+
+The workflows run the script after they validate `ADD_TO_PROJECT_PAT`. You only need to run it by hand after changing Project #5 outside the repo workflow.
+
+`ADD_TO_PROJECT_PAT` must be a repository secret with organization Projects read/write access for Project #5 and read access to issues and pull requests in `eneo-ai/eneo`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| An epic appears under `Unscheduled`. | Set `Roadmap version` on the epic. |
+| A field exists but you cannot see it in the current view. | Open `View` -> `Fields` and tick the field. The export can read hidden fields. |
+| The export workflow says `Missing ADD_TO_PROJECT_PAT`. | Add a repository secret named `ADD_TO_PROJECT_PAT`. |
+| A task gets `needs:epic`. | Add a `Parent epic` issue reference such as `#123`. |
+| A card is missing from the SVG. | Check that `Kind` is `Epic` or the issue has the `kind:epic` label. |
+
+`Add item` creates a new project item. The `+` in a table header adds or shows fields in that view.

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -13,6 +13,7 @@
       "name": "docs-site",
       "version": "0.1.0",
       "dependencies": {
+        "@theguild/remark-mermaid": "^0.3.0",
         "classnames": "^2.5.1",
         "next": "15.3.8",
         "nextra": "^4.6.1",
@@ -22,6 +23,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@next/eslint-plugin-next": "15.3.8",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -1284,7 +1286,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+    "fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
@@ -2350,8 +2352,6 @@
 
     "@mdx-js/mdx/estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
-    "@next/eslint-plugin-next/fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
-
     "@redocly/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@redocly/openapi-core/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
@@ -2458,6 +2458,8 @@
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "nextra/fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
     "nextra/yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "node-exports-info/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
@@ -2508,8 +2510,6 @@
 
     "@img/sharp-wasm32/@emnapi/runtime/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@next/eslint-plugin-next/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
     "@redocly/openapi-core/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
 
     "@ts-morph/common/minimatch/brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
@@ -2531,6 +2531,8 @@
     "mode-watcher/svelte-toolbelt/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
 
     "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "nextra/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "svelte-check/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 


### PR DESCRIPTION
## Summary
- Adds `ADD_TO_PROJECT_PAT` preflight checks before workflows use Project #5.
- Adds `.github/scripts/ensure-project-fields.mjs` so Project #5 gets the required roadmap fields and standard options automatically.
- Documents the roadmap model in the docs site: epics, tasks, version buckets, export artifacts, token permissions, and field setup.
- Keeps `Roadmap version` as a text field so `2.2`, `2.7 RC`, `2.X`, or future buckets do not require code changes or Project option maintenance.
- Adds explicit docs-site dependencies needed by Bun workspace resolution for Nextra Mermaid output and Next ESLint config resolution.

## Why
Project #5 is the canonical planning surface for roadmap epics, active work, findings, bugs, and chores. The export workflow should read from that project and produce Markdown, Mermaid, or SVG artifacts without committing generated files to the repo. The token and field setup must be clear enough that maintainers can run the workflow without hand-debugging `gh` errors or missing Project fields.

The workflow changes follow OWASP GitHub Actions security guidance in the practical places this PR touches: privileged token use stays in base-branch workflow code, shell inputs go through `env`, checkout keeps `persist-credentials: false`, and the token requirement is documented as a secret rather than a variable.

## What changed
- `.github/workflows/export-roadmap.yml`: validates `ADD_TO_PROJECT_PAT`, ensures Project #5 roadmap fields exist, then exports the roadmap artifact.
- `.github/workflows/add-to-project.yml`: validates the same secret and ensures Project fields before adding issues or PRs to Project #5.
- `.github/scripts/ensure-project-fields.mjs`: creates missing text/date fields, merges standard single-select options, preserves team-specific options, and includes a self-test.
- `.github/workflows/ci.yml`: runs the new script self-test in script tests.
- `.github/PROJECT_WORKFLOW.md`: updates the canonical workflow docs for token permissions, field contracts, version rules, and setup validation.
- `frontend/apps/docs-site/src/content/contributing/project-roadmap.mdx`: adds user-facing docs for creating epics, linking tasks, setting versions, and exporting roadmap snapshots.
- `frontend/apps/docs-site/package.json` and `frontend/bun.lock`: add direct dependencies required for docs-site build resolution with Bun.

## What was deliberately not changed
- Does not commit generated roadmap SVG/Markdown/Mermaid files. The export workflow uploads them as Actions artifacts.
- Does not automate GitHub Project view layouts. The setup script handles fields and field options only.
- Does not derive roadmap buckets from GitHub Releases, release-candidate tags, or milestones. `Roadmap version` remains the planning source of truth.
- Does not replace `ADD_TO_PROJECT_PAT` with `github.token`, because organization Project access needs a token with Project permissions.

## Deletion / consolidation
- Consolidates roadmap metadata around one Project #5 model instead of separate manual assumptions for Project fields, issue-body fallbacks, and export behavior.
- Removes older docs drift that treated Project `Kind` as optional while workflows and views now depend on it.
- Removes the `Roadmap version` single-select guidance so version buckets do not require Project option maintenance.

## Risk and rollback
- GitHub Actions risk: export/intake now run a field setup step with `ADD_TO_PROJECT_PAT`. The token must have organization Projects read/write access for Project #5 and read access to issues/PRs in `eneo-ai/eneo`.
- Project schema risk: if someone creates a same-named field with the wrong type, the setup script fails with an explicit error instead of silently creating duplicate planning state.
- Docs-site risk: direct dependencies add small lockfile churn, but they fix Bun workspace resolution for Nextra Mermaid output and Next ESLint config loading.
- Rollback: revert this commit. Existing manually configured Project fields remain in GitHub unless a maintainer removes them.

## Validation
- `node --check .github/scripts/ensure-project-fields.mjs`
- `node --check .github/scripts/project-intake.mjs`
- `node --check .github/scripts/ensure-planning-labels.mjs`
- `node --check scripts/export_github_roadmap.mjs`
- `node .github/scripts/ensure-project-fields.mjs --self-test`
- `node .github/scripts/project-intake.mjs --self-test`
- `node scripts/export_github_roadmap.mjs --self-test`
- YAML parse for `.github/workflows/*.yml` and `.github/ISSUE_TEMPLATE/*.yml`
- `git diff --cached --check`
- `bun install --frozen-lockfile`
- `bun run --cwd frontend/apps/docs-site build`
- `pre-commit run --files` for all changed project/docs files
- Live Project #5 field check with `gh project field-list 5 --owner eneo-ai --format json`
- `node .github/scripts/ensure-project-fields.mjs` against Project #5
