### PR TITLE
feat(deployment): add optional module overlay and operator guide

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -166,7 +166,7 @@ docker network create proxy_tier
 docker compose up -d
 ```
 
-> **Note on networks**: `proxy_tier` is the only network you create manually. The compose file also defines two managed networks: `data_net` (internal — PostgreSQL and Redis are isolated from the internet and from Traefik/frontend) and `module_net` (reserved for optional module containers). See the [network isolation section](deployment/README.md#network-isolation) for details.
+> **Note on networks**: `proxy_tier` is the only network you create manually. The compose file also defines two managed networks: `data_net` (internal — PostgreSQL and Redis are isolated from the internet and from Traefik/frontend) and `module_net` (used by optional module containers). See the [network isolation section](deployment/README.md#network-isolation) for details, and [MODULES.md](deployment/MODULES.md) for enabling optional modules.
 
 The initial startup may take a few minutes as Docker downloads the necessary container images. Once done, you can visit `https://your-domain.com` in your browser.
 

--- a/docs/deployment/MODULES.md
+++ b/docs/deployment/MODULES.md
@@ -1,0 +1,148 @@
+# Eneo Modules — Operator Guide
+
+Modules are **optional add-on web apps** that run next to your Eneo installation: each module is its own container on its own domain (e.g. `ttt.your-domain.com`), enabled per instance with a Docker Compose profile. The core Eneo images are never modified — enabling or removing a module never touches your main deployment.
+
+> Modules are being rolled out incrementally. This guide documents the platform; each module's catalog entry lists its image, version and minimum Eneo version.
+
+## Security model
+
+Three properties, in order of importance:
+
+1. **Scoped credentials.** Each module holds one Eneo **service key** (`sk_`) with the narrowest possible scope and permission. The key lives only in the module's env file on the server — it is never sent to the browser. Compromising a module's UI session cannot yield more access than that one key grants.
+2. **Network isolation.** Modules join only `module_net`, which is `internal` — they can reach the backend at `http://backend:8000` and **nothing else**: no PostgreSQL, no Redis, and no outbound internet. Even a fully compromised module container has no path to the data layer and no way to exfiltrate directly.
+3. **BFF pattern.** The browser only ever talks to the module's own domain. The module's server side (backend-for-frontend) holds the credentials and forwards requests to Eneo.
+
+Note: modules are not network-isolated *from each other* — the authorization boundary between modules is key scoping, which is why step 2 below matters. A module that needs an external API cannot call it directly; such calls go through the Eneo backend.
+
+## User login (SSO via Eneo)
+
+Modules have **no login of their own and no IdP configuration**. Eneo is the single OIDC client in the installation, and module login rides on the user's Eneo session:
+
+1. An unauthenticated user on the module domain is redirected to Eneo.
+2. Eneo authenticates the user as usual (existing session, or your IdP), verifies that the user may use the module, and redirects back with a one-time, short-lived ticket.
+3. The module's server side exchanges the ticket with the backend over the internal network and establishes its own session cookie.
+
+For operators this means: no extra client registration in your IdP per module, and users already signed in to Eneo reach modules without seeing a login screen. Each module's catalog entry states the minimum Eneo version that supports this handoff.
+
+## Enabling a module
+
+Using **Tal till text** as the example (module id `tal-till-text`):
+
+### 1. DNS
+
+Point the module domain at the same server as your Eneo installation:
+
+```
+ttt.your-domain.com  A  <your-server-ip>
+```
+
+Traefik picks up TLS via Let's Encrypt automatically once the container starts.
+
+### 2. Mint a scoped service key
+
+Create an `sk_` key as a tenant admin (a user whose role has the API keys permission). Log in, then create the key:
+
+```bash
+ENEO_URL=https://your-domain.com
+
+# 1. Get a session token (admin user)
+TOKEN=$(curl -fsS -X POST "$ENEO_URL/api/v1/users/login/token/" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=admin@your-company.com&password=..." | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+# 2. Create the module's service key
+curl -fsS -X POST "$ENEO_URL/api/v1/api-keys" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "mod-tal-till-text",
+    "description": "Service key for the Tal till text module",
+    "key_type": "sk_",
+    "ownership": "service",
+    "permission": "write",
+    "scope_type": "space",
+    "scope_id": "<uuid-of-the-space-the-module-works-in>",
+    "rate_limit": 1000
+  }'
+```
+
+The response contains the secret **once** (`"secret": "sk_..."`). Store it directly in the module's env file — it cannot be retrieved again, only rotated.
+
+**Scoping guidance:**
+
+- Use the **narrowest** `scope_type` that covers the module's documented needs — each module's catalog entry states what it requires (e.g. a dedicated space). Avoid `tenant`-scoped keys for modules.
+- `permission`: `write` is normally enough. Never `admin` for a module.
+- Set a `rate_limit` matching expected usage; the backend enforces it per hour (Redis-backed).
+- Consider `expires_at` + calendar-driven rotation for high-sensitivity modules. Rotation has a grace period (default 24 h), so it is zero-downtime: rotate, update the env file, `docker compose up -d` the module.
+
+### 3. Configure env files
+
+```bash
+cp env_modules.template env_modules.env          # shared defaults (first module only)
+cp env_module_ttt.template env_module_ttt.env    # module secrets
+# Fill in: ENEO_MODULE_API_KEY (from step 2), SESSION_SECRET
+```
+
+Edit `docker-compose.modules.yml` and replace the `CHANGE THIS` placeholders (module domain in 3 label locations + `MODULE_PUBLIC_URL` + `ENEO_PUBLIC_URL`).
+
+### 4. Start
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.modules.yml \
+  --profile tal-till-text up -d
+```
+
+Pin the module version in production by setting `MODULE_TTT_VERSION` (defaults to `latest`). Module versions are pinned **independently** of your Eneo version — check the module's compatibility notes before upgrading either.
+
+### 5. Verify
+
+```bash
+# Module is healthy and routed with TLS
+curl -fsS https://ttt.your-domain.com/health
+
+# Module can reach the backend...
+docker exec eneo_mod_tal_till_text wget -q -O- http://backend:8000/version
+
+# ...but not the data layer (both must FAIL)
+docker exec eneo_mod_tal_till_text getent hosts db
+docker exec eneo_mod_tal_till_text getent hosts redis
+
+# ...and has no internet egress (must FAIL)
+docker exec eneo_mod_tal_till_text wget -q --spider -T 5 https://example.com
+```
+
+## Disabling a module
+
+```bash
+# 1. Stop and remove the container
+# (do NOT use `down` with a profile - that would stop the whole stack)
+docker compose -f docker-compose.yml -f docker-compose.modules.yml \
+  --profile tal-till-text stop mod-tal-till-text
+docker compose -f docker-compose.yml -f docker-compose.modules.yml \
+  --profile tal-till-text rm -f mod-tal-till-text
+
+# 2. Revoke its key (API keys admin UI, or the API)
+curl -fsS -X POST "$ENEO_URL/api/v1/api-keys/<key-id>/revoke" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"reason_code": "decommissioned", "reason_text": "Module disabled"}'
+```
+
+Always do both — a stopped container with a live key is a dormant credential.
+
+## Running several modules
+
+- One profile, one env file, one domain per module. Use `--profile all-modules` only in test environments.
+- Each module's key is scoped to its own resources — never share a key between modules.
+- Module images upgrade independently: `MODULE_<X>_VERSION` per module, `docker compose ... pull mod-<x> && ... up -d mod-<x>`.
+
+## Troubleshooting
+
+**Module container never becomes healthy / keeps restarting**
+Check `docker logs eneo_mod_tal_till_text`. The most common causes are a missing/invalid `ENEO_MODULE_API_KEY` (the module fails fast on startup) or an Eneo backend below the module's minimum version.
+
+**404 or certificate errors on the module domain**
+Verify DNS points at the server, the domain is identical in all `CHANGE THIS` locations, and the router names in the Traefik labels don't collide with another module's.
+
+**Module gets 401/403 from the backend**
+The key is revoked, expired, or scoped to the wrong resource. Check the key's state and scope in the API keys admin. 429 means the key's `rate_limit` is too low for real usage.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -7,9 +7,11 @@ Quick deployment reference for Eneo using Docker Compose.
 ## Files in This Directory
 
 - `docker-compose.yml` - Complete production stack (Traefik, frontend, backend, worker, PostgreSQL, Redis)
+- `docker-compose.modules.yml` - Optional module overlay (inert unless a `--profile` is passed; see [MODULES.md](MODULES.md))
 - `env_backend.template` - Backend configuration (API keys, OIDC, multi-tenancy)
 - `env_frontend.template` - Frontend configuration (URLs, OIDC)
 - `env_db.template` - Database credentials
+- `env_modules.template` / `env_module_ttt.template` - Module configuration (only needed when enabling modules)
 
 ## Quick Start
 
@@ -62,7 +64,7 @@ The stack uses three Docker networks:
 |---|---|---|
 | `proxy_tier` (external, created in step 6) | Traefik, frontend, backend, worker | Ingress and outbound access (LLM APIs, OIDC, crawling) |
 | `data_net` (`internal: true`) | db, redis, backend, worker, db-init | Data layer — no internet egress, unreachable from Traefik/frontend |
-| `module_net` | Traefik, backend | Reserved for optional module containers |
+| `module_net` | Traefik, backend, optional modules | Module traffic — modules reach the backend only (see [MODULES.md](MODULES.md)) |
 
 The backend is the only service on all three networks. PostgreSQL and Redis are not reachable from the frontend or Traefik containers, and have no outbound internet access.
 

--- a/docs/deployment/docker-compose.modules.yml
+++ b/docs/deployment/docker-compose.modules.yml
@@ -1,0 +1,77 @@
+# ============================================================================
+# ENEO OPTIONAL MODULES - Docker Compose Overlay
+# ============================================================================
+# Optional module containers, deployed ON TOP of the core stack:
+#
+#   docker compose -f docker-compose.yml -f docker-compose.modules.yml \
+#     --profile <module-id> up -d
+#
+# This file is INERT by default: every module is gated behind a Compose
+# profile, so plain `docker compose up -d` never starts any of them.
+#
+# WHAT A MODULE IS:
+#   A self-contained web app on its own domain. It joins module_net only,
+#   calls the Eneo backend at http://backend:8000 with a scoped service key
+#   (sk_), and can never reach PostgreSQL or Redis. See MODULES.md for the
+#   full operator guide (DNS, API key, env files, verification).
+#
+# ADDING A NEW MODULE:
+#   Copy the mod-tal-till-text service below and change: service name,
+#   profile, image, MODULE_ID, public domain (3 label locations + 1 env),
+#   Traefik router/service names, and the module env file.
+#
+# NETWORK NOTE:
+#   module_net is internal: modules have NO outbound internet access. All
+#   module traffic goes to backend:8000, and user login is handed off from
+#   the user's Eneo session (SSO) - the browser does the redirect legs, so
+#   the module itself never needs to reach an IdP. A module that genuinely
+#   needs an external API must go through the backend.
+# ============================================================================
+
+x-module-common: &module-common
+  restart: unless-stopped
+  networks:
+    - module_net
+  depends_on:
+    backend:
+      condition: service_healthy
+
+services:
+  mod-tal-till-text:
+    <<: *module-common
+    profiles: ["tal-till-text", "all-modules"]
+    image: ghcr.io/eneo-ai/eneo-mod-tal-till-text:${MODULE_TTT_VERSION:-latest}
+    container_name: eneo_mod_tal_till_text
+    environment:
+      - ENEO_BACKEND_URL=http://backend:8000
+      - ENEO_PUBLIC_URL=https://your-domain.com                # CHANGE THIS
+      - MODULE_PUBLIC_URL=https://ttt.your-domain.com          # CHANGE THIS
+      - MODULE_ID=tal-till-text
+    env_file:
+      - env_modules.env
+      - env_module_ttt.env
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    labels:
+      - "traefik.enable=true"
+      # Modules are routed over module_net, overriding Traefik's default
+      # provider network (proxy_tier) from the core compose file.
+      - "traefik.docker.network=eneo_module_net"
+      - "traefik.http.routers.mod-ttt.rule=Host(`ttt.your-domain.com`)"  # CHANGE THIS
+      - "traefik.http.routers.mod-ttt.entrypoints=web"
+      - "traefik.http.routers.mod-ttt.middlewares=redirect-to-https"
+      - "traefik.http.routers.mod-ttt-secure.rule=Host(`ttt.your-domain.com`)"  # CHANGE THIS
+      - "traefik.http.routers.mod-ttt-secure.entrypoints=websecure"
+      - "traefik.http.routers.mod-ttt-secure.tls=true"
+      - "traefik.http.routers.mod-ttt-secure.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.mod-ttt-secure.service=mod-ttt-svc"
+      - "traefik.http.services.mod-ttt-svc.loadbalancer.server.port=3000"
+
+networks:
+  module_net:
+    driver: bridge
+    internal: true  # must match the declaration in docker-compose.yml

--- a/docs/deployment/docker-compose.yml
+++ b/docs/deployment/docker-compose.yml
@@ -31,8 +31,11 @@
 #   data_net   (internal) - PostgreSQL and Redis. No internet egress, and only
 #                           backend, worker and db-init can reach them. Frontend,
 #                           Traefik and future module containers cannot.
-#   module_net            - Traefik and backend. Reserved for optional module
-#                           containers (see docs/plans/modules-platform/).
+#   module_net (internal) - Traefik and backend. Reserved for optional module
+#                           containers. Modules get no internet egress; all
+#                           their calls go to backend:8000, and user login is
+#                           handed off from the Eneo session (SSO) rather than
+#                           the module talking to an IdP itself.
 #   Backend is the only service on all three networks - the single gateway
 #   between the outside world, the data layer, and modules.
 #
@@ -124,6 +127,14 @@ services:
       - "traefik.http.routers.eneo-backend-secure.service=eneo-backend-svc"
       - "traefik.http.services.eneo-backend-svc.loadbalancer.server.port=8000"
       - "traefik.http.routers.eneo-backend-secure.priority=10"
+    healthcheck:
+      # Module containers (docker-compose.modules.yml) gate their startup on
+      # this. /version is unauthenticated and does not depend on the worker.
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/version', timeout=5)\""]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
     depends_on:
       db:
         condition: service_healthy
@@ -207,6 +218,7 @@ networks:
     internal: true  # no internet egress; unreachable from Traefik/frontend/modules
   module_net:
     driver: bridge
+    internal: true  # modules have no internet egress; ingress arrives via Traefik
 
 volumes:
   eneo_postgres_data:

--- a/docs/deployment/env_module_ttt.template
+++ b/docs/deployment/env_module_ttt.template
@@ -1,0 +1,17 @@
+# ============================================================================
+# TAL TILL TEXT MODULE - per-module secrets and configuration
+# ============================================================================
+# Copy to env_module_ttt.env. See MODULES.md for how to mint the API key.
+#
+# SECURITY: everything in this file stays server-side in the module
+# container. None of these values are ever sent to the browser.
+#
+# USER LOGIN: modules have no IdP configuration of their own. Users log in
+# via their Eneo session (SSO handoff from the backend) - see MODULES.md.
+
+# Scoped Eneo service key (sk_...) - mint per MODULES.md, narrowest scope
+# that covers the module's needs. Rotate via the API keys admin UI/API.
+ENEO_MODULE_API_KEY=sk_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Session cookie signing secret (32+ chars): openssl rand -hex 32
+SESSION_SECRET=

--- a/docs/deployment/env_modules.template
+++ b/docs/deployment/env_modules.template
@@ -1,0 +1,11 @@
+# ============================================================================
+# SHARED MODULE DEFAULTS - applied to every module container
+# ============================================================================
+# Copy to env_modules.env. Module-specific secrets do NOT belong here;
+# they go in the per-module env file (e.g. env_module_ttt.env).
+
+# Log level for module containers (debug, info, warn, error)
+LOG_LEVEL=info
+
+# Node environment for module runtimes
+NODE_ENV=production


### PR DESCRIPTION
## Summary

Second step of the modules platform (follows #532): the deployment template can now attach **optional module containers** as an opt-in overlay, without any change to core images.

- **`docs/deployment/docker-compose.modules.yml`** — module overlay, **inert by default**: every module sits behind a Compose profile, so plain `docker compose up -d` never starts one. Enabling is additive:
  ```bash
  docker compose -f docker-compose.yml -f docker-compose.modules.yml --profile tal-till-text up -d
  ```
  Contains `mod-tal-till-text` as the first (and copyable) module service definition. The image is published when the module has its first release — until then the profile simply has nothing to pull, and nothing changes for any operator.
- **`docs/deployment/MODULES.md`** — operator guide: security model, user-login flow, scoped `sk_` key runbook (via `POST /api/v1/api-keys` as tenant admin), enable/verify/disable procedures, troubleshooting.
- **`env_modules.template` / `env_module_ttt.template`** — shared + per-module env conventions. Module secrets stay server-side.
- **Backend healthcheck** on `/version` in the core compose file — the overlay's `depends_on: backend: service_healthy` requires it. `/version` deliberately, not `/api/healthz`: worker health must not gate module startup.

## Security design (the important part)

**`module_net` is now `internal: true`.** Modules get **zero** network reach except `backend:8000`: no Postgres, no Redis, no outbound internet. This works because module user-login is an **SSO handoff from the Eneo session** — the browser does the redirect legs and the module exchanges a backend-issued one-time ticket server-to-server over `module_net`. Modules are never OIDC clients of their own, so:

- municipalities register **no additional IdP clients** per module,
- users already signed in to Eneo reach modules without a login screen,
- a fully compromised module container can neither reach the data layer nor exfiltrate directly.

The authorization boundary between modules remains **key scoping** (api-keys v2), which the runbook enforces: narrowest scope, `write` max, rate limit, rotation with grace period.

The backend handoff endpoints (ticket issue/exchange) are the next PR — this one is deliberately deployment-only.

## ⚠️ Release note (in addition to the #532 note)

`module_net` changed from a regular bridge (#532) to `internal: true`. Fresh installs are unaffected. Anyone who adopted the template between #532 and this change will get an automatic network recreate on the next `docker compose up -d` (brief recreate of traefik/backend). Worth one line in the next release notes together with the #532 migration note.

## Verification

- `docker compose config` validates: overlay adds `mod-tal-till-text` only when the profile is passed; service gets `module_net` only; core-only and merged renders declare **identical** `module_net` (no recreate surprises when adding the overlay later).
- Live isolation test with stand-in containers in the exact rendered topology: Traefik→module ingress **works** over the internal network, module→backend **works**, module→db **blocked**, module internet egress **blocked**, `data_net` egress **blocked**.
- Operator-facing commands in MODULES.md avoid the `docker compose --profile <x> down` footgun (which would stop the whole stack) — documented `stop` + `rm -f` instead.