### PR TITLE
fix(project): clarify roadmap PR linkage

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-epic.yml
+++ b/.github/ISSUE_TEMPLATE/1-epic.yml
@@ -24,7 +24,7 @@ body:
     id: roadmap_version
     attributes:
       label: Roadmap version
-      description: Release bucket for grouping and export, for example 2.7, 2.7 RC, 2.X, Future, or Unscheduled. Use Project Start date/Target date for timeline placement.
+      description: Release bucket for grouping and export, for example 2.2, 2.2 RC, 2.X, Future, or Unscheduled. Use Project Start date/Target date for timeline placement.
       placeholder: "2.2"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/2-development-task.yml
+++ b/.github/ISSUE_TEMPLATE/2-development-task.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Development tasks must belong to an epic. Add the parent epic as a GitHub sub-issue relationship and reference it below. This is the main planning field developers need to keep the roadmap connected.
+        Development tasks must belong to an epic. Add this task as a GitHub sub-issue of the epic when available, and reference the epic below. When you open a pull request for this task, put `Fixes #123` in the PR body so GitHub links the implementation back to this task.
 
   - type: input
     id: parent_epic

--- a/.github/PROJECT_WORKFLOW.md
+++ b/.github/PROJECT_WORKFLOW.md
@@ -44,9 +44,9 @@ Epics carry a `Roadmap version` value in the issue body and/or Project field, fo
 
 `Roadmap version` is a release bucket for grouping, filtering, and export. It is not the timeline field for GitHub's Roadmap layout.
 
-Use the version string that is useful for planning. Adding `2.7` or `2.7 RC` should not require a code change; update the issue or Project field value. Project #5 should keep `Roadmap version` as a text field so new version buckets do not require Project option maintenance. The issue body remains a free-form export fallback.
+Use the version string that is useful for planning. Adding `2.2` or `2.2 RC` should not require a code change; update the issue or Project field value. Project #5 should keep `Roadmap version` as a text field so new version buckets do not require Project option maintenance. The issue body remains a free-form export fallback.
 
-GitHub Releases and release-candidate tags are delivery artifacts, not the source of truth for roadmap planning. Use release names such as `2.7 RC` in `Roadmap version` only when the roadmap needs that planning bucket.
+GitHub Releases and release-candidate tags are delivery artifacts, not the source of truth for roadmap planning. Use release names such as `2.2 RC` in `Roadmap version` only when the roadmap needs that planning bucket.
 
 For a real GitHub Roadmap timeline, configure one of these in Project #5:
 
@@ -64,6 +64,7 @@ Recommended views:
 - `Findings`: table, filter `kind:finding` or optional `Kind:Finding`.
 - `Needs triage`: table, filter `label:needs:triage`.
 - `Needs epic`: table, filter `label:needs:epic`.
+- `Needs task link`: table, filter `label:needs:task-link`.
 - `Done since last committee`: table, filter epics/tasks done since the last committee meeting date.
 
 ## Required GitHub setup
@@ -77,7 +78,7 @@ Configure this once after merge:
 - Optional custom issue types later: `Epic`, `Finding`, `Initiative`.
 - Required Project fields: `Kind`, `Status`, `Roadmap version`, `Start date`, `Target date`, `Priority`, `Area`, `Owner / lead`, `Sponsor / municipality`, `Decision needed`.
 - Enable hidden Project fields: `Parent issue`, `Sub-issue progress`.
-- Recommended views: `Committee Roadmap`, `Standup`, `Epics`, `Active work`, `Findings`, `Needs triage`, `Needs epic`, `Done since last committee`.
+- Recommended views: `Committee Roadmap`, `Standup`, `Epics`, `Active work`, `Findings`, `Needs triage`, `Needs epic`, `Needs task link`, `Done since last committee`.
 
 Issue forms also list `projects: ["eneo-ai/5"]` for convenience. If the issue creator lacks write access to the org project, the intake workflow and Project auto-add should still add the item.
 
@@ -140,6 +141,8 @@ Use `Epic` when the idea belongs on the roadmap and may contain several implemen
 
 Use `Development task` when the work is already scoped enough to build. A task should reference an epic in `Parent epic`, for example `#123`. This is the main planning metadata developers need to keep current.
 
