### PR TITLE
fix(models): surface encryption configuration errors

### DIFF
--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -40,6 +40,12 @@ else
     echo -e "${GREEN}${BOLD}All .env files found or created from templates!${NC} Please check the files for any missing variables."
 fi
 
+if [ -f "/workspace/backend/.env" ] && ! grep -Eq '^[[:space:]]*ENCRYPTION_KEY=[^[:space:]]+' "/workspace/backend/.env"; then
+    echo -e "${YELLOW}${BOLD}ENCRYPTION_KEY is empty.${NC} Saving provider credentials in Admin > Models will fail until it is configured."
+    echo "Generate one with: cd backend && uv run python -m eneo.cli.generate_encryption_key"
+    echo "Add the generated value to backend/.env, then restart the backend."
+fi
+
 echo ""
 echo -e "${BLUE}${BOLD}To run the project, use the following commands${NC}"
 echo ""

--- a/backend/.env.template
+++ b/backend/.env.template
@@ -161,6 +161,7 @@ OIDC_CLOCK_LEEWAY_SECONDS=120
 # ENCRYPTION_KEY is REQUIRED when enabling:
 #   - TENANT_CREDENTIALS_ENABLED=true (tenant-specific LLM API keys)
 #   - FEDERATION_PER_TENANT_ENABLED=true (tenant-specific IdPs)
+#   - Model provider management in Admin > Models
 #
 # ENCRYPTION_KEY is OPTIONAL but RECOMMENDED for:
 #   - Worker/crawler HTTP authentication for protected websites

--- a/backend/src/eneo/main/exceptions.py
+++ b/backend/src/eneo/main/exceptions.py
@@ -63,6 +63,8 @@ class ErrorCodes(int, Enum):
     SYSTEM_USER_PROTECTED = 9040
     # AI provider deterministically rejected the request (4xx upstream)
     PROVIDER_REJECTED_REQUEST = 9041
+    # Deployment configuration errors
+    ENCRYPTION_NOT_CONFIGURED = 9042
 
 
 class NotFoundException(Exception):
@@ -364,6 +366,10 @@ class APIKeyNotConfiguredException(Exception):
     pass
 
 
