### PR TITLE
test(skills): lock deletion provenance contract

### DIFF
--- a/backend/tests/integration/skills/test_skill_concurrency.py
+++ b/backend/tests/integration/skills/test_skill_concurrency.py
@@ -5,6 +5,7 @@ from uuid import UUID, uuid4
 import pytest
 import sqlalchemy as sa
 
+from eneo.apps.app_runs.app_run_repo import _serialize_skill_provenance
 from eneo.database.tables.app_table import AppRuns
 from eneo.database.tables.assistant_table import Assistants
 from eneo.database.tables.job_table import Jobs
@@ -17,7 +18,7 @@ from eneo.main.exceptions import (
 )
 from eneo.main.models import Status
 from eneo.roles.permissions import Permission
-from eneo.skills.domain.skill import SkillBindingReference, SkillExecutionReference
+from eneo.skills.domain.skill import SkillBindingReference
 
 
 @dataclass(frozen=True)
@@ -179,21 +180,6 @@ async def _wait_for_held_write(
         if not event_waiter.done():
             event_waiter.cancel()
             await asyncio.gather(event_waiter, return_exceptions=True)
-
-
-def _serialize_provenance(
-    provenance: tuple[SkillExecutionReference, ...],
-) -> list[dict[str, object]]:
-    return [
-        {
-            "skill_id": str(reference.skill_id),
-            "skill_revision_id": str(reference.skill_revision_id),
-            "revision_number": reference.revision_number,
-            "content_digest": reference.content_digest,
-            "position": reference.position,
-        }
-        for reference in provenance
-    ]
 
 
 async def test_fresh_install_owner_has_every_tenant_permission(admin_user):
@@ -517,7 +503,9 @@ async def test_new_binding_serializes_before_delete_validation(
     assert [binding.skill_id for binding in persisted] == [resources.first_skill_id]
 
 
-async def test_queued_app_run_snapshot_blocks_concurrent_skill_deletion(
+@pytest.mark.parametrize("terminal_status", [Status.COMPLETE, Status.FAILED])
+async def test_queued_app_run_snapshot_blocks_concurrent_skill_deletion_until_terminal(
+    terminal_status: Status,
     skill_concurrency_resources: SkillConcurrencyResources,
     db_container,
     db_session,
@@ -545,6 +533,7 @@ async def test_queued_app_run_snapshot_blocks_concurrent_skill_deletion(
             snapshot_ready.set()
             await persist_snapshot.wait()
             job_id = uuid4()
+            app_run_id = uuid4()
             container.session().add(
                 Jobs(
                     id=job_id,
@@ -555,18 +544,21 @@ async def test_queued_app_run_snapshot_blocks_concurrent_skill_deletion(
             )
             container.session().add(
                 AppRuns(
+                    id=app_run_id,
                     tenant_id=resources.tenant_id,
                     user_id=resources.user_id,
                     app_id=resources.app_id,
                     job_id=job_id,
                     completion_model_id=resources.completion_model_id,
-                    skill_provenance=_serialize_provenance(composition.provenance),
+                    skill_provenance=_serialize_skill_provenance(
+                        composition.provenance
+                    ),
                 )
             )
             await container.session().flush()
             snapshot_persisted.set()
             await release_snapshot.wait()
-            return composition.provenance, job_id
+            return composition.provenance, job_id, app_run_id
 
     async def delete():
         async with db_container() as container:
@@ -599,7 +591,7 @@ async def test_queued_app_run_snapshot_blocks_concurrent_skill_deletion(
         release_snapshot.set()
 
     snapshot, _ = await asyncio.gather(snapshot_task, delete_task)
-    provenance, job_id = snapshot
+    provenance, job_id, app_run_id = snapshot
 
     async with db_container() as container:
         skill = await container.skill_repo().get(skill_id=resources.first_skill_id)
@@ -618,13 +610,37 @@ async def test_queued_app_run_snapshot_blocks_concurrent_skill_deletion(
         await container.session().execute(
             sa.update(Jobs)
             .where(Jobs.id == job_id)
-            .values(status=Status.COMPLETE.value)
+            .values(status=terminal_status.value)
         )
         deleted = await container.skill_service().delete_skill(
             skill_id=resources.first_skill_id
         )
 
     assert deleted.id == resources.first_skill_id
+    async with db_container() as container:
+        repo = container.skill_repo()
+        retained_app_run = await container.app_run_repo().get(app_run_id)
+        persisted_app_run = await container.session().get(AppRuns, app_run_id)
+
+        assert await repo.get(skill_id=resources.first_skill_id) is None
+        assert (
+            await repo.get_revision(
+                skill_id=resources.first_skill_id,
+                revision_id=resources.first_revision_id,
+            )
+            is None
+        )
+        assert retained_app_run is not None
+        assert retained_app_run.skill_provenance == provenance
+        assert persisted_app_run is not None
+        assert persisted_app_run.skill_provenance is not None
+        assert set(persisted_app_run.skill_provenance[0]) == {
+            "skill_id",
+            "skill_revision_id",
+            "revision_number",
+            "content_digest",
+            "position",
+        }
 
 
 async def test_concurrent_same_content_revision_has_one_created_outcome(

--- a/docs/enterprise-skills-roadmap.md
+++ b/docs/enterprise-skills-roadmap.md
@@ -87,18 +87,28 @@ The foundation merged into `develop` before this roadmap was written:
   provenance. It squash-merged as `a29e9464` on 2026-07-22.
 - PR #559 added paginated immutable revision history and conflict-safe
   restore-as-a-new-revision. It squash-merged as `8ef96390` on 2026-07-22.
+- PR #560 added the admin-owned organisation catalogue, exact publication
+  lifecycle, and direct approved-revision reuse. It squash-merged as
+  `71de15e5` on 2026-07-23.
+- PR #574 added tenant-scoped adoption and drift evidence to the existing Skill
+  detail. It squash-merged as `dfe9dbe7` on 2026-07-23.
+- PR #577 added the organisation-wide emergency execution block. It
+  squash-merged as `b186f175` on 2026-07-23.
 
-The delivery graph was last verified on 2026-07-22:
+The delivery graph was last verified on 2026-07-23:
 
-| Work item                                                | Purpose                                         | Base                                                  | State and next action                                                                                                                                                    |
-| -------------------------------------------------------- | ----------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [#552](https://github.com/eneo-ai/eneo/pull/552)         | S1 first-class local Skills                     | `develop`                                             | Merged as `a29e9464`. Full local verification and all required GitHub checks passed; Review 7 found no current findings and Opus high gave green light at score 8.       |
-| [#559](https://github.com/eneo-ai/eneo/pull/559)         | Skill revision restore                          | `develop`                                             | Merged as `8ef96390`. Full CI passed; Review 5 inspected all 29 paths with no findings, and Opus high gave green light at score 8.                                       |
-| [#560](https://github.com/eneo-ai/eneo/pull/560)         | O1 organisation catalogue                       | `develop` at `8ef96390`                               | Active replay. Complete the admin-only authority correction and picker projection, then render and review the full UX before Fable high, `/review`, CI, Opus, and merge. |
-| [Issue #551](https://github.com/eneo-ai/eneo/issues/551) | File, InfoBlob, and Icon object-content cutover | Current `develop` after the object-content foundation | Open. This gates the fallback file-reference path, not the preferred internal-MCP core split.                                                                            |
-| [#464](https://github.com/eneo-ai/eneo/pull/464)         | MCP file references                             | `develop`                                             | Open and conflict-marked. It belongs to the object-content/file track.                                                                                                   |
-| [#538](https://github.com/eneo-ai/eneo/pull/538)         | Internal MCP and on-demand knowledge            | `feat/mcp-file-ref-and-identity`                      | Open and coupled to #464. Split its internal-effect/knowledge core from file references before selective Skills if the maintainers accept the split.                     |
-| [#541](https://github.com/eneo-ai/eneo/pull/541)         | Web search MCP provider                         | `feat/agentic-rag-knowledge-mcp`                      | Draft. It should not gate Skills.                                                                                                                                        |
+| Work item                                                | Purpose                                         | State and next action                                                                                                                    |
+| -------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| [#552](https://github.com/eneo-ai/eneo/pull/552)         | S1 first-class local Skills                     | Merged as `a29e9464`; required CI and final review passed.                                                                               |
+| [#559](https://github.com/eneo-ai/eneo/pull/559)         | Skill revision restore                          | Merged as `8ef96390`; required CI and final review passed.                                                                               |
+| [#560](https://github.com/eneo-ai/eneo/pull/560)         | O1 organisation catalogue                       | Merged as `71de15e5`; required CI, final review, and product review passed.                                                              |
+| [#574](https://github.com/eneo-ai/eneo/pull/574)         | O1 adoption and drift evidence                  | Merged as `dfe9dbe7`; required CI and final review passed.                                                                               |
+| [#577](https://github.com/eneo-ai/eneo/pull/577)         | O1 emergency execution block                    | Merged as `b186f175`; required CI passed and the final review found no current findings.                                                 |
+| Goal task T007                                           | O1 deletion and retained-provenance closure     | Active. Lock the existing terminal-run recovery contract with PostgreSQL behavior proof and concise operator documentation before O1 GA. |
+| [Issue #551](https://github.com/eneo-ai/eneo/issues/551) | File, InfoBlob, and Icon object-content cutover | Open. This gates the fallback file-reference path, not the preferred internal-MCP core split.                                            |
+| [#464](https://github.com/eneo-ai/eneo/pull/464)         | MCP file references                             | Open and conflict-marked. It belongs to the object-content/file track.                                                                   |
+| [#538](https://github.com/eneo-ai/eneo/pull/538)         | Internal MCP and on-demand knowledge            | Open and coupled to #464. Split its internal effect/knowledge core before selective Skills if maintainers accept that split.             |
+| [#541](https://github.com/eneo-ai/eneo/pull/541)         | Web search MCP provider                         | Draft. It does not gate Skills.                                                                                                          |
 
 Passing checks on an old PR head do not remove the need to rebase and rerun the
 full checks against the current `develop` branch.
@@ -549,18 +559,11 @@ on-demand loading ineffective without adding a second event source.
    `8ef96390` on 2026-07-22. Restore remains a copy-to-new-revision operation;
    the reviewed current revision is checked under the append lock and a stale
    review returns 409 without discarding dirty editor content.
-3. **Active:** rebase #560 on merged #559. Keep organisation navigation canonical and retain
-   O1 publication, direct reuse, the adoption-projection contract, and this roadmap. Put the
-   admin-only Organisation correction in #560; do not create another stacked PR
-   for a small subtractive alignment.
-   Before merge, run the complete catalogue and binding flow, capture desktop
-   and responsive evidence, address verified accessibility or UX problems, and
-   obtain both a Fable high whole-PR assessment and explicit product approval.
-   #560 lands the catalogue foundation; queued task T005 owns the adoption
-   projection and remains required before O1 is generally available.
-4. Before O1 is generally available, land the emergency execution block in #560
-   or a narrow follow-up. Do not delay the #560 rebase to absorb unrelated #553
-   work.
+3. **Completed:** #560, #574, and #577 delivered the organisation catalogue,
+   adoption evidence, and emergency execution block on `develop`.
+4. **Active:** T007 closes deletion and retained provenance with the existing
+   Skill and App-run owners. Do not add lifecycle state or product behavior
+   unless a behavior test disproves the accepted contract.
 5. Build O2 after O1 if local editable copies remain the next product priority.
    O2 has no internal MCP dependency.
 
@@ -645,6 +648,9 @@ flowchart LR
 - Parent saves update fields and bindings atomically.
 - Provider-facing instructions preserve exact revision and order.
 - Queued App runs retain bounded provenance and stay stable after later edits.
+- Bound Skills and retained queued or running App runs block deletion. Complete
+  and failed runs keep readable body-free provenance but no longer retain an
+  otherwise eligible Skill.
 - Personal Chat uses Governance Policy pins and rejects direct default-Assistant
   bindings.
 - Zero-Skill behaviour remains byte-equivalent.
@@ -714,6 +720,7 @@ flowchart LR
 | Published revision changes                      | Existing resources do not advance. A builder approves each update.                                                          |
 | Skill is unpublished                            | New attachments stop; retained exact pins keep running.                                                                     |
 | Published Skill is found harmful                | Tenant admin blocks the Skill identity. New turns and not-started App runs stop; pins and audit evidence remain.            |
+| Skill deletion could invalidate a queued run    | Bindings and retained queued/running App-run evidence block deletion; terminal runs retain body-free IDs and digests.       |
 | Author loses permission during a draft          | Parent save reauthorises and commits atomically or fails without partial bindings.                                          |
 | End user lacks catalogue permission             | Parent-resource access still runs its approved pins.                                                                        |
 | Two Skills contradict each other                | Saved order is visible. The author resolves the conflict; Eneo does not invent semantic precedence.                         |
@@ -737,6 +744,9 @@ flowchart LR
 - Use the organisation execution block for an incident. In-flight provider
   requests finish, while later turns and App runs that have not begun provider
   execution fail closed with a recorded reason.
+- Detach a local or never-published organisation draft before deletion. Wait
+  for retained App runs to complete or fail; their body-free provenance remains
+  readable after an eligible hard deletion.
 - Roll back a selective-activation release by keeping existing bindings as
   `always`; do not drop mode or evidence columns until the team has migrated the
   data.

--- a/docs/goals/enterprise-skills-rollout/state.yaml
+++ b/docs/goals/enterprise-skills-rollout/state.yaml
@@ -30,12 +30,12 @@ continuity:
   current_thread_id: "019f8f85-2ea6-7030-8c48-6d90143da5e0"
   previous_thread_id: "019f84c4-21db-7a00-b2cd-ae3d294d14ba"
   rotation_count: 1
-  completed_write_tasks_in_thread: 1
-  handoff_note: notes/handoff.md
-  last_handoff_at: "2026-07-23T16:52:16Z"
-  last_verified_revision: "dfe9dbe7b6ed8c899c08acf15df84cd8e609934b"
+  completed_write_tasks_in_thread: 2
+  handoff_note: null
+  last_handoff_at: null
+  last_verified_revision: "b186f175d84df3f4c89ef0f244b675f152191934"
 
-active_task: T006
+active_task: T007
 
 tasks:
   - id: T001
@@ -380,7 +380,7 @@ tasks:
   - id: T006
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Add the organisation-wide emergency Skill execution block before O1 becomes generally available."
     inputs:
@@ -433,14 +433,53 @@ tasks:
     stop_if:
       - "The implementation mutates or silently advances retained bindings."
       - "Closing the provider-start boundary requires a new distributed lease or retry owner rather than deepening the existing immutable execution-plan boundary."
-    receipt: null
+    receipt:
+      result: done
+      summary: "Added the organisation-wide emergency Skill execution block, closed the final review findings, passed all local and GitHub gates, and squash-merged PR #577."
+      merged_pr: 577
+      source_head: "629844805028446bb4530a27b78bddabfe38128d"
+      merge_commit: "b186f175d84df3f4c89ef0f244b675f152191934"
+      merged_at: "2026-07-23T19:58:44Z"
+      github_checks: "All 18 reported checks reached a terminal non-failing state; 16 passed and 2 scope-dependent checks were skipped."
+      review: "Review 3 inspected the final head, confirmed F2-F3 resolved, and found no current in-scope findings."
+      review_url: "https://github.com/eneo-ai/eneo/pull/577#issuecomment-5062578555"
+      changed_files:
+        - "backend/alembic/versions/202607231730_add_skill_execution_blocks.py"
+        - "backend/src/eneo/settings/"
+        - "backend/src/eneo/skills/"
+        - "backend/tests/integration/migrations/test_skills_schema_round_trip.py"
+        - "backend/tests/integration/skills/test_skill_execution_blocks.py"
+        - "backend/tests/unittests/"
+        - "frontend/apps/docs-site/src/content/guides/skills.mdx"
+        - "frontend/apps/web/src/routes/(app)/spaces/organization/skills/[skillId]/"
+        - "frontend/packages/eneo-js/"
+      commands:
+        - cmd: "focused backend unit suites"
+          status: pass
+        - cmd: "focused PostgreSQL execution-block integration suite"
+          status: pass
+        - cmd: "isolated execution-block migration test"
+          status: pass
+        - cmd: "backend Ruff, Ruff format, Pyright, and uv lock checks"
+          status: pass
+        - cmd: "frontend Prettier and docs-site production build"
+          status: pass
+        - cmd: "required GitHub CI and final /review"
+          status: pass
+      verification:
+        - "53 focused unit tests passed."
+        - "8 focused PostgreSQL execution-block integration tests passed."
+        - "The isolated execution-block migration test passed."
+        - "Backend Ruff, Ruff format, Pyright, and uv lock checks passed."
+        - "Frontend Prettier and the docs-site production build passed."
 
   - id: T007
     type: worker
     assignee: Worker
-    status: queued
+    status: active
     reasoning_hint: high
     objective: "Close the O1 deletion and retained-provenance contract before general availability."
+    tracking_issue: "https://github.com/eneo-ai/eneo/issues/579"
     inputs:
       - "Merged Skill deletion, binding, audit, and queued App-run contracts"
       - "docs/enterprise-skills-roadmap.md"
@@ -448,12 +487,20 @@ tasks:
       - "Keep instruction bodies out of retained runtime evidence."
       - "Serialize deletion with canonical binding and App-run owners."
       - "Document an explicit retention and terminal-run recovery contract."
+      - "Treat this as a contract-lock slice: add no production code when the missing behavior proofs pass on the merged implementation."
+      - "Do not add a reverse delete-before-queue test: an App binding already blocks deletion, so a later snapshot cannot retain the deleted Skill."
+    allowed_files:
+      - "backend/tests/integration/skills/test_skill_concurrency.py"
+      - "docs/enterprise-skills-roadmap.md"
+      - "docs/goals/enterprise-skills-rollout/state.yaml"
+      - "frontend/apps/docs-site/src/content/guides/skills.mdx"
     verify:
       - "Bound and nonterminal-run deletion conflicts"
-      - "Terminal-run recovery and bounded ID/digest provenance"
+      - "Complete and failed terminal-run recovery, hard-deleted Skill/revision rows, and readable bounded ID/digest provenance"
       - "Deletion and queue concurrency behavior"
     stop_if:
       - "Closing the contract requires duplicating App-run lifecycle state."
+      - "A behavior proof fails and the fix needs production files outside this contract-lock slice."
     receipt: null
 
   - id: T008
@@ -516,10 +563,10 @@ checks:
   dirty_fingerprint: "main worktree contains unrelated user-owned changes; roadmap files are isolated"
   last_verification:
     result: pass
-    task: T001
+    task: T006
     commands:
-      - "backend: 3709 non-integration tests passed"
-      - "backend: 63 focused Skill/session tests passed"
-      - "backend: Ruff check and format passed"
-      - "backend: Pyright 0 errors, 0 warnings"
-      - "frontend: 45 files, 244 unit tests passed"
+      - "GitHub: all 18 reported PR #577 checks reached a terminal non-failing state"
+      - "backend: 53 focused unit tests passed"
+      - "backend: 8 focused PostgreSQL execution-block integration tests passed"
+      - "backend: isolated migration test, Ruff, format, Pyright, and uv lock checks passed"
+      - "frontend: Prettier and docs-site production build passed"

--- a/frontend/apps/docs-site/src/content/guides/skills.mdx
+++ b/frontend/apps/docs-site/src/content/guides/skills.mdx
@@ -267,3 +267,12 @@ Chat requests.
 No. It stops runtime composition while preserving exact pins and adoption
 evidence. This lets administrators see the full impact, remediate resources,
 and later unblock with an auditable reason.
+
+### When can I delete a Skill?
+
+First detach it from every Assistant, App, and Personal Chat policy. A queued or
+running App run whose history still exists also blocks deletion until it
+completes or fails. Completed and failed runs keep only the Skill and revision
+IDs, revision number, digest, and position—not the instruction body. Previously
+published organisation Skills remain as audit history and cannot be
+hard-deleted.


### PR DESCRIPTION
## Changes

- extends the existing PostgreSQL queue/delete test across complete and failed
  App runs
- proves eligible hard deletion removes the Skill and revision while the
  production-serialized App-run provenance stays readable and body-free
- updates the enterprise roadmap, Goal Maker state, and concise Skills FAQ with
  the same retention and recovery contract

No production behavior, schema, API, or lifecycle owner changed.

## Why

The merged implementation already distinguishes nonterminal App runs from
terminal history, but its strongest ADR claim was not locked by behavior tests:
failed-run recovery and provenance readability after real hard deletion. This
closes that O1 general-availability gate without inventing new implementation.

## Planning

- Task: Fixes #579
- Parent epic: #545

## Testing

- `uv run pytest tests/integration/skills/test_skill_concurrency.py tests/unittests/apps/app_runs/test_app_run_provenance.py -q` — 21 passed
- `uv run pytest tests/integration/skills/test_skill_concurrency.py::test_queued_app_run_snapshot_blocks_concurrent_skill_deletion_until_terminal -q` — 2 passed after the final serializer/assertion cleanup
- `uv run ruff check tests/integration/skills/test_skill_concurrency.py` — passed
- `uv run ruff format --check tests/integration/skills/test_skill_concurrency.py` — passed
- `bunx prettier --check ../docs/enterprise-skills-roadmap.md apps/docs-site/src/content/guides/skills.mdx` — passed
- `bun run --cwd apps/docs-site build` — passed, including Pagefind indexing
- Goal Maker state checker and `git diff --check` — passed
- Claude same-session commit gate — green, `GREEN_LIGHT: yes`, score 8

## Screenshots

Not applicable; no product UI changed.
