### PR TITLE
feat(deployment): isolate data layer with three-network topology

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -166,6 +166,8 @@ docker network create proxy_tier
 docker compose up -d
 ```
 
+> **Note on networks**: `proxy_tier` is the only network you create manually. The compose file also defines two managed networks: `data_net` (internal — PostgreSQL and Redis are isolated from the internet and from Traefik/frontend) and `module_net` (reserved for optional module containers). See the [network isolation section](deployment/README.md#network-isolation) for details.
+
 The initial startup may take a few minutes as Docker downloads the necessary container images. Once done, you can visit `https://your-domain.com` in your browser.
 
 ### Step 4: First-Time Login (Critical Security Step)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -215,15 +215,15 @@ docker compose down
 
 Eneo uses several Docker volumes for persistent data storage:
 
-| Volume | Path | Description |
-|--------|------|-------------|
-| `eneo_postgres_data` | `/var/lib/postgresql/data` | PostgreSQL database storage |
-| `eneo_redis_data` | `/data` | Redis cache and job queue state |
-| `eneo_backend_data` | `/app/data` | Backend application data |
-| `eneo_exports_data` | `/app/exports` | Audit log exports (auto-cleaned after 24h) |
-| `traefik_letsencrypt` | `/letsencrypt` | SSL certificates |
+| Docker volume | Path | Description |
+|---------------|------|-------------|
+| `eneo_eneo_postgres_data` | `/var/lib/postgresql/data` | PostgreSQL database storage |
+| `eneo_eneo_redis_data` | `/data` | Redis cache and job queue state |
+| `eneo_eneo_backend_data` | `/app/data` | Backend application data |
+| `eneo_eneo_temp_files` | `/tmp` | Temporary files and audit log exports (auto-cleaned after 24h) |
+| `eneo_traefik_letsencrypt` | `/letsencrypt` | SSL certificates |
 
-> **Note**: The `eneo_exports_data` volume is shared between `backend` and `worker` services for large audit log exports. Export files are automatically cleaned up after 24 hours.
+> **Note**: Docker volume names include the fixed Compose project prefix from `name: eneo`. The corresponding Compose volume keys in `docker-compose.yml` omit the first `eneo_` prefix.
 
 ## 🔄 Upgrading Your Eneo Instance
 
@@ -296,7 +296,7 @@ docker compose exec db pg_dump -U eneo eneo_db > backup_$(date +%Y%m%d).sql
 
 # Back up your volumes
 docker compose down