+Open pull requests against development tasks, not epics. Put a closing reference such as `Fixes #123` in the PR body, where `#123` is the task issue. The task owns the parent epic relationship.
+
 Use `Finding` when something has been observed but is not yet planned. A finding can later be converted into one or more tasks under an epic.
 
 Use a Project draft item for an initiative that belongs to Eneo as a whole but does not yet belong to a repo. Convert it to an issue once implementation needs tracking in a repo.
@@ -150,6 +153,7 @@ AI-assisted development should follow the same model:
 2. If AI is asked to plan new roadmap work, create or suggest an `Epic`.
 3. If AI is asked to split an approved epic, create `Development task` issues and link each one to the epic.
 4. AI-created tasks must include the parent epic reference in the issue body so automation and exports can resolve the relationship.
+5. AI-created PRs must link the development task with a closing reference such as `Fixes #123`.
 
 Do not create disconnected tasks for roadmap work. If there is no suitable epic, create the epic first and then add tasks under it.
 
@@ -205,6 +209,8 @@ Preferred relationship:
 
 The `Parent epic` body field is intentionally duplicated with the GitHub relationship because it is stable for exports and automation. If the `Parent epic` section exists but is empty, the intake script must keep `needs:epic` even if another issue is mentioned elsewhere in the task.
 
+Pull requests should close the task issue, not the epic. This keeps the roadmap at outcome level and the code review at implementation level.
+
 ## Findings
 
 Findings are not treated as private by default. They remain in the canonical Eneo project with `kind:finding` and `needs:triage`.
@@ -223,8 +229,9 @@ When a finding becomes planned work:
 - adds opened or reopened issues and PRs to project #5;
 - labels structured issues by kind;
 - marks development tasks with `needs:epic` if their `Parent epic` field does not reference an epic issue.
+- marks non-draft PRs with `needs:task-link` if the PR body does not contain a closing task reference such as `Fixes #123`.
 
-The workflow is non-blocking for PRs. It keeps project intake visible without making planning metadata a release gate. If this workflow is expanded later, keep privileged workflow code on the base branch and do not checkout/run PR head code in jobs that use `ADD_TO_PROJECT_PAT`.
+The workflow is non-blocking for PRs. It uses labels to make missing planning links visible without making planning metadata a release gate. If this workflow is expanded later, keep privileged workflow code on the base branch and do not checkout/run PR head code in jobs that use `ADD_TO_PROJECT_PAT`.
 
 When adding workflow inputs or untrusted issue/PR text to a `run:` step, pass the value through `env:` and reference the environment variable in shell. Do not interpolate GitHub contexts directly into shell commands in jobs that use `ADD_TO_PROJECT_PAT`. Checkout steps should keep `persist-credentials: false` unless the job must push back to the repository.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,10 +5,9 @@
 <!-- Why was this needed? -->
 
 ## Planning
-<!-- Link the issue this PR closes, and the parent epic when relevant. -->
+<!-- Link the development task this PR closes. The task owns the parent epic link. -->
 
-- Issue:
-- Epic:
+- Task: Fixes #
 
 ## Testing
 <!-- How did you test this? -->

