### PR TITLE
fix: use max_completion_tokens for Azure deployments

### DIFF
--- a/backend/src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py
+++ b/backend/src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py
@@ -419,6 +419,39 @@ class TenantModelAdapter(CompletionModelAdapter):
             },
         )
 
+    def _uses_max_completion_tokens(self) -> bool:
+        """Azure rejects max_tokens on some deployments even without reasoning metadata."""
+        provider_type = self.provider_type.lower()
+        if provider_type == "azure":
+            return True
+        return provider_type == "openai" and bool(
+            getattr(self.model, "reasoning", False)
+        )
+
+    def _set_output_token_limit_param(self, model_kwargs_dict: dict[str, Any]) -> None:
+        max_output_tokens = self.model.max_output_tokens
+
+        if self._uses_max_completion_tokens():
+            explicit_max_tokens = model_kwargs_dict.pop("max_tokens", None)
+            if "max_completion_tokens" not in model_kwargs_dict:
+                model_kwargs_dict["max_completion_tokens"] = (
+                    explicit_max_tokens
+                    if explicit_max_tokens is not None
+                    else max_output_tokens
+                )
+                logger.debug(
+                    "Using max_completion_tokens=%s",
+                    model_kwargs_dict["max_completion_tokens"],
+                )
+            return
+
+        if (
+            "max_tokens" not in model_kwargs_dict
+            and "max_completion_tokens" not in model_kwargs_dict
+        ):
+            model_kwargs_dict["max_tokens"] = max_output_tokens
+            logger.debug("Using max_tokens=%s", max_output_tokens)
+
     def _raise_provider_unavailable(
         self, *, phase: str, exc: BaseException
     ) -> NoReturn:
@@ -722,14 +755,10 @@ class TenantModelAdapter(CompletionModelAdapter):
                 ] in (None, "none", ""):
                     del model_kwargs_dict["reasoning_effort"]
 
-            # Ensure max_tokens is set - some APIs (e.g., vLLM, OpenAI-compatible)
-            # require it explicitly or return empty responses
-            if (
-                "max_tokens" not in model_kwargs_dict
-                and "max_completion_tokens" not in model_kwargs_dict
-            ):
-                model_kwargs_dict["max_tokens"] = self.model.max_output_tokens
-                logger.debug(f"Added default max_tokens={self.model.max_output_tokens}")
+            # Ensure an output-token cap is set. Azure rejects the legacy
+            # max_tokens parameter on some deployments even when LiteLLM
+            # reports it as supported.
+            self._set_output_token_limit_param(model_kwargs_dict)
 
             kwargs.update(model_kwargs_dict)
 

--- a/backend/src/eneo/model_providers/domain/model_provider_service.py
+++ b/backend/src/eneo/model_providers/domain/model_provider_service.py
@@ -552,7 +552,8 @@ class ModelProviderService:
         provider_type = provider.provider_type.lower()
         base_kwargs: dict[str, Any] = {
             "messages": [{"role": "user", "content": "hi"}],
-            "max_tokens": 1,
+            "max_completion_tokens": 1,
+            "drop_params": True,
             "api_key": api_key,
         }
 

--- a/backend/tests/unit/test_tenant_model_adapter_iterate_stream.py
+++ b/backend/tests/unit/test_tenant_model_adapter_iterate_stream.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 import httpx
 import pytest
 
-from eneo.ai_models.completion_models.completion_model import ResponseType
+from eneo.ai_models.completion_models.completion_model import ModelKwargs, ResponseType
 from eneo.completion_models.infrastructure.adapters.tenant_model_adapter import (
     PROVIDER_UNAVAILABLE_CODE,
     PROVIDER_UNAVAILABLE_MESSAGE,
@@ -144,12 +144,82 @@ class _ResourceMCPProxy(_FakeMCPProxy):
         ]
 
 
+class _FakeCredentialResolver:
+    def __init__(self, provider_type: str):
+        self.provider_type = provider_type
+
+    def get_api_key(self, *, required=False):  # noqa: ARG002
+        return "test-key"
+
+    def get_credential_field(self, *, field, required=False):  # noqa: ARG002
+        values = {
+            "endpoint": "https://models.example",
+            "api_version": "2026-01-01",
+            "deployment_name": "gpt-5-prod",
+        }
+        return values.get(field)
+
+
 def _make_adapter() -> TenantModelAdapter:
     adapter = object.__new__(TenantModelAdapter)
     adapter.litellm_model = "openai/test-model"
     adapter.provider_type = "openai"
     adapter.model = SimpleNamespace(name="test-model")
     return adapter