-docker run --rm -v eneo_postgres_data:/data -v $(pwd):/backup ubuntu tar czf /backup/postgres_data_backup.tar.gz /data
+docker run --rm -v eneo_eneo_postgres_data:/data -v $(pwd):/backup ubuntu tar czf /backup/postgres_data_backup.tar.gz /data
 ```
 
 ### Upgrading Between Minor Versions
@@ -340,7 +340,7 @@ docker compose exec db pg_dump -U eneo eneo_db > backup.sql
 docker compose down
 
 # 3. Remove volumes (ensures clean state)
-docker volume rm eneo_postgres_data eneo_redis_data eneo_backend_data
+docker volume rm eneo_eneo_postgres_data eneo_eneo_redis_data eneo_eneo_backend_data
 # Verify volumes are removed: docker volume ls
 
 # 4. Start with fresh installation

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -20,8 +20,8 @@ cp env_frontend.template env_frontend.env
 cp env_db.template env_db.env
 
 # 2. Edit docker-compose.yml (replace your-domain.com with your actual domain):
-#    - Line 38: your-email@domain.com (Let's Encrypt email)
-#    - Lines 65, 68, 91, 94: your-domain.com (4 locations)
+#    - Line 55: your-email@domain.com (Let's Encrypt email)
+#    - Lines 88, 91, 116, 119: your-domain.com (4 locations)
 
 # 3. Configure env_db.env:
 #    - POSTGRES_PASSWORD=your-secure-password
@@ -52,6 +52,41 @@ docker logs eneo_db_init
 # Should see: "Great! Your Tenant and User are all set up."
 
 # 8. Login with DEFAULT_USER_EMAIL / DEFAULT_USER_PASSWORD (change password immediately!)
+```
+
+## Network Isolation
+
+The stack uses three Docker networks:
+
+| Network | Services | Purpose |
+|---|---|---|
+| `proxy_tier` (external, created in step 6) | Traefik, frontend, backend, worker | Ingress and outbound access (LLM APIs, OIDC, crawling) |
+| `data_net` (`internal: true`) | db, redis, backend, worker, db-init | Data layer — no internet egress, unreachable from Traefik/frontend |
+| `module_net` | Traefik, backend | Reserved for optional module containers |
+
+The backend is the only service on all three networks. PostgreSQL and Redis are not reachable from the frontend or Traefik containers, and have no outbound internet access.
+
+### Upgrading an existing installation
+
+Installations created from an earlier version of this file had every service on `proxy_tier`. The new topology is applied by recreating the containers:
+
+```bash
+docker compose up -d
+```
+
+Containers are recreated with new network membership; the `eneo_postgres_data` and `eneo_redis_data` volumes are untouched. Expected downtime is a few seconds.
+
+**Check before upgrading:** anything *outside* this compose file that connected to `db:5432` or `redis:6379` over `proxy_tier` (external backup jobs, admin tools) will lose access. Run such tools with `docker exec` (e.g. `docker exec eneo_db pg_dump ...`) or attach them to `eneo_data_net` explicitly.
+
+**Verify after upgrading:**
+
+```bash
+# Should FAIL (frontend can no longer resolve the database):
+docker exec eneo_frontend getent hosts db
+
+# Should succeed:
+docker exec eneo_backend python -c "import socket; socket.getaddrinfo('db', 5432)"
+curl -fsS https://your-domain.com/version
 ```
 
 ## Troubleshooting

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -74,7 +74,7 @@ Installations created from an earlier version of this file had every service on 
 docker compose up -d
 ```
 
-Containers are recreated with new network membership; the `eneo_postgres_data` and `eneo_redis_data` volumes are untouched. Expected downtime is a few seconds.
+Containers are recreated with new network membership; the Compose-managed PostgreSQL and Redis volumes are untouched (normally `eneo_eneo_postgres_data` and `eneo_eneo_redis_data` as Docker volumes). Expected downtime is a few seconds.
 
 **Check before upgrading:** anything *outside* this compose file that connected to `db:5432` or `redis:6379` over `proxy_tier` (external backup jobs, admin tools) will lose access. Run such tools with `docker exec` (e.g. `docker exec eneo_db pg_dump ...`) or attach them to `eneo_data_net` explicitly.
 

--- a/docs/deployment/docker-compose.yml
+++ b/docs/deployment/docker-compose.yml
@@ -20,8 +20,9 @@
 #   4. frontend starts
 #
 # VOLUME MANAGEMENT:
-#   The "name: eneo" ensures consistent volume names (eneo_postgres_data, etc.)
-#   regardless of which directory you run commands from.
+#   The "name: eneo" fixes the Compose project name regardless of which
+#   directory you run commands from. Docker creates volumes with that project
+#   prefix, for example eneo_eneo_postgres_data.
 #   To completely reset: docker compose down -v && docker compose up -d
 #
 # NETWORK ISOLATION:

--- a/docs/deployment/docker-compose.yml
+++ b/docs/deployment/docker-compose.yml
@@ -4,8 +4,8 @@
 # Complete production stack with Traefik reverse proxy and Let's Encrypt SSL
 #
 # BEFORE DEPLOYING:
-#   1. Replace "your-email@domain.com" (line 38) with your email
-#   2. Replace "your-domain.com" (lines 65, 68, 91, 94) with your domain
+#   1. Replace "your-email@domain.com" (line 55) with your email
+#   2. Replace "your-domain.com" (lines 88, 91, 116, 119) with your domain
 #   3. Configure environment files (env_backend.env, env_frontend.env, env_db.env)
 #   4. Create external network: docker network create proxy_tier
 #
@@ -23,6 +23,17 @@
 #   The "name: eneo" ensures consistent volume names (eneo_postgres_data, etc.)
 #   regardless of which directory you run commands from.
 #   To completely reset: docker compose down -v && docker compose up -d
+#
+# NETWORK ISOLATION:
+#   proxy_tier (external) - Traefik, frontend, backend, worker. Internet-facing
+#                           traffic and outbound access (LLM APIs, OIDC, crawls).
+#   data_net   (internal) - PostgreSQL and Redis. No internet egress, and only
+#                           backend, worker and db-init can reach them. Frontend,
+#                           Traefik and future module containers cannot.
+#   module_net            - Traefik and backend. Reserved for optional module
+#                           containers (see docs/plans/modules-platform/).
+#   Backend is the only service on all three networks - the single gateway
+#   between the outside world, the data layer, and modules.
 #
 # Full documentation: ../DEPLOYMENT.md
 # ============================================================================
@@ -43,6 +54,11 @@ services:
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
       - "--certificatesresolvers.letsencrypt.acme.email=your-email@domain.com"  # CHANGE THIS
       - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+      # Default network for reaching routed containers. Services on multiple
+      # networks (backend) would otherwise get a random - possibly unreachable -
+      # network IP. Module containers override this with their own
+      # traefik.docker.network label on eneo_module_net.
+      - "--providers.docker.network=proxy_tier"
     ports:
       - "80:80"
       - "443:443"
@@ -51,6 +67,7 @@ services:
       - "traefik_letsencrypt:/letsencrypt"
     networks:
       - proxy_tier
+      - module_net
     labels:
       # IMPORTANT: traefik.enable=true is required for Traefik to read these labels
       # (because exposedbydefault=false is set above)
@@ -92,6 +109,8 @@ services:
       - eneo_temp_files:/tmp  # Also used for audit log exports (/tmp/exports)
     networks:
       - proxy_tier
+      - data_net
+      - module_net
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.eneo-backend.rule=Host(`your-domain.com`) && (PathPrefix(`/api`) || PathPrefix(`/scim`) || PathPrefix(`/docs`) || PathPrefix(`/openapi.json`) || PathPrefix(`/version`))"  # CHANGE THIS
@@ -128,6 +147,7 @@ services:
       - eneo_temp_files:/tmp  # Shared with backend for audit log exports (/tmp/exports)
     networks:
       - proxy_tier
+      - data_net
     depends_on:
       - backend
 
@@ -140,7 +160,7 @@ services:
     volumes:
       - eneo_postgres_data:/var/lib/postgresql/data
     networks:
-      - proxy_tier
+      - data_net
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
@@ -154,7 +174,7 @@ services:
     volumes:
       - eneo_redis_data:/data
     networks:
-      - proxy_tier
+      - data_net
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -170,7 +190,7 @@ services:
     env_file:
       - env_backend.env
     networks:
-      - proxy_tier
+      - data_net
     depends_on:
       db:
         condition: service_healthy
@@ -181,6 +201,11 @@ services:
 networks:
   proxy_tier:
     external: true
+  data_net:
+    driver: bridge
+    internal: true  # no internet egress; unreachable from Traefik/frontend/modules
+  module_net:
+    driver: bridge
 
 volumes:
   eneo_postgres_data:

--- a/frontend/apps/docs-site/src/content/guides/deployment.mdx
+++ b/frontend/apps/docs-site/src/content/guides/deployment.mdx
@@ -157,6 +157,35 @@ Navigate to `https://your-domain.com`
 
 ---
 