+class EncryptionNotConfiguredException(Exception):
+    pass
+
+
 class SystemUserProtected(Exception):
     """Raised when an admin path tries to delete or mutate a system user.
 
@@ -477,6 +483,11 @@ EXCEPTION_MAP = {
     ),
     TenantSuspendedException: (403, "Tenant is suspended", ErrorCodes.TENANT_SUSPENDED),
     APIKeyNotConfiguredException: (503, None, ErrorCodes.API_KEY_NOT_CONFIGURED),
+    EncryptionNotConfiguredException: (
+        503,
+        None,
+        ErrorCodes.ENCRYPTION_NOT_CONFIGURED,
+    ),
     # File extraction errors - use None to pass through the exception's own message
     ExtractionError: (400, None, ErrorCodes.FILE_EXTRACTION_ERROR),
     EncryptedFileError: (400, None, ErrorCodes.FILE_ENCRYPTED),

--- a/backend/src/eneo/model_providers/presentation/model_provider_router.py
+++ b/backend/src/eneo/model_providers/presentation/model_provider_router.py
@@ -391,7 +391,7 @@ async def get_provider(
     "/",
     response_model=ModelProviderPublic,
     description="Create a new model provider.",
-    responses=responses.get_responses([400, 403, 409]),
+    responses=responses.get_responses([400, 403, 409, 503]),
 )
 async def create_provider(
     data: ModelProviderCreate,
@@ -415,7 +415,7 @@ async def create_provider(
     "/{provider_id}/",
     response_model=ModelProviderPublic,
     description="Update an existing model provider.",
-    responses=responses.get_responses([403, 404, 409]),
+    responses=responses.get_responses([403, 404, 409, 503]),
 )
 async def update_provider(
     provider_id: UUID,
@@ -441,7 +441,7 @@ async def update_provider(
     description=(
         "List available models from the provider's API using its credentials."
     ),
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([404, 503]),
 )
 async def list_provider_models(
     provider_id: UUID,
@@ -466,7 +466,7 @@ async def list_provider_models(
     "/{provider_id}/test/",
     response_model=dict[str, Any],
     description="Test connectivity to a model provider.",
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([404, 503]),
 )
 async def test_provider(
     provider_id: UUID,
@@ -482,7 +482,7 @@ async def test_provider(
     description=(
         "Validate that a model works with this provider by making a minimal API call."
     ),
-    responses=responses.get_responses([404]),
+    responses=responses.get_responses([404, 503]),
 )
 async def validate_model(
     provider_id: UUID,

--- a/backend/src/eneo/model_providers/presentation/model_provider_router.py
+++ b/backend/src/eneo/model_providers/presentation/model_provider_router.py
@@ -119,7 +119,7 @@ ServiceDep = Annotated[ModelProviderService, Depends(get_model_provider_service)
     "/",
     response_model=list[ModelProviderPublic],
     description="List all model providers for the tenant.",
-    responses=responses.get_responses([403]),
+    responses=responses.get_responses([403, 503]),
 )
 async def list_providers(
     user: CurrentUser,
@@ -374,7 +374,7 @@ async def get_model_defaults(
 @router.get(
     "/{provider_id}/",
     response_model=ModelProviderPublic,
-    responses=responses.get_responses([403, 404]),
+    responses=responses.get_responses([403, 404, 503]),
 )
 async def get_provider(
     provider_id: UUID,
@@ -497,7 +497,7 @@ async def validate_model(
     "/{provider_id}/",
     response_model=dict[str, str],
     description="Delete a model provider.",
-    responses=responses.get_responses([400, 403, 404]),
+    responses=responses.get_responses([400, 403, 404, 503]),
 )
 async def delete_provider(
     provider_id: UUID,

--- a/backend/src/eneo/settings/encryption_service.py
+++ b/backend/src/eneo/settings/encryption_service.py
@@ -9,6 +9,7 @@ from typing import Optional, Protocol, Union
 from cryptography.fernet import Fernet, InvalidToken
 from typing_extensions import override
 
+from eneo.main.exceptions import EncryptionNotConfiguredException
 from eneo.main.logging import get_logger
 
 logger = get_logger(__name__)
@@ -22,6 +23,10 @@ class EncryptionService:
 
     VERSION_PREFIX = "enc:fernet:v1:"
     MAX_CREDENTIAL_LENGTH = 10240  # 10KB - reasonable limit for API keys
+    NOT_CONFIGURED_MESSAGE = (
+        "Credential encryption is not configured. Set ENCRYPTION_KEY and restart "
+        "the backend."
+    )
 
     class _HasEncryptionKey(Protocol):
         encryption_key: Optional[str]
@@ -60,8 +65,10 @@ class EncryptionService:
             self._fernet = Fernet(key_value.encode())
             logger.debug("Encryption service initialized")
         except Exception as e:
-            logger.error(f"Invalid encryption key: {e}")
-            raise ValueError(f"ENCRYPTION_KEY must be valid Fernet key: {e}")
+            raise EncryptionNotConfiguredException(
+                "Credential encryption is unavailable because ENCRYPTION_KEY is "
+                "invalid. Generate a valid Fernet key and restart the backend."
+            ) from e
 
     def is_active(self) -> bool:
         """Check if encryption is enabled."""
@@ -87,10 +94,11 @@ class EncryptionService:
             Versioned encrypted string: enc:fernet:v1:<ciphertext>
 
         Raises:
-            ValueError: If encryption not configured or plaintext too long
+            EncryptionNotConfiguredException: If encryption is not configured
+            ValueError: If plaintext is too long
         """
         if not self._fernet:
-            raise ValueError("Encryption not configured")
+            raise EncryptionNotConfiguredException(self.NOT_CONFIGURED_MESSAGE)
 
         if not plaintext:
             raise ValueError("Cannot encrypt empty string")
@@ -118,7 +126,10 @@ class EncryptionService:
             Decrypted plaintext API key
 
         Raises:
-            ValueError: If decryption fails, version unsupported, or plaintext when encryption is required
+            EncryptionNotConfiguredException: If encrypted data exists but
+                encryption is not configured
+            ValueError: If decryption fails, the version is unsupported, or
+                plaintext is provided when encryption is required
         """
         if not ciphertext:
             raise ValueError("Cannot decrypt empty string")
@@ -150,10 +161,7 @@ class EncryptionService:
             )
 
         if not self._fernet:
-            raise ValueError(
-                "Cannot decrypt: encryption key not configured. "
-                "Set ENCRYPTION_KEY environment variable."
-            )
+            raise EncryptionNotConfiguredException(self.NOT_CONFIGURED_MESSAGE)
 
         try:
             decrypted_bytes = self._fernet.decrypt(token.encode())

--- a/backend/tests/unittests/model_providers/test_model_provider_encryption_errors.py
+++ b/backend/tests/unittests/model_providers/test_model_provider_encryption_errors.py
@@ -1,0 +1,30 @@
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from eneo.main.exceptions import EncryptionNotConfiguredException
+from eneo.model_providers.domain.model_provider_service import ModelProviderService
+from eneo.settings.encryption_service import EncryptionService
+
+
+@pytest.mark.asyncio
+async def test_create_provider_without_encryption_key_fails_before_persistence():
+    repository = MagicMock()
+    repository.get_by_name = AsyncMock(return_value=None)
+    repository.create = AsyncMock()
+    service = ModelProviderService(
+        repository=repository,
+        encryption=EncryptionService(None),
+    )
+
+    with pytest.raises(EncryptionNotConfiguredException, match="ENCRYPTION_KEY"):
+        await service.create(
+            tenant_id=uuid4(),
+            name="OpenAI",
+            provider_type="openai",
+            credentials={"api_key": "sk-test-key"},
+            config={},
+        )
+
+    repository.create.assert_not_awaited()

--- a/backend/tests/unittests/model_providers/test_model_provider_encryption_errors.py
+++ b/backend/tests/unittests/model_providers/test_model_provider_encryption_errors.py
@@ -1,10 +1,19 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
-from eneo.main.exceptions import EncryptionNotConfiguredException
+from eneo.authentication.auth_dependencies import get_current_active_user
+from eneo.database.database import get_session_with_transaction
+from eneo.main.config import reset_settings
+from eneo.main.exceptions import EncryptionNotConfiguredException, ErrorCodes
 from eneo.model_providers.domain.model_provider_service import ModelProviderService
+from eneo.model_providers.presentation.model_provider_router import router
+from eneo.roles.permissions import Permission
+from eneo.server.exception_handlers import add_exception_handlers
 from eneo.settings.encryption_service import EncryptionService
 
 
@@ -28,3 +37,41 @@ async def test_create_provider_without_encryption_key_fails_before_persistence()
         )
 
     repository.create.assert_not_awaited()
+
+
+def test_all_service_dependent_provider_routes_document_configuration_503(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENCRYPTION_KEY", "malformed-key")
+    reset_settings()
+
+    app = FastAPI()
+    app.include_router(router, prefix="/model-providers")
+    add_exception_handlers(app)
+    app.dependency_overrides[get_current_active_user] = lambda: SimpleNamespace(
+        tenant_id=uuid4(), permissions=[Permission.ADMIN]
+    )
+    app.dependency_overrides[get_session_with_transaction] = lambda: MagicMock()
+
+    try:
+        response = TestClient(app, raise_server_exceptions=False).get(
+            "/model-providers/"
+        )
+    finally:
+        reset_settings()
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["eneo_error_code"] == ErrorCodes.ENCRYPTION_NOT_CONFIGURED
+    assert "ENCRYPTION_KEY is invalid" in payload["message"]
+
+    openapi = app.openapi()
+    for path, method in (
+        ("/model-providers/", "get"),
+        ("/model-providers/{provider_id}/", "get"),
+        ("/model-providers/{provider_id}/", "delete"),
+    ):
+        response_schema = openapi["paths"][path][method]["responses"]["503"]
+        assert response_schema["content"]["application/json"]["schema"] == {
+            "$ref": "#/components/schemas/GeneralError"
+        }

--- a/backend/tests/unittests/server/test_exception_handlers.py
+++ b/backend/tests/unittests/server/test_exception_handlers.py
@@ -1,9 +1,12 @@
+import logging
+
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from sqlalchemy.exc import IntegrityError
 
 from eneo.main.exceptions import (
     BadRequestException,
+    EncryptionNotConfiguredException,
     ErrorCodes,
     FileTooLargeException,
 )
@@ -131,3 +134,27 @@ def test_exception_handler_omits_details_for_exceptions_without_details():
     assert body["message"] == "Bad input"
     assert body["eneo_error_code"] == ErrorCodes.BAD_REQUEST
     assert "details" not in body
+
+
+def test_encryption_not_configured_returns_actionable_503_and_logs_it(caplog):
+    app = FastAPI()
+    add_exception_handlers(app)
+
+    @app.post("/providers")
+    async def create_provider():
+        raise EncryptionNotConfiguredException(
+            "Credential encryption is not configured. Set ENCRYPTION_KEY and "
+            "restart the backend."
+        )
+
+    with caplog.at_level(logging.ERROR, logger="eneo.server.exception_handlers"):
+        response = TestClient(app, raise_server_exceptions=False).post("/providers")
+
+    assert response.status_code == 503
+    assert response.json()["eneo_error_code"] == ErrorCodes.ENCRYPTION_NOT_CONFIGURED
+    assert response.json()["message"] == (
+        "Credential encryption is not configured. Set ENCRYPTION_KEY and restart "
+        "the backend."
+    )
+    assert "POST /providers → 503" in caplog.text
+    assert "ENCRYPTION_KEY" in caplog.text

--- a/backend/tests/unittests/settings/test_encryption_service_initialization.py
+++ b/backend/tests/unittests/settings/test_encryption_service_initialization.py
@@ -30,6 +30,7 @@ from unittest.mock import patch
 import pytest
 
 from eneo.main.container.container import Container
+from eneo.main.exceptions import EncryptionNotConfiguredException
 from eneo.settings.encryption_service import EncryptionService
 
 
@@ -50,8 +51,9 @@ class TestEncryptionServiceInitialization:
             clear=False,  # Keep other env vars
         ):
             # Need to reload settings module to pick up new env vars
-            from eneo.main import config
             from importlib import reload
+
+            from eneo.main import config
 
             reload(config)
 
@@ -78,6 +80,15 @@ class TestEncryptionServiceInitialization:
 
         assert service.decrypt("sk-legacy-plaintext") == "sk-legacy-plaintext"
 
+    def test_decrypt_encrypted_value_without_key_raises_configuration_error(self):
+        configured_service = EncryptionService(
+            "FNVdDyfq0lBPAvjz_WS-9PB2UQzkbqCnwuA4KU9UbPU="
+        )
+        ciphertext = configured_service.encrypt("sk-test-key")
+
+        with pytest.raises(EncryptionNotConfiguredException, match="ENCRYPTION_KEY"):
+            EncryptionService(None).decrypt(ciphertext)
+
     def test_encryption_service_inactive_when_initialized_without_key(self):
         """Test EncryptionService is inactive when initialized without a key."""
         # Create service directly without key
@@ -86,10 +97,23 @@ class TestEncryptionServiceInitialization:
         # Assert: Service should be inactive
         assert not service.is_active()
 
+    def test_encrypt_without_key_raises_typed_configuration_error(self):
+        service = EncryptionService(None)
+
+        with pytest.raises(EncryptionNotConfiguredException) as exc_info:
+            service.encrypt("sk-test-key")
+
+        assert str(exc_info.value) == (
+            "Credential encryption is not configured. Set ENCRYPTION_KEY and "
+            "restart the backend."
+        )
+
     def test_encryption_service_fails_on_invalid_fernet_key(self):
-        """Test EncryptionService raises error with invalid Fernet key."""
-        # Act & Assert: Invalid key should raise ValueError
-        with pytest.raises(ValueError, match="ENCRYPTION_KEY must be valid Fernet key"):
+        """Test EncryptionService raises a typed error with an invalid Fernet key."""
+        with pytest.raises(
+            EncryptionNotConfiguredException,
+            match="ENCRYPTION_KEY is invalid",
+        ):
             EncryptionService("invalid-not-base64-fernet-key")
 
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -39,9 +39,18 @@ When VS Code opens:
 
 ### Step 3: Configure Environment
 
-Now edit `backend/.env` and add your AI provider key:
+Generate an encryption key before saving provider credentials in the admin UI:
 
 ```bash
+cd backend
+uv run python -m eneo.cli.generate_encryption_key
+```
+
+Add the generated value and your AI provider key to `backend/.env`:
+
+```bash
+ENCRYPTION_KEY=<generated-44-character-key>
+
 # Example for OpenAI
 OPENAI_API_KEY=sk-proj-your-actual-key-here
 

--- a/docs/deployment/env_backend.template
+++ b/docs/deployment/env_backend.template
@@ -122,6 +122,7 @@ OIDC_CLOCK_LEEWAY_SECONDS=120
 # ENCRYPTION_KEY is REQUIRED when enabling:
 #   - TENANT_CREDENTIALS_ENABLED=true (tenant-specific LLM API keys)
 #   - FEDERATION_PER_TENANT_ENABLED=true (tenant-specific IdPs)
+#   - Model provider management in Admin > Models
 #
 # Generate key:
 #   Development: uv run python -m eneo.cli.generate_encryption_key

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -625,6 +625,7 @@
   "eneo_error_9035": "The assistant's model does not meet this space's security classification requirements.",
   "eneo_error_9036": "An external tool service is temporarily unavailable. Please try again later.",
   "eneo_error_9037": "An external tool service rejected the connection credentials. Contact your administrator to verify the server configuration.",
+  "eneo_error_9042": "Credential encryption is not configured. Ask a system administrator to set ENCRYPTION_KEY and restart the backend.",
   "exit_fullscreen": "Exit fullscreen",
   "export": "Export",
   "export_data": "Export Data",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -622,6 +622,7 @@
   "eneo_error_9035": "Assistentens modell uppfyller inte ytans krav på säkerhetsklassning.",
   "eneo_error_9036": "En extern verktygstjänst är tillfälligt otillgänglig. Försök igen senare.",
   "eneo_error_9037": "En extern verktygstjänst avvisade anslutningsuppgifterna. Kontakta din administratör för att verifiera serverkonfigurationen.",
+  "eneo_error_9042": "Kryptering av anslutningsuppgifter är inte konfigurerad. Be en systemadministratör att ange ENCRYPTION_KEY och starta om backend.",
   "exit_fullscreen": "Avsluta helskärm",
   "export": "Exportera",
   "export_data": "Exportera data",

--- a/frontend/apps/web/src/lib/core/errors/getErrorMessage.test.ts
+++ b/frontend/apps/web/src/lib/core/errors/getErrorMessage.test.ts
@@ -1,0 +1,28 @@
+import { EneoError } from "@eneo/eneo-js";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("$lib/paraglide/messages", () => ({
+  m: {
+    eneo_error_9042: () => "Credential encryption must be configured before saving secrets.",
+    request_failed: () => "Request failed."
+  }
+}));
+
+import { getErrorMessage } from "./getErrorMessage";
+
+describe("getErrorMessage", () => {
+  it("localizes missing credential encryption configuration", () => {
+    const error = new EneoError(
+      "Backend fallback",
+      "RESPONSE",
+      503,
+      9042,
+      {},
+      { endpoint: "POST@/api/v1/admin/model-providers/" }
+    );
+
+    expect(getErrorMessage(error)).toBe(
+      "Credential encryption must be configured before saving secrets."
+    );
+  });
+});

--- a/frontend/apps/web/src/lib/core/errors/getErrorMessage.ts
+++ b/frontend/apps/web/src/lib/core/errors/getErrorMessage.ts
@@ -37,6 +37,7 @@ const ERROR_CODE_MESSAGES: Record<number, () => string> = {
   9036: () => m.eneo_error_9036(), // MCP_UPSTREAM_ERROR
   9037: () => m.eneo_error_9037(), // MCP_UPSTREAM_AUTH_ERROR
   9017: () => m.eneo_error_9017(), // NAME_COLLISION (duplicate display name)
+  9042: () => m.eneo_error_9042(), // ENCRYPTION_NOT_CONFIGURED
 
   // --- AI service errors ---
   9008: () => m.eneo_error_9008(), // QUOTA_EXCEEDED

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/AddWizard.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/AddWizard.svelte
@@ -284,9 +284,8 @@
         if (!result.success && result.error) {
           warnings.push(`${model.name}: ${result.error}`);
         }
-      } catch {
-        // Validation endpoint failure is non-fatal — we'll let the create
-        // call surface a real error if there is one.
+      } catch (error: unknown) {
+        warnings.push(`${model.name}: ${getErrorMessage(error)}`);
       }
     }
     return warnings;

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepCredentials.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/StepCredentials.svelte
@@ -15,7 +15,7 @@
   import { getEneo } from "$lib/core/Eneo";
   import { m } from "$lib/paraglide/messages";
   import { toast } from "$lib/components/toast";
-  import { toastError } from "$lib/core/errors";
+  import { getErrorMessage, toastError } from "$lib/core/errors";
 
   import { Input } from "$lib/components/ui/input/index.js";
   import { Button } from "$lib/components/ui/button/index.js";
@@ -109,7 +109,7 @@
       toast.success(m.provider_created_success());
       onComplete({ providerId: provider.id });
     } catch (e: unknown) {
-      error = e instanceof Error ? e.message : m.failed_to_create_provider();
+      error = getErrorMessage(e);
       toastError(e, m.failed_to_create_provider());
     } finally {
       isSubmitting = false;

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/models/ModelDraftList.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/models/ModelDraftList.svelte
@@ -7,10 +7,12 @@
 -->
 
 <script lang="ts">
+  import { EneoError } from "@eneo/eneo-js";
   import { Loader2, CircleCheck, CircleX, Zap, Trash2 } from "lucide-svelte";
   import { Button } from "$lib/components/ui/button/index.js";
   import { m } from "$lib/paraglide/messages";
   import { getEneo } from "$lib/core/Eneo";
+  import { getErrorMessage } from "$lib/core/errors";
   import type { WizardModelDraft } from "../wizardState";
   import type { ModelType } from "./draft";
 
@@ -52,10 +54,14 @@
           ? { status: "success", message: m.model_test_success() }
           : { status: "error", message: result.error || m.model_test_failed() }
       };
-    } catch {
+    } catch (error: unknown) {
       validationStates = {
         ...validationStates,
-        [index]: { status: "error", message: m.model_test_connection_error() }
+        [index]: {
+          status: "error",
+          message:
+            error instanceof EneoError ? getErrorMessage(error) : m.model_test_connection_error()
+        }
       };
     }
   }

--- a/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/models/loadModels.ts
+++ b/frontend/apps/web/src/routes/(app)/admin/models/AddWizard/models/loadModels.ts
@@ -11,6 +11,7 @@
  *   3. Some providers (Azure) cannot list models at all; we skip both.
  */
 import type { Eneo } from "@eneo/eneo-js";
+import { getErrorMessage } from "$lib/core/errors";
 import {
   NO_SUGGESTIONS_PROVIDERS,
   type ModelProviderCapabilities
@@ -66,8 +67,8 @@ export async function loadLiveModels(
     }));
 
     return { models, error: null };
-  } catch {
-    return { models: [], error: "Could not fetch models from provider" };
+  } catch (error: unknown) {
+    return { models: [], error: getErrorMessage(error) };
   }
 }
 

--- a/frontend/apps/web/src/routes/(app)/admin/models/ProviderDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/ProviderDialog.svelte
@@ -20,7 +20,7 @@
   import { getEneo } from "$lib/core/Eneo";
   import { m } from "$lib/paraglide/messages";
   import { toast } from "$lib/components/toast";
-  import { toastError } from "$lib/core/errors";
+  import { getErrorMessage, toastError } from "$lib/core/errors";
 
   import * as Dialog from "$lib/components/ui/dialog/index.js";
   import * as Field from "$lib/components/ui/field/index.js";
@@ -172,7 +172,7 @@
       toast.success(m.provider_updated_success());
       dialogOpen = false;
     } catch (e: unknown) {
-      error = e instanceof Error ? e.message : m.failed_to_update_provider();
+      error = getErrorMessage(e);
       toastError(e, m.failed_to_update_provider());
     } finally {
       isSubmitting = false;

--- a/frontend/packages/eneo-js/src/types/schema.d.ts
+++ b/frontend/packages/eneo-js/src/types/schema.d.ts
@@ -10929,7 +10929,8 @@ export interface components {
       | 9038
       | 9039
       | 9040
-      | 9041;
+      | 9041
+      | 9042;
     /**
      * ExpiringKeySummaryItem
      * @description Lightweight summary of a single expiring API key.
@@ -30496,6 +30497,15 @@ export interface operations {
           "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
+      /** @description Service Unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   get_provider_capabilities_api_v1_admin_model_providers_capabilities__get: {
@@ -30721,6 +30731,15 @@ export interface operations {
           "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
+      /** @description Service Unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   delete_provider_api_v1_admin_model_providers__provider_id___delete: {
@@ -30826,6 +30845,15 @@ export interface operations {
           "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
+      /** @description Service Unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   test_provider_api_v1_admin_model_providers__provider_id__test__post: {
@@ -30866,6 +30894,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Service Unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
     };
@@ -30912,6 +30949,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Service Unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
     };

--- a/frontend/packages/eneo-js/src/types/schema.d.ts
+++ b/frontend/packages/eneo-js/src/types/schema.d.ts
@@ -30437,6 +30437,15 @@ export interface operations {
           "application/json": components["schemas"]["GeneralError"];
         };
       };
+      /** @description Service Unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   create_provider_api_v1_admin_model_providers__post: {
@@ -30669,6 +30678,15 @@ export interface operations {
           "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
+      /** @description Service Unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
     };
   };
   update_provider_api_v1_admin_model_providers__provider_id___put: {
@@ -30798,6 +30816,15 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+      /** @description Service Unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
         };
       };
     };


### PR DESCRIPTION
## Summary

- Return a typed, actionable `503` when credential encryption is missing or invalid.
- Show localized Swedish and English guidance throughout the model-provider admin flow.
- Warn developers during devcontainer startup and document the required setup.
- Surface provider validation failures that were previously discarded.

## Why

Missing `ENCRYPTION_KEY` was an expected deployment/configuration failure, but it escaped as an untyped `ValueError`. The API therefore returned a generic 500, logs lacked a stable error code, and the frontend could only show “Upstream server error.”

`EncryptionService` remains the source of truth for encryption availability, while the central API error adapter owns the HTTP/logging contract and the frontend error mapper owns localized presentation. Unexpected 500 responses remain sanitized.

## What changed

- Added `EncryptionNotConfiguredException` and error code `9042`, mapped centrally to an actionable `503`.
- Declared the 503 contract on affected provider endpoints and regenerated `@eneo/eneo-js` schema types.
- Reused `getErrorMessage` for provider create/edit/list/test/validation failures.
- Added devcontainer, environment-template, and installation guidance.
- Added service, exception-adapter, and frontend error-mapping tests.

## What was deliberately not changed

- No blanket exposure of raw 500 messages.
- No new error framework, middleware layer, dependency, database change, or provider-flow redesign.
- Unrelated integration/runtime failures remain out of scope and should be typed at their canonical owners when encountered.

## Deletion / consolidation

Provider UI paths now reuse the existing centralized error mapper instead of presenting raw SDK messages. A silent catch in model validation was removed. No compatibility path was deleted.

## Risk and rollback

Low API/frontend risk: this changes a previously unhandled configuration failure from 500 to 503 and adds one generated error-code member. Existing unexpected failures retain current behavior. Rollback is a single commit revert; no data or schema recovery is needed.

## Planning

- Task: Fixes #563
- Parent epic: #562
- Peer review was not run at the user's explicit request.

## Validation

- `30 passed`: focused encryption service, route/OpenAPI contract, exception adapter, provider service, and provider model-list backend tests.
- `pyright --pythonpath .venv/bin/python ...`: 0 errors.
- Ruff check/format, route metadata, schema drift/generated client comparison: passed.
- i18n duplicate/parity checks, Prettier, ESLint, and `svelte-check`: passed with 0 errors/warnings.
- Focused frontend error-mapper test: passed.
- Full frontend unit run: 210/211 passed; one unrelated knowledge-list browser test failed during a Vite dependency reload and passed immediately when rerun in isolation.
- Commit and pre-push hooks: passed.

## Screenshots

Not captured: the UI change is localized error copy for the reported failure path, and reproducing it requires a deliberately missing backend encryption key.