### PR TITLE
fix(review): align AI review dispatch with v3.1 contract

### DIFF
--- a/.github/workflows/ai-review-request.yml
+++ b/.github/workflows/ai-review-request.yml
@@ -1,4 +1,6 @@
 name: Request Eneo AI review
+# Contract: eneo-ai-review-trigger/v3.1
+# Canonical source: eneo-ai-bot/eneo-security-review-infra/examples/github/ai-review-request.yml
 
 on:
   issue_comment:
@@ -6,7 +8,6 @@ on:
 
 permissions:
   issues: write
-  pull-requests: write
 
 concurrency:
   group: eneo-ai-review-${{ github.event.repository.full_name }}-${{ github.event.issue.number }}
@@ -14,26 +15,25 @@ concurrency:
 
 jobs:
   request-review:
-    # Coarse gate: a PR comment that starts with the trigger token. The Python step
-    # below is the precise, security-relevant gate and separates review requests
-    # from deterministic feedback commands. Keep this role list in sync with the
-    # precise association check below.
+    # Coarse gate: a PR comment that starts with the lowercase trigger token.
+    # The Python step below owns the exact command grammar and authorization.
+    # Keep this role list in sync with the precise association check below.
     if: >-
       github.event.issue.pull_request &&
       (startsWith(github.event.comment.body, '@review') || startsWith(github.event.comment.body, '/review')) &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      HERMES_REVIEW_URL: ${{ secrets.HERMES_REVIEW_URL }}
-      HERMES_WEBHOOK_SECRET: ${{ secrets.HERMES_WEBHOOK_SECRET }}
-      HERMES_REVIEW_FEEDBACK_URL: ${{ secrets.HERMES_REVIEW_FEEDBACK_URL }}
-      HERMES_REVIEW_FEEDBACK_SECRET: ${{ secrets.HERMES_REVIEW_FEEDBACK_SECRET }}
-      ALLOWED_USERS: ${{ vars.AI_REVIEW_ALLOWED_USERS }}
+    timeout-minutes: 5
 
     steps:
       - name: Authorize requester and send signed review request
         id: dispatch
+        env:
+          HERMES_REVIEW_URL: ${{ secrets.HERMES_REVIEW_URL }}
+          HERMES_WEBHOOK_SECRET: ${{ secrets.HERMES_WEBHOOK_SECRET }}
+          HERMES_REVIEW_FEEDBACK_URL: ${{ secrets.HERMES_REVIEW_FEEDBACK_URL }}
+          HERMES_REVIEW_FEEDBACK_SECRET: ${{ secrets.HERMES_REVIEW_FEEDBACK_SECRET }}
+          ALLOWED_USERS: ${{ vars.AI_REVIEW_ALLOWED_USERS }}
         shell: python
         run: |
           import hashlib
@@ -42,6 +42,7 @@ jobs:
           import os
           import re
           import urllib.error
+          import urllib.parse
           import urllib.request
 
           with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as handle:
@@ -49,20 +50,25 @@ jobs:
 
 
           def ignore(reason):
-              # Clean no-op: the workflow ran but this was not a valid maintainer request.
-              # Exit 0 so ignored comments are NOT counted as failed runs (keeps metrics honest).
+              # A clean no-op keeps ignored comments out of workflow-failure metrics.
               print(f"ignored: {reason}")
               raise SystemExit(0)
 
 
           def parse_review_command(body):
-              match = re.match(r"^[@/]review(?:\s+(?P<rest>\S.*))?$", body, flags=re.IGNORECASE | re.DOTALL)
+              match = re.match(r"^[@/]review(?:\s+(?P<rest>\S.*))?$", body, flags=re.DOTALL)
               if not match:
                   return None
               return "feedback" if match.group("rest") else "review"
 
 
-          trigger = event["comment"]["body"].strip()
+          class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+              def redirect_request(self, request, file_pointer, code, message, headers, new_url):
+                  return None
+
+
+          # Commands must begin at the first character; trailing whitespace is harmless.
+          trigger = event["comment"]["body"].rstrip()
           if event["comment"]["user"].get("type") == "Bot":
               ignore("bot comments cannot invoke the reviewer")
 
@@ -83,7 +89,7 @@ jobs:
 
           mode = parse_review_command(trigger)
           if mode is None:
-              ignore(f"comment is not an Eneo review command ({trigger!r})")
+              ignore("comment does not match the exact Eneo review command grammar")
 
           if mode == "review":
               webhook_url = os.environ.get("HERMES_REVIEW_URL", "").strip()
@@ -92,11 +98,19 @@ jobs:
           else:
               webhook_url = os.environ.get("HERMES_REVIEW_FEEDBACK_URL", "").strip()
               webhook_secret = os.environ.get("HERMES_REVIEW_FEEDBACK_SECRET", "").strip()
-              # Namespace feedback deliveries defensively because review and feedback
-              # requests both originate from GitHub issue comments.
+              # Review and feedback requests both originate from issue comments.
               delivery_id = f"{event['comment']['id']}:feedback"
           if not webhook_url or not webhook_secret:
               raise SystemExit(f"{mode} webhook secrets are not configured")
+
+          parsed_url = urllib.parse.urlparse(webhook_url)
+          if (
+              parsed_url.scheme != "https"
+              or not parsed_url.netloc
+              or parsed_url.username is not None
+              or parsed_url.password is not None
+          ):
+              raise SystemExit(f"{mode} webhook URL must be an HTTPS URL without credentials")
 
           payload = {
               "repository": {"full_name": event["repository"]["full_name"]},
@@ -114,34 +128,41 @@ jobs:
               method="POST",
               headers={
                   "Content-Type": "application/json",
-                  "User-Agent": "Eneo-AI-Review-Trigger/3.0",
+                  "User-Agent": "Eneo-AI-Review-Trigger/3.1",
                   "X-GitHub-Event": "issue_comment",
-                  # Keep this stable across workflow retries so Hermes' one-hour
-                  # idempotency cache cannot start a duplicate agent run.
+                  # Stable across retries so Hermes cannot start a duplicate run.
                   "X-GitHub-Delivery": delivery_id,
                   "X-Hub-Signature-256": signature,
               },
           )
-          timeout = 900 if mode == "review" else 60
 
           try:
-              with urllib.request.urlopen(request, timeout=timeout) as response:
-                  text = response.read(4096).decode("utf-8", errors="replace")
-                  print(f"Eneo {mode} webhook accepted the request: HTTP {response.status} {text}")
+              opener = urllib.request.build_opener(NoRedirectHandler())
+              with opener.open(request, timeout=60) as response:
+                  response.read(4096)
+                  print(f"Eneo {mode} webhook accepted the request: HTTP {response.status}")
           except urllib.error.HTTPError as error:
-              detail = error.read(4096).decode("utf-8", errors="replace")
-              raise SystemExit(f"Eneo {mode} webhook rejected the request: HTTP {error.code} {detail}")
-          except urllib.error.URLError as error:
-              raise SystemExit(f"Eneo {mode} webhook could not be reached: {error.reason}")
+              raise SystemExit(
+                  f"Eneo {mode} webhook rejected the request: HTTP {error.code}"
+              ) from None
+          except urllib.error.URLError:
+              raise SystemExit(f"Eneo {mode} webhook could not be reached") from None
+          except TimeoutError:
+              raise SystemExit(f"Eneo {mode} webhook could not be reached") from None
 
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
               output.write("dispatched=true\n")
+              output.write(f"mode={mode}\n")
 
       - name: Acknowledge receipt with an eyes reaction
-        if: steps.dispatch.outputs.dispatched == 'true'
+        if: >-
+          steps.dispatch.outputs.dispatched == 'true' &&
+          steps.dispatch.outputs.mode == 'review'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
-        run: gh api --method POST "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content=eyes
+        run: >-
+          gh api --silent --method POST
+          "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content=eyes


