### PR TITLE
fix(review): restore eyes reaction permission

### DIFF
--- a/.github/workflows/ai-review-request.yml
+++ b/.github/workflows/ai-review-request.yml
@@ -8,6 +8,9 @@ on:
 
 permissions:
   issues: write
+  # GitHub's Actions integration requires this when reacting to a pull-request
+  # conversation comment, even though the REST path is under issue comments.
+  pull-requests: write
 
 concurrency:
   group: eneo-ai-review-${{ github.event.repository.full_name }}-${{ github.event.issue.number }}
@@ -158,11 +161,14 @@ jobs:
         if: >-
           steps.dispatch.outputs.dispatched == 'true' &&
           steps.dispatch.outputs.mode == 'review'
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           COMMENT_ID: ${{ github.event.comment.id }}
-        run: >-
-          gh api --silent --method POST
-          "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content=eyes
+        shell: bash
+        run: |
+          if ! gh api --silent --method POST \
+            "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -f content=eyes >/dev/null 2>&1; then
+            echo "::warning::Review request was accepted, but GitHub refused the eyes reaction. Check the workflow token's Issues and Pull requests write permissions."
+          fi


### PR DESCRIPTION
## TL;DR
Restore the PR-comment permission that the live workflow proved is needed for the eyes acknowledgement. The review webhook itself already dispatches successfully.

## Summary
- Restore `pull-requests: write` alongside `issues: write`.
- Keep the eyes reaction non-blocking after successful review dispatch.
- Surface a sanitized workflow warning if GitHub still refuses acknowledgement.

## Why
The canonical signed-dispatch workflow is owned by `eneo-ai-bot/eneo-security-review-infra`; Eneo keeps a thin exact copy. In Actions run 29321482484, the signed review webhook returned HTTP 202, but GitHub returned `403 Resource not accessible by integration` when adding the eyes reaction with only `issues: write`.

## What changed
- `.github/workflows/ai-review-request.yml`: synchronized the canonical permission and acknowledgement correction.

## What was deliberately not changed
- No application code, model settings, Hermes runtime, review prompt, authorization grammar, secrets, or webhook payload changed.
- No automatic review was added; reviews still require an explicit `/review` comment.

## Deletion / consolidation
Removed the generic `continue-on-error` path. The reaction step now handles its own optional failure and emits one sanitized warning. The workflow remains byte-for-byte identical to the canonical infrastructure copy.

## Risk and rollback
The workflow token regains PR write permission for the reaction step. Webhook secrets remain scoped to the separate dispatch step, and no PR code is checked out or executed. Revert commit `71753ba42` to roll back, with the known consequence that eyes acknowledgement may fail again.

## Validation
- Eneo commit hooks — passed
- Eneo pre-push check — passed
- YAML validation through the canonical bundle — passed
- Embedded dispatch compile through the canonical bundle — passed
- `git diff --check` — passed
- Canonical/Eneo SHA-256 parity — `db6b40a1aefbfb9958c56e2ce0a425bb82e23c121be93cec27f8a11c0fab732c`

Peer-review automation was not used because the user explicitly requested no Claude loop.
