### PR TITLE
docs: make object content storage easier to operate

### DIFF
--- a/frontend/apps/docs-site/src/content/docs/_meta.ts
+++ b/frontend/apps/docs-site/src/content/docs/_meta.ts
@@ -4,6 +4,7 @@ const meta: MetaRecord = {
   index: "Overview",
   "getting-started": "Getting Started",
   architecture: "Architecture",
+  "object-content-architecture": "Object Content Architecture",
   "audit-logging": "Audit Logging",
   "api-key-management": "API Key Management",
   "release-sboms": "Release SBOMs",

--- a/frontend/apps/docs-site/src/content/docs/architecture.mdx
+++ b/frontend/apps/docs-site/src/content/docs/architecture.mdx
@@ -179,7 +179,7 @@ LIMIT 5;
 
 ### Durable Object Content
 
-Durable file data is split across two canonical owners:
+Durable file data has two canonical owners:
 
 | PostgreSQL control plane | Private S3-compatible byte plane |
 | --- | --- |
@@ -188,70 +188,19 @@ Durable file data is split across two canonical owners:
 | Concrete authorization references, holds, and retention | Full extracted text or transcription when it is not a bounded searchable fact |
 | Audit and bounded reconciliation/query facts | No authorization, tenant routing, or lifecycle decisions |
 
-PostgreSQL retains bounded text/search facts that must be queried or indexed.
-Large or complete variants live only in object storage. Object keys are opaque
-and deployment-scoped; filenames and tenant identifiers are not encoded into
-them. Ordinary APIs never expose endpoint, bucket, key, or provider details.
+PostgreSQL records durable intent before remote work. Eneo verifies the
+PostgreSQL-owned SHA-256 before returning full or range responses, and a bounded
+reconciler resolves process and network failures. A durable binding prevents a
+database from silently adopting the wrong bucket.
 
 The application uses one vendor-neutral S3-compatible contract. The reference
-deployment bundles an Eneo-built and attested SeaweedFS image. Self-hosted or
-European-operated compatible endpoints, including externally operated MinIO,
-use the same configuration and conformance tests—there is no provider plugin,
-product-code branch, or Amazon service dependency.
+deployment bundles an Eneo-built and attested SeaweedFS image; external
+endpoints such as MinIO use the same path.
 
-Uploads, deletes, and reconciliation follow the finite lifecycle `pending` →
-`available`/`failed` → `retained` or `delete_pending` → `tombstoned`. PostgreSQL
-records durable intent before remote work, and a bounded reconciler resolves
-process/network crash interleavings. Canonical full-byte SHA-256 is computed by
-Eneo while streaming; ETag, CRC, and multipart composite checksums are never the
-canonical digest.
-
-Retention is enforced at the database boundary as well as in the reconciler.
-Active holds and retained content reject hard deletion. A tombstone can be
-purged only when its database-owned purge horizon is present and has elapsed;
-no horizon means retain it. Deleting the account that created a hold removes
-only that attribution—the hold and content lifecycle remain unchanged.
-
-Reads are trusted only after Eneo recomputes that canonical digest. Full and
-single-range responses therefore perform one bounded-memory full read into a
-temporary spool before emitting bytes; a range is sliced from the verified
-spool. This is linear in object size and may use temporary disk beyond the
-configured memory threshold, avoiding both unverified partial responses and an
-unbounded memory allocation.
-
-PostgreSQL and the byte plane also share one durable deployment binding.
-Startup, readiness, and every reconciliation run verify the private bucket
-marker before any lifecycle or orphan mutation. A reachable empty or foreign
-bucket returns `configuration_required`; Eneo neither adopts it nor marks live
-rows missing.
-
-First-start pairing is serialized by a bounded PostgreSQL claim. Only its owner
-may conditionally create the non-overwriting marker; competing API or worker
-processes stay unready and then verify the confirmed pair. Crash recovery reuses
-an existing marker, while a recorded-but-missing marker fails closed as an
-ambiguous outcome instead of creating a second byte plane. PostgreSQL also uses
-a deferred commit-time fence so every new `pending` record has its first
-concrete File, InfoBlob, or Icon reference in the creation transaction.
-
-Reconciliation accepts an inventory cycle only when every page has a complete,
-advancing cursor. An invalid page fails the run before PostgreSQL records a
-completed cycle. A complete cycle marks absent available content failed; held
-or otherwise retained content stays retained while health reports the missing
-bytes. A truncated multipart page must provide an advancing next-key and
-next-upload-ID marker pair.
-
-The platform foundation does not itself cut existing File, InfoBlob, Icon, or
-Flow producers over to the new owner. Those migrations are separate vertical
-slices so each producer can copy and verify bytes before deleting its previous
-authority.
-
-Until a producer adopts the foundation, a deployment may omit every
-`OBJECT_CONTENT_*` setting and run with an explicit disabled capability. A
-partial configuration fails startup. Disabled is healthy only while PostgreSQL
-contains no non-tombstoned object-content rows; otherwise startup and readiness
-fail closed so reconciliation or deletion cannot be silently suspended. Once a
-record exists, the S3-compatible byte plane remains mandatory. This deployment
-capability is intentionally not a tenant or administrator toggle.
+Read [Object Content Architecture](/docs/object-content-architecture) for the
+complete lifecycle, integrity, reconciliation, binding, and image publication
+design. The [Object Content Storage guide](/guides/object-content-storage)
+covers deployment and operations.
 
 ---
 

--- a/frontend/apps/docs-site/src/content/docs/index.mdx
+++ b/frontend/apps/docs-site/src/content/docs/index.mdx
@@ -23,6 +23,13 @@ Understand how Eneo is built:
 - Authentication and authorization
 - Real-time communication (SSE, WebSockets)
 
+### [Object Content Architecture](/docs/object-content-architecture)
+Understand how Eneo stores and protects durable file bytes:
+- PostgreSQL control plane and S3-compatible byte plane
+- Integrity, lifecycle, retention, and reconciliation
+- Database/bucket binding and failure behavior
+- SeaweedFS image build, provenance, and SBOM attestations
+
 ### [Audit Logging](/docs/audit-logging)
 Audit trails for compliance and security:
 - How audit logs are created and stored

--- a/frontend/apps/docs-site/src/content/docs/object-content-architecture.mdx
+++ b/frontend/apps/docs-site/src/content/docs/object-content-architecture.mdx
@@ -1,0 +1,190 @@
+# Object Content Architecture
+
+Eneo separates durable content identity from durable bytes. PostgreSQL is the
+control plane. A private S3-compatible bucket is the byte plane. This boundary
+keeps authorization and lifecycle decisions in typed application data while
+allowing operators to choose a compatible storage service.
+
+import { Callout } from "nextra/components";
+
+<Callout type="info">
+  Looking for deployment steps? Start with the [Object Content Storage
+  guide](/guides/object-content-storage).
+</Callout>
+
+## Ownership boundary
+
+| PostgreSQL control plane                              | S3-compatible byte plane                           |
+| ----------------------------------------------------- | -------------------------------------------------- |
+| Content identity and lifecycle state                  | Original and derived byte streams                  |
+| Authorization references, holds, and retention        | Opaque objects addressed by deployment-scoped keys |
+| Canonical SHA-256, exact size, and media type         | S3 protocol checksums and ETags                    |
+| Durable intent, audit facts, and reconciliation state | Multipart state and deletion visibility            |
+
+The bucket never decides who may read content or when Eneo may delete it.
+Object keys contain neither filenames nor organization identifiers, and
+ordinary APIs return neither endpoint, bucket, key, nor provider details.
+
+```mermaid
+flowchart LR
+  client[Client] --> api[Backend API]
+  api --> service[Object-content lifecycle]
+  worker[Worker and reconciler] --> service
+  service --> postgres[(PostgreSQL\ncontrol plane)]
+  service --> s3[(Private S3-compatible\nbyte plane)]
+  postgres -. durable intent and identity .-> service
+  s3 -. byte stream and inventory .-> service
+```
+
+## Write, read, and delete invariants
+
+Eneo records durable PostgreSQL intent before remote object-store work. Uploads
+compute the canonical full-byte SHA-256 while streaming. S3 ETags, CRCs, and
+multipart composite checksums help with transport, but they never replace that
+digest.
+
+Eneo verifies the full object against the PostgreSQL digest before returning
+bytes. A range response also verifies and spools the full object before slicing
+the requested interval. Memory use stays bounded; larger objects use temporary
+disk. Operators must therefore size temporary storage for the largest allowed
+object multiplied by measured concurrent reads and uploads.
+
+Deletion starts with irreversible PostgreSQL intent. Holds and retention block
+hard deletion. A tombstone becomes purgeable only after its database-owned
+purge time exists and has passed. Missing purge time means retain, not delete.
+
+```mermaid
+stateDiagram-v2
+  [*] --> pending
+  pending --> available: upload verified
+  pending --> failed: upload cannot converge
+  available --> retained: hold or retention applies
+  available --> delete_pending: final reference removed
+  failed --> delete_pending: cleanup requested
+  retained --> delete_pending: retention and holds released
+  delete_pending --> tombstoned: remote deletion observed
+  tombstoned --> [*]: purge horizon passed
+```
+
+## Crash recovery and reconciliation
+
+Network and process failures can interrupt the gap between a committed intent
+and remote work. Bounded leases, idempotent retries, multipart abort records,
+and a queue-neutral reconciler close that gap. The current worker schedules the
+reconciler with ARQ, but the lifecycle code does not depend on ARQ.
+
+The reconciler trusts an inventory only after every page returns a complete,
+advancing cursor. An invalid or non-advancing page fails the run before Eneo
+marks unseen rows missing. A complete scan can mark absent available content as
+failed; retained content stays retained while health reports missing bytes.
+
+Unknown remote objects become orphan candidates. Eneo waits through repeated
+complete inventories and the configured grace period before deletion. This
+protects bytes that are newer than a restored PostgreSQL snapshot.
+
+## Database and bucket binding
+
+PostgreSQL and the bucket share one random deployment binding. On first start,
+PostgreSQL grants one process a bounded claim. That process records creation
+intent, creates a non-overwriting marker in the bucket, and confirms the pair
+in PostgreSQL. Other API and worker processes wait, then verify the confirmed
+pair.
+
+Startup, readiness, and reconciliation all verify this binding before mutating
+content. Eneo does not adopt a reachable empty or foreign bucket. A missing or
+mismatched marker yields `configuration_required`, which forces an operator to
+restore the matching database and byte-store pair instead of silently accepting
+data loss.
+
+`OBJECT_CONTENT_DEPLOYMENT_ID` adds a stable namespace to opaque object keys.
+Operators generate it once and preserve it through upgrades and restores. It is
+not a feature toggle, credential, or migration mechanism.
+
+## Provider-independent contract
+
+The application has one S3-compatible adapter. The bundled SeaweedFS service,
+external MinIO, and other endpoints use the same path. There is no provider
+registry or Amazon-specific product branch.
+
+The supported contract includes:
+
+- SigV4 authentication with path or virtual-host addressing;
+- paginated object and multipart inventories;
+- single-part and multipart writes;
+- `HEAD`, streaming `GET`, and one byte range;
+- multipart completion, abort, and ordered part listing;
+- deletion with observable not-found convergence.
+
+Native range support remains an endpoint conformance requirement even though
+Eneo verifies a full read before serving a range.
+
+## Why the reference deployment uses SeaweedFS
+
+The Docker Compose stack needs a private S3-compatible byte plane that can run
+beside the backend and worker without adding a public service. SeaweedFS fits
+that reference role and supports the required protocol subset. It does not
+become an application dependency: an operator can replace it with any endpoint
+that passes the same contract.
+
+The bundled service is intentionally single-node. Organizations that require
+multi-node availability should operate an external service with their standard
+redundancy, encryption, capacity, and disaster-recovery controls.
+
+## Image build and publication
+
+Eneo builds the reference image from a pinned SeaweedFS source archive rather
+than republishing an upstream container image. The build uses pinned builder
+and distroless runtime image digests, compiles a static binary, and runs as a
+non-root user.
+
+```mermaid
+flowchart TD
+  source[Pinned SeaweedFS source archive] --> sourcePolicy[Source hash, license, and Go vulnerability policy]
+  sourcePolicy --> buildAMD[Build linux/amd64]
+  sourcePolicy --> buildARM[Build linux/arm64]
+  buildAMD --> verifyAMD[Smoke test, SBOM, image scan]
+  buildARM --> verifyARM[Smoke test, SBOM, image scan]
+  verifyAMD --> attestAMD[Platform provenance and SPDX attestation]
+  verifyARM --> attestARM[Platform provenance and SPDX attestation]
+  attestAMD --> manifest[Multi-platform manifest]
+  attestARM --> manifest
+  manifest --> manifestAttest[Manifest provenance attestation]
+  manifestAttest --> registryVerify[Independent registry verification]
+  registryVerify --> release[Release digest and SBOM assets]
+```
+
+The build workflow performs these checks before publication:
+
+1. It verifies the pinned source archive and the expected upstream commit.
+2. It checks the Go module graph, licenses, and source vulnerability policy.
+3. It builds and smoke-tests separate `linux/amd64` and `linux/arm64` images.
+4. It scans the image, generates CycloneDX 1.6 and SPDX SBOMs, and blocks the
+   configured vulnerability policy failures.
+5. It signs platform provenance and SPDX SBOM attestations with Eneo's GitHub
+   Actions identity.
+6. It creates the multi-platform manifest, signs its provenance, and verifies
+   the registry attestations independently before publishing evidence.
+
+The release workflow resolves immutable image digests, verifies SeaweedFS
+manifest provenance plus both platform SBOM attestations, and attaches
+`IMAGE-DIGESTS.txt`, CycloneDX, SPDX, readable package tables, and checksums to
+the GitHub Release.
+
+These attestations prove which source and workflow Eneo used. They do not claim
+that SeaweedFS upstream signed Eneo's image or the pinned source commit. See
+[Release SBOMs](/docs/release-sboms) for exact filenames and verification
+commands.
+
+## Operational consequences
+
+- PostgreSQL and the object store must share one backup and restore point.
+- The stable deployment ID and internal marker must survive restoration.
+- Readiness can fail while liveness stays healthy; Eneo never falls back to a
+  filesystem or PostgreSQL byte column.
+- Endpoint capacity, PostgreSQL state, reconciliation lag, temporary spool
+  space, and multipart cleanup all need monitoring.
+- Changing provider is a verified content migration, not an endpoint edit
+  performed while writers run.
+
+The [Object Content Storage guide](/guides/object-content-storage) turns these
+constraints into deployment and recovery steps.

--- a/frontend/apps/docs-site/src/content/docs/release-sboms.mdx
+++ b/frontend/apps/docs-site/src/content/docs/release-sboms.mdx
@@ -5,6 +5,10 @@ published backend, frontend, and bundled object-store container images. The file
 GitHub Release so you can download the dependency inventory for the exact
 version you run.
 
+For the SeaweedFS build and runtime trust boundary, see [Object Content
+Architecture](/docs/object-content-architecture). For deployment, start with
+[Object Content Storage](/guides/object-content-storage).
+
 The release workflow covers:
 
 - `ghcr.io/eneo-ai/eneo-backend:<version>`

--- a/frontend/apps/docs-site/src/content/guides/_meta.ts
+++ b/frontend/apps/docs-site/src/content/guides/_meta.ts
@@ -1,16 +1,17 @@
-import type { MetaRecord } from 'nextra';
+import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {
-  index: 'Overview',
-  authentication: 'Authentication & OIDC',
-  'scim-provisioning': 'SCIM Provisioning',
-  'audit-logging': 'Audit Logging',
-  'ai-providers': 'AI Provider Configuration',
-  'mcp-servers': 'MCP Servers',
-  deployment: 'Deployment',
-  'document-processing': 'Document Processing',
-  'sharepoint-integration': 'SharePoint Integration',
-  'upgrade-1-7-0': 'Upgrading to 1.7.0',
-}
+  index: "Overview",
+  authentication: "Authentication & OIDC",
+  "scim-provisioning": "SCIM Provisioning",
+  "audit-logging": "Audit Logging",
+  "ai-providers": "AI Provider Configuration",
+  "mcp-servers": "MCP Servers",
+  deployment: "Deployment",
+  "object-content-storage": "Object Content Storage",
+  "document-processing": "Document Processing",
+  "sharepoint-integration": "SharePoint Integration",
+  "upgrade-1-7-0": "Upgrading to 1.7.0",
+};
 
 export default meta;

--- a/frontend/apps/docs-site/src/content/guides/deployment.mdx
+++ b/frontend/apps/docs-site/src/content/guides/deployment.mdx
@@ -375,151 +375,21 @@ curl -fsS https://your-domain.com/version
 
 ## Object Content Storage
 
-PostgreSQL owns content identity, authorization references, canonical SHA-256,
-size/type, lifecycle, holds, retention, audit, and bounded reconciliation facts.
-The private S3-compatible endpoint owns durable byte streams. Endpoint, bucket,
-key, and provider details are never exposed by ordinary APIs.
-
-The reference deployment enables object content. During a custom rollout,
-backend and worker may omit every `OBJECT_CONTENT_*` setting and start with the
-capability explicitly disabled, but only while PostgreSQL has no active
-object-content records. Blank or partial settings fail startup. Disabled
-readiness is healthy with code `disabled`; the public settings response exposes
-only `object_content_enabled=false`, never endpoint, bucket, or key. If active
-records exist, Eneo fails closed with `configuration_required` until the full
-configuration is restored. This is deployment state, not an administrator or
-tenant toggle. API and worker processes evaluate it independently, so give each
-process the same setting set. Before the first active row, any mismatch appears
-in their capability/readiness projections; after a row exists, a disabled
-process fails the safety guard.
-
-On the first enabled startup, Eneo creates one random PostgreSQL identity and
-grants one process a bounded bootstrap claim. Only that process may
-conditionally create the private, non-overwriting bucket marker; competing API
-or worker processes remain unready and later verify the confirmed pair.
-Startup, readiness, and every reconciliation run require the same pair before
-mutating content state. A reachable empty or foreign bucket reports
-`configuration_required`; Eneo never silently adopts or overwrites it.
-
-The claim expires after `OBJECT_CONTENT_BINDING_CLAIM_SECONDS` (default `30`),
-which must cover the configured readiness request window. Recovery verifies a
-marker written before a crash. The timeout controls liveness and retry timing;
-durable creation intent supplies the safety guarantee. If PostgreSQL says marker
-creation began but the configured store has no marker, Eneo fails closed rather
-than create one in a possibly different store; stop writers and reconciliation
-and recover the matching PostgreSQL/object backup pair. The marker is internal
-and must be preserved with the bucket backup—it is not an administrator or
-tenant setting. Invalid configuration diagnostics omit supplied values,
-including a rejected credential-bearing endpoint URL.
-
-The reference deployment starts an Eneo-built SeaweedFS 4.39 image. Eneo pins
-and reviews upstream source, builds minimal non-root amd64/arm64 images, blocks
-license and HIGH/CRITICAL vulnerability policy failures, publishes CycloneDX
-1.6/SPDX SBOMs, and signs provenance with GitHub OIDC. This is an Eneo-attested
-build—not supplier-signed upstream provenance.
-
-Self-hosted and European-operated endpoints, including external MinIO, use the
-same application contract; there is no provider-specific code or Amazon service
-dependency. To use one, configure its HTTPS endpoint, SigV4 signing scope,
-bucket, credentials, addressing style, and optional private CA, then run:
-
-```bash
-docker compose up -d --scale object-content=0
-```
-
-Leave `ENEO_SEAWEEDFS_IMAGE` pinned to the verified release digest because
-Compose validates the complete file; scale zero prevents that service from
-starting, and Eneo connects only to the configured external endpoint.
-
-The signing-scope value does not determine where the bundled volume lives. The
-bundled SeaweedFS service uses `local`; an external endpoint must use the value
-required by its operator. Eneo always connects to the explicit endpoint and
-never discovers or falls back to an Amazon service.
-
-### Use an external MinIO deployment
-
-Deploy and license MinIO under its current production guidance; Eneo does not
-ship or administer it. Create one private `eneo-object-content` bucket and one
-non-admin application identity limited to list and multipart-list on that
-bucket, plus get, put, delete, multipart-abort, and multipart-part-list on its
-objects. The part-list permission is exercised by Eneo's endpoint conformance
-suite. MinIO policy files use IAM-compatible `arn:aws:s3` resource strings as
-local syntax; this does not introduce an Amazon service dependency.
-
-Configure the protected deployment `.env` with the MinIO API endpoint and
-application credentials:
-
-```dotenv
-OBJECT_CONTENT_ENDPOINT_URL=https://minio.storage.example.eu:9000
-OBJECT_CONTENT_REGION=<the MinIO operator's signing scope>
-OBJECT_CONTENT_BUCKET=eneo-object-content
-OBJECT_CONTENT_ACCESS_KEY_ID=<application access key>
-OBJECT_CONTENT_SECRET_ACCESS_KEY=<application secret key>
-OBJECT_CONTENT_ALLOW_INSECURE_HTTP=false
-```
-
-Keep path-style addressing unless the MinIO operator provides wildcard DNS and
-TLS for virtual-host buckets. Mount a private CA into both backend and worker
-when required. Start Eneo with `--scale object-content=0`, verify `/api/readyz`,
-then validate single/multipart upload, ordered parts, full/range read, delete,
-and paired restore in staging against the exact MinIO build before production
-use. Eneo's object-content integration suite defines the expected behaviors.
-
-The repository's [object-content operations guide](https://github.com/eneo-ai/eneo/blob/develop/docs/deployment/OBJECT_CONTENT.md#external-minio-example)
-contains the exact least-privilege policy and commands. See MinIO's current
-[installation](https://docs.min.io/aistor/installation/),
-[TLS](https://docs.min.io/aistor/installation/linux/network-encryption/enable-tls-encryption/),
-and [S3 compatibility](https://docs.min.io/aistor/developers/s3-api-compatibility/)
-documentation for the storage service itself.
-
 <Callout type="warning">
-  **No database-only backup is complete.** Stop writers and back up PostgreSQL
-  and the object byte plane as one named recovery point. Preserve the stable
-  deployment UUID. Restore both halves while reconciliation is stopped, verify
-  readiness plus full/range reads, and only then reopen traffic.
+  PostgreSQL and object storage form one recovery unit. Back up and restore
+  them together.
 </Callout>
 
-The settings in `env_backend.env` control transport timeouts, bounded spool and
-multipart sizes, leases, retries, and reconciliation concurrency. They do not
-define business upload limits; administrators retain ownership of user-facing
-limits. Object keys and storage topology remain tenant-neutral.
+The reference Compose stack runs a private, Eneo-built SeaweedFS service.
+Deployments that need an existing storage platform or multi-node availability
+can use another compatible endpoint, including MinIO. Both paths use the same
+S3 contract and fail closed when configuration or the database/bucket binding
+does not match.
 
-PostgreSQL rejects direct deletion of active holds and retained content.
-Tombstone cleanup is also fail-closed: a row is purgeable only after its
-database-owned purge horizon is present and has elapsed. Do not treat a null
-horizon as an immediate-delete default. Account erasure may clear the user
-attribution on a hold, but it does not release that hold or advance content
-deletion.
-
-PostgreSQL also rejects a new `pending` content row that reaches commit without
-its first concrete File, InfoBlob, or Icon reference. Producers must create that
-reference in the same transaction as the content intent; later attachment of an
-ownerless pending row is never a recovery path.
-
-Object inventory pages must return complete, advancing cursors. Eneo rejects an
-invalid page without completing the scan or marking unseen rows missing. A
-complete scan reports missing retained bytes as an integrity failure without
-changing the retained lifecycle state. A truncated multipart page must include
-an advancing next-key and next-upload-ID marker pair.
-
-Full and single-range reads recompute the PostgreSQL-owned SHA-256 before
-emitting response bytes. Memory use is bounded by the configured spool
-threshold; larger objects use temporary disk, and each verified read is linear
-in full object size. Capacity planning must include the resulting concurrent
-temporary-disk demand.
-
-Capacity planning must cover PostgreSQL and the byte plane. Monitor bucket
-bytes/object count, durable free space, request latency/errors, pending and
-failed content, delete backlog, reconciliation lag, multipart uploads, and
-orphan-candidate age. Size the backend/worker temporary volume for concurrent
-in-flight spools: memory remains bounded at the configured threshold, while the
-remainder uses temporary disk until upload completes. Organizations needing
-multi-node storage availability should use an externally operated compatible
-endpoint with their standard redundancy and disaster-recovery controls.
-
-See the repository's [durable object-content operations guide](https://github.com/eneo-ai/eneo/blob/develop/docs/deployment/OBJECT_CONTENT.md)
-for the exact S3 subset, TLS/custom-CA setup, attestation verification, paired
-backup/restore, skew recovery, capacity, upgrade, and rollback procedures.
+Follow [Object Content Storage](/guides/object-content-storage) for the image
+digest, credentials, MinIO policy, TLS, readiness, backup, and troubleshooting
+steps. See [Object Content Architecture](/docs/object-content-architecture) for
+the control-plane boundary, lifecycle, reconciliation, and image supply chain.
 
 ---
 
@@ -933,4 +803,5 @@ docker compose up -d --scale backend=3 --scale worker=2
 - [SharePoint Integration](/guides/sharepoint-integration) - Connect SharePoint and OneDrive
 - [Authentication Architecture](/docs/authentication-architecture) - Technical authentication details
 - [System Architecture](/docs/architecture) - Complete architecture overview
+- [Object Content Storage](/guides/object-content-storage) - Configure SeaweedFS, MinIO, backups, and readiness
 - [Release SBOMs and attestations](/docs/release-sboms) - Verify shipped image digests and provenance

--- a/frontend/apps/docs-site/src/content/guides/index.mdx
+++ b/frontend/apps/docs-site/src/content/guides/index.mdx
@@ -33,6 +33,13 @@ Deploy Eneo in production environments:
 - SSL/TLS certificates with Let's Encrypt
 - Environment configuration best practices
 
+### [Object Content Storage](/guides/object-content-storage)
+Configure the private byte store used by Eneo:
+- Run the bundled SeaweedFS service
+- Connect MinIO or another S3-compatible endpoint
+- Verify image provenance and readiness
+- Plan capacity, backup, restore, and troubleshooting
+
 ### [Document Processing](/guides/document-processing)
 Upload and process documents for AI-powered knowledge bases:
 - Supported file formats (PDF, Word, Excel, PowerPoint)

--- a/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
+++ b/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
@@ -1,0 +1,274 @@
+# Object Content Storage
+
+Set up the private S3-compatible storage that Eneo uses for original files and
+derived content. The reference Docker Compose deployment includes SeaweedFS,
+but you can connect Eneo to another compatible endpoint, including MinIO.
+
+import { Callout, Steps } from "nextra/components";
+
+<Callout type="warning">
+  PostgreSQL and object storage form one recovery unit. Back up and restore them
+  together. A database-only or bucket-only backup is incomplete.
+</Callout>
+
+## What this storage is for
+
+PostgreSQL stores content identity, permissions, lifecycle state, retention,
+size, media type, and the canonical SHA-256 digest. The object store holds the
+bytes. Eneo never uses the bucket as an authorization source and does not expose
+bucket names or object keys through ordinary APIs.
+
+Choose one deployment model:
+
+| Model                           | Best fit                                                                                                     | You operate                                                          |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| Bundled SeaweedFS               | Single-node and evaluation deployments that use the reference Compose stack                                  | The `object-content` service and its durable volume                  |
+| External S3-compatible endpoint | Deployments that need an existing storage platform, multi-node availability, or organization-managed backups | The endpoint, bucket, identity, TLS, capacity, and recovery controls |
+
+Eneo uses one S3-compatible contract for both models. It does not select an
+Amazon service implicitly, and MinIO does not require a provider-specific Eneo
+integration.
+
+## Use the bundled SeaweedFS service
+
+The reference stack keeps SeaweedFS on the private `object_content_net`. Only
+the backend and worker can reach it; Traefik and the frontend cannot.
+
+<Steps>
+
+### Copy the deployment configuration
+
+Follow the [deployment guide](/guides/deployment) to copy the Compose and
+environment templates. The reference stack enables object content, so fill in
+the object-content values in `.env` before running Compose.
+
+### Pin the release image
+
+Download `IMAGE-DIGESTS.txt` from the Eneo GitHub Release you plan to run. Copy
+the digest reference from the single `seaweedfs manifest` row:
+
+```dotenv
+ENEO_SEAWEEDFS_IMAGE=ghcr.io/eneo-ai/eneo-seaweedfs@sha256:<manifest-digest>
+```
+
+Use the manifest digest, not the `linux/amd64` or `linux/arm64` platform row.
+The manifest selects the correct image for the host architecture.
+
+Verify Eneo's build provenance before deployment:
+
+```bash
+gh attestation verify \
+  "oci://ghcr.io/eneo-ai/eneo-seaweedfs@sha256:<manifest-digest>" \
+  --repo eneo-ai/eneo \
+  --predicate-type https://slsa.dev/provenance/v1
+```
+
+See [Release SBOMs](/docs/release-sboms) for platform SBOM verification and the
+full release asset inventory.
+
+### Generate credentials and the deployment ID
+
+Generate separate high-entropy credentials and one UUID:
+
+```bash
+openssl rand -hex 32
+openssl rand -hex 48
+uuidgen
+```
+
+Store the results in the protected deployment `.env`:
+
+```dotenv
+OBJECT_CONTENT_ACCESS_KEY_ID=<generated access key>
+OBJECT_CONTENT_SECRET_ACCESS_KEY=<generated secret key>
+OBJECT_CONTENT_DEPLOYMENT_ID=<generated UUID>
+OBJECT_CONTENT_ENDPOINT_URL=http://object-content:8333
+OBJECT_CONTENT_REGION=local
+OBJECT_CONTENT_BUCKET=eneo-object-content
+OBJECT_CONTENT_ALLOW_INSECURE_HTTP=true
+```
+
+Keep the UUID unchanged through upgrades and restores. It scopes opaque object
+keys and binds this PostgreSQL database to its byte store. Changing it does not
+migrate existing content.
+
+### Start and verify the stack
+
+```bash
+docker compose config --quiet
+docker compose up -d
+docker compose ps
+curl --fail https://eneo.example.eu/api/readyz
+```
+
+Readiness should report object content as ready. If it reports
+`configuration_required`, stop writers and check the endpoint, bucket,
+deployment ID, and restored backup pair before retrying. Do not create a new
+bucket marker by hand.
+
+</Steps>
+
+`OBJECT_CONTENT_ALLOW_INSECURE_HTTP=true` is appropriate only for this private
+Compose network. Do not publish port 8333 through the reverse proxy.
+
+## Use MinIO or another compatible endpoint
+
+Operate the external service according to its current security, licensing,
+availability, and backup guidance. Eneo needs one private bucket and one
+non-admin application identity. The endpoint must support SigV4 plus the S3
+operations Eneo uses: paginated object and multipart listing, single and
+multipart writes, `HEAD`, streaming reads, one byte range, abort, and deletion.
+
+### MinIO example
+
+Create a dedicated bucket:
+
+```bash
+mc mb eneo-minio/eneo-object-content
+```
+
+Save this least-privilege policy as `eneo-object-content-policy.json`:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket", "s3:ListBucketMultipartUploads"],
+      "Resource": ["arn:aws:s3:::eneo-object-content"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts"
+      ],
+      "Resource": ["arn:aws:s3:::eneo-object-content/*"]
+    }
+  ]
+}
+```
+
+MinIO uses `arn:aws:s3` strings as local IAM-compatible policy syntax. These
+identifiers do not connect MinIO or Eneo to AWS. If you change the bucket name,
+change both policy resources.
+
+Create a service identity through your MinIO console, identity provider, or
+secret-safe automation. Then attach the policy without putting the secret key
+on the command line:
+
+```bash
+mc admin policy create eneo-minio eneo-object-content \
+  ./eneo-object-content-policy.json
+mc admin policy attach eneo-minio eneo-object-content \
+  --user '<service-identity>'
+```
+
+Configure Eneo with the S3 API endpoint and application credentials:
+
+```dotenv
+OBJECT_CONTENT_ENDPOINT_URL=https://minio.storage.example.eu:9000
+OBJECT_CONTENT_REGION=<MinIO signing scope>
+OBJECT_CONTENT_BUCKET=eneo-object-content
+OBJECT_CONTENT_ACCESS_KEY_ID=<application access key>
+OBJECT_CONTENT_SECRET_ACCESS_KEY=<application secret key>
+OBJECT_CONTENT_DEPLOYMENT_ID=<stable deployment UUID>
+OBJECT_CONTENT_ALLOW_INSECURE_HTTP=false
+```
+
+Keep `OBJECT_CONTENT_ADDRESSING_STYLE=path` in `env_backend.env` unless the
+endpoint has wildcard DNS and TLS for virtual-host bucket names. For a private
+CA, mount the certificate read-only into both backend and worker and set
+`OBJECT_CONTENT_CA_BUNDLE` to its in-container path.
+
+Compose still validates `ENEO_SEAWEEDFS_IMAGE`, so keep the verified release
+digest in `.env`. Start Eneo with the bundled service scaled to zero:
+
+```bash
+docker compose up -d --scale object-content=0
+curl --fail https://eneo.example.eu/api/readyz
+```
+
+Before production traffic, test the exact endpoint version and configuration in
+staging. Cover single and multipart upload, ordered part listing, full and range
+read, deletion visibility, and a paired restore.
+
+## Production checklist
+
+- Keep the endpoint private. Expose neither its S3 API nor administrative UI
+  through Eneo's public reverse proxy.
+- Give Eneo one bucket-scoped application identity, not administrator
+  credentials.
+- Alert on bucket bytes, object count, free capacity, request errors and
+  latency, failed or pending content, delete backlog, reconciliation lag, and
+  old multipart uploads.
+- Size temporary storage for concurrent uploads and reads. Eneo verifies a full
+  object before returning a full or range response; larger objects spill from
+  bounded memory to temporary disk.
+- Back up PostgreSQL and the bucket under one recovery ID while writers and
+  reconciliation are stopped. Preserve `OBJECT_CONTENT_DEPLOYMENT_ID` and the
+  internal bucket marker.
+- Test restores in isolation before reopening traffic.
+
+## Configuration behavior
+
+| Configuration                                                                        | Result                                                                       |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| All `OBJECT_CONTENT_*` application settings absent and no active object-content rows | Eneo starts with the capability disabled                                     |
+| Any value blank, partial, or invalid                                                 | Startup fails with a configuration error                                     |
+| Complete configuration and matching database/bucket pair                             | Readiness reports ready                                                      |
+| Complete configuration but an unavailable endpoint                                   | The process stays live; readiness fails and dependent operations return 503  |
+| Reachable bucket that does not match PostgreSQL                                      | Readiness reports `configuration_required`; Eneo does not adopt or mutate it |
+
+Once Eneo stores an active object-content record, the byte plane remains
+required. There is no filesystem or PostgreSQL byte fallback.
+
+## Troubleshooting and FAQ
+
+### Why does Eneo bundle SeaweedFS?
+
+It gives the reference Compose deployment a small private S3-compatible service
+with a reproducible Eneo build for `linux/amd64` and `linux/arm64`. It is a
+single-node reference store, not a requirement or the default answer for
+multi-node availability.
+
+### Is MinIO supported?
+
+Yes, as an external S3-compatible endpoint. Eneo does not bundle or administer
+MinIO. Validate your exact MinIO build and configuration against the operations
+listed above.
+
+### Does Eneo require AWS S3?
+
+No. Eneo always uses the endpoint you configure. SigV4 and IAM-style policy
+names describe protocol syntax; they do not select an AWS service.
+
+### Why does readiness say `configuration_required`?
+
+The configured bucket and PostgreSQL database do not present the same durable
+binding, or active rows exist while object storage is disabled. Restore the
+matching pair and the original deployment ID. Do not replace the marker.
+
+### Can I rotate credentials?
+
+Yes. Update backend and worker together, and update the bundled store or
+external service identity in the same maintenance window. Verify readiness
+before resuming writes. Credential rotation must not change the deployment ID,
+bucket, or existing object keys.
+
+### Can I back up only PostgreSQL?
+
+No. PostgreSQL contains identities and lifecycle state; the bucket contains the
+bytes. Restore both from the same recovery point.
+
+## Learn how it works
+
+- [Object content architecture](/docs/object-content-architecture) explains
+  lifecycle, integrity, reconciliation, binding, and failure behavior.
+- [Release SBOMs](/docs/release-sboms) explains image digests, SBOM assets, and
+  attestation verification.
+- [Deployment](/guides/deployment) covers the complete Eneo service stack.


### PR DESCRIPTION
## Summary
- add a practical SeaweedFS and external S3-compatible setup guide, including MinIO
- document the control-plane boundary, lifecycle, recovery, and image attestation flow
- replace duplicated deployment and architecture sections with clear entry points

## Validation
- bun run --cwd apps/docs-site build