### PR DESCRIPTION
TL;DR: This updates only the Eneo GitHub Actions entrypoint for the external AI reviewer. It synchronizes the deployed workflow with the canonical v3.1 contract now merged in [`eneo-ai-bot/eneo-security-review-infra#4`](https://github.com/eneo-ai-bot/eneo-security-review-infra/pull/4). Review requests remain explicit through `/review`; feedback remains routed through the feedback bridge. No backend, frontend, API, database, dependency, or model configuration changes are included in this repository.

## Summary

- Synchronize `.github/workflows/ai-review-request.yml` with the canonical v3.1 signed dispatch workflow.
- Accept only exact lowercase `/review` and `@review` commands, with trailing text routed as feedback.
- Keep authorization deny-by-default and require both an allowlisted login and a trusted repository association.
- Scope webhook secrets to the dispatch step, enforce credential-free HTTPS destinations, reject redirects, and cap network waits at 60 seconds.
- Add an eyes reaction only after a review request is accepted; feedback keeps its own success/error reaction owner.
- Grant only `issues: write`, the permission required by the issue-comment reaction endpoint used here.

## Why

This workflow is Eneo’s thin outbound adapter into the published reviewer dispatch contract. The canonical workflow in `eneo-security-review-infra` is the source of truth; keeping a divergent copy in Eneo risks mismatched command parsing, duplicate acknowledgements, leaked response details, overly broad credentials, and deployment behavior that the reviewer infrastructure no longer tests.

The update keeps ownership clear: Eneo owns when a maintainer may dispatch a request, while the reviewer infrastructure owns the signed webhook contract and review implementation.

## What changed

- `.github/workflows/ai-review-request.yml`
  - renamed and versioned the workflow contract;
  - reduced the job timeout from 20 minutes to 5 minutes;
  - moved webhook secrets from job scope to the dispatch step;
  - added exact command parsing and a clean ignored-command path;
  - validated webhook URLs as HTTPS without embedded credentials;
  - disabled redirects before sending the signed request;
  - replaced the 900-second review request wait with a 60-second network bound;
  - stopped logging webhook response/error bodies and user-supplied malformed command bodies;
  - emitted deterministic `dispatched` and `mode` outputs;
  - added a non-blocking eyes reaction for accepted review mode only;
  - removed the unused `pull-requests: write` permission.

## What was deliberately not changed

- No Eneo backend, frontend, API, schema, migration, generated client, dependency, or test-suite behavior.
- No reviewer model or runtime configuration; that is deployed from the infrastructure repository.
- No automatic review on every push. A maintainer still explicitly posts `/review` after fixes are pushed.
- No change to configured webhook URLs, secrets, allowlisted users, or repository roles.
- No merge of this PR as part of the infrastructure deployment.

## Deletion / consolidation

- Removed duplicated workflow behavior that had drifted from the canonical v3.1 example.
- Removed job-wide secret exposure; only the signed dispatch step receives reviewer secrets.
- Removed webhook body logging and the raw malformed-comment echo.
- Removed the redundant eyes reaction for feedback commands.
- Removed `pull-requests: write`; the workflow calls `POST /issues/comments/{comment_id}/reactions`, whose reaction permission is `issues: write`. The pull-request permission applies to inline review-comment endpoints instead. See [GitHub’s Reactions API permission table](https://docs.github.com/en/rest/reactions/reactions?apiVersion=2022-11-28).

## Risk and rollback

- Command parsing is intentionally stricter and case-sensitive. `/review` and `@review` remain supported; variants such as `/Review`, leading whitespace, or `/reviewx` are ignored.
- A bad or unavailable webhook now fails within the bounded workflow window and does not receive a misleading eyes reaction.
- The eyes acknowledgement remains best-effort (`continue-on-error: true`) and still has the exact `issues: write` permission required by its endpoint.
- Rollback is a one-commit revert of this workflow file. No data or application rollback is needed.

## Validation

- Repository commit hooks — PASS: large-file, merge-conflict, secret, preflight, ownership, and commit-message checks.
- Repository pre-push check — PASS.
- `git diff --check origin/develop -- .github/workflows/ai-review-request.yml` — PASS.
- Ruby YAML parse — PASS.
- Embedded Python dispatch script compile — PASS.
- Byte-for-byte parity with the canonical infrastructure workflow — PASS.
- Canonical workflow behavior tests — PASS, including response-read timeout handling and review-only acknowledgement.
- SHA-256 of both canonical and deployed workflow copies: `f0774a1c340c638ac832c4157e21e5b0f2246ff571268b96377edc37d2c86532`.

Peer-review automation was deliberately skipped because the requester explicitly asked not to run that loop; the workflow received an independent read-only audit plus the deterministic validation above.
