### PR TITLE
fix(review): restore eyes reaction permission

### DIFF
--- a/.github/workflows/ai-review-request.yml
+++ b/.github/workflows/ai-review-request.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 concurrency:
   group: eneo-ai-review-${{ github.event.repository.full_name }}-${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary
- Restores `pull-requests: write` for the AI review request workflow.
- Keeps the existing eyes reaction step unchanged.
- Fixes the `Resource not accessible by integration` 403 seen when acknowledging `/review` and `@review` comments.

## Why
The workflow successfully dispatches review requests, but the acknowledgement reaction currently fails with GitHub `HTTP 403` even though `issues: write` is present. The previous working setup included pull request write permission for this PR-comment workflow.

## What changed
- `.github/workflows/ai-review-request.yml`: add `pull-requests: write` next to the existing `issues: write` permission.

## What was deliberately not changed
- No trigger parsing changes.
- No webhook payload changes.
- No secret or token changes.
- No changes to the review bot container or Dokploy deployment.

## Risk and rollback
This grants the workflow token PR write scope for this workflow run. The workflow remains restricted to trusted PR comments and the existing allowlist. Rollback is removing the single permission line.

## Validation
- Verified current failed workflow logs show `gh: Resource not accessible by integration (HTTP 403)` in the eyes reaction step.
- Verified branch diff is one line in `.github/workflows/ai-review-request.yml`.