+## Network Isolation
+
+The Docker Compose stack uses three networks:
+
+| Network | Services | Purpose |
+|---------|----------|---------|
+| `proxy_tier` (external) | Traefik, frontend, backend, worker | Ingress and outbound access for APIs, OIDC, and crawls |
+| `data_net` (`internal: true`) | db, redis, backend, worker, db-init | Data layer without internet egress, isolated from Traefik and frontend |
+| `module_net` | Traefik, backend | Reserved for optional module containers |
+
+PostgreSQL and Redis are only attached to `data_net`. They are not reachable from frontend or Traefik containers, and they have no outbound internet access.
+
+<Callout type="warning">
+  **Existing installations:** Older deployment files put every service on `proxy_tier`. Running `docker compose up -d` with the current template recreates containers with the new network membership while keeping PostgreSQL and Redis volumes intact. External backup jobs or admin tools that connected to `db:5432` or `redis:6379` over `proxy_tier` must run through `docker exec` or attach to `eneo_data_net`.
+</Callout>
+
+Verify the isolation after upgrading:
+
+```bash
+# Should fail: frontend can no longer resolve the database
+docker exec eneo_frontend getent hosts db
+
+# Should succeed
+docker exec eneo_backend python -c "import socket; socket.getaddrinfo('db', 5432)"
+curl -fsS https://your-domain.com/version
+```
+
+---
+
 ## Environment Configuration
 
 <Tabs items={['Backend', 'Frontend', 'Database']}>