+
+
+def _make_prepare_kwargs_adapter(
+    *, provider_type: str = "azure", reasoning: bool = True, model_name: str = "gpt-5"
+) -> TenantModelAdapter:
+    model = SimpleNamespace(
+        name=model_name,
+        provider_id=uuid4(),
+        max_output_tokens=4096,
+        reasoning=reasoning,
+    )
+    return TenantModelAdapter(
+        model=model,
+        credential_resolver=_FakeCredentialResolver(provider_type),
+        provider_type=provider_type,
+    )
+
+
+def test_prepare_kwargs_uses_max_completion_tokens_for_azure_reasoning_model():
+    adapter = _make_prepare_kwargs_adapter(provider_type="azure", reasoning=True)
+
+    kwargs = adapter._prepare_kwargs(model_kwargs=ModelKwargs())
+
+    assert kwargs["max_completion_tokens"] == 4096
+    assert "max_tokens" not in kwargs
+
+
+def test_prepare_kwargs_uses_max_completion_tokens_for_azure_non_reasoning_model():
+    adapter = _make_prepare_kwargs_adapter(
+        provider_type="azure", reasoning=False, model_name="gpt-4o-2"
+    )
+
+    kwargs = adapter._prepare_kwargs(model_kwargs=ModelKwargs())
+
+    assert kwargs["max_completion_tokens"] == 4096
+    assert "max_tokens" not in kwargs
+
+
+def test_prepare_kwargs_remaps_explicit_max_tokens_for_azure_reasoning_model():
+    adapter = _make_prepare_kwargs_adapter(provider_type="azure", reasoning=True)
+
+    kwargs = adapter._prepare_kwargs(model_kwargs={"max_tokens": 123})
+
+    assert kwargs["max_completion_tokens"] == 123
+    assert "max_tokens" not in kwargs
+
+
+def test_prepare_kwargs_keeps_max_tokens_for_hosted_vllm_model():
+    adapter = _make_prepare_kwargs_adapter(provider_type="hosted_vllm", reasoning=False)
+
+    kwargs = adapter._prepare_kwargs(model_kwargs=ModelKwargs())
+
+    assert kwargs["max_tokens"] == 4096
+    assert "max_completion_tokens" not in kwargs
 
 
 def test_build_tool_result_with_references_uses_self_describing_resource_blocks():

--- a/backend/tests/unittests/model_providers/test_provider_connection.py
+++ b/backend/tests/unittests/model_providers/test_provider_connection.py
@@ -1,0 +1,47 @@
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from eneo.model_providers.domain.model_provider_service import ModelProviderService
+
+
+def _build_service_with_provider(
+    provider_type: str,
+) -> tuple[ModelProviderService, Any]:
+    provider = MagicMock()
+    provider.id = uuid4()
+    provider.provider_type = provider_type
+    provider.credentials = {"api_key": "ciphertext"}
+    provider.config = {
+        "endpoint": "https://models.example",
+        "api_version": "2026-01-01",
+        "deployment_name": "gpt-5-prod",
+    }
+
+    repository = MagicMock()
+    repository.get_by_id = AsyncMock(return_value=provider)
+
+    service = ModelProviderService(repository=repository, encryption=MagicMock())
+    service._decrypt_credentials = lambda creds: {"api_key": "test-key"}  # type: ignore[method-assign]
+    return service, provider
+
+
+@pytest.mark.asyncio
+async def test_connection_uses_max_completion_tokens_for_azure(monkeypatch):
+    captured_kwargs: dict[str, Any] = {}
+
+    async def fake_acompletion(**kwargs: Any) -> None:
+        captured_kwargs.update(kwargs)
+
+    monkeypatch.setattr("litellm.acompletion", fake_acompletion)
+    service, provider = _build_service_with_provider("azure")
+
+    result = await service.test_connection(provider.id)
+
+    assert result == {"success": True, "message": "Connection successful"}
+    assert captured_kwargs["model"] == "azure/gpt-5-prod"
+    assert captured_kwargs["max_completion_tokens"] == 1
+    assert captured_kwargs["drop_params"] is True
+    assert "max_tokens" not in captured_kwargs


### PR DESCRIPTION
## Summary

Fixes #534.

This updates the LiteLLM completion boundary so Eneo does not inject the legacy `max_tokens` parameter for Azure tenant models. Some Azure deployments, including a production `gpt-4o-2` deployment, reject `max_tokens` and require `max_completion_tokens`.

## Root cause

`TenantModelAdapter._prepare_kwargs` added `max_tokens` from `model.max_output_tokens` whenever no output-token cap was present. LiteLLM does not reliably rewrite that dynamically for Azure deployments: `drop_params=True` only removes parameters LiteLLM considers unsupported, and LiteLLM reports both `max_tokens` and `max_completion_tokens` as supported for Azure model routes. The request therefore reached Azure with `max_tokens` and was rejected.

## Changes

- Use `max_completion_tokens` for Azure tenant runtime kwargs regardless of Eneo reasoning metadata.
- Keep `max_completion_tokens` for OpenAI reasoning models.
- Keep `max_tokens` for self-hosted/OpenAI-compatible providers such as `hosted_vllm`.
- Translate explicit raw `max_tokens` into `max_completion_tokens` for Azure/OpenAI reasoning models instead of forwarding it.
- Align provider connection tests with the existing model-validation path by using `max_completion_tokens` and `drop_params=True`.
- Add focused unit coverage for Azure reasoning, Azure non-reasoning deployment names, hosted_vllm, and Azure provider connection kwargs.

## Validation

- `uv run pytest tests/unit/test_tenant_model_adapter_iterate_stream.py tests/unittests/model_providers/test_provider_connection.py -q`
- `uv run ruff check src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py src/eneo/model_providers/domain/model_provider_service.py tests/unit/test_tenant_model_adapter_iterate_stream.py tests/unittests/model_providers/test_provider_connection.py`
- `uv run pyright src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py src/eneo/model_providers/domain/model_provider_service.py tests/unit/test_tenant_model_adapter_iterate_stream.py tests/unittests/model_providers/test_provider_connection.py`