### PR TITLE
fix(ci): authenticate SeaweedFS attestation verification

### DIFF
--- a/.github/workflows/build_and_push_images.yml
+++ b/.github/workflows/build_and_push_images.yml
@@ -598,6 +598,7 @@ jobs:
 
       - name: Independently verify registry provenance and SBOM attestations
         env:
+          GH_TOKEN: ${{ github.token }}
           IMAGE: ${{ env.REGISTRY }}/${{ env.SEAWEEDFS_IMAGE_NAME }}
           MANIFEST_DIGEST: ${{ steps.manifest.outputs.manifest-digest }}
         run: |

--- a/.github/workflows/release_sbom.yml
+++ b/.github/workflows/release_sbom.yml
@@ -393,6 +393,7 @@ jobs:
 
       - name: Verify SeaweedFS provenance and platform SBOM attestations
         env:
+          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Why

The post-merge SeaweedFS publication job created the images and attestations, then failed because `gh attestation verify` had no `GH_TOKEN`. The release verification step had the same latent failure.

## What

Pass `github.token` only to the two attestation-verification steps. No image, publishing, or permission behavior changes.

Validated with targeted token assertions, YAML parsing, diff checks, and repository commit/push hooks.
