### PR TITLE
chore(roadmap): publish safe JSON feed for eneo.ai

### DIFF
--- a/.github/PROJECT_WORKFLOW.md
+++ b/.github/PROJECT_WORKFLOW.md
@@ -267,6 +267,43 @@ Export a slide-like committee roadmap SVG:
 GH_TOKEN=... node scripts/export_github_roadmap.mjs --owner eneo-ai --project 5 --format svg --audience committee --output committee-roadmap.svg
 ```
 
+Export the public website data contract:
+
+```bash
+GH_TOKEN=... node scripts/export_github_roadmap.mjs \
+  --owner eneo-ai \
+  --project 5 \
+  --repository eneo-ai/eneo \
+  --format json \
+  --audience default \
+  --output roadmap.json
+```
+
+JSON is always a public projection. It includes only real issue epics whose
+Project payload has `content.type: Issue` and the exact repository
+`eneo-ai/eneo`; Project draft items and issues from other repositories are
+excluded. Public item fields are an explicit allowlist. Adding a Project field
+or an internal exporter field never adds it to public JSON automatically.
+
+Schema version 1 exposes these item fields:
+
+- `number`, `url`, `title`, and the complete Epic `Summary`;
+- Project `status`, `roadmapVersion`, `area`, `priority`, `startDate`, and
+  `targetDate`;
+- `group`: `in_progress`, `next`, `later`, or `delivered`.
+
+The envelope also exposes `unpublishedItemCount`. It counts epic-level Project
+items that are not public `eneo-ai/eneo` issues. A non-zero value is a
+transparency gap: convert the item to a public epic issue or reclassify it if it
+does not belong on the roadmap. The export still succeeds so the public page
+does not become stale, but consumers should surface or alert on the count.
+
+`Done` items are delivered. Active or blocked items are in progress. `Todo`
+items in the earliest concrete numeric release family among public `Todo` items
+are next; remaining items are later. The raw status and roadmap version remain
+in the projection so the website can change presentation without reparsing
+Project data.
+
 Export with explicit columns, for example when a committee deck should always show empty future buckets:
 
 ```bash