--- a/.github/scripts/ensure-planning-labels.mjs
+++ b/.github/scripts/ensure-planning-labels.mjs
@@ -32,6 +32,11 @@ const labels = [
     description: "Development task needs a linked parent epic before it is ready",
   },
   {
+    name: "needs:task-link",
+    color: "fbca04",
+    description: "Pull request needs a linked development task issue",
+  },
+  {
     name: "needs:triage",
     color: "fef2c0",
     description: "Needs product or engineering triage before planning",

--- a/.github/scripts/project-intake.mjs
+++ b/.github/scripts/project-intake.mjs
@@ -57,14 +57,20 @@ async function handleIssue(item) {
 }
 
 async function handlePullRequest(item) {
-  const text = `${item.title || ""}\n${item.body || ""}`;
-
-  if (/(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+/i.test(text)) {
+  if (item.draft) {
     return;
   }
 
+  const text = `${item.title || ""}\n${item.body || ""}`;
+
+  if (hasClosingIssueReference(text)) {
+    removeLabel(item.number, "needs:task-link");
+    return;
+  }
+
+  addLabel(item.number, "needs:task-link");
   console.log(
-    `PR #${item.number} has no closing issue reference. Keeping project intake non-blocking.`,
+    `PR #${item.number} has no linked development task. Added needs:task-link.`,
   );
 }
 
@@ -115,6 +121,18 @@ function hasEpicReference(body) {
 function hasIssueReference(value) {
   return /(^|\s)#\d+\b/.test(value)
     || /github\.com\/[^/\s]+\/[^/\s]+\/issues\/\d+/i.test(value);
+}
+
+function hasClosingIssueReference(value) {
+  const keyword = String.raw`\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)`;
+  const issueReference = [
+    String.raw`#\d+`,
+    String.raw`[^/\s]+\/[^/\s]+#\d+`,
+    String.raw`https?:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/\d+`,
+  ].join("|");
+  const pattern = new RegExp(`${keyword}:?\\s+(?:${issueReference})\\b`, "i");
+
+  return pattern.test(value);
 }
 
 function hasHeading(body, heading) {
@@ -256,6 +274,19 @@ function runSelfTest() {
     hasEpicReference("Legacy task created before the form existed. Parent #123."),
     true,
     "legacy unstructured task bodies should keep the issue-reference fallback",
+  );
+
+  assert.equal(hasClosingIssueReference("fixes #123"), true);
+  assert.equal(hasClosingIssueReference("Closes: #123"), true);
+  assert.equal(
+    hasClosingIssueReference("Resolves https://github.com/eneo-ai/eneo/issues/123"),
+    true,
+  );
+  assert.equal(hasClosingIssueReference("Fixes: eneo-ai/eneo#123"), true);
+  assert.equal(
+    hasClosingIssueReference("This PR implements #123"),
+    false,
+    "generic issue mentions should not count as task-closing references",
   );
 
   console.log("project-intake self-test passed");

--- a/frontend/apps/docs-site/src/content/contributing/project-roadmap.mdx
+++ b/frontend/apps/docs-site/src/content/contributing/project-roadmap.mdx
@@ -32,6 +32,18 @@ Use one item kind per issue or draft item.
 
 The SVG roadmap shows epics only. Tasks still matter because they show how developers deliver each epic.
 
+## Delivery Chain
+
+Use this chain when planned work moves from roadmap discussion to code review.
+
+| Level | GitHub item | Link to keep current |
+| --- | --- | --- |
+| Roadmap card | Epic issue or Project draft item with `Kind: Epic` | Set `Roadmap version`, `Sponsor / municipality`, and `Owner / lead`. |
+| Buildable work | Development task issue with `Kind: Task` | Add `Parent epic: #123` and, when available, add it as a GitHub sub-issue of the epic. |
+| Code review | Pull request | Add `Fixes #456` in the PR body, where `#456` is the development task. |
+
+Do not point PRs at epics. The task connects implementation work to the roadmap card.
+
 ## Fields That Matter
 
 Project #5 uses these planning fields.
@@ -69,7 +81,7 @@ Set `Roadmap version` to the release bucket that should contain the epic:
 2.2
 ```
 
-The export accepts free text. Use values such as `2.2`, `2.3`, `2.7 RC`, `2.X`, `Future`, or `Unscheduled`.
+The export accepts free text. Use values such as `2.2`, `2.2 RC`, `2.3`, `2.X`, `Future`, or `Unscheduled`.
 
 ### Fill in visible roadmap metadata
 
@@ -104,6 +116,20 @@ When GitHub sub-issues are available, add the task as a sub-issue of the epic to
 
 Tasks without a parent epic get the `needs:epic` label. That label means the task needs planning context before the team treats it as roadmap work.
 
+## Open Pull Requests
+
+Pull requests should link to development tasks, not epics. Add a closing reference in the PR body:
+
+```text
+Fixes #123
+```
+
+Use the task issue number. The task owns the `Parent epic` link, and the epic stays at roadmap level.
+
+Non-draft PRs without a closing task reference get the `needs:task-link` label. The label is non-blocking, but it keeps unlinked implementation work visible in Project #5.
+
+Project draft items work well for early planning. Convert a draft item to an issue before implementation starts so developers can link tasks and pull requests to real repository history.
+
 ## Export The Roadmap
 
 Run the manual GitHub Actions workflow:
@@ -132,7 +158,7 @@ Examples:
 | Roadmap version | Export behavior |
 | --- | --- |
 | `2.2` | Places the epic in the `2.2` column. |
-| `2.7 RC` | Places the epic in a `2.7 RC` column when that column is requested or present in data. |
+| `2.2 RC` | Places the epic in a `2.2 RC` column when that column is requested or present in data. |
 | `2.X` | Places the epic in the future bucket. |
 | `Future` | Normalizes to `2.X` in the export. |
 | Empty | Places the epic in `Unscheduled`. |
@@ -177,6 +203,7 @@ The workflows run the script after they validate `ADD_TO_PROJECT_PAT`. You only 
 | A field exists but you cannot see it in the current view. | Open `View` -> `Fields` and tick the field. The export can read hidden fields. |
 | The export workflow says `Missing ADD_TO_PROJECT_PAT`. | Add a repository secret named `ADD_TO_PROJECT_PAT`. |
 | A task gets `needs:epic`. | Add a `Parent epic` issue reference such as `#123`. |
+| A PR gets `needs:task-link`. | Add a closing task reference such as `Fixes #123` to the PR body. |
 | A card is missing from the SVG. | Check that `Kind` is `Epic` or the issue has the `kind:epic` label. |
 
 `Add item` creates a new project item. The `+` in a table header adds or shows fields in that view.


### PR DESCRIPTION
## Summary
- Simplifies the PR template so implementation PRs link to a development task, not both task and epic.
- Adds a non-blocking `needs:task-link` label for non-draft PRs without a closing task reference.
- Keeps linked PRs tidy by removing `needs:task-link` when the PR body includes `Fixes #123`, `Closes owner/repo#123`, or a GitHub issue URL.
- Updates docs-site, workflow docs, and issue templates to describe the `Epic -> Development task -> PR` chain.

## Why
The roadmap should stay readable for project leads and stakeholders while developers keep normal GitHub issue and PR workflows. The source of truth is now clearer:
- Epics own roadmap metadata and SVG export cards.
- Development tasks own implementation scope and the parent epic link.
- Pull requests close development tasks.

## What changed
- `.github/pull_request_template.md`: replaces separate issue/epic prompts with one task-closing prompt.
- `.github/scripts/project-intake.mjs`: labels non-draft PRs missing a closing task reference and removes the label when the reference exists.
- `.github/scripts/ensure-planning-labels.mjs`: creates/updates `needs:task-link`.
- `.github/ISSUE_TEMPLATE/*`: keeps version examples on `2.2` and tells task authors how to link PRs back to tasks.
- `.github/PROJECT_WORKFLOW.md` and `frontend/apps/docs-site/src/content/contributing/project-roadmap.mdx`: document the developer flow and troubleshooting path.

## What was deliberately not changed
- No hard CI gate was added for roadmap metadata.
- No PR comments were added for missing task links; labels are enough and avoid comment churn.
- No automation was added to create GitHub sub-issue relationships, because GitHub's relationship UI remains the human-facing source of truth.
- No roadmap export behavior changed; SVG cards still come from epics.

## Deletion / consolidation
- Removed the duplicate `Epic:` prompt from the PR template. The task already owns the parent epic relation, so asking for both in every PR made the workflow noisier.

## Risk and rollback
Risk is low: this is a non-blocking label and documentation/template polish. If the label is noisy, revert this commit or remove the `needs:task-link` branch in `project-intake.mjs`. Existing issues, project fields, and roadmap exports continue to work.

## Validation
- `node --check .github/scripts/ensure-project-fields.mjs`
- `node --check .github/scripts/project-intake.mjs`
- `node --check .github/scripts/ensure-planning-labels.mjs`
- `node --check scripts/export_github_roadmap.mjs`
- `node .github/scripts/ensure-project-fields.mjs --self-test`
- `node .github/scripts/project-intake.mjs --self-test`
- `node scripts/export_github_roadmap.mjs --self-test`
- Dry-run PR fixtures for linked, unlinked, and draft PRs
- YAML parse for `.github/workflows/*.yml` and `.github/ISSUE_TEMPLATE/*.yml`
- `git diff --check`
- `bun run --cwd frontend/apps/docs-site build`
- `pre-commit run --files ...`
