### PR TITLE
fix(crawler): use Crochet reactor for embedded Scrapy

### DIFF
--- a/backend/src/eneo/crawler/crawler.py
+++ b/backend/src/eneo/crawler/crawler.py
@@ -210,6 +210,8 @@ def create_runner(
     filepath_str = str(filepath)
     # Scrapy settings values have heterogeneous types; dict[str, Any] is correct here.
     settings: dict[str, Any] = {
+        # Crochet owns the platform-default Twisted reactor for this embedded runner.
+        "TWISTED_REACTOR": None,
         "FEEDS": {filepath_str: {"format": "jsonl", "item_classes": [CrawledPage]}},
         # All settings use get_crawler_setting() for tenant-aware resolution
         "CLOSESPIDER_ITEMCOUNT": get_crawler_setting(

--- a/backend/tests/unittests/crawler/test_crawl_manager_graceful_shutdown.py
+++ b/backend/tests/unittests/crawler/test_crawl_manager_graceful_shutdown.py
@@ -10,6 +10,9 @@ Run with: pytest tests/unittests/crawler/test_crawl_manager_graceful_shutdown.py
 """
 
 import asyncio
+import subprocess
+import sys
+import textwrap
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -30,6 +33,51 @@ from eneo.main.exceptions import CrawlTimeoutError
 
 class TestCrawlManagerLifecycle:
     """Tests for CrawlManager start/stop/wait_for_completion lifecycle."""
+
+    def test_crawl_uses_reactor_installed_by_crochet(self):
+        """A fresh worker process crawls with Crochet's Twisted reactor."""
+        script = textwrap.dedent(
+            """
+            from pathlib import Path
+            from tempfile import TemporaryDirectory
+
+            import crochet
+
+            crochet.setup()
+
+            from scrapy import Spider
+
+            from eneo.crawler.crawler import CrawlManager
+            from eneo.crawler.parse_html import CrawledPage
+
+
+            class ItemSpider(Spider):
+                name = "item"
+
+                async def start(self):
+                    yield CrawledPage(
+                        url="https://example.com",
+                        title="Example",
+                        content="Crawled",
+                    )
+
+
+            with TemporaryDirectory() as tmpdir:
+                output = Path(tmpdir) / "items.jsonl"
+                manager = CrawlManager()
+                result = manager.start_crawl(ItemSpider, filepath=output)
+                result.wait(timeout=5.0)
+                assert '"content": "Crawled"' in output.read_text()
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        assert completed.returncode == 0, completed.stderr
 
     def test_crawl_manager_initializes_clean_state(self):
         """CrawlManager initializes with None crawler and event not set."""


### PR DESCRIPTION
## TL;DR

Scrapy 2.13+ expects `AsyncioSelectorReactor` by default. Eneo embeds Scrapy in Crochet, which has already installed and started the platform reactor (`EPollReactor` on Linux), so Scrapy rejects the mismatch before fetching any page.

This sets `TWISTED_REACTOR` to `None`, Scrapy's documented setting for using the host application's existing reactor. It does not disable Twisted.

## Summary

- Make the existing `create_runner` owner use Crochet's installed reactor.
- Add a fresh-process regression test that starts Crochet and verifies Scrapy exports a crawled item.

## Why

Every crawler job failed before network access, then surfaced the secondary `no pages returned` error. The crawler must follow Crochet's reactor lifecycle rather than Scrapy's standalone default.

## What changed

`create_runner` now sets `TWISTED_REACTOR=None` for all embedded `CrawlerRunner` instances. The regression test reproduces the worker import order in a subprocess.

## What was deliberately not changed

- No Scrapy/Twisted dependency pin or downgrade.
- No worker startup rewrite.
- No changes to the separate Kravla migration in #487.

## Deletion / consolidation

No new compatibility path was added; the reactor choice stays in the existing crawler-settings owner.

## Risk and rollback

Low risk. `None` keeps Twisted enabled and uses Crochet's already-running reactor, but it intentionally stops requiring asyncio-reactor-specific behavior. The current crawler uses Crochet/Deferreds, and the regression test exercises a real item export. Revert commit `e2f02777b` to roll back.

## Planning

No matching development task or existing reactor-fix PR was found. This remains draft until planning linkage is confirmed.

## Validation

- Red before the fix: regression test failed with the reported reactor mismatch.
- `pytest tests/unittests/crawler -q` — 62 passed.
- `ruff check` for both changed files — passed.
- `ruff format --check` for both changed files — passed.
- Repository pre-push checks — passed.
- Full Pyright was not run locally because no matching devcontainer was available for the clean PR worktree; CI remains the type-check authority.

## Screenshots

Not applicable.