### PR TITLE
fix(security): update SeaweedFS source pin

### DIFF
--- a/.github/workflows/build_and_push_images.yml
+++ b/.github/workflows/build_and_push_images.yml
@@ -28,7 +28,7 @@ env:
   BACKEND_IMAGE_NAME: eneo-ai/eneo-backend
   FRONTEND_IMAGE_NAME: eneo-ai/eneo-frontend
   SEAWEEDFS_IMAGE_NAME: eneo-ai/eneo-seaweedfs
-  SEAWEEDFS_VERSION: 4.39-eneo.1
+  SEAWEEDFS_VERSION: 4.40-eneo.1
   BUILDX_VERSION: v0.33.0
   BUILDKIT_IMAGE: moby/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
   QEMU_IMAGE: docker.io/tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
@@ -355,7 +355,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           provenance: false
           sbom: false
-          build-args: SOURCE_DATE_EPOCH=1783656494
+          build-args: SOURCE_DATE_EPOCH=1784519823
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.SEAWEEDFS_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true,rewrite-timestamp=true
           cache-from: type=gha,scope=seaweedfs-${{ matrix.slug }}
           cache-to: type=gha,mode=max,scope=seaweedfs-${{ matrix.slug }}
@@ -379,7 +379,7 @@ jobs:
           provenance: false
           sbom: false
           no-cache: true
-          build-args: SOURCE_DATE_EPOCH=1783656494
+          build-args: SOURCE_DATE_EPOCH=1784519823
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.SEAWEEDFS_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true,rewrite-timestamp=true
 
       - name: Verify reproducible platform digest

--- a/.github/workflows/build_and_push_images.yml
+++ b/.github/workflows/build_and_push_images.yml
@@ -289,6 +289,8 @@ jobs:
           persist-credentials: false
 
       - name: Verify pinned source, licenses, and reachable vulnerabilities
+        env:
+          GITHUB_API_TOKEN: ${{ github.token }}
         run: docker/seaweedfs/verify-supply-chain.sh source seaweedfs-source-evidence
 
       - name: Upload source policy evidence

--- a/.github/workflows/release_sbom.yml
+++ b/.github/workflows/release_sbom.yml
@@ -24,7 +24,7 @@ env:
   BACKEND_IMAGE: ghcr.io/eneo-ai/eneo-backend
   FRONTEND_IMAGE: ghcr.io/eneo-ai/eneo-frontend
   SEAWEEDFS_IMAGE: ghcr.io/eneo-ai/eneo-seaweedfs
-  SEAWEEDFS_VERSION: 4.39-eneo.1
+  SEAWEEDFS_VERSION: 4.40-eneo.1
   PLATFORM: linux/amd64
   PLATFORM_OS: linux
   PLATFORM_ARCH: amd64

--- a/docker/seaweedfs/Dockerfile
+++ b/docker/seaweedfs/Dockerfile
@@ -6,18 +6,18 @@ FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.25.12-bookworm@sha256:
 
 ARG TARGETARCH
 ARG TARGETOS
-ARG SOURCE_DATE_EPOCH=1783656494
+ARG SOURCE_DATE_EPOCH=1784519823
 
 WORKDIR /build
-ADD --checksum=sha256:cd6f53fb3e4d1ad955af60e6c3128b3306666168907c24d31a4f28b677b1c028 \
-    https://github.com/seaweedfs/seaweedfs/archive/db42bb49757b459551607939807017d7a9d5a94a.tar.gz \
+ADD --checksum=sha256:2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e \
+    https://github.com/seaweedfs/seaweedfs/archive/875cd1f67ea25e8965a4f5ba1e6aaf501ba6b6fa.tar.gz \
     /tmp/seaweedfs.tar.gz
 
 RUN mkdir source \
     && tar --extract --gzip --file=/tmp/seaweedfs.tar.gz \
         --strip-components=1 --directory=source \
     && test "$(sha256sum /tmp/seaweedfs.tar.gz | cut -d ' ' -f 1)" \
