### PR TITLE
chore(ci): gate expensive checks by change scope

### DIFF
--- a/.github/scripts/ci-change-scope.mjs
+++ b/.github/scripts/ci-change-scope.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const outputNames = [
+  "full",
+  "backend",
+  "frontend",
+  "frontend_e2e",
+  "schema",
+  "scripts",
+  "route_metadata",
+  "docker_backend",
+  "docker_frontend",
+  "docker_devcontainer",
+];
+
+if (process.argv.includes("--self-test")) {
+  runSelfTest();
+  process.exit(0);
+}
+
+try {
+  const filesPath = getArgValue("--files");
+  const files = filesPath
+    ? fs.readFileSync(filesPath, "utf8").split("\n")
+    : process.argv.slice(2).filter((arg) => !arg.startsWith("--"));
+
+  writeOutputs(classify(files));
+} catch (error) {
+  console.error(`::warning::Failed to classify changed files. Running full CI. ${error.message}`);
+  writeOutputs(allTrue());
+}
+
+function classify(rawFiles) {
+  const files = normalizeFiles(rawFiles);
+
+  if (files.length === 0) {
+    return allTrue();
+  }
+
+  const full = files.some(isFullCiFile);
+  const backend = full || files.some(isBackendFile);
+  const frontend = full || files.some(isShippedFrontendFile);
+  const frontendE2e = full || backend || frontend || files.some(isE2eFile);
+  const schema = full || backend || files.some(isSchemaFile);
+  const scripts = full || files.some(isScriptTestFile);
+  const routeMetadata = full || backend || files.includes("scripts/check_route_metadata.py");
+  const dockerBackend = full || backend;
+  const dockerFrontend = full || frontend;
+  const dockerDevcontainer = full || files.some((file) => file.startsWith(".devcontainer/"));
+
+  return {
+    full,
+    backend,
+    frontend,
+    frontend_e2e: frontendE2e,
+    schema,
+    scripts,
+    route_metadata: routeMetadata,
+    docker_backend: dockerBackend,
+    docker_frontend: dockerFrontend,
+    docker_devcontainer: dockerDevcontainer,
+  };
+}
+
+function isFullCiFile(file) {
+  return file.startsWith(".github/workflows/")
+    || file === ".github/scripts/ci-change-scope.mjs"
+    || file === ".pre-commit-config.yaml"
+    || file === "Taskfile.yml"
+    || file === ".gitignore"
+    || file === "docker-compose.e2e.yml"
+    || file === "docker-compose.e2e.ci.yml";
+}
+
+function isBackendFile(file) {
+  return file.startsWith("backend/");
+}
+
+function isShippedFrontendFile(file) {
+  return file.startsWith("frontend/") && !file.startsWith("frontend/apps/docs-site/");
+}
+
+function isE2eFile(file) {
+  return file.startsWith("e2e/") || file === "docker-compose.e2e.ci.yml";
+}
+
+function isSchemaFile(file) {
+  return file.startsWith("frontend/packages/eneo-js/");
+}
+
+function isScriptTestFile(file) {
+  return file.startsWith("scripts/") || file.startsWith(".github/scripts/");
+}
+
+function normalizeFiles(rawFiles) {
+  return rawFiles
+    .map((file) => file.trim().replaceAll("\\", "/"))
+    .map((file) => file.replace(/^\.\//, ""))
+    .filter(Boolean);
+}
+
+function allTrue() {
+  return Object.fromEntries(outputNames.map((name) => [name, true]));
+}
+
+function writeOutputs(scope) {
+  for (const name of outputNames) {
+    console.log(`${name}=${scope[name] ? "true" : "false"}`);
+  }
+}
+
+function getArgValue(name) {
+  const index = process.argv.indexOf(name);
+
+  if (index === -1) {
+    return null;
+  }
+
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+
+  return value;
+}
+
+function runSelfTest() {
+  assert.deepEqual(
+    classify(["frontend/apps/docs-site/src/content/contributing/project-roadmap.mdx"]),
+    {
+      full: false,
+      backend: false,
+      frontend: false,
+      frontend_e2e: false,
+      schema: false,
+      scripts: false,
+      route_metadata: false,
+      docker_backend: false,
+      docker_frontend: false,
+      docker_devcontainer: false,
+    },
+    "docs-site-only changes should not run expensive app/backend CI",
+  );
+
+  assert.equal(classify(["backend/src/eneo/server/main.py"]).backend, true);
+  assert.equal(classify(["backend/src/eneo/server/main.py"]).frontend_e2e, true);
+  assert.equal(classify(["backend/src/eneo/server/main.py"]).schema, true);
+  assert.equal(classify(["backend/src/eneo/server/main.py"]).route_metadata, true);
+  assert.equal(classify(["backend/src/eneo/server/main.py"]).docker_backend, true);
+
+  assert.equal(classify(["frontend/apps/web/src/routes/+page.svelte"]).frontend, true);
+  assert.equal(classify(["frontend/apps/web/src/routes/+page.svelte"]).frontend_e2e, true);
+  assert.equal(classify(["frontend/apps/web/src/routes/+page.svelte"]).docker_frontend, true);
+  assert.equal(classify(["frontend/apps/web/src/routes/+page.svelte"]).schema, false);
+
+  assert.equal(classify(["frontend/knip.json"]).frontend, true);
+  assert.equal(classify(["frontend/knip.json"]).frontend_e2e, true);
+  assert.equal(classify(["frontend/packages/eneo-js/src/types/schema.d.ts"]).schema, true);
+  assert.equal(classify([".github/scripts/project-intake.mjs"]).scripts, true);
+  assert.equal(classify(["e2e/mock_model_server.py"]).frontend_e2e, true);
+  assert.equal(classify([".devcontainer/Dockerfile"]).docker_devcontainer, true);
+
+  const fullScope = classify([".github/workflows/ci.yml"]);
+  for (const name of outputNames) {
+    assert.equal(fullScope[name], true, `CI workflow changes should enable ${name}`);
+  }
+
+  const docsWorkflowScope = classify([".github/workflows/deploy_docs.yml"]);
+  for (const name of outputNames) {
+    assert.equal(docsWorkflowScope[name], true, `workflow changes should enable ${name}`);
+  }
+
+  const emptyScope = classify([]);
+  for (const name of outputNames) {
+    assert.equal(emptyScope[name], true, `empty change lists should fail open for ${name}`);
+  }
+
+  console.log("ci-change-scope self-test passed");
+}

--- a/.github/scripts/render-diff-coverage.mjs
+++ b/.github/scripts/render-diff-coverage.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+if (process.argv.includes("--self-test")) {
+  runSelfTest();
+  process.exit(0);
+}
+
+const frontendPath = getArgValue("--frontend") || "fe.json";
+const backendPath = getArgValue("--backend") || "be.json";
+const outputPath = getArgValue("--output") || "diff-coverage.md";
+const summaryPath = getArgValue("--summary") || process.env.GITHUB_STEP_SUMMARY;
+
+const body = renderReport([
+  ["Frontend", load(frontendPath)],
+  ["Backend", load(backendPath)],
+]);
+
+fs.writeFileSync(outputPath, body);
+
+if (summaryPath) {
+  fs.appendFileSync(summaryPath, body);
+}
+
+function renderReport(entries) {
+  const areas = entries.filter(([, data]) => data && (data.total_num_lines || 0) > 0);
+  const rows = [];
+  const details = [];
+
+  for (const [label, data] of areas) {
+    const total = data.total_num_lines || 0;
+    const miss = data.total_num_violations || 0;
+    const pct = Math.round(data.total_percent_covered || 0);
+
+    rows.push(`| ${label} | ${total} | ${miss} | ${pct}% |`);
+
+    const files = Object.entries(data.src_stats || {})
+      .map(([file, stats]) => [file, stats.violation_lines || []])
+      .filter(([, violationLines]) => violationLines.length)
+      .map(([file, violationLines]) => `- \`${shorten(file)}\` - ${ranges(violationLines)}`);
+
+    if (files.length) {
+      details.push([label, files]);
+    }
+  }
+
+  let body = [
+    "<!-- diff-coverage-report -->",
+    "## Patch coverage",
+    "",
+    "Share of this PR's new or changed lines exercised by tests. Report-only; never gates the PR.",
+    "",
+  ].join("\n");
+
+  if (rows.length) {
+    body += [
+      "| Area | Changed | Uncovered | Coverage |",
+      "| --- | ---: | ---: | ---: |",
+      rows.join("\n"),
+      "",
+    ].join("\n");
+  } else {
+    body += "_No changed lines with coverage data in this PR._\n";
+  }
+
+  for (const [label, files] of details) {
+    const count = files.length;
+    body += [
+      "",
+      `<details><summary>Uncovered lines: ${label} (${count} file${count === 1 ? "" : "s"})</summary>`,
+      "",
+      files.join("\n"),
+      "",
+      "</details>",
+      "",
+    ].join("\n");
+  }
+
+  return body.endsWith("\n") ? body : `${body}\n`;
+}
+
+function load(path) {
+  try {
+    return JSON.parse(fs.readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function shorten(path) {
+  const segments = path.split("/");
+  return segments.length > 3 ? `.../${segments.slice(-3).join("/")}` : path;
+}
+
+function ranges(values) {
+  const sorted = [...new Set(values)].sort((a, b) => a - b);
+  const out = [];
+  let start = null;
+  let previous = null;
+
+  for (const value of sorted) {
+    if (start === null) {
+      start = value;
+      previous = value;
+    } else if (value === previous + 1) {
+      previous = value;
+    } else {
+      out.push([start, previous]);
+      start = value;
+      previous = value;
+    }
+  }
+
+  if (start !== null) {
+    out.push([start, previous]);
+  }
+
+  return out.map(([first, last]) => (first === last ? `${first}` : `${first}-${last}`)).join(", ");
+}
+
+function getArgValue(name) {
+  const index = process.argv.indexOf(name);
+
+  if (index === -1) {
+    return null;
+  }
+
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+
+  return value;
+}
+
+function runSelfTest() {
+  assert.equal(
+    renderReport([
+      ["Frontend", null],
+      ["Backend", null],
+    ]).includes("No changed lines with coverage data"),
+    true,
+  );
+
+  const report = renderReport([
+    [
+      "Backend",
+      {
+        total_num_lines: 4,
+        total_num_violations: 2,
+        total_percent_covered: 50,
+        src_stats: {
+          "backend/src/eneo/example.py": {
+            violation_lines: [10, 11, 14],
+          },
+        },
+      },
+    ],
+  ]);
+
+  assert.equal(report.includes("| Backend | 4 | 2 | 50% |"), true);
+  assert.equal(report.includes("`.../src/eneo/example.py` - 10-11, 14"), true);
+
+  console.log("render-diff-coverage self-test passed");
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,67 @@ env:
   OPENAI_API_KEY: test-api-key
 
 jobs:
+  changes:
+    name: Change scope
+    runs-on: ubuntu-latest
+    outputs:
+      full: ${{ steps.scope.outputs.full }}
+      backend: ${{ steps.scope.outputs.backend }}
+      frontend: ${{ steps.scope.outputs.frontend }}
+      frontend_e2e: ${{ steps.scope.outputs.frontend_e2e }}
+      schema: ${{ steps.scope.outputs.schema }}
+      scripts: ${{ steps.scope.outputs.scripts }}
+      route_metadata: ${{ steps.scope.outputs.route_metadata }}
+      docker_backend: ${{ steps.scope.outputs.docker_backend }}
+      docker_frontend: ${{ steps.scope.outputs.docker_frontend }}
+      docker_devcontainer: ${{ steps.scope.outputs.docker_devcontainer }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: changed-files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base="$PR_BASE_SHA"
+          else
+            base="$BEFORE_SHA"
+          fi
+
+          head="$HEAD_SHA"
+          files="$RUNNER_TEMP/changed-files.txt"
+
+          if [[ -z "$base" || "$base" =~ ^0+$ ]]; then
+            git diff-tree --no-commit-id --name-only -r "$head" > "$files"
+          else
+            git diff --name-only "$base" "$head" > "$files"
+          fi
+
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Changed files"
+            echo ""
+            if [[ -s "$files" ]]; then
+              sed 's/^/- `/' "$files" | sed 's/$/`/'
+            else
+              echo "_No changed files detected. CI will fail open and run all scoped jobs._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Classify CI scope
+        id: scope
+        run: node .github/scripts/ci-change-scope.mjs --files "${{ steps.changed-files.outputs.files }}" >> "$GITHUB_OUTPUT"
+
   branch-policy:
     if: github.event_name == 'pull_request'
     name: Branch policy
@@ -70,6 +131,8 @@ jobs:
 
   backend-quality:
     name: Backend quality
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -117,6 +180,8 @@ jobs:
 
   backend-tests:
     name: Backend tests
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -187,6 +252,8 @@ jobs:
 
   script-tests:
     name: Script tests
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.scripts == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -200,10 +267,14 @@ jobs:
         run: |
           node .github/scripts/ensure-project-fields.mjs --self-test
           node .github/scripts/project-intake.mjs --self-test
+          node .github/scripts/ci-change-scope.mjs --self-test
+          node .github/scripts/render-diff-coverage.mjs --self-test
           node scripts/export_github_roadmap.mjs --self-test
 
   route-metadata:
     name: Route metadata
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.route_metadata == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -226,6 +297,8 @@ jobs:
 
   frontend:
     name: Frontend
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -291,6 +364,8 @@ jobs:
 
   frontend-e2e:
     name: Frontend E2E
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.frontend_e2e == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -361,6 +436,8 @@ jobs:
 
   schema-drift:
     name: Schema drift
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.schema == 'true'
     runs-on: ubuntu-latest
     services:
       redis:
@@ -459,18 +536,17 @@ jobs:
 
   # Reports how well the tests cover the lines THIS PR changed (patch coverage),
   # for frontend and backend separately. Report-only: never fails the PR and is
-  # not part of the aggregate `CI` gate below. Posts/updates a sticky PR comment
-  # and writes the same compact report to the job summary.
+  # not part of the aggregate `CI` gate below. Writes a compact report to the
+  # job summary and uploads the same markdown as an artifact.
   coverage-diff:
     name: Coverage diff
-    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+    if: ${{ !cancelled() && github.event_name == 'pull_request' && (needs.frontend.result == 'success' || needs.backend-tests.result == 'success') }}
     runs-on: ubuntu-latest
     needs:
       - frontend
       - backend-tests
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -521,88 +597,9 @@ jobs:
             diff-cover be.xml --compare-branch "origin/$BASE" --fail-under 0 --format json:be.json || true
           fi
 
-      - name: Post or update PR comment
+      - name: Write diff coverage summary
         if: ${{ !cancelled() }}
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require("fs");
-            const marker = "<!-- diff-coverage-report -->";
-
-            const load = (p) => {
-              try {
-                return JSON.parse(fs.readFileSync(p, "utf8"));
-              } catch {
-                return null;
-              }
-            };
-            // Show only the tail of long paths so the list stays readable.
-            const shorten = (p) => {
-              const s = p.split("/");
-              return s.length > 3 ? "…/" + s.slice(-3).join("/") : p;
-            };
-            // Collapse a sorted line list into "12, 18–20" style ranges.
-            const ranges = (nums) => {
-              const sorted = [...new Set(nums)].sort((a, b) => a - b);
-              const out = [];
-              let start = null;
-              let prev = null;
-              for (const n of sorted) {
-                if (start === null) start = prev = n;
-                else if (n === prev + 1) prev = n;
-                else {
-                  out.push([start, prev]);
-                  start = prev = n;
-                }
-              }
-              if (start !== null) out.push([start, prev]);
-              return out.map(([a, b]) => (a === b ? `${a}` : `${a}–${b}`)).join(", ");
-            };
-
-            // Drop areas with no changed lines so the comment only shows what's relevant.
-            const areas = [
-              ["Frontend", load("fe.json")],
-              ["Backend", load("be.json")],
-            ].filter(([, d]) => d && (d.total_num_lines || 0) > 0);
-
-            const rows = [];
-            const details = [];
-            for (const [label, d] of areas) {
-              const total = d.total_num_lines || 0;
-              const miss = d.total_num_violations || 0;
-              const pct = Math.round(d.total_percent_covered || 0);
-              rows.push(`| ${label} | ${total} | ${miss} | ${pct}% |`);
-              const files = Object.entries(d.src_stats || {})
-                .map(([f, st]) => [f, st.violation_lines || []])
-                .filter(([, vl]) => vl.length)
-                .map(([f, vl]) => `- \`${shorten(f)}\` — ${ranges(vl)}`);
-              if (files.length) details.push([label, files]);
-            }
-
-            let body = `${marker}\n## 📊 Patch coverage\n\nShare of this PR's new/changed lines exercised by tests. Report-only — never gates the PR.\n\n`;
-            if (rows.length) {
-              body += `| Area | Changed | Uncovered | Coverage |\n| --- | ---: | ---: | ---: |\n${rows.join("\n")}\n`;
-            } else {
-              body += "_No changed lines with coverage data in this PR._\n";
-            }
-            for (const [label, files] of details) {
-              const n = files.length;
-              body += `\n<details><summary>Uncovered lines — ${label} (${n} file${n === 1 ? "" : "s"})</summary>\n\n${files.join("\n")}\n\n</details>\n`;
-            }
-
-            fs.writeFileSync("diff-coverage.md", body);
-            await core.summary.addRaw(body).write();
-
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
-            const existing = comments.find((c) => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }
+        run: node .github/scripts/render-diff-coverage.mjs --frontend fe.json --backend be.json --output diff-coverage.md --summary "$GITHUB_STEP_SUMMARY"
 
       - name: Upload diff-coverage report
         if: ${{ !cancelled() }}
@@ -617,6 +614,12 @@ jobs:
 
   docker-builds:
     name: Docker builds (${{ matrix.image }})
+    needs: changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.docker_backend == 'true' ||
+      needs.changes.outputs.docker_frontend == 'true' ||
+      needs.changes.outputs.docker_devcontainer == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -634,9 +637,19 @@ jobs:
 
     steps:
       - name: Checkout
+        if: >-
+          github.event_name != 'pull_request' ||
+          (matrix.image == 'backend' && needs.changes.outputs.docker_backend == 'true') ||
+          (matrix.image == 'frontend' && needs.changes.outputs.docker_frontend == 'true') ||
+          (matrix.image == 'devcontainer' && needs.changes.outputs.docker_devcontainer == 'true')
         uses: actions/checkout@v4
 
       - name: Build Docker image
+        if: >-
+          github.event_name != 'pull_request' ||
+          (matrix.image == 'backend' && needs.changes.outputs.docker_backend == 'true') ||
+          (matrix.image == 'frontend' && needs.changes.outputs.docker_frontend == 'true') ||
+          (matrix.image == 'devcontainer' && needs.changes.outputs.docker_devcontainer == 'true')
         env:
           DOCKER_BUILDKIT: "1"
         run: docker build --pull --file "${{ matrix.file }}" --tag "eneo-${{ matrix.image }}:ci" "${{ matrix.context }}"
@@ -646,6 +659,7 @@ jobs:
     runs-on: ubuntu-latest
     if: always()
     needs:
+      - changes
       - branch-policy
       - backend-quality
       - backend-tests
@@ -660,6 +674,7 @@ jobs:
     steps:
       - name: Check required jobs
         env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
           BRANCH_POLICY_RESULT: ${{ needs.branch-policy.result }}
           BACKEND_QUALITY_RESULT: ${{ needs.backend-quality.result }}
           BACKEND_TESTS_RESULT: ${{ needs.backend-tests.result }}
@@ -688,6 +703,7 @@ jobs:
             esac
           }
 
+          check_result "Change scope" "$CHANGES_RESULT"
           check_result "Branch policy" "$BRANCH_POLICY_RESULT"
           check_result "Backend quality" "$BACKEND_QUALITY_RESULT"
           check_result "Backend tests" "$BACKEND_TESTS_RESULT"

--- a/frontend/apps/docs-site/src/content/contributing/project-roadmap.mdx
+++ b/frontend/apps/docs-site/src/content/contributing/project-roadmap.mdx
@@ -44,6 +44,13 @@ Use this chain when planned work moves from roadmap discussion to code review.
 
 Do not point PRs at epics. The task connects implementation work to the roadmap card.
 
+```mermaid
+flowchart LR
+  PR["PR #140<br/>Fixes #456"] --> Task["Task #456<br/>Build role filter"]
+  Task --> Epic["Epic #123<br/>Improved role management"]
+  Epic --> Roadmap["Roadmap export<br/>2.2"]
+```
+
 ## Fields That Matter
 
 Project #5 uses these planning fields.

--- a/frontend/apps/web/tests/chat.spec.ts
+++ b/frontend/apps/web/tests/chat.spec.ts
@@ -20,8 +20,8 @@ test("a streamed answer is saved and can be reopened from history", async ({ pag
 
   await page.getByRole("tablist").getByRole("tab").nth(1).click();
 
-  const savedConversation = page.locator("table tbody button").first();
-  await expect(savedConversation).toBeVisible();
+  const savedConversation = page.getByRole("button", { name: question }).first();
+  await expect(savedConversation).toBeVisible({ timeout: 15_000 });
   await savedConversation.click();
 
   const conversation = page.locator("#session-message-container");


### PR DESCRIPTION
## Summary
- Adds a fail-open `Change scope` job to classify PR changes before expensive CI jobs run.
- Skips backend, frontend, E2E, schema, and Docker jobs for docs-site-only PRs while keeping the aggregate `CI` check intact.
- Preserves contract safety: backend changes still run backend checks, schema drift, frontend E2E, route metadata, and backend Docker build.
- Adds a small Mermaid example to the roadmap docs showing `PR -> Task -> Epic -> Roadmap export`.

## Why
Docs and workflow-only changes should not wait on the full backend/frontend test matrix. The aggregate `CI` check remains the review surface, while job-level skips avoid GitHub's required-check pending behavior from workflow-level path filters.

## What changed
- `.github/scripts/ci-change-scope.mjs`: owns path classification and self-tests. It fails open by marking all scopes true if file detection is empty or unexpected.
- `.github/workflows/ci.yml`: gates expensive jobs from the change-scope outputs on pull requests only. Pushes to `develop` and `release/**` still run the full workflow.
- `.github/scripts/render-diff-coverage.mjs`: replaces inline coverage-diff JavaScript in YAML and writes the same report to job summary/artifact without PR write permissions.
- `frontend/apps/docs-site/src/content/contributing/project-roadmap.mdx`: adds a Mermaid sketch for the task-link flow.

## What was deliberately not changed
- No workflow-level `paths-ignore` was added, because skipped workflows can leave required checks pending.
- No backend/frontend contract checks were skipped for backend changes.
- The duplicated Python setup retry loops were left for a separate cleanup PR.
- Push builds on `develop` and release branches still run full CI.

## Deletion / consolidation
- Removed the `coverage-diff` PR comment writer and `pull-requests: write` permission.
- Moved diff coverage markdown rendering into a testable script instead of inline workflow JavaScript.

## Risk and rollback
Risk is concentrated in CI path classification. The detector fails open, so an unexpected condition runs more CI rather than less. If the gating causes confusion, revert this commit to restore the previous always-run behavior.

## Validation
- `node --check .github/scripts/ci-change-scope.mjs`
- `node .github/scripts/ci-change-scope.mjs --self-test`
- `node --check .github/scripts/render-diff-coverage.mjs`
- `node .github/scripts/render-diff-coverage.mjs --self-test`
- Existing project workflow self-tests for roadmap/project scripts
- Sample scope outputs for docs-only, frontend root config, backend, and root config changes
- YAML parse for `.github/workflows/*.yml`
- `git diff --check`
- `bun run --cwd frontend/apps/docs-site build`
- `pre-commit run --files ...`