@@ -274,6 +311,53 @@ GH_TOKEN=... node scripts/export_github_roadmap.mjs --owner eneo-ai --project 5 
 ```
 
 The `Export roadmap graph` workflow can also be run manually in GitHub Actions. It uploads the generated roadmap as an artifact and lets the runner choose `default`, `committee`, or `standup` audience.
+
+The same workflow runs every six hours and uploads the public JSON projection
+as the stable artifact `eneo-roadmap-public-json` with 30-day retention.
+Scheduled exports are read-only and do not run the Project field setup script.
+Manual Markdown, Mermaid, and SVG artifacts can contain Project-only planning
+metadata, are not public website inputs, and have one-day retention.
+
+### Website automation handoff
+
+The website workflow should download the latest successful scheduled
+`eneo-roadmap-public-json` artifact, translate and cache only changed item
+content, then commit its own rendered data only when that downstream data
+changes.
+
+GitHub's automatic `GITHUB_TOKEN` is scoped to the repository where the
+workflow runs. A workflow in `eneo-ai-website` therefore needs a fine-grained
+token stored there as `ROADMAP_ARTIFACT_TOKEN` with read-only Actions access to
+`eneo-ai/eneo`. It does not need organization Project access when it consumes
+the artifact. Keep `ANTHROPIC_API_KEY` only in the website repository for the
+translation step.
+
+A shell-based consumer can resolve and download the artifact with:
+
+```bash
+run_id="$(
+  GH_TOKEN="$ROADMAP_ARTIFACT_TOKEN" gh run list \
+    --repo eneo-ai/eneo \
+    --workflow export-roadmap.yml \
+    --event schedule \
+    --status success \
+    --limit 1 \
+    --json databaseId \
+    --jq '.[0].databaseId'
+)"
+
+GH_TOKEN="$ROADMAP_ARTIFACT_TOKEN" gh run download "$run_id" \
+  --repo eneo-ai/eneo \
+  --name eneo-roadmap-public-json \
+  --dir data/roadmap-source
+```
+
+The website should retain its last committed roadmap if source download,
+schema validation, or translation fails. Pin `schemaVersion: 1`, reject unknown
+schema versions, and hash item `title` plus `summary` for translation caching;
+do not include the envelope `generatedAt` in that cache key. Alert or visibly
+flag a non-zero `unpublishedItemCount` instead of silently presenting the feed
+as complete.
 
 If an epic appears under `Unscheduled`, set its `Roadmap version` Project field or fill in the `Roadmap version` section in the epic issue body. The export does not use GitHub Releases, tags, or milestones as the roadmap source of truth.
 

--- a/.github/workflows/export-roadmap.yml
+++ b/.github/workflows/export-roadmap.yml
@@ -1,6 +1,8 @@
 name: Export roadmap graph
 
 on:
+  schedule:
+    - cron: "17 */6 * * *"
   workflow_dispatch:
     inputs:
       format:
@@ -10,6 +12,7 @@ on:
           - markdown
           - mermaid
           - svg
+          - json
         default: markdown
       audience:
         description: Output audience
@@ -27,25 +30,70 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: export-roadmap-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   export:
     runs-on: ubuntu-latest
     steps:
       - name: Check out export script
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           persist-credentials: false
 
-      - name: Resolve output extension
+      - name: Resolve export settings
         id: output
         env:
-          FORMAT: ${{ inputs.format }}
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_FORMAT: ${{ inputs.format }}
+          REQUESTED_AUDIENCE: ${{ inputs.audience }}
+          REQUESTED_VERSIONS: ${{ inputs.versions }}
         run: |
-          case "$FORMAT" in
-            mermaid) echo "extension=mmd" >> "$GITHUB_OUTPUT" ;;
-            svg) echo "extension=svg" >> "$GITHUB_OUTPUT" ;;
-            *) echo "extension=md" >> "$GITHUB_OUTPUT" ;;
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            format="json"
+            audience="default"
+            versions=""
+          else
+            format="${REQUESTED_FORMAT:-markdown}"
+            audience="${REQUESTED_AUDIENCE:-default}"
+            versions="${REQUESTED_VERSIONS:-}"
+          fi
+
+          case "$format" in
+            json)
+              if [ "$audience" != "default" ]; then
+                echo "::error title=Invalid JSON audience::JSON roadmap exports require the default audience."
+                exit 1
+              fi
+              extension="json"
+              artifact_name="eneo-roadmap-public-json"
+              retention_days="30"
+              ;;
+            mermaid)
+              extension="mmd"
+              artifact_name="eneo-roadmap-${audience}-mermaid"
+              retention_days="1"
+              ;;
+            svg)
+              extension="svg"
+              artifact_name="eneo-roadmap-${audience}-svg"
+              retention_days="1"
+              ;;
+            *)
+              extension="md"
+              artifact_name="eneo-roadmap-${audience}-markdown"
+              retention_days="1"
+              ;;
           esac
+
+          echo "format=$format" >> "$GITHUB_OUTPUT"
+          echo "audience=$audience" >> "$GITHUB_OUTPUT"
+          echo "versions=$versions" >> "$GITHUB_OUTPUT"
+          echo "extension=$extension" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+          echo "retention_days=$retention_days" >> "$GITHUB_OUTPUT"
 
       - name: Validate project export token
         env:
@@ -59,6 +107,7 @@ jobs:
           gh project item-list 5 --owner eneo-ai --limit 1 --format json >/dev/null
 
       - name: Ensure roadmap project fields
+        if: github.event_name == 'workflow_dispatch'
         run: node .github/scripts/ensure-project-fields.mjs
         env:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
@@ -70,18 +119,21 @@ jobs:
           node scripts/export_github_roadmap.mjs \
             --owner eneo-ai \
             --project 5 \
+            --repository "$REPOSITORY" \
             --format "$FORMAT" \
             --audience "$AUDIENCE" \
             --versions "$VERSIONS" \
             --output roadmap.${{ steps.output.outputs.extension }}
         env:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          FORMAT: ${{ inputs.format }}
-          AUDIENCE: ${{ inputs.audience }}
-          VERSIONS: ${{ inputs.versions }}
+          REPOSITORY: eneo-ai/eneo
+          FORMAT: ${{ steps.output.outputs.format }}
+          AUDIENCE: ${{ steps.output.outputs.audience }}
+          VERSIONS: ${{ steps.output.outputs.versions }}
 
       - name: Upload roadmap artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: eneo-roadmap-${{ inputs.audience }}-${{ inputs.format }}
+          name: ${{ steps.output.outputs.artifact_name }}
           path: roadmap.${{ steps.output.outputs.extension }}
+          retention-days: ${{ steps.output.outputs.retention_days }}

--- a/frontend/apps/docs-site/src/content/contributing/project-roadmap.mdx
+++ b/frontend/apps/docs-site/src/content/contributing/project-roadmap.mdx
@@ -15,7 +15,9 @@ Eneo tracks product planning in one GitHub Project:
 Use the project for roadmap epics, active development tasks, findings, bugs, and chores. The roadmap export reads the same project data and turns epics into Markdown, Mermaid, or SVG snapshots.
 
 <Callout type="info">
-  Project #5 has the roadmap fields listed below. The Actions workflows also run a setup script that recreates missing fields when the project configuration drifts.
+  Project #5 has the roadmap fields listed below. Project intake and manual
+  roadmap exports also run a setup script that recreates missing fields when the
+  project configuration drifts.
 </Callout>
 
 ## Planning Model
@@ -148,6 +150,47 @@ Choose:
 
 The workflow uploads the result as an Actions artifact. It does not commit generated SVG files to the repository.
 
+### Public Website Feed
+
+The same workflow generates a public JSON projection every six hours:
+
+```text
+Artifact: eneo-roadmap-public-json
+Schema: 1
+Retention: 30 days
+```
+
+The feed includes only issue-backed epics from `eneo-ai/eneo`. Project draft
+items and issues from other repositories are excluded. Its four groups are
+`in_progress`, `next`, `later`, and `delivered`.
+
+`unpublishedItemCount` reports how many epic-level Project items are not public
+issues. A non-zero value should be surfaced or alerted on until those items are
+converted to public epic issues or reclassified. The feed still updates so the
+website does not become stale.
+
+Run the same export locally with:
+
+```bash
+GH_TOKEN=... node scripts/export_github_roadmap.mjs \
+  --owner eneo-ai \
+  --project 5 \
+  --repository eneo-ai/eneo \
+  --format json \
+  --audience default \
+  --output roadmap.json
+```
+
+JSON is an allowlisted public contract. Adding another Project field does not
+publish that field automatically. Manual Markdown, Mermaid, and SVG artifacts
+may contain Project-only planning metadata and are retained for one day; do not
+use them as public website inputs.
+
+The website repository needs its own read-only `ROADMAP_ARTIFACT_TOKEN` with
+Actions access to `eneo-ai/eneo` because the automatic `GITHUB_TOKEN` cannot
+read another repository's artifacts. It does not need direct Project access
+when it consumes this feed.
+
 ## Version Rules
 
 The project does not hardcode future versions. Add the version string to the epic's `Roadmap version` field.
@@ -191,7 +234,7 @@ Priority
 Kind
 ```
 
-The workflows run the script after they validate `ADD_TO_PROJECT_PAT`. You only need to run it by hand after changing Project #5 outside the repo workflow.
+Project intake and manual roadmap exports run the script after they validate `ADD_TO_PROJECT_PAT`. You only need to run it by hand after changing Project #5 outside the repo workflow.
 
 `ADD_TO_PROJECT_PAT` must be a repository secret with organization Projects read/write access for Project #5 and read access to issues and pull requests in `eneo-ai/eneo`.
 

--- a/scripts/export_github_roadmap.mjs
+++ b/scripts/export_github_roadmap.mjs
@@ -8,10 +8,12 @@ const args = parseArgs(process.argv.slice(2));
 const selfTest = args["self-test"] === "true";
 const owner = args.owner || process.env.PROJECT_OWNER || "eneo-ai";
 const project = args.project || process.env.PROJECT_NUMBER || "5";
+const repository = args.repository || process.env.ROADMAP_REPOSITORY || "";
 const limit = args.limit || "1000";
 const format = args.format || "markdown";
 const audience = args.audience || "default";
 const versions = parseVersionList(args.versions || "");
+const generatedAt = new Date().toISOString();
 
 if (selfTest) {
   runSelfTest();
@@ -27,7 +29,15 @@ const epics = (data.items || [])
   .map(toEpic)
   .sort(compareEpics);
 
-const output = renderOutput(epics, { owner, project, format, audience, versions });
+const output = renderOutput(epics, {
+  owner,
+  project,
+  repository,
+  format,
+  audience,
+  versions,
+  generatedAt,
+});
 
 if (args.output) {
   fs.writeFileSync(args.output, output);
@@ -36,6 +46,10 @@ if (args.output) {
 }
 
 function renderOutput(epics, context) {
+  if (context.format === "json") {
+    return renderPublicJson(epics, context);
+  }
+
   if (context.format === "mermaid") {
     return renderMermaid(epics, context);
   }
@@ -160,8 +174,92 @@ function toEpic(item, index) {
       getSectionValue(body, ["Sub-issue progress", "Progress"]),
       "",
     ]),
+    summary: getSectionBody(body, ["Summary"]),
+    contentType: item.content?.type || "",
+    repository: item.content?.repository || "",
     version,
   };
+}
+
+function renderPublicJson(epics, context) {
+  if (context.audience !== "default") {
+    throw new Error("JSON roadmap exports require the default audience");
+  }
+
+  if (!context.repository) {
+    throw new Error("JSON roadmap exports require --repository");
+  }
+
+  const publicEpics = epics.filter((epic) => (
+    epic.contentType === "Issue"
+    && epic.repository === context.repository
+    && Number.isInteger(epic.number)
+    && Boolean(epic.url)
+  ));
+  const nextVersionRank = publicNextVersionRank(publicEpics);
+  const groupOrder = ["in_progress", "next", "later", "delivered"];
+  const items = publicEpics
+    .map((epic) => ({
+      number: epic.number,
+      url: epic.url,
+      title: epic.title,
+      summary: epic.summary,
+      status: epic.status,
+      roadmapVersion: versionGroup(epic.version),
+      area: epic.area,
+      priority: epic.priority,
+      startDate: epic.startDate,
+      targetDate: epic.targetDate,
+      group: publicRoadmapGroup(epic, nextVersionRank),
+    }))
+    .sort((left, right) => (
+      groupOrder.indexOf(left.group) - groupOrder.indexOf(right.group)
+      || compareVersions(left.roadmapVersion, right.roadmapVersion)
+      || comparePriority(left.priority, right.priority)
+      || left.title.localeCompare(right.title)
+    ));
+
+  return `${JSON.stringify({
+    schemaVersion: 1,
+    generatedAt: context.generatedAt,
+    source: {
+      owner: context.owner,
+      project: context.project,
+      repository: context.repository,
+    },
+    groups: groupOrder,
+    unpublishedItemCount: epics.length - publicEpics.length,
+    items,
+  }, null, 2)}\n`;
+}
+
+function publicNextVersionRank(epics) {
+  const ranks = epics
+    .filter((epic) => equals(epic.status, "Todo"))
+    .map((epic) => versionRank(versionGroup(epic.version)))
+    .filter((rank) => rank < 8_000);
+
+  return ranks.length > 0 ? Math.min(...ranks) : null;
+}
+
+function publicRoadmapGroup(epic, nextVersionRank) {
+  if (isDone(epic)) {
+    return "delivered";
+  }
+
+  if (isActive(epic) || isBlocked(epic)) {
+    return "in_progress";
+  }
+
+  if (
+    equals(epic.status, "Todo")
+    && nextVersionRank !== null
+    && versionRank(versionGroup(epic.version)) === nextVersionRank
+  ) {
+    return "next";
+  }
+
+  return "later";
 }
 
 function renderMarkdown(epics, context) {
@@ -679,6 +777,31 @@ function getSectionValue(body, headings) {
   return "";
 }
 
+function getSectionBody(body, headings) {
+  for (const heading of headings) {
+    const escaped = escapeRegExp(heading);
+    const pattern = new RegExp(
+      `^#{2,6}\\s+${escaped}\\s*$([\\s\\S]*?)(?=^#{2,6}\\s+|$(?![\\s\\S]))`,
+      "im",
+    );
+    const match = body.match(pattern);
+
+    if (!match) {
+      continue;
+    }
+
+    const value = match[1]
+      .replace(/<!--[\s\S]*?-->/g, "")
+      .trim();
+
+    if (value) {
+      return value;
+    }
+  }
+
+  return "";
+}
+
 function getLabels(item) {
   return (item.labels || []).map((label) => {
     if (typeof label === "string") {
@@ -894,7 +1017,14 @@ function runSelfTest() {
         number: 101,
         title: "Personlig chatt 2.0",
         url: "https://github.com/eneo-ai/eneo/issues/101",
+        type: "Issue",
+        repository: "eneo-ai/eneo",
         body: [
+          "## Summary",
+          "People can use a safer personal chat.",
+          "",
+          "The rollout remains controlled by administrators.",
+          "",
           "## Roadmap version",
           "2.7",
           "",
@@ -918,6 +1048,9 @@ function runSelfTest() {
       content: {
         number: 102,
         title: "Extern kostnadsuppfoljning",
+        url: "https://github.com/eneo-ai/eneo/issues/102",
+        type: "Issue",
+        repository: "eneo-ai/eneo",
         body: "## Roadmap version\n2.7 RC\n",
       },
       Status: "Todo",
@@ -928,6 +1061,9 @@ function runSelfTest() {
       content: {
         number: 103,
         title: "Crawl 2.0",
+        url: "https://github.com/eneo-ai/eneo/issues/103",
+        type: "Issue",
+        repository: "eneo-ai/eneo",
         body: "## Roadmap version\nFuture\n## Owner / lead\nSearch\n",
       },
       Status: "Todo",
@@ -946,6 +1082,156 @@ function runSelfTest() {
   const epics = items.filter(isEpic).map(toEpic).sort(compareEpics);
 
   assert.equal(epics.length, 3, "generic Version fields must not turn tasks into roadmap epics");
+
+  const publicExportItems = [
+    ...items,
+    {
+      id: "draft-1",
+      kind: "Epic",
+      title: "Private Project draft",
+      status: "Todo",
+      "roadmap version": "2.7",
+      content: {
+        type: "DraftIssue",
+        body: "## Summary\nThis draft must never be published.\n",
+      },
+    },
+    {
+      id: "foreign-1",
+      kind: "Epic",
+      title: "Foreign repository epic",
+      status: "Todo",
+      "roadmap version": "2.7",
+      content: {
+        number: 104,
+        title: "Foreign repository epic",
+        url: "https://github.com/eneo-ai/private-planning/issues/104",
+        type: "Issue",
+        repository: "eneo-ai/private-planning",
+        body: "## Summary\nThis issue belongs to another repository.\n",
+      },
+    },
+    {
+      id: "item-4",
+      kind: "Epic",
+      status: "Done",
+      "roadmap version": "2.6",
+      content: {
+        number: 105,
+        title: "Delivered epic",
+        url: "https://github.com/eneo-ai/eneo/issues/105",
+        type: "Issue",
+        repository: "eneo-ai/eneo",
+        body: "## Summary\nThis outcome has shipped.\n",
+      },
+    },
+    {
+      id: "item-5",
+      kind: "Epic",
+      status: "In review",
+      "roadmap version": "2.7",
+      content: {
+        number: 106,
+        title: "Unknown status epic",
+        url: "https://github.com/eneo-ai/eneo/issues/106",
+        type: "Issue",
+        repository: "eneo-ai/eneo",
+        body: "## Summary\nThis status is not part of the public grouping contract.\n",
+      },
+    },
+    {
+      id: "item-6",
+      kind: "Epic",
+      status: "Blocked",
+      "roadmap version": "Future",
+      content: {
+        number: 107,
+        title: "Blocked future epic",
+        url: "https://github.com/eneo-ai/eneo/issues/107",
+        type: "Issue",
+        repository: "eneo-ai/eneo",
+        body: "## Summary\nThis work has started but is currently blocked.\n",
+      },
+    },
+  ];
+  const publicExportEpics = publicExportItems
+    .filter(isEpic)
+    .map(toEpic)
+    .sort(compareEpics);
+  const publicJson = JSON.parse(renderOutput(publicExportEpics, {
+    owner: "eneo-ai",
+    project: "5",
+    repository: "eneo-ai/eneo",
+    format: "json",
+    audience: "default",
+    versions: [],
+    generatedAt: "2026-07-23T12:00:00.000Z",
+  }));
+  const publicItemKeys = [
+    "area",
+    "group",
+    "number",
+    "priority",
+    "roadmapVersion",
+    "startDate",
+    "status",
+    "summary",
+    "targetDate",
+    "title",
+    "url",
+  ];
+
+  assert.deepEqual(Object.keys(publicJson).sort(), [
+    "generatedAt",
+    "groups",
+    "items",
+    "schemaVersion",
+    "source",
+    "unpublishedItemCount",
+  ]);
+  assert.deepEqual(Object.keys(publicJson.source).sort(), ["owner", "project", "repository"]);
+  assert.equal(publicJson.schemaVersion, 1);
+  assert.deepEqual(publicJson.groups, ["in_progress", "next", "later", "delivered"]);
+  assert.equal(publicJson.unpublishedItemCount, 2);
+  assert.deepEqual(publicJson.items.map((epic) => epic.number), [101, 107, 102, 106, 103, 105]);
+  assert.ok(publicJson.items.every((epic) => (
+    JSON.stringify(Object.keys(epic).sort()) === JSON.stringify(publicItemKeys)
+  )), "public roadmap items must expose only the schema allowlist");
+  assert.equal(publicJson.items.find((epic) => epic.number === 101).group, "in_progress");
+  assert.equal(publicJson.items.find((epic) => epic.number === 107).group, "in_progress");
+  assert.equal(publicJson.items.find((epic) => epic.number === 102).group, "next");
+  assert.equal(publicJson.items.find((epic) => epic.number === 103).group, "later");
+  assert.equal(publicJson.items.find((epic) => epic.number === 105).group, "delivered");
+  assert.equal(publicJson.items.find((epic) => epic.number === 106).group, "later");
+  assert.equal(
+    publicJson.items.find((epic) => epic.number === 101).summary,
+    "People can use a safer personal chat.\n\nThe rollout remains controlled by administrators.",
+  );
+  assert.doesNotMatch(JSON.stringify(publicJson), /Private Project draft|Foreign repository epic/);
+  assert.throws(
+    () => renderOutput(publicExportEpics, {
+      owner: "eneo-ai",
+      project: "5",
+      repository: "eneo-ai/eneo",
+      format: "json",
+      audience: "committee",
+      versions: [],
+      generatedAt: "2026-07-23T12:00:00.000Z",
+    }),
+    /JSON roadmap exports require the default audience/,
+  );
+  assert.throws(
+    () => renderOutput(publicExportEpics, {
+      owner: "eneo-ai",
+      project: "5",
+      repository: "",
+      format: "json",
+      audience: "default",
+      versions: [],
+      generatedAt: "2026-07-23T12:00:00.000Z",
+    }),
+    /JSON roadmap exports require --repository/,
+  );
 
   const markdown = renderOutput(epics, {
     owner: "eneo-ai",


### PR DESCRIPTION
## Summary

- Add schema-versioned public JSON output to the existing Project 5 roadmap exporter.
- Publish a stable `eneo-roadmap-public-json` artifact every six hours without mutating Project fields.
- Exclude Project drafts and foreign-repository issues through an exact type/repository filter and strict field allowlist.
- Report `unpublishedItemCount` so filtered epic-level Project items remain a visible transparency gap.
- Document the read-only website handoff, translation cache contract, failure fallback, and token permissions.

## Why

Project 5 and `scripts/export_github_roadmap.mjs` are the canonical owners of Eneo roadmap planning and export semantics. The website needs a machine-readable feed, but a second website-owned issue parser would duplicate status/version rules and direct Project access could publish private draft content. This change deepens the existing exporter with one safe public projection and keeps translation/rendering downstream.

## What changed

- `scripts/export_github_roadmap.mjs`
  - adds JSON schema version 1;
  - requires the default audience and an explicit repository;
  - includes only `Issue` content with exact repository `eneo-ai/eneo`;
  - serializes an explicit public field allowlist;
  - preserves the full Epic Summary;
  - derives `in_progress`, `next`, `later`, and `delivered`;
  - reports the dynamic count of epic-level Project items outside the public feed.
- `.github/workflows/export-roadmap.yml`
  - schedules read-only public exports every six hours;
  - uses one stable artifact name and bounded retention;
  - skips Project field mutation on scheduled runs;
  - pins checkout and artifact upload actions to verified immutable SHAs.
- `.github/PROJECT_WORKFLOW.md` and the docs-site roadmap guide
  - define the public contract and the `eneo-ai-website` download/fallback setup.

## What was deliberately not changed

- No `eneo.ai` or `eneo-ai-website` code.
- No AI translation, translation cache implementation, or rendering.
- No Project fields, Project views, issue templates, or current epic content.
- No repository dispatch, cross-repository write token, reusable workflow layer, or second parser.
- No hardcoded live epic numbers or titles.

## Deletion / consolidation

No duplicate exporter was introduced. The website no longer needs direct organization Project access if it consumes this artifact; it only needs a fine-grained read-only token with Actions access to `eneo-ai/eneo`. Existing Markdown, Mermaid, and SVG paths remain owned by the same exporter.

## Risk and rollback

The change is additive for consumers. Existing Markdown, Mermaid, and SVG outputs are byte-identical for the same live input. The public JSON surface is guarded by exact envelope/item key assertions, a schema version, adversarial draft/foreign-repository fixtures, and fail-closed audience/repository checks.

Rollback is a revert of commit `cd303490f`. The website contract requires retaining its last committed roadmap if download, schema validation, or translation fails.

## Planning

- Task: no matching development task exists; the unrelated roadmap search result #551 was deliberately not linked.
- Canonical Project: `eneo-ai/5`, Roadmap view 4.

## Public-data evidence

Sanitized live `gh project item-list` shapes:

- Project draft: `content.type = DraftIssue`; repository, number, and URL are absent.
- Public epic issue: `content.type = Issue`; `content.repository = eneo-ai/eneo`; number and public issue URL are present.
- Project 5 currently contains no foreign-repository epic. A self-test fixture with repository `eneo-ai/private-planning` proves the exact-match rejection path.

Current live export result:

- 4 public issue epics.
- 2 epic-level Project items excluded from item content.
- `unpublishedItemCount: 2` exposes that publication gap without disclosing private text.
- Every public issue has a non-empty Summary.

## Validation

- RED: `node scripts/export_github_roadmap.mjs --self-test` failed with `Unsupported roadmap export format: json`.
- GREEN: `node scripts/export_github_roadmap.mjs --self-test`.
- `actionlint` 1.7.12 on `.github/workflows/export-roadmap.yml`.
- `node --check` on:
  - `.github/scripts/ensure-project-fields.mjs`
  - `.github/scripts/project-intake.mjs`
  - `.github/scripts/ensure-planning-labels.mjs`
  - `scripts/export_github_roadmap.mjs`
- Self-tests:
  - `node .github/scripts/ensure-project-fields.mjs --self-test`
  - `node .github/scripts/project-intake.mjs --self-test`
  - `node scripts/export_github_roadmap.mjs --self-test`
- Live Project 5 JSON contract validation with exact envelope/item allowlists, public issue URL restriction, and non-empty summaries.
- Byte comparisons passed for live committee Markdown, default Mermaid, and committee SVG against pre-change baselines.
- `git diff --check`, commit hooks, and pre-push checks passed.

Action pin verification:

- `actions/checkout` tag `v4.4.0` -> `11d5960a326750d5838078e36cf38b85af677262`
- `actions/upload-artifact` tag `v4.6.2` -> `ea165f8d65b6e75b540449e92b4886f43607fa02`

## Peer review

Claude peer-loop session `public-roadmap-export`:

- plan review: changes required, score 6;
- revised plan: green, score 8;
- implementation commit gate: green, score 8;
- transparency verification: green, score 9.