@@ -656,11 +685,11 @@ gunzip -c backup_20250108.sql.gz | docker compose exec -T db psql -U eneo eneo
 docker compose down
 
 # Backup PostgreSQL data volume
-docker run --rm -v eneo_postgres_data:/data -v $(pwd):/backup ubuntu \
+docker run --rm -v eneo_eneo_postgres_data:/data -v $(pwd):/backup ubuntu \
   tar czf /backup/postgres_volume_$(date +%Y%m%d).tar.gz /data
 
 # Backup Redis data volume (optional)
-docker run --rm -v eneo_redis_data:/data -v $(pwd):/backup ubuntu \
+docker run --rm -v eneo_eneo_redis_data:/data -v $(pwd):/backup ubuntu \
   tar czf /backup/redis_volume_$(date +%Y%m%d).tar.gz /data
 ```
 
@@ -677,6 +706,10 @@ docker compose exec -T db pg_dump -U eneo eneo | gzip > backup_$(date +%Y%m%d).s
 ### Update version tags (if pinned)
 
 Edit `docker-compose.yml` and update version tags (e.g., `v1.2.3` → `v1.2.4`).
+
+### Review network changes
+
+If your current deployment predates the three-network template, `docker compose up -d` recreates containers with the new network membership. External backup jobs or admin tools that connected to `db:5432` or `redis:6379` over `proxy_tier` must run through `docker exec` or attach to `eneo_data_net`.
 
 ### Pull and deploy
 


### PR DESCRIPTION
## Summary

Splits the single `proxy_tier` network in the production deployment template into three Docker networks, so the data layer is no longer reachable from every container in the stack:

| Network | Services | Purpose |
|---|---|---|
| `proxy_tier` (external, unchanged) | Traefik, frontend, backend, worker | Ingress + outbound access (LLM APIs, OIDC, crawling) |
| `data_net` (**`internal: true`**, new) | db, redis, backend, worker, db-init | Data layer — no internet egress, unreachable from Traefik/frontend/modules |
| `module_net` (new) | Traefik, backend | Reserved for upcoming optional module containers |

The backend is the only service bridging all three networks — the single gateway between the outside world, the data layer, and future modules. Even if a Traefik/frontend (or later, module) container is compromised, there is no network path to PostgreSQL or Redis.

Traefik also gets an explicit `--providers.docker.network=proxy_tier` so multi-network services (backend) always resolve to a reachable IP instead of a random network's.

## ⚠️ Must be communicated in the next release

This change ships in the deployment **template**, so nothing changes automatically for existing installations — operators only pick it up when they adopt the updated `docker-compose.yml`. But when they do:

- Anything **outside** the compose file that connected to `db:5432` / `redis:6379` over `proxy_tier` (external backup jobs, pgAdmin-style admin tools) **loses access** and must switch to `docker exec` or join `eneo_data_net` explicitly.
- Operators running **customized compose files** need to port the topology manually.

**Release notes for the next release must include a line along these lines:**

> The deployment template now isolates PostgreSQL/Redis on an internal network. Existing installations are unaffected until you update your `docker-compose.yml`; before doing so, read the upgrade section in `docs/deployment/README.md` (external tools that connected to the database over `proxy_tier` will need adjustment).

The upgrade steps, breakage checklist, and post-upgrade verification commands are included in `docs/deployment/README.md` in this PR. Internal environments that deploy from this template (e.g. any Dokploy stack syncing it) should adopt the change deliberately, not implicitly on next deploy.

## Changes

- `docs/deployment/docker-compose.yml` — three-network topology, Traefik default provider network, updated header docs + line references
- `docs/deployment/README.md` — network isolation section + upgrade guide for existing installations (breakage checklist, verification commands)
- `docs/DEPLOYMENT.md` — note that only `proxy_tier` is created manually

## Verification

- `docker compose config` validates cleanly (with stub env files)
- Rendered config confirms exact intended membership: db/redis/db-init on `data_net` only, frontend on `proxy_tier` only, backend on all three, traefik on `proxy_tier` + `module_net`, worker on `proxy_tier` + `data_net`
- Network names render as `eneo_data_net` / `eneo_module_net`, matching the Traefik labels the future module overlay will reference

## Context

First step of the modules-platform plan (network isolation is a standalone security hardening worth shipping independently of modules). `module_net` is intentionally added now so the upcoming `docker-compose.modules.yml` overlay can attach to it without touching the core template again.