-        = "cd6f53fb3e4d1ad955af60e6c3128b3306666168907c24d31a4f28b677b1c028"
+        = "2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e"
 
 WORKDIR /build/source/weed
 RUN --mount=type=cache,target=/go/pkg/mod,sharing=locked \
@@ -29,7 +29,7 @@ RUN --mount=type=cache,target=/go/pkg/mod,sharing=locked \
       -buildvcs=false \
       -mod=readonly \
       -trimpath \
-      -ldflags="-buildid= -s -w -X github.com/seaweedfs/seaweedfs/weed/util/version.COMMIT=db42bb49757b459551607939807017d7a9d5a94a" \
+      -ldflags="-buildid= -s -w -X github.com/seaweedfs/seaweedfs/weed/util/version.COMMIT=875cd1f67ea25e8965a4f5ba1e6aaf501ba6b6fa" \
       -o /out/weed .
 
 RUN mkdir -m 0700 /out/data \
@@ -41,13 +41,13 @@ LABEL org.opencontainers.image.title="Eneo SeaweedFS object-content store" \
       org.opencontainers.image.description="Eneo-built reference S3-compatible byte store for object content" \
       org.opencontainers.image.source="https://github.com/eneo-ai/eneo" \
       org.opencontainers.image.vendor="Eneo" \
-      org.opencontainers.image.version="4.39-eneo.1" \
+      org.opencontainers.image.version="4.40-eneo.1" \
       org.opencontainers.image.licenses="Apache-2.0" \
       io.eneo.upstream.name="SeaweedFS" \
-      io.eneo.upstream.version="4.39" \
-      io.eneo.upstream.commit="db42bb49757b459551607939807017d7a9d5a94a" \
-      io.eneo.upstream.tree="da91641fdd520e465c68fa48af3b3ad07ad86822" \
-      io.eneo.upstream.archive.sha256="cd6f53fb3e4d1ad955af60e6c3128b3306666168907c24d31a4f28b677b1c028"
+      io.eneo.upstream.version="4.40" \
+      io.eneo.upstream.commit="875cd1f67ea25e8965a4f5ba1e6aaf501ba6b6fa" \
+      io.eneo.upstream.tree="f6590c71c41ec414fc193b89e9d9dd586d39ad17" \
+      io.eneo.upstream.archive.sha256="2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e"
 
 COPY --from=builder --chown=65532:65532 /out/weed /usr/local/bin/weed
 COPY --from=builder /out/SEAWEEDFS-LICENSE /licenses/seaweedfs/LICENSE

--- a/docker/seaweedfs/Dockerfile
+++ b/docker/seaweedfs/Dockerfile
@@ -9,6 +9,7 @@ ARG TARGETOS
 ARG SOURCE_DATE_EPOCH=1784519823
 
 WORKDIR /build
+COPY patches/0001-upgrade-grpc-to-1.82.1.patch /tmp/seaweedfs-security.patch
 ADD --checksum=sha256:2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e \
     https://github.com/seaweedfs/seaweedfs/archive/875cd1f67ea25e8965a4f5ba1e6aaf501ba6b6fa.tar.gz \
     /tmp/seaweedfs.tar.gz
@@ -17,7 +18,11 @@ RUN mkdir source \
     && tar --extract --gzip --file=/tmp/seaweedfs.tar.gz \
         --strip-components=1 --directory=source \
     && test "$(sha256sum /tmp/seaweedfs.tar.gz | cut -d ' ' -f 1)" \
-        = "2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e"
+        = "2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e" \
+    && test "$(sha256sum /tmp/seaweedfs-security.patch | cut -d ' ' -f 1)" \
+        = "54cc9bd8b0cfadebbce56754914655526cee882075141fd64790686bd4ac409e" \
+    && git -C source apply --check /tmp/seaweedfs-security.patch \
+    && git -C source apply /tmp/seaweedfs-security.patch
 
 WORKDIR /build/source/weed
 RUN --mount=type=cache,target=/go/pkg/mod,sharing=locked \
@@ -47,7 +52,8 @@ LABEL org.opencontainers.image.title="Eneo SeaweedFS object-content store" \
       io.eneo.upstream.version="4.40" \
       io.eneo.upstream.commit="875cd1f67ea25e8965a4f5ba1e6aaf501ba6b6fa" \
       io.eneo.upstream.tree="f6590c71c41ec414fc193b89e9d9dd586d39ad17" \
-      io.eneo.upstream.archive.sha256="2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e"
+      io.eneo.upstream.archive.sha256="2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e" \
+      io.eneo.downstream.patch.sha256="54cc9bd8b0cfadebbce56754914655526cee882075141fd64790686bd4ac409e"
 
 COPY --from=builder --chown=65532:65532 /out/weed /usr/local/bin/weed
 COPY --from=builder /out/SEAWEEDFS-LICENSE /licenses/seaweedfs/LICENSE

--- a/docker/seaweedfs/patches/0001-upgrade-grpc-to-1.82.1.patch
+++ b/docker/seaweedfs/patches/0001-upgrade-grpc-to-1.82.1.patch
@@ -1,0 +1,84 @@
+Subject: [PATCH] build: upgrade gRPC to 1.82.1
+
+SeaweedFS 4.40 pins gRPC 1.81.1, which is affected by
+GHSA-hrxh-6v49-42gf. Keep this downstream patch until an upstream
+SeaweedFS release includes gRPC 1.82.1 or newer.
+
+diff --git a/go.mod b/go.mod
+--- a/go.mod
++++ b/go.mod
+@@ -102,7 +102,7 @@ require (
+ 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
+ 	google.golang.org/api v0.287.0
+ 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
+-	google.golang.org/grpc v1.81.1
++	google.golang.org/grpc v1.82.1
+ 	google.golang.org/protobuf v1.36.11
+ 	gopkg.in/inf.v0 v0.9.1 // indirect
+ 	modernc.org/b v1.0.0 // indirect
+@@ -300,7 +300,7 @@ require (
+ 	github.com/Azure/go-ntlmssp v0.1.1 // indirect
+ 	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
+ 	github.com/Files-com/files-sdk-go/v3 v3.3.82 // indirect
+-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
++	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 // indirect
+ 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
+ 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
+ 	github.com/IBM/go-sdk-core/v5 v5.21.2 // indirect
+@@ -482,7 +482,7 @@ require (
+ 	go.etcd.io/bbolt v1.4.3 // indirect
+ 	go.etcd.io/etcd/api/v3 v3.6.12 // indirect
+ 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+-	go.opentelemetry.io/contrib/detectors/gcp v1.42.0 // indirect
++	go.opentelemetry.io/contrib/detectors/gcp v1.43.0 // indirect
+ 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
+ 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
+ 	go.opentelemetry.io/otel v1.43.0 // indirect
+@@ -494,7 +494,7 @@ require (
+ 	go.uber.org/zap v1.27.1 // indirect
+ 	golang.org/x/term v0.45.0
+ 	golang.org/x/time v0.15.0
+-	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect
++	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 // indirect
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d // indirect
+ 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
+ 	gopkg.in/validator.v2 v2.0.1 // indirect
+diff --git a/go.sum b/go.sum
+--- a/go.sum
++++ b/go.sum
+@@ -595,6 +595,8 @@
+ github.com/Files-com/files-sdk-go/v3 v3.3.82/go.mod h1:IPk80dOmc7VFC0DJ85xMTPmre+8xoXX6kGHAkf5jRRw=
+ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 h1:DHa2U07rk8syqvCge0QIGMCE1WxGj9njT44GH7zNJLQ=
+ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
++github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0 h1:rIkQfkCOVKc1OiRCNcSDD8ml5RJlZbH/Xsq7lbpynwc=
++github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.32.0/go.mod h1:RD2SsorTmYhF6HkTmDw7KmPYQk8OBYwTkuasChwv7R4=
+ github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 h1:UnDZ/zFfG1JhH/DqxIZYU/1CUAlTUScoXD/LcM2Ykk8=
+ github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0/go.mod h1:IA1C1U7jO/ENqm/vhi7V9YYpBsp+IMyqNrEN94N7tVc=
+ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.55.0 h1:7t/qx5Ost0s0wbA/VDrByOooURhp+ikYwv20i9Y07TQ=
+@@ -2090,6 +2092,8 @@
+ go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+ go.opentelemetry.io/contrib/detectors/gcp v1.42.0 h1:kpt2PEJuOuqYkPcktfJqWWDjTEd/FNgrxcniL7kQrXQ=
+ go.opentelemetry.io/contrib/detectors/gcp v1.42.0/go.mod h1:W9zQ439utxymRrXsUOzZbFX4JhLxXU4+ZnCt8GG7yA8=
++go.opentelemetry.io/contrib/detectors/gcp v1.43.0 h1:62yY3dT7/ShwOxzA0RsKRgshBmfElKI4d/Myu2OxDFU=
++go.opentelemetry.io/contrib/detectors/gcp v1.43.0/go.mod h1:RyaZMFY7yi1kAs45S6mbFGz8O8rqB0dTY14uzvG4LCs=
+ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 h1:yI1/OhfEPy7J9eoa6Sj051C7n5dvpj0QX8g4sRchg04=
+ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0/go.mod h1:NoUCKYWK+3ecatC4HjkRktREheMeEtrXoQxrqYFeHSc=
+ go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.63.0 h1:2pn7OzMewmYRiNtv1doZnLo3gONcnMHlFnmOR8Vgt+8=
+@@ -2811,6 +2815,8 @@
+ google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:L43LFes82YgSonw6iTXTxXUX1OlULt4AQtkik4ULL/I=
+ google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 h1:VPWxll4HlMw1Vs/qXtN7BvhZqsS9cdAittCNvVENElA=
+ google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9/go.mod h1:7QBABkRtR8z+TEnmXTqIqwJLlzrZKVfAUm7tY3yGv0M=
++google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478 h1:yQugLulqltosq0B/f8l4w9VryjV+N/5gcW0jQ3N8Qec=
++google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478/go.mod h1:C6ADNqOxbgdUUeRTU+LCHDPB9ttAMCTff6auwCVa4uc=
+ google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d h1:mpAgMyM9vQHxycBlDq50y1VHpfSfVwzXvrQKtYbXuUY=
+ google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
+ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
+@@ -2855,6 +2861,8 @@
+ google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGONTY8=
+ google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
+ google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
++google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
++google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+ google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+ google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6 h1:ExN12ndbJ608cboPYflpTny6mXSzPrDLh0iTaVrRrds=
+ google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6/go.mod h1:6ytKWczdvnpnO+m+JiG9NjEDzR1FJfsnmJdG7B8QVZ8=

--- a/docker/seaweedfs/verify-supply-chain.sh
+++ b/docker/seaweedfs/verify-supply-chain.sh
@@ -2,9 +2,9 @@
 
 set -euo pipefail
 
-readonly SOURCE_COMMIT="db42bb49757b459551607939807017d7a9d5a94a"
-readonly SOURCE_TREE="da91641fdd520e465c68fa48af3b3ad07ad86822"
-readonly SOURCE_ARCHIVE_SHA256="cd6f53fb3e4d1ad955af60e6c3128b3306666168907c24d31a4f28b677b1c028"
+readonly SOURCE_COMMIT="875cd1f67ea25e8965a4f5ba1e6aaf501ba6b6fa"
+readonly SOURCE_TREE="f6590c71c41ec414fc193b89e9d9dd586d39ad17"
+readonly SOURCE_ARCHIVE_SHA256="2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e"
 readonly SOURCE_LICENSE_SHA256="d789d433cc11da163273d1e39be2e8fa67642f9a58ef220d3f258fa9c14ef613"
 readonly GO_IMAGE="docker.io/library/golang:1.25.12-bookworm@sha256:ea341baa9bd5ba6784f6d7161ace70544349a6242d54d34a0fbfd2c4d51c9d58"
 readonly GO_LICENSES_REVISION="3e084b0caf710f7bfead967567539214f598c0a2"
@@ -156,7 +156,7 @@ EOF
         "$output_directory/govulncheck.txt"
 
     cat >"$output_directory/SOURCE-PROVENANCE.txt" <<EOF
-upstream=SeaweedFS 4.39
+upstream=SeaweedFS 4.40
 source_commit=$SOURCE_COMMIT
 source_tree=$SOURCE_TREE
 source_archive_sha256=$SOURCE_ARCHIVE_SHA256

--- a/docker/seaweedfs/verify-supply-chain.sh
+++ b/docker/seaweedfs/verify-supply-chain.sh
@@ -6,6 +6,10 @@ readonly SOURCE_COMMIT="875cd1f67ea25e8965a4f5ba1e6aaf501ba6b6fa"
 readonly SOURCE_TREE="f6590c71c41ec414fc193b89e9d9dd586d39ad17"
 readonly SOURCE_ARCHIVE_SHA256="2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e"
 readonly SOURCE_LICENSE_SHA256="d789d433cc11da163273d1e39be2e8fa67642f9a58ef220d3f258fa9c14ef613"
+readonly DOWNSTREAM_PATCH_NAME="0001-upgrade-grpc-to-1.82.1.patch"
+readonly DOWNSTREAM_PATCH_SHA256="54cc9bd8b0cfadebbce56754914655526cee882075141fd64790686bd4ac409e"
+readonly SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly DOWNSTREAM_PATCH="$SCRIPT_DIRECTORY/patches/$DOWNSTREAM_PATCH_NAME"
 readonly GO_IMAGE="docker.io/library/golang:1.25.12-bookworm@sha256:ea341baa9bd5ba6784f6d7161ace70544349a6242d54d34a0fbfd2c4d51c9d58"
 readonly GO_LICENSES_REVISION="3e084b0caf710f7bfead967567539214f598c0a2"
 readonly GOVULNCHECK_VERSION="v1.6.0"
@@ -43,7 +47,7 @@ audit_source() {
     local source_directory
     local upstream_tree
 
-    for command in curl diff docker jq sha256sum tar; do
+    for command in curl diff docker git jq sha256sum tar; do
         require_command "$command"
     done
 
@@ -76,6 +80,12 @@ audit_source() {
         exit 1
     }
 
+    printf '%s  %s\n' "$DOWNSTREAM_PATCH_SHA256" "$DOWNSTREAM_PATCH" \
+        | sha256sum --check --strict -
+    git -C "$source_directory" apply --check "$DOWNSTREAM_PATCH"
+    git -C "$source_directory" apply "$DOWNSTREAM_PATCH"
+    cp "$DOWNSTREAM_PATCH" "$output_directory/$DOWNSTREAM_PATCH_NAME"
+
     docker run --rm \
         --volume "$source_directory:/src:ro" \
         --volume "$output_directory:/out" \
@@ -102,6 +112,8 @@ audit_source() {
             and .Version == "v0.23.0"
             and .Replace.Path == "github.com/apache/thrift"
             and .Replace.Version == "v0.23.1-0.20260429145742-d2acd3c49e58")
+        and any(.[]; .Path == "google.golang.org/grpc"
+            and .Version == "v1.82.1")
         ' "$output_directory/modules.json" >/dev/null
 
     cut -d, -f3 "$output_directory/licenses.csv" | LC_ALL=C sort -u \
@@ -161,13 +173,16 @@ source_commit=$SOURCE_COMMIT
 source_tree=$SOURCE_TREE
 source_archive_sha256=$SOURCE_ARCHIVE_SHA256
 source_license=Apache-2.0
+downstream_patch=$DOWNSTREAM_PATCH_NAME
+downstream_patch_sha256=$DOWNSTREAM_PATCH_SHA256
 builder=$GO_IMAGE
 go_licenses_revision=$GO_LICENSES_REVISION
 govulncheck_version=$GOVULNCHECK_VERSION
 EOF
     (
         cd "$output_directory"
-        sha256sum -- SOURCE-PROVENANCE.txt govulncheck.txt licenses.csv modules.json \
+        sha256sum -- SOURCE-PROVENANCE.txt "$DOWNSTREAM_PATCH_NAME" \
+            govulncheck.txt licenses.csv modules.json \
             >SOURCE-SHA256SUMS
     )
 }
@@ -197,7 +212,8 @@ audit_image() {
     docker image inspect "$image_ref" | jq -e \
         --arg commit "$SOURCE_COMMIT" \
         --arg tree "$SOURCE_TREE" \
-        --arg archive "$SOURCE_ARCHIVE_SHA256" '
+        --arg archive "$SOURCE_ARCHIVE_SHA256" \
+        --arg patch "$DOWNSTREAM_PATCH_SHA256" '
         length == 1
         and .[0].Config.User == "65532:65532"
         and .[0].Config.WorkingDir == "/data"
@@ -209,6 +225,7 @@ audit_image() {
         and .[0].Config.Labels["io.eneo.upstream.commit"] == $commit
         and .[0].Config.Labels["io.eneo.upstream.tree"] == $tree
         and .[0].Config.Labels["io.eneo.upstream.archive.sha256"] == $archive
+        and .[0].Config.Labels["io.eneo.downstream.patch.sha256"] == $patch
         ' >/dev/null
 
     "$SYFT_CMD" "docker:$image_ref" --platform "$platform" --quiet \

--- a/docker/seaweedfs/verify-supply-chain.sh
+++ b/docker/seaweedfs/verify-supply-chain.sh
@@ -46,6 +46,16 @@ audit_source() {
     local work_directory
     local source_directory
     local upstream_tree
+    local -a github_api_arguments=(
+        --fail
+        --location
+        --silent
+        --show-error
+        --proto '=https'
+        --tlsv1.2
+        --header 'Accept: application/vnd.github+json'
+        --header 'X-GitHub-Api-Version: 2022-11-28'
+    )
 
     for command in curl diff docker git jq sha256sum tar; do
         require_command "$command"
@@ -67,9 +77,13 @@ audit_source() {
     printf '%s  %s\n' "$SOURCE_LICENSE_SHA256" "$source_directory/LICENSE" \
         | sha256sum --check --strict -
 
+    if [[ -n "${GITHUB_API_TOKEN:-}" ]]; then
+        github_api_arguments+=(
+            --header "Authorization: Bearer $GITHUB_API_TOKEN"
+        )
+    fi
     upstream_tree="$(
-        curl --fail --location --silent --show-error \
-            --proto '=https' --tlsv1.2 \
+        curl "${github_api_arguments[@]}" \
             "https://api.github.com/repos/seaweedfs/seaweedfs/git/commits/${SOURCE_COMMIT}" \
             | jq -er --arg commit "$SOURCE_COMMIT" '
                 select(.sha == $commit) | .tree.sha

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -77,10 +77,11 @@ The repository uses GitHub security features and CI to prevent regressions:
   push/manual runs and uses the GitHub OIDC workflow identity—no PAT, registry
   password, or signing key. It pins the SeaweedFS 4.40 source commit/archive,
   Dockerfile frontend, compiler image, runtime image, tools, and every Action by
-  immutable digest or full commit SHA. It publishes only after both Linux
-  platform candidates pass source/license policy, the exact reference Compose
-  bootstrap and persistence smoke, a reachable Go vulnerability scan, and a
-  Grype gate that includes unfixed HIGH/CRITICAL findings.
+  immutable digest or full commit SHA. A hashed downstream patch upgrades gRPC
+  to 1.82.1 until upstream includes that security fix. It publishes only after
+  both Linux platform candidates pass source/license policy, the exact reference
+  Compose bootstrap and persistence smoke, a reachable Go vulnerability scan,
+  and a Grype gate that includes unfixed HIGH/CRITICAL findings.
 - SeaweedFS source-license classifier gaps are resolved only by exact
   module/version/license-file hashes in `docker/seaweedfs/verify-supply-chain.sh`.
   Any dependency, version, license content, or unknown-package drift fails the

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -75,7 +75,7 @@ The repository uses GitHub security features and CI to prevent regressions:
 - The bundled object store is an Eneo-built artifact, not an upstream-signed
   SeaweedFS image. The trusted publication job is restricted to protected
   push/manual runs and uses the GitHub OIDC workflow identity—no PAT, registry
-  password, or signing key. It pins the SeaweedFS 4.39 source commit/archive,
+  password, or signing key. It pins the SeaweedFS 4.40 source commit/archive,
   Dockerfile frontend, compiler image, runtime image, tools, and every Action by
   immutable digest or full commit SHA. It publishes only after both Linux
   platform candidates pass source/license policy, the exact reference Compose

--- a/docs/deployment/OBJECT_CONTENT.md
+++ b/docs/deployment/OBJECT_CONTENT.md
@@ -27,6 +27,8 @@ the private `object_content_net`. The image is built from upstream commit
 pins the source archive, build image, runtime image, and GitHub Actions; scans
 the exact amd64 and arm64 image digests; publishes CycloneDX 1.6 and SPDX SBOMs;
 and signs provenance and SBOM attestations with Eneo's GitHub Actions identity.
+The source evidence also records a hashed downstream patch that upgrades gRPC
+to 1.82.1 until an upstream SeaweedFS release contains the fix.
 This proves what Eneo built. It is not supplier-signed SeaweedFS provenance.
 
 An operator may instead use a self-hosted or European-operated S3-compatible

--- a/docs/deployment/OBJECT_CONTENT.md
+++ b/docs/deployment/OBJECT_CONTENT.md
@@ -21,9 +21,9 @@ This is a deployment capability, not a tenant or administrator feature toggle.
 
 ## Choose the endpoint
 
-The reference Compose deployment starts an Eneo-built SeaweedFS 4.39 service on
+The reference Compose deployment starts an Eneo-built SeaweedFS 4.40 service on
 the private `object_content_net`. The image is built from upstream commit
-`db42bb49757b459551607939807017d7a9d5a94a`, not from an upstream image. Eneo
+`875cd1f67ea25e8965a4f5ba1e6aaf501ba6b6fa`, not from an upstream image. Eneo
 pins the source archive, build image, runtime image, and GitHub Actions; scans
 the exact amd64 and arm64 image digests; publishes CycloneDX 1.6 and SPDX SBOMs;
 and signs provenance and SBOM attestations with Eneo's GitHub Actions identity.


### PR DESCRIPTION
## Why

The SeaweedFS image policy on `develop` rejects the 4.39 source because of reachable `GO-2026-5970`. SeaweedFS 4.40 fixes that dependency but still pins gRPC 1.81.1, which the image gate rejects for `GHSA-hrxh-6v49-42gf`.

## Change

- pin the official SeaweedFS 4.40 release commit and verified source metadata
- apply a hashed, removal-scoped downstream patch for gRPC 1.82.1
- audit the patched source and record the patch in image labels, evidence, and provenance
- keep workflow, SBOM, release, and operator documentation aligned

## Verification

- patched source policy: 0 reachable vulnerabilities
- amd64 image builds and reports SeaweedFS 4.40 at the pinned commit
- Grype v0.110.0: no HIGH or CRITICAL findings
- shell syntax, diff checks, commit hooks, and pre-push checks pass
- full manual branch publication workflow reruns after this update