### PR TITLE
Plan selective Skill activation rollout

### DIFF
--- a/docs/adr/marketplace-hub-package-portability-and-skills.md
+++ b/docs/adr/marketplace-hub-package-portability-and-skills.md
@@ -687,11 +687,23 @@ text, overwrites history, advances existing Assistant/App pins, or updates
 silently. A manager may instead fork the local content into a new independent
 Skill.
 
-An installed copy has an independent local execution identity. A later
-unpublication or execution block on the source does not silently disable a
-locally modified copy, but the source state remains visible in install/update
-status so administrators can inspect and block affected local identities
-explicitly.
+An installed copy has an independent local execution identity, and the central
+execution-block owner covers that identity. A tenant administrator may block an
+installed local identity explicitly through the same owner, authorization, and
+audit record as an organisation block: Assistant composition excludes the
+blocked local identity, and an App run that has not started provider execution
+fails closed before provider work, even when its saved snapshot predates the
+block. Installing from or applying an update of a currently blocked source
+fails closed with a typed reason.
+
+A later unpublication or execution block on the source still does not silently
+disable a locally modified copy. The source state remains visible in
+install/update status, administrators receive affected-copy visibility for a
+blocked source, and each unsafe local identity is blocked explicitly rather
+than through silent propagation from the source. O2 behavior tests must cover
+a bound, locally modified installed copy whose source is blocked — including
+the queued-App pre-provider path — proving the local identity keeps running
+until its own block exists and stops when that block is set.
 
 Three version concepts remain separate:
 

--- a/docs/adr/marketplace-hub-package-portability-and-skills.md
+++ b/docs/adr/marketplace-hub-package-portability-and-skills.md
@@ -1,6 +1,7 @@
 # Marketplace Hub, package portability, and Skills
 
-- **Status:** Proposed
+- **Status:** Partially accepted — local Skills through O1 are implemented;
+  selective activation, O2, S2, and Marketplace remain gated
 - **Date:** 2026-07-15
 - **Decision owners:** Product, security, architecture, and operations
 - **Scope:** Central Marketplace Hub, Eneo instance connector, portable package
@@ -47,11 +48,12 @@ have worked elsewhere, understand Assistants as smaller named capabilities, and
 choose when to adopt a new version. Delivery follows two safe tracks. The local
 track finishes Skills, then adds revision restore, organisation publication and
 approved catalogue reuse; optional install-by-copy remains a separate
-customisation workflow. Selective loading can proceed in parallel once its MCP
-dependency is ready, and portable Skill/Assistant packages follow. The external
-track may start the Hub baseline and a Flow-only pilot now because the Flow
-package already exists. Skill and Assistant Marketplace listings remain
-disabled until their local package contracts ship.
+customisation workflow. Selective loading proceeds through the existing
+completion loop without a loopback-MCP dependency, and portable Skill/Assistant
+packages follow. Although the Flow profile makes the external track technically
+independent, the current product order places all new Marketplace work last.
+Skill and Assistant Marketplace listings remain disabled until their local
+package contracts ship.
 
 ## Outcome
 
@@ -114,8 +116,8 @@ not authorize implementation of the next:
    install-by-copy into editable Spaces is a later workflow for customisation,
    not a prerequisite for catalogue use.
 3. **Selective activation:** trusted on-demand loading for Assistant and
-   organisation-configured personal-chat bindings after the internal MCP
-   foundation. Apps remain eager.
+   organisation-configured personal-chat bindings through one concrete frozen
+   plan consumed by the existing completion loop. Apps remain eager.
 4. **Package verticals:** strict Assistant, App, Skill, and later Knowledge Bundle
    profiles. Each owns its plan, apply, receipt, and failure behavior. The
    Assistant profile starts only after the selective-activation contract is
@@ -123,17 +125,18 @@ not authorize implementation of the next:
    always-only shape. App knowledge and Flow Skill snapshots retain separate
    gates.
 5. **Marketplace Hub:** one external catalogue and distribution service plus the
-   native Eneo connector. Its baseline and Flow-only pilot can proceed without
-   Skills because the existing Flow package is the first enabled kind. The Hub
-   advertises later Skill/Assistant kinds only after their contracts pass the
-   cross-repository gates.
+   native Eneo connector. The existing Flow package removes a technical Skills
+   dependency, but the current product order still defers this layer until the
+   local #553, O2, and S2 gates are complete. The Hub advertises later
+   Skill/Assistant kinds only after their contracts pass the cross-repository
+   gates.
 
 The first end-to-end Marketplace slice is Flow-only because the Flow package
 vertical already exists. The first local Skill slice has one deterministic
 binding behavior: every pinned revision is composed in order. Selective
-activation is a separate required delivery after the trusted internal MCP
-foundation and before Assistant package portability. Source-bearing packages
-remain a separate future decision.
+activation is a separate required delivery through the existing completion loop
+before Assistant package portability. Source-bearing packages remain a separate
+future decision.
 
 ## Problem and why it matters
 
@@ -670,6 +673,11 @@ with explicit state:
   last installed source revision; and
 - **Up to date** only when neither condition applies.
 
+If the source display name or slug collides in the target Space, planning stops
+with a typed conflict and requires the installer to choose the local identity.
+The service never auto-suffixes a name or creates a second copy for a newer
+source revision.
+
 Editing an installed Skill is ordinary local authoring and creates a new
 immutable local revision. Applying an approved source update also creates the
 next local revision and atomically advances the recorded source revision. A Use
@@ -678,6 +686,12 @@ requires a typed preview and explicit replacement confirmation. No path merges
 text, overwrites history, advances existing Assistant/App pins, or updates
 silently. A manager may instead fork the local content into a new independent
 Skill.
+
+An installed copy has an independent local execution identity. A later
+unpublication or execution block on the source does not silently disable a
+locally modified copy, but the source state remains visible in install/update
+status so administrators can inspect and block affected local identities
+explicitly.
 
 Three version concepts remain separate:
 
@@ -709,10 +723,12 @@ acquire independent tool permissions.
 Request-selective activation is not part of S1 or its schema. Until the complete
 runtime lands, APIs do not expose or persist activation state and the UI makes no
 on-demand claim. [Development Task #553](https://github.com/eneo-ai/eneo/issues/553)
-owns the end-to-end delivery after the internal MCP foundation in
-[PR #538](https://github.com/eneo-ai/eneo/pull/538) has merged. It must complete
-before S2 freezes the portable Assistant binding contract. This branch must not
-recreate or partially cherry-pick that internal-tool foundation.
+owns the end-to-end delivery through the existing completion loop. It must
+complete before S2 freezes the portable Assistant binding contract.
+[PR #538](https://github.com/eneo-ai/eneo/pull/538) remains useful evidence for
+tool identity, collision, and approval handling, but its loopback FastMCP,
+knowledge, file, bearer-token, and registry stack is not a merge dependency and
+must not be copied into Skills.
 
 #### Modes, lifecycle, and policy ownership
 
@@ -731,30 +747,40 @@ Changes affect the next turn; they do not mutate an already frozen plan or cance
 an in-flight provider request. Ordinary removal from one Assistant remains an
 explicit edit to that Assistant.
 
-The existing `SettingService` and settings router own the organisation activation
-settings API. They gain typed organisation-scoped persistence for on-demand
-enablement, Skill-context percentage, attached-Skill count, per-turn activation
-limit, and execution blocks. Do not store these values in the current per-user
-`SettingsRepository`, encode numeric policy as feature flags, or introduce a
-generic tenant-policy framework. Governance Policy continues to own only the
-personal-chat bindings and their modes. Each settings change emits the existing
-audited organisation-settings event with actor and old/new typed values.
+The existing Admin Settings route and translated `Admin > Overview/Översikt` page own the
+administrator-facing surface. The `eneo.skills` domain owns one typed Skill
+runtime policy with on-demand enablement, Skill-context percentage,
+attached-Skill count, per-turn activation limit, and execution blocks;
+`SettingService` delegates rather than duplicating its validation. Do not store
+these values in the current per-user `SettingsRepository`, encode numeric policy
+as feature flags, or introduce a generic tenant-policy framework. Governance
+Policy continues to own only the personal-chat bindings and their modes. Each
+settings change emits the existing audited organisation-settings event with
+actor and old/new typed values.
 
 Agent Skills defines field limits and recommends progressive disclosure; it does
-not prescribe a total catalog budget. Eneo therefore ships clearly labelled,
+not prescribe a total catalog budget. Eneo therefore seeds clearly labelled,
 administrator-editable starting values rather than claiming standard limits:
 
 - at most 100 attached Skills per Assistant; and
-- at most 2% of the selected model's input window for Skill-attributable context.
+- at most 10% of the selected model's input window for Skill-attributable
+  context.
 
-The percentage is the primary cost guard because equal Skill counts can have very
-different token costs. The count remains a reviewability and abuse guard. The
-current `SKILL_MAX_BINDINGS` environment value seeds the organisation value during
+The page lets an administrator enable or disable selective activation, change
+the stored count and percentage, lower the per-turn activation ceiling, and
+restore seeded defaults without code or deployment. It shows the resulting
+allowance and capability for each applicable model before save. The percentage
+is the primary cost guard because equal Skill counts can have very different
+token costs. The count remains a reviewability and abuse guard. The current
+`SKILL_MAX_BINDINGS` environment value seeds the organisation value during
 migration; after that, the stored organisation value is the source of truth and
 the environment is not consulted per request. A platform safety ceiling of ten
 accepted on-demand activations per turn bounds prompt-injection fan-out and the
-evidence list; an administrator may choose a lower value. No content is silently
-truncated.
+evidence list; an administrator may choose a lower value. Model context windows
+and platform safety bounds cannot be raised through this page. No content is
+silently truncated. Ten percent is a measured starting value rather than a model
+truth: the selected model window, stored administrator value, and exact LiteLLM
+preflight remain authoritative.
 
 #### Token budget and compatibility behavior
 
@@ -772,6 +798,9 @@ optional context:
 
 - a newly saved configuration must fit the model input window and may reject a
   newly added Skill that exceeds the organisation's configured Skill share;
+- a model is on-demand-capable for that saved configuration only when required
+  bodies, the complete descriptor catalogue, the activation-tool schema, and the
+  largest single attached on-demand body fit the configured Skill share;
 - migrated `always` configurations that already exceed that share continue to
   answer and expose the measured overage instead of silently losing required
   instructions;
@@ -782,10 +811,18 @@ optional context:
 
 The percentage budget governs optional additions at runtime; the model input
 window governs required content. Lowering a setting never makes an otherwise
-valid base request fail. For a policy that permits several models, preflight each
-model against its own window and tokenizer and show the most restrictive result.
-A very small window may therefore make on-demand unavailable; the editor explains
-that state instead of asking the administrator to infer it from a failed turn.
+valid base request fail. The exact save rejection condition depends on the
+binding owner. An Assistant save that adds or edits an `on_demand` binding
+evaluates the Assistant's currently effective completion model. A Governance
+Policy save evaluates every completion model that the policy currently permits,
+including models admitted by its provider selection. If any model in the
+applicable set fails the activatability invariant, the mode edit is rejected.
+Models that are merely tenant-available do not participate in an Assistant save.
+A model admitted later through provider-based policy expansion is post-save
+drift and uses the visible `always_only` fallback until corrected. API, UI, and
+tests use this one condition. The editor shows each model result and explains a
+small-window failure instead of asking the administrator to infer it from a
+failed turn.
 
 #### Frozen turn plan and prompt composition
 
@@ -795,6 +832,12 @@ lookup, measured budget, and policy decisions. It performs no mutable binding
 lookup after construction. A separate frozen `SkillCatalogDescriptor` carries the
 exact revision ID, name, slug, non-empty description, revision number, digest,
 and binding position, but never instructions.
+
+That descriptor is server-side plan/evidence data. The model-facing catalogue
+contains only a plan-local activation key, display name, and description. Exact
+revision IDs, digests, source information, and positions are not advertised and
+cannot be supplied by the model. The plan maps the key back to the frozen exact
+revision.
 
 The existing `compose_skill_instructions` owner remains the sole body-composition
 path. The administrator/system instructions keep their current precedence.
@@ -815,19 +858,32 @@ truthful than silently changing the meaning of `on_demand`.
 
 #### Trusted activation and explainability
 
-One parameterized Skills tool is registered through PR #538's internal MCP owner.
-Its exact registered identity—not its display name or result shape—produces a
-narrow trusted prompt-activation effect at the completion-loop boundary. A
-colliding external tool is rejected. The effect is not ordinary tool text, is not
-user-approvable, and does not give the model adapter a `SkillService` dependency.
-Activation is applied before sibling external tool calls from the same round,
-rebuilds a copy of the proposed outbound messages, and reruns the exact token
-checks before committing the new prompt. Streaming and non-streaming paths call
-the same private applicator and share one parameterized behavior suite.
+The completion context injects one reserved Eneo built-in Skills function whose
+name contains no double underscore. It is not an MCP server and never performs
+HTTP loopback. External MCP functions are always proxy-prefixed as
+`server__tool`, so they cannot equal the reserved identity through a display
+name, result payload, registration order, or sanitisation collision. Tool
+merging nevertheless drops any external exact-name collision defensively and
+records a closed collision reason.
+
+The completion module, alongside `Context`, owns the concrete frozen value that
+the provider adapter consumes. The Skills owner maps `SkillTurnPlan` into that
+value before provider work, so the adapter imports no Skills module. It
+recognizes the reserved call before external MCP dispatch, never routes
+activation through `call_tools_parallel`, and never asks for user tool approval.
+Both provider loops call one private applicator that validates the plan-local
+key, records a closed result, recomposes through the existing Skill body owner in
+saved order, and reruns the exact token checks before the next provider call.
+Accepted activation preempts sibling external calls from the same round:
+siblings are not dispatched, receive protocol-valid deferred results, and may be
+requested again after the updated context is in place. Do not create a
+one-method port, generic effect registry, or parallel loopback path for this
+single consumer.
 
 Keep `Question.skill_provenance` as the backward-compatible final-active exact
-revision list. New Assistant and personal-chat turns add typed, body-free
-activation evidence with:
+revision list. New Assistant and personal-chat turns add a separate nullable
+`skill_activation` JSONB field that always round-trips through one versioned,
+strict Pydantic model with:
 
 - effective behavior (`selective | always_only | eager`);
 - available and policy-blocked exact revisions;
@@ -844,14 +900,31 @@ show a compact “active / available” summary. The permission-gated debug pane
 shows candidates, initial and accepted/rejected revisions, order, token budget,
 fallbacks, and exact digests.
 
+The existing question placeholder/finalisation lifecycle owns these writes.
+Normal completion updates the placeholder in place. Stream abort or failure uses
+the existing fresh-session partial-save path and extends that bounded update; it
+does not add an event table or hold a request transaction across provider work.
+
 The same delivery adds generated contracts, natural Swedish/English shadcn-svelte
-controls, responsive and accessible states, and behavior tests for migration,
-model changes, small and large windows, LiteLLM fallback, multiple models,
-execution blocks, hostile external tools, prompt-injected unknown IDs, repeated
-and over-limit activation, sibling calls, concurrent binding changes, optional
-overflow, abort/error persistence, streaming parity, and unchanged Apps. Manual
-one-turn mentions, conversation toggles, Group Chat routing, Marketplace/package
-work, and generic control-effect frameworks remain outside this gate.
+controls through existing surfaces. `Admin > Overview/Översikt` receives one Skill runtime
+settings group with installed `Field`, `InputGroup`, `Switch`, `Alert`, `Badge`,
+`Table`, and save patterns. The shared `SkillBindingsEditor` adds one
+`Always | On demand` Select per exact binding for both Assistant settings and
+Personal Chat, with inline per-model failures rather than tooltip-only
+explanations. Its App consumer renders no mode control and continues accepting
+only eager bindings. A rejected save preserves the draft and focuses the first
+invalid control. Loading, stale projection, partial, estimated, empty, disabled,
+error, success, narrow-screen, keyboard, and screen-reader states are
+behavior-tested in Swedish and English. No dashboard, wizard, parallel form
+store, or new design system is introduced.
+
+Tests also cover migration, model changes, small and large windows, LiteLLM
+fallback, multiple models, execution blocks, hostile external tools,
+prompt-injected unknown IDs, repeated and over-limit activation, sibling calls,
+concurrent binding changes, optional overflow, abort/error persistence,
+streaming parity, and unchanged Apps. Manual one-turn mentions, conversation
+toggles, Group Chat routing, Marketplace/package work, and generic
+control-effect frameworks remain outside this gate.
 
 ## Deferred Skill knowledge and portable source documents
 
@@ -1583,26 +1656,26 @@ ADR that defines that feature.
 
 An unresolved row blocks only the dependent layer named in the last column.
 
-| Decision                                | Current direction                                                                                                                                                                                    | State                                                                    | Blocks                         |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------ |
-| Repository ownership                    | `eneo-ai/eneo` owns Skills, packages, installers, and connector; `eneo-ai/eneo-marketplace` owns the Hub.                                                                                            | Resolved                                                                 | Repository bootstrap           |
-| Execution order                         | Finish S1 first. Organisation catalogue and selective activation may then proceed independently. Hub Gate 0 and the Flow-only vertical may proceed now; Skill/Assistant Hub enablement waits for S2. | Resolved by product request                                              | Package-kind enablement        |
-| Hub operator/topology                   | Sundsvalls kommun/Eneo operates one central Hub.                                                                                                                                                     | Resolved by product request; legal/controller roles still need sign-off. | Production Hub                 |
-| Local install authority                 | Local Eneo tenant administrator configures, plans, confirms, and installs.                                                                                                                           | Resolved                                                                 | Connector/install              |
-| Human identity boundary                 | Hub and Eneo human identities remain completely separate.                                                                                                                                            | Resolved                                                                 | All Hub integration            |
-| First end-to-end kind                   | Prove the Hub/connector with existing Flow packages before enabling new kinds.                                                                                                                       | Recommended for acceptance                                               | Hub pilot                      |
-| Publisher organizations and visibility  | Explicit allowlist; public-authenticated, organization, and selected-instance audiences; no per-user audience.                                                                                       | Policy owner/initial allowlist open                                      | Hub publication                |
-| Moderation/separation of duties         | Public/inter-municipal releases require review; private organization policy may be lighter.                                                                                                          | Exact self-approval rule open                                            | Hub publication                |
-| Licenses, source rights, classification | Controlled vocabulary, attestation, takedown, incident, residency, retention, and prohibited-data policy.                                                                                            | Open                                                                     | Source-bearing publication     |
-| Hub human authentication                | Hub-owned identity provider and provisioning/offboarding; never Eneo OIDC coupling.                                                                                                                  | Provider/owner open                                                      | Hub human portal               |
-| Instance authentication                 | OAuth client credentials using `private_key_jwt` or mTLS, short-lived scoped tokens.                                                                                                                 | Mechanism/lifetime/rotation owner open                                   | Connector enrollment           |
-| Release version/update                  | Hub SemVer, immutable/yank/revoke, install-new only; no auto-update or merge.                                                                                                                        | Recommended for acceptance                                               | Hub release/install            |
-| Signing                                 | Deferred until offline Hub-origin proof, mirrors, federation, third parties, or regulation creates the threat.                                                                                       | Deferred trigger                                                         | No first-release blocker       |
-| Selective Skill activation              | S1 stays eager. Task #553 adds the complete trusted runtime after PR #538 and before S2 freezes Assistant bindings.                                                                                  | Planned; no partial schema or UI in S1                                   | PR #538 and Task #553          |
-| Organisation Skill catalogue            | One organisation-Space aggregate, exact published pointer, tenant-scoped browse, and same-tenant approved-revision attachment. Optional install-by-copy serves editable customisation later.         | Planned after S1                                                         | Organisation publication/reuse |
-| Source asset limits/scanning            | Separate Knowledge Bundle Gate 0 selects media types, caps, scanners, quarantine SLA, and cleanup.                                                                                                   | Open                                                                     | Source-bearing packages        |
-| Template catalogs                       | Keep tenant templates as local shortcuts; choose migration/deletion plan for global galleries.                                                                                                       | Deployed-row preflight and product decision open                         | Cross-instance catalog launch  |
-| Telemetry/privacy                       | Instance-level authorized/denied download counts only by default; no Eneo human/content/local IDs.                                                                                                   | Retention/analytics policy open                                          | Publisher analytics            |
+| Decision                                | Current direction                                                                                                                                                                            | State                                                                    | Blocks                         |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------ |
+| Repository ownership                    | `eneo-ai/eneo` owns Skills, packages, installers, and connector; `eneo-ai/eneo-marketplace` owns the Hub.                                                                                    | Resolved                                                                 | Repository bootstrap           |
+| Execution order                         | Finish the local Skills train in ROI order: #553, O2, then S2. All new external Marketplace work is last even though the Flow profile is technically independent.                            | Resolved by product request                                              | Package-kind enablement        |
+| Hub operator/topology                   | Sundsvalls kommun/Eneo operates one central Hub.                                                                                                                                             | Resolved by product request; legal/controller roles still need sign-off. | Production Hub                 |
+| Local install authority                 | Local Eneo tenant administrator configures, plans, confirms, and installs.                                                                                                                   | Resolved                                                                 | Connector/install              |
+| Human identity boundary                 | Hub and Eneo human identities remain completely separate.                                                                                                                                    | Resolved                                                                 | All Hub integration            |
+| First end-to-end kind                   | Prove the Hub/connector with existing Flow packages before enabling new kinds.                                                                                                               | Recommended for acceptance                                               | Hub pilot                      |
+| Publisher organizations and visibility  | Explicit allowlist; public-authenticated, organization, and selected-instance audiences; no per-user audience.                                                                               | Policy owner/initial allowlist open                                      | Hub publication                |
+| Moderation/separation of duties         | Public/inter-municipal releases require review; private organization policy may be lighter.                                                                                                  | Exact self-approval rule open                                            | Hub publication                |
+| Licenses, source rights, classification | Controlled vocabulary, attestation, takedown, incident, residency, retention, and prohibited-data policy.                                                                                    | Open                                                                     | Source-bearing publication     |
+| Hub human authentication                | Hub-owned identity provider and provisioning/offboarding; never Eneo OIDC coupling.                                                                                                          | Provider/owner open                                                      | Hub human portal               |
+| Instance authentication                 | OAuth client credentials using `private_key_jwt` or mTLS, short-lived scoped tokens.                                                                                                         | Mechanism/lifetime/rotation owner open                                   | Connector enrollment           |
+| Release version/update                  | Hub SemVer, immutable/yank/revoke, install-new only; no auto-update or merge.                                                                                                                | Recommended for acceptance                                               | Hub release/install            |
+| Signing                                 | Deferred until offline Hub-origin proof, mirrors, federation, third parties, or regulation creates the threat.                                                                               | Deferred trigger                                                         | No first-release blocker       |
+| Selective Skill activation              | S1 stays eager. Task #553 adds the complete trusted runtime through the existing completion loop before S2 freezes Assistant bindings.                                                       | Planned; no partial schema or UI in S1                                   | Task #553                      |
+| Organisation Skill catalogue            | One organisation-Space aggregate, exact published pointer, tenant-scoped browse, and same-tenant approved-revision attachment. Optional install-by-copy serves editable customisation later. | Planned after S1                                                         | Organisation publication/reuse |
+| Source asset limits/scanning            | Separate Knowledge Bundle Gate 0 selects media types, caps, scanners, quarantine SLA, and cleanup.                                                                                           | Open                                                                     | Source-bearing packages        |
+| Template catalogs                       | Keep tenant templates as local shortcuts; choose migration/deletion plan for global galleries.                                                                                               | Deployed-row preflight and product decision open                         | Cross-instance catalog launch  |
+| Telemetry/privacy                       | Instance-level authorized/denied download counts only by default; no Eneo human/content/local IDs.                                                                                           | Retention/analytics policy open                                          | Publisher analytics            |
 
 ## Delivery sequence and implementation gates
 
@@ -1616,28 +1689,30 @@ The canonical delivery records are
 defines the contract and gates; the Epics track status and implementation work.
 
 The selected product priority is Skills first, but the dependency graph does not
-create a false Marketplace blocker. S1 merges into `develop`. Revision restore
-and the organisation catalogue then deepen the local Skill owner. The internal
-MCP foundation in PR #538 independently enables Task #553; organisation
-catalogue work does not wait for selective activation, and Task #553 does not
-wait for the catalogue. S2 starts after S1 and Task #553 because the Assistant
-package must preserve the closed binding-mode contract.
+create a false Marketplace blocker. S1, revision restore, O1, and its GA gates
+have merged into `develop`. Task #553 now has the highest product ROI and uses
+the existing completion loop; it does not wait for PR #538's loopback transport.
+O2 follows as a lower-priority editable-copy workflow. The selected product
+order finishes O2 before S2, although editable copies are not a package-schema
+dependency. S2 also waits for the Flow package vertical to land on `develop`,
+because the Assistant package must preserve the closed binding-mode contract and
+shared package mechanics need two real consumers.
 
-The external Hub baseline and Flow-only vertical may start before S1 or S2
-merges because they consume the already supported Flow package profile. The
-native Flow connector starts after the Hub discovery/download contract and the
-Flow lifecycle record are accepted. Neither track advertises Skill or Assistant
-releases until S2 passes the cross-repository contract gates. This allows useful
-work today without letting unfinished Skill schemas leak into the Hub.
+The external Hub and native connector remain technically separable because they
+can consume the Flow profile, but the current product order defers all new
+Marketplace work until the local #553, O2, and S2 gates are complete. Neither
+track advertises Skill or Assistant releases until S2 passes the cross-repository
+contract gates.
 
 ### Active Skills phase
 
 S1 is the complete eager local vertical, not separate backend and frontend
-deliveries. H1, O1, and O2 are later local review units. O1 depends on H1 only
-where the management page exposes restore, and O2 depends on O1. Task #553 is
-one end-to-end selective-activation vertical after PR #538 and may proceed in
-parallel. S2 adds portability after S1 and Task #553; it does not turn the
-organisation catalogue into a package or runtime dependency.
+deliveries. H1 and O1 are complete. Task #553 is the next end-to-end
+selective-activation vertical, delivered through dormant-to-visible slices so
+no API or UI accepts `on_demand` before runtime semantics exist. O2 follows
+without a completion-loop dependency. S2 adds portability after Task #553 and
+the Flow package landing; it does not turn the organisation catalogue into a
+package or runtime dependency.
 
 | Review unit                                                      | Included outcome                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Required proof before merge                                                                                                                                                                                                                                                                                                                                                                             | Deliberately excluded                                                                                                                                                                     |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -1674,7 +1749,7 @@ governance.
 
 | Slice and canonical owner                                                                                      | Change                                                                                                                                                                                                                                                           | Depends on                                                                               | Acceptance evidence                                                                                                                                                                                                                                                                                                    |
 | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **S2.1 — Earned package mechanics**: current Flow package mechanics, then `eneo.packages`                      | Move only archive, manifest-coordinate, exact-digest, and closed-dispatch code that now has at least two consumers. Keep kind entry sets and validation in their verticals; delete the old generic copies in the same mechanical commit.                         | S1 and Task #553 merged to `develop`.                                                    | Existing Flow package bytes, plans, receipts, round trips, and strict invalid fixtures remain unchanged immediately after the move; dependency tests forbid vertical imports and kind-named validators in `eneo.packages`.                                                                                             |
+| **S2.1 — Earned package mechanics**: current Flow package mechanics, then `eneo.packages`                      | Move only archive, manifest-coordinate, exact-digest, and closed-dispatch code that now has at least two consumers. Keep kind entry sets and validation in their verticals; delete the old generic copies in the same mechanical commit.                         | Task #553, O2 product gate, and the Flow package vertical merged to `develop`.           | Existing Flow package bytes, plans, receipts, round trips, and strict invalid fixtures remain unchanged immediately after the move; dependency tests forbid vertical imports and kind-named validators in `eneo.packages`.                                                                                             |
 | **S2.2 — Canonical Skill snapshot**: `eneo.skills` portable contract                                           | Define the strict fields above, Agent Skills core-field mapping, binding-mode mapping, digest rules, fixed metadata constraints, destination guardrail/context checks, generated schema, and valid/invalid conformance fixtures.                                 | S2.1.                                                                                    | Supported `name`/description/Markdown and closed binding-mode mapping round-trip; unknown/extra fields, invalid modes, local IDs, knowledge, executable content, bad references, duplicate keys/positions, digest mismatch, unsafe archives, configured-limit failure, and context-fit failure reject before mutation. |
 | **S2.3 — Standalone Skill vertical**: `skill_packages`                                                         | Export one exact revision; read and plan a target Space/slug; apply through the Skill owner; create one inactive, unbound Skill at local revision 1; write a concrete Skill receipt.                                                                             | S2.2.                                                                                    | Export-read-plan-install-export preserves semantic content; slug conflict is explicit; retries are idempotent; wrong-kind and unauthorized installs fail before mutation; receipt FK and terminal invariants hold.                                                                                                     |
 | **S2.4 — Assistant with nested Skills vertical**: `assistant_packages` and canonical Assistant authoring owner | Export base Assistant content plus exact pinned Skill snapshots, positions, and activation modes; plan model/knowledge mappings and every new identity; install nested Skills and one unpublished Assistant transactionally; write a concrete Assistant receipt. | S2.2 and S2.3 primitives, without calling the standalone installer as a generic wrapper. | Clean-instance round trip preserves instructions, positions, modes, digests, and unpublished state; destination conflicts and unsupported fields are visible; failure creates no partial parent or Skills; installed execution matches the preview.                                                                    |
@@ -1686,11 +1761,12 @@ own product and runtime gates.
 
 ### Marketplace track
 
-The Marketplace track is no longer blocked as one unit by unfinished Skills.
-The existing Flow package provides a real first consumer, so Hub decision
-closure, repository baseline, contract conformance, and the Flow-only Hub
-vertical may begin now. Teams may still staff Skills first as a product
-priority; that staffing choice is not encoded as a technical dependency.
+The Marketplace track is not technically blocked as one unit by unfinished
+Skills because the Flow package provides a real first consumer. Product ordering
+is stricter than that dependency graph: no new Hub, connector, or Flow-only
+Marketplace implementation starts until #553, O2, and S2 are complete. This
+keeps the current investment on local Skills without pretending that the Hub is
+a runtime prerequisite.
 
 The first Marketplace kind remains Flow. It proves external identity,
 authorization, moderation, artifact, download, connector, and local-install
@@ -1826,9 +1902,9 @@ are not hidden work inside another delivery.
   drafts, stale revisions, ordinary sibling-Space Skills, and foreign-tenant
   references cannot be newly attached.
 - Install-to-Space proves same tenant and target edit authority, is idempotent
-  per exact source/target identity, and retains one canonical local installation
-  when editable local customisation is required. Installation is not required
-  for exact catalogue attachment.
+  per source Skill and target Space, and retains one canonical local installation
+  when editable local customisation is required. Installation is not required for
+  exact catalogue attachment.
 - Cross-tenant source attempts fail before mutation. Composite provenance and
   tenant-cascade migration tests prove the selected deferrable deletion behavior.
 - Local modifications and source updates are independent visible states.

--- a/docs/enterprise-skills-roadmap.md
+++ b/docs/enterprise-skills-roadmap.md
@@ -245,6 +245,12 @@ O2 should provide:
 - one canonical installation per source Skill and target Space;
 - a clear `up to date | update available | locally modified` state;
 - preview and explicit approval before replacing a local copy's contents;
+- explicit tenant-admin emergency block and unblock of each installed local
+  identity through the existing central execution-block owner, enforced in
+  Assistant composition and queued App pre-provider checks;
+- install and update that fail closed while the source is currently blocked;
+- affected-copy visibility when a source is blocked, with each unsafe local
+  identity blocked explicitly instead of silently propagating the source block;
 - no automatic update, text merge, or silent parent rebinding; and
 - unchanged parent pins after installing or updating the local copy.
 
@@ -802,6 +808,11 @@ flowchart LR
 - Adoption counts are tenant-scoped, exact, paginated, and free of N+1 queries.
 - O2 install and update are idempotent, previewed, explicit, and leave parent
   pins unchanged.
+- A bound, locally modified installed copy can be blocked through the central
+  execution-block owner with tenant-admin authority; Assistant composition and
+  queued App pre-provider checks enforce that local-identity block, and
+  install/update from a currently blocked source fails closed. Behaviour tests
+  cover the queued-App path.
 
 ### Task #553
 
@@ -860,6 +871,7 @@ flowchart LR
 | Published revision changes                      | Existing resources do not advance. A builder approves each update.                                                          |
 | Skill is unpublished                            | New attachments stop; retained exact pins keep running.                                                                     |
 | Published Skill is found harmful                | Tenant admin blocks the Skill identity. New turns and not-started App runs stop; pins and audit evidence remain.            |
+| Blocked source has installed local copies       | Copies keep their independent identity. Admins see affected copies, block each unsafe local identity explicitly, and install/update from the blocked source fails closed. |
 | Skill deletion could invalidate a queued run    | Bindings and retained queued/running App-run evidence block deletion; terminal runs retain body-free IDs and digests.       |
 | Author loses permission during a draft          | Parent save reauthorises and commits atomically or fails without partial bindings.                                          |
 | End user lacks catalogue permission             | Parent-resource access still runs its approved pins.                                                                        |

--- a/docs/enterprise-skills-roadmap.md
+++ b/docs/enterprise-skills-roadmap.md
@@ -94,21 +94,24 @@ The foundation merged into `develop` before this roadmap was written:
   detail. It squash-merged as `dfe9dbe7` on 2026-07-23.
 - PR #577 added the organisation-wide emergency execution block. It
   squash-merged as `b186f175` on 2026-07-23.
+- PR #580 locked the deletion and retained-provenance recovery contract. It
+  squash-merged as `c642da49` on 2026-07-23.
 
 The delivery graph was last verified on 2026-07-23:
 
-| Work item                                                | Purpose                                         | State and next action                                                                                                                    |
-| -------------------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| [#552](https://github.com/eneo-ai/eneo/pull/552)         | S1 first-class local Skills                     | Merged as `a29e9464`; required CI and final review passed.                                                                               |
-| [#559](https://github.com/eneo-ai/eneo/pull/559)         | Skill revision restore                          | Merged as `8ef96390`; required CI and final review passed.                                                                               |
-| [#560](https://github.com/eneo-ai/eneo/pull/560)         | O1 organisation catalogue                       | Merged as `71de15e5`; required CI, final review, and product review passed.                                                              |
-| [#574](https://github.com/eneo-ai/eneo/pull/574)         | O1 adoption and drift evidence                  | Merged as `dfe9dbe7`; required CI and final review passed.                                                                               |
-| [#577](https://github.com/eneo-ai/eneo/pull/577)         | O1 emergency execution block                    | Merged as `b186f175`; required CI passed and the final review found no current findings.                                                 |
-| Goal task T007                                           | O1 deletion and retained-provenance closure     | Active. Lock the existing terminal-run recovery contract with PostgreSQL behavior proof and concise operator documentation before O1 GA. |
-| [Issue #551](https://github.com/eneo-ai/eneo/issues/551) | File, InfoBlob, and Icon object-content cutover | Open. This gates the fallback file-reference path, not the preferred internal-MCP core split.                                            |
-| [#464](https://github.com/eneo-ai/eneo/pull/464)         | MCP file references                             | Open and conflict-marked. It belongs to the object-content/file track.                                                                   |
-| [#538](https://github.com/eneo-ai/eneo/pull/538)         | Internal MCP and on-demand knowledge            | Open and coupled to #464. Split its internal effect/knowledge core before selective Skills if maintainers accept that split.             |
-| [#541](https://github.com/eneo-ai/eneo/pull/541)         | Web search MCP provider                         | Draft. It does not gate Skills.                                                                                                          |
+| Work item                                                | Purpose                                         | State and next action                                                                                               |
+| -------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| [#552](https://github.com/eneo-ai/eneo/pull/552)         | S1 first-class local Skills                     | Merged as `a29e9464`; required CI and final review passed.                                                          |
+| [#559](https://github.com/eneo-ai/eneo/pull/559)         | Skill revision restore                          | Merged as `8ef96390`; required CI and final review passed.                                                          |
+| [#560](https://github.com/eneo-ai/eneo/pull/560)         | O1 organisation catalogue                       | Merged as `71de15e5`; required CI, final review, and product review passed.                                         |
+| [#574](https://github.com/eneo-ai/eneo/pull/574)         | O1 adoption and drift evidence                  | Merged as `dfe9dbe7`; required CI and final review passed.                                                          |
+| [#577](https://github.com/eneo-ai/eneo/pull/577)         | O1 emergency execution block                    | Merged as `b186f175`; required CI passed and the final review found no current findings.                            |
+| [#580](https://github.com/eneo-ai/eneo/pull/580)         | O1 deletion and retained-provenance closure     | Merged as `c642da49`; PostgreSQL behavior proof, documentation, required CI, and final full-coverage review passed. |
+| [Issue #551](https://github.com/eneo-ai/eneo/issues/551) | File, InfoBlob, and Icon object-content cutover | Open. This gates the fallback file-reference path, not the preferred internal-MCP core split.                       |
+| [#464](https://github.com/eneo-ai/eneo/pull/464)         | MCP file references                             | Open and conflict-marked. It belongs to the object-content/file track.                                              |
+| [#538](https://github.com/eneo-ai/eneo/pull/538)         | Loopback internal MCP and on-demand knowledge   | Open and coupled to #464. It is useful comparison evidence, not a merge dependency for selective Skills.            |
+| [#541](https://github.com/eneo-ai/eneo/pull/541)         | Web search MCP provider                         | Draft. It does not gate Skills.                                                                                     |
+| `refactor/flows-clean`                                   | Flow package export/import vertical             | Active at `77202b4f`; it must land on `develop` before S2 extracts any shared package mechanics.                    |
 
 Passing checks on an old PR head do not remove the need to rebase and rerun the
 full checks against the current `develop` branch.
@@ -135,9 +138,9 @@ We reuse its existing navigation and layout and do not build a duplicate editor
 under Admin.
 
 The global workspace tab keeps the name `Organisation`. Inside Admin, the
-current overview destination should be labelled `Översikt` rather than a second
-`Organisation`; this removes the visible name collision without changing either
-route's responsibility.
+current overview destination is labelled `Overview` / `Översikt` rather than a
+second `Organisation`; this removes the visible name collision without changing
+either route's responsibility.
 
 Ordinary builders work where their resource already lives. An Assistant or App
 editor uses the published-catalogue projection to search, preview, and attach an
@@ -239,11 +242,16 @@ variant with an independent lifecycle.
 O2 should provide:
 
 - an idempotent install command with exact source provenance;
-- one canonical installation per source revision and target Space;
+- one canonical installation per source Skill and target Space;
 - a clear `up to date | update available | locally modified` state;
 - preview and explicit approval before replacing a local copy's contents;
 - no automatic update, text merge, or silent parent rebinding; and
 - unchanged parent pins after installing or updating the local copy.
+
+A name or slug collision stops the install preview and requires the installer
+to choose the target identity explicitly. Eneo never auto-suffixes the copy.
+Installing a newer source revision updates the existing canonical copy; it does
+not create another copy merely because the source revision changed.
 
 O2 is not a prerequisite for attaching an approved organisation Skill. It must
 not become a generic package installer before S2 provides a second real package
@@ -264,17 +272,17 @@ impact belong to Task #553, when descriptions begin to control runtime loading.
 Eneo should extend the existing role, Space, resource, and Governance Policy
 owners. It should not add a parallel tenant-policy framework.
 
-| Action                                                       | Initial authority                                                                             |
-| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| Enter the Organisation workspace                             | Tenant administrator                                                                          |
-| Author or publish an organisation Skill                      | Tenant administrator in `Organisation > Skills`                                               |
-| Browse and attach a published organisation Skill             | `Use Skills` plus edit access to the target Assistant or App, through its catalogue picker    |
-| Read or attach a local Skill                                 | `Use Skills`, the relevant Space action, and edit access to the target Assistant or App       |
-| Create, revise, restore, deactivate, or delete a local Skill | `Use Skills` plus `Manage Skills` and the relevant action in the owning personal/shared Space |
-| Configure Personal Chat Skills                               | Tenant administrator through Governance Policy                                                |
-| Set organisation Skill runtime limits                        | Tenant administrator through the existing settings owner                                      |
-| View per-Skill audit, adoption, and drift                    | Tenant administrator on the organisation Skill detail page                                    |
-| View fleet-wide runtime health                               | Existing `Insights` permission in `Admin > Insikter`                                          |
+| Action                                                       | Initial authority                                                                                   |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| Enter the Organisation workspace                             | Tenant administrator                                                                                |
+| Author or publish an organisation Skill                      | Tenant administrator in `Organisation > Skills`                                                     |
+| Browse and attach a published organisation Skill             | `Use Skills` plus edit access to the target Assistant or App, through its catalogue picker          |
+| Read or attach a local Skill                                 | `Use Skills`, the relevant Space action, and edit access to the target Assistant or App             |
+| Create, revise, restore, deactivate, or delete a local Skill | `Use Skills` plus `Manage Skills` and the relevant action in the owning personal/shared Space       |
+| Configure Personal Chat Skills                               | Tenant administrator through Governance Policy                                                      |
+| Set organisation Skill runtime limits                        | Tenant administrator in `Admin > Overview/Översikt`, backed by the typed Skill runtime-policy owner |
+| View per-Skill audit, adoption, and drift                    | Tenant administrator on the organisation Skill detail page                                          |
+| View fleet-wide runtime health                               | Existing `Insights` permission in `Admin > Insikter`                                                |
 
 Configuration-time authorization is conjunctive: tenant capability, Space
 action, and parent-resource edit permission must all allow the requested
@@ -308,19 +316,30 @@ user need.
 
 ### Organisation policy
 
-The tenant administrator owns changeable product policy. The first defaults are:
+The tenant administrator owns changeable product policy. The first seeded
+defaults are:
 
 - at most 100 attached Skills per Assistant;
-- at most 2% of the selected model's input context for total Skill-attributable
+- at most 10% of the selected model's input context for total Skill-attributable
   context; and
 - at most 10 accepted on-demand activations per turn. Ten is a fixed platform
   safety ceiling; an administrator may lower it.
 
-The attached-count and context-percentage defaults are stored organisation
-settings after initial seeding. They are not hard-coded model limits. A count
-guard helps reviewability and abuse control; the context percentage controls the
-real model cost. The organisation catalogue itself may contain more than 100
-Skills.
+The existing `Admin > Overview/Översikt` settings surface lets a tenant administrator
+enable or disable selective activation, change the attached-Skill limit and
+total Skill-context percentage, lower the per-turn activation ceiling, and
+restore the seeded defaults without code or a deployment. The typed Skill
+runtime-policy owner persists those organisation values and validates their
+product bounds; the current user-bound `SettingsRepository` and numeric feature
+flags are not suitable storage owners. Every change records the actor and old
+and new typed values through the existing audit owner.
+
+The seeded values are never consulted as runtime constants after persistence.
+A count guard helps reviewability and abuse control; the context percentage
+controls the real model cost. The organisation catalogue itself may contain
+more Skills than the attachment limit. Ten percent is a measured starting value,
+not a universal model truth. The selected model window, hard platform safety
+ceilings, and the administrator's stored value remain authoritative.
 
 ## Runtime activation
 
@@ -356,6 +375,11 @@ The model receives compact descriptors plus one trusted internal activation
 tool. The Skill description is the only discovery description. Eneo should not
 add a second `activation_hint` field that can drift.
 
+The model-visible descriptor contains one plan-local activation key, display
+name, and description. Exact revision ID, revision number, digest, source, and
+position stay in the frozen server-side plan and evidence; advertising those
+fields would spend context without helping selection.
+
 Mentioning a Skill name in the base prompt is neither authorization nor a
 reliable selector. The prompt can tell the model to choose relevant Skills, but
 the trusted activation tool, exact binding set, and policy decide what may enter
@@ -389,9 +413,14 @@ evaluation platform.
 
 ### Stable activation rules
 
-- The activation tool uses an internal identity, not a display name that an MCP
-  server can forge.
-- External tool-name collisions fail closed.
+- The activation tool uses a reserved internal identity containing no double
+  underscore, not a display name that an MCP server can forge. External MCP
+  names are always proxy-prefixed `server__tool`, so the namespaces cannot
+  coincide. Tool merging still drops an external exact-name collision
+  defensively and records a closed collision reason.
+- An accepted activation preempts external sibling calls from the same provider
+  round. Siblings are not dispatched, receive protocol-valid deferred results,
+  and may be requested again after the updated Skill context is in place.
 - Accepted bodies follow saved binding order, independent of tool-call order.
 - Repeated activation is idempotent and appears once in evidence.
 - Eneo validates optional additions against the selected model's context before
@@ -407,6 +436,17 @@ table or use character counts as a policy decision.
 
 The percentage measures all Skill-attributable context: required `always`
 bodies, descriptors, the activation tool schema, and accepted on-demand bodies.
+At save time, the activatability invariant requires the required bodies,
+complete attached descriptor catalogue, tool schema, and largest single
+attached on-demand body to fit. An Assistant save that adds or edits an
+`on_demand` binding evaluates its currently effective completion model. A
+Governance Policy save evaluates every completion model that the policy
+currently permits because Personal Chat may select any of them. The API rejects
+that mode edit when any model in the applicable set fails; models merely
+available to the tenant do not participate in an Assistant save. A model added
+later through provider-based policy expansion is post-save drift and produces
+the documented visible `always_only` fallback until the policy or budget is
+corrected. API, UI, and tests share this one condition.
 Enforcement follows the split contract in
 [Token budget and compatibility behavior](adr/marketplace-hub-package-portability-and-skills.md#token-budget-and-compatibility-behavior):
 new or edited configurations may be rejected when a newly added Skill exceeds
@@ -420,9 +460,48 @@ The UI should show:
 - token count for each bound revision;
 - descriptor tokens, required body tokens, and optional maximum;
 - configured percentage and resulting token allowance;
-- whether any advertised descriptions were shortened for this model and budget;
 - exact provider count or named estimate/fallback; and
 - the most restrictive result when an Assistant can use several models.
+
+### Authoring and administration UX
+
+The user-facing controls ship together in slice 5, after the dormant policy,
+plan, evidence, and trusted runtime paths exist. Slice 2 exposes the typed policy
+and read-only projections through generated contracts but does not show a mode
+that runtime still ignores.
+
+The existing Eneo and shadcn-svelte component vocabulary remains authoritative:
+
+- `Admin > Overview/Översikt` adds one **Skill runtime** settings group with a Switch for
+  selective activation, typed number fields for attachment and context-share
+  limits, a bounded per-turn activation field, a reset-to-defaults action, and a
+  model result table. It does not add a dashboard, wizard, or modal.
+- The shared `SkillBindingsEditor` remains the binding owner for both Assistant
+  settings and Personal Chat Governance Policy. Each binding row adds an
+  `Always | On demand` Select beside its existing exact-revision state. The
+  Assistant view shows its effective-model result; Personal Chat shows every
+  policy-permitted model that blocks the mode. The App consumer renders no mode
+  control and retains its eager-only binding contract.
+- Existing `Field`, `InputGroup`, `Switch`, `Select`, `Alert`, `Badge`, `Table`,
+  `Skeleton`, `Button`, and save-bar patterns are reused. No parallel form
+  library, design system, hidden validation store, or decorative card grid is
+  introduced.
+- An unavailable on-demand choice has an inline reason and remediation, never a
+  tooltip-only explanation. A rejected save preserves the draft, focuses the
+  first invalid control, and keeps the existing dirty/discard workflow.
+- Loading, refresh, empty-model, estimated-count, partial projection, stale
+  response, save error, disabled, and success states are explicit. Background
+  projection responses are generation-owned so stale results cannot overwrite a
+  newer draft.
+- Controls keep keyboard order, labelled fieldsets or fields,
+  `aria-describedby`, the existing save live region, 44-pixel narrow-screen
+  targets, and single-column row fallbacks. Swedish and English copy uses
+  concrete terms: `Alltid`, `Vid behov`, measured allowance, and the exact
+  blocking model.
+- Motion is limited to existing state transitions and respects reduced motion.
+  Responsive browser checks cover tenant admin, Assistant builder, Personal
+  Chat policy, non-admin denial, a tool-capable model, and a no-tool or
+  budget-incompatible model.
 
 ### Behaviour with many Skills
 
@@ -433,15 +512,24 @@ The UI should show:
 | 50 to 100 Skills                | Enforce the organisation's attachment and percentage policy. Warn at authoring time when optional discovery will not fit.                      |
 | 200 or more organisation Skills | Keep them in the catalogue, but do not attach or advertise all of them by default. Builders select the approved subset needed by the resource. |
 
-Codex uses 2% of the context window only for its initial Skill list. Eneo's 2%
-pool covers more, so the similar number is inspiration rather than equivalent
-evidence. Before #553 ships, measure a realistic 20-Skill catalogue, activation
-tool, `always` bodies, and at least one representative on-demand body with each
-model the product labels on-demand-capable. Raise the default or mark on-demand
-unavailable for models where that representative activation cannot fit. Keep one
-admin-controlled percentage unless production evidence earns a second budget.
-Derive on-demand capability from native tool support and the same LiteLLM budget
-calculation. Do not maintain a curated per-model availability table.
+Codex uses 2% of the context window only for its initial Skill list. Claude Code
+defaults its listing to 1% and shortens descriptions before omitting lower-use
+descriptions. Eneo's single percentage also pays for required and activated
+bodies, so copying either listing percentage would be a category error.
+
+A local calibration fixture with 300-character Swedish descriptions measured
+1,408 catalogue tokens for 20 Skills, 54 tool-schema tokens, and 1,801 tokens
+for one representative body with the existing LiteLLM counters. The 3,263-token
+total exceeds 2% of a 128k window. The 10% starting value leaves useful room for
+`always` content and larger attached sets while save-time validation remains the
+real guard.
+
+Before #553 ships, rerun the fixture for every model the product labels
+on-demand-capable. Mark on-demand unavailable where the complete configuration
+fails the activatability invariant. Keep one admin-controlled percentage unless
+production evidence earns a separate discovery budget. Derive capability from
+native tool support and the same LiteLLM calculation; do not maintain a curated
+per-model availability table.
 
 ### Descriptor shortening and operator guidance
 
@@ -531,21 +619,21 @@ on-demand loading ineffective without adding a second event source.
 
 ## Architecture ownership
 
-| Responsibility                                   | Canonical owner                                                          | Reuse or change                                                                        |
-| ------------------------------------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| Skill identity and immutable revisions           | `eneo.skills`                                                            | Deepen one module; do not create an organisation-only Skill type.                      |
-| Organisation lifecycle and publication           | `OrganizationSkillService`                                               | Require tenant admin for lifecycle writes; keep published catalogue reads separate.    |
-| Published organisation catalogue projection      | Existing catalogue list/preview methods                                  | Preserve `Use Skills` access for pickers; never use workspace access as a substitute.  |
-| Local Skill authorization                        | Existing Space actor                                                     | Preserve tenant capability plus Space-action checks; add no parallel ACL.              |
-| Parent binding authorization and composition     | Existing `SkillService`                                                  | Preserve Skill read plus parent edit and runtime composition checks.                   |
-| Assistant and App binding writes                 | Existing parent update commands                                          | Replace the ordered binding facet atomically with parent fields. No binding write API. |
-| Personal Chat selection                          | Governance Policy                                                        | Add exact approved revision pins to the existing policy.                               |
-| Final prompt, model window, and token accounting | Completion context module                                                | Consume one frozen Skill plan and LiteLLM counts.                                      |
-| Organisation runtime policy                      | Existing settings service with typed organisation persistence            | Seed defaults once; stored admin values become authoritative.                          |
-| Trusted on-demand activation                     | Internal MCP/effect registry from the #538 core                          | Reuse a typed internal identity. Do not let the external MCP catalogue confer trust.   |
-| Chat diagnostics                                 | Canonical generic debug panel and retained turn evidence                 | Add Skill sections to the existing panel.                                              |
-| Audit                                            | Existing audit domain                                                    | Record lifecycle, publication, binding, policy, and bounded runtime events.            |
-| Package portability                              | Existing Flow package mechanics after a second consumer earns extraction | Move shared mechanics during S2, then delete duplicate vertical copies.                |
+| Responsibility                                   | Canonical owner                                                          | Reuse or change                                                                                                         |
+| ------------------------------------------------ | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| Skill identity and immutable revisions           | `eneo.skills`                                                            | Deepen one module; do not create an organisation-only Skill type.                                                       |
+| Organisation lifecycle and publication           | `OrganizationSkillService`                                               | Require tenant admin for lifecycle writes; keep published catalogue reads separate.                                     |
+| Published organisation catalogue projection      | Existing catalogue list/preview methods                                  | Preserve `Use Skills` access for pickers; never use workspace access as a substitute.                                   |
+| Local Skill authorization                        | Existing Space actor                                                     | Preserve tenant capability plus Space-action checks; add no parallel ACL.                                               |
+| Parent binding authorization and composition     | Existing `SkillService`                                                  | Preserve Skill read plus parent edit and runtime composition checks.                                                    |
+| Assistant and App binding writes                 | Existing parent update commands                                          | Replace the ordered binding facet atomically with parent fields. No binding write API.                                  |
+| Personal Chat selection                          | Governance Policy                                                        | Add exact approved revision pins to the existing policy.                                                                |
+| Final prompt, model window, and token accounting | Completion context module                                                | Own the adapter-facing frozen value, consume the mapped Skill plan, and use LiteLLM counts.                             |
+| Organisation runtime policy                      | `eneo.skills` typed runtime-policy owner, exposed in Admin Settings      | Seed defaults once; stored admin values become authoritative and audited.                                               |
+| Trusted on-demand activation                     | Existing completion loop with its concrete completion-owned frozen value | Use a reserved Eneo built-in identity. Do not route the authority change through loopback MCP or external tool results. |
+| Chat diagnostics                                 | Canonical generic debug panel and retained turn evidence                 | Add Skill sections to the existing panel.                                                                               |
+| Audit                                            | Existing audit domain                                                    | Record lifecycle, publication, binding, policy, and bounded runtime events.                                             |
+| Package portability                              | Existing Flow package mechanics after a second consumer earns extraction | Move shared mechanics during S2, then delete duplicate vertical copies.                                                 |
 
 ## Delivery and merge order
 
@@ -561,11 +649,17 @@ on-demand loading ineffective without adding a second event source.
    review returns 409 without discarding dirty editor content.
 3. **Completed:** #560, #574, and #577 delivered the organisation catalogue,
    adoption evidence, and emergency execution block on `develop`.
-4. **Active:** T007 closes deletion and retained provenance with the existing
-   Skill and App-run owners. Do not add lifecycle state or product behavior
-   unless a behavior test disproves the accepted contract.
-5. Build O2 after O1 if local editable copies remain the next product priority.
-   O2 has no internal MCP dependency.
+4. **Completed:** T007/PR #580 locked deletion and retained provenance with the
+   existing Skill and App-run owners and merged as `c642da49`.
+5. **Next:** implement Task #553 in small vertical slices. It has the highest
+   current ROI because it bounds recurring context cost and lets authors keep
+   specialised instructions available without making every body eager.
+6. Consolidate T008 typed lifecycle conflicts after the #553 backend core. It is
+   real debt but does not gate selective activation.
+7. Build O2 editable copies after #553. O2 remains useful but lower priority and
+   has no completion-loop dependency.
+8. Keep T009 evidence-gated. Start it only when search and source labels prove
+   insufficient around 200 or more catalogue entries.
 
 ### O1 admin-only alignment inside #560
 
@@ -598,45 +692,77 @@ red behaviour test proves an actual defect. No data migration or compatibility
 flag is warranted because delegated organisation access has not shipped; only a
 pilot running this develop stack would need release communication.
 
-### Internal MCP and selective activation
+### Selective activation boundary and slices
 
-The clean path splits #538 at its real ownership boundary:
+PR #538 implements loopback FastMCP servers, scoped bearer identity, and
+knowledge/file consumers across 21 files. Task #553 does not need that transport
+to perform an in-process system-prompt transition, so #538 is no longer a merge
+gate. Reuse its hardening lessons, not its HTTP/token/registry stack.
 
-1. Rebase the internal-effect registry/proxy and on-demand Knowledge consumer on
-   current `develop` after the Skills foundation. Keep file-reference behaviour
-   out of that PR.
-2. Leave MCP file references behind #551 and #464. If the maintainers reject the
-   split, use the fallback order `#551 -> #464 -> cleaned #538`.
-3. Treat #541 web search as an independent consumer. It must not gate Skills.
-4. Rebase the generic debug branch on its canonical parent and keep one debug
-   implementation.
-5. Implement Task #553 after S1 and the trusted internal MCP/effect core are in
-   `develop`. Integrate Skill evidence into the generic debug panel.
+Implement #553 through these reviewable slices:
+
+1. **Dormant binding contract:** add closed modes only to Assistant and
+   Governance Policy bindings, backfill `always`, and prove byte-equivalent
+   behavior. Do not accept `on_demand` from public writes yet.
+2. **Policy and projection:** add the typed Skill runtime policy behind the
+   existing Admin Settings route and return per-model token/capability
+   projections using the canonical LiteLLM counters. Do not use the current
+   user-bound settings row or numeric feature flags. Keep controls unavailable
+   to non-admin users.
+3. **Frozen plan and evidence:** make every existing eager turn consume one
+   immutable plan; add typed, body-free activation evidence while behavior
+   remains all-`always`.
+4. **Trusted runtime:** map `SkillTurnPlan` into a concrete frozen value owned
+   beside completion `Context`, inject one reserved Eneo activation function,
+   and handle it before external MCP dispatch in both provider loops through one
+   private applicator. Recompose with the existing Skill composer and recheck
+   fit before the next provider call. The adapter imports no Skills module; do
+   not create a one-method port or generic effect framework.
+5. **Save contract and UI:** only after runtime behavior exists, accept
+   `on_demand`; expose the Admin runtime-policy group and shared binding-row mode
+   controls with calm Swedish/English shadcn-svelte states; add responsive,
+   accessibility, stale-response, and model-projection tests; run
+   positive/negative activation fixtures; and update the docs guide.
+
+The reserved Eneo function contains no double underscore, while external MCP
+proxy names are always `server__tool`. Tool merging nevertheless drops an
+external definition whose name exactly equals the reserved identity and records
+a closed collision reason. Accepted activation calls are applied before any
+external dispatch; sibling external calls from that round receive protocol-valid
+deferred results and may be requested again. Unknown, duplicated, forged, or
+colliding activation calls fail closed. #541 web search and the #551/#464 file
+track remain independent.
 
 ### Portability and external marketplace
 
 S2 starts after Task #553 because Assistant packages must preserve
-`always | on_demand` bindings. S2 should reuse the Flow package export/import
-work and extract shared archive mechanics only when both verticals need them.
+`always | on_demand` bindings. The current product order also finishes O2 first,
+although editable copies are not a package-schema prerequisite. S2 waits until
+the Flow package vertical on `refactor/flows-clean` has landed on `develop`, then
+extracts only archive,
+manifest-coordinate, digest, and closed-dispatch mechanics that have two real
+consumers; kind-specific validation, planning, installation, and receipts stay
+in their product owners.
 
-The external Marketplace can continue its Flow-only work in its own repository.
-Eneo should not advertise external Skill or Assistant packages until S2 has
-versioned fixtures, plan/apply behaviour, receipts, and cross-repository contract
-tests.
+The external Marketplace is technically independent of local runtime, but the
+current product order defers all new Marketplace work until the local #553, O2,
+and S2 gates are complete. Eneo must not advertise external Skill or Assistant
+packages until S2 has versioned fixtures, plan/apply behaviour, receipts, and
+cross-repository contract tests.
 
 ```mermaid
 flowchart LR
     D[develop foundations] --> S1[#552 S1]
     S1 --> H1[#559 restore]
     H1 --> O1[#560 organisation catalogue]
-    O1 --> O2[O2 optional install/update]
-    S1 --> IMCP[#538 internal MCP core split]
-    IMCP --> SEL[#553 selective activation]
-    SEL --> S2[S2 Skill and Assistant packages]
+    O1 --> SEL[#553 selective activation]
+    SEL --> O2[O2 optional install/update]
+    O2 --> S2[S2 Skill and Assistant packages]
+    FLOW[Flow package vertical on develop] --> S2
     S2 --> EXT[External Skill/Assistant Marketplace]
     F551[#551 object file cutover] --> F464[#464 MCP file references]
-    F464 -. fallback if no split .-> IMCP
-    W[#541 web search] -. independent .-> IMCP
+    F464 -. independent .-> SEL
+    W[#541 web search] -. independent .-> SEL
 ```
 
 ## Acceptance gates
@@ -680,9 +806,23 @@ flowchart LR
 ### Task #553
 
 - Existing rows remain `always` and continue to answer after policy changes.
+- Tenant admins can change the seeded enablement, attachment, context-share, and
+  activation-limit values in `Admin > Overview/Översikt` without code or deployment;
+  typed storage, bounds, reset, audit actor, and old/new values have behaviour
+  tests.
+- Assistant and Personal Chat mode controls reuse `SkillBindingsEditor`, preserve
+  drafts on validation failure, explain each blocking model inline, and pass
+  Swedish/English keyboard, screen-reader, narrow-screen, and stale-response
+  checks using installed shadcn-svelte primitives.
+- The App consumer of `SkillBindingsEditor` renders no mode control, accepts no
+  mode field, and has a behavior test that pins eager-only operation.
 - The save contract defines one exact rejection condition for a newly added
-  Skill that exceeds the configured share; API, UI, and tests use the same
-  condition.
+  or edited `on_demand` binding: use the Assistant's effective selected model or
+  every model currently permitted by the Governance Policy. API, UI, and tests
+  use the same condition.
+- Every advertised on-demand Skill is individually activatable within the saved
+  model configuration: required bodies, complete descriptors, tool schema, and
+  the largest single on-demand body fit the configured share.
 - Streaming and non-streaming paths produce the same plan and evidence.
 - External tool-name collisions, forged calls, repeated calls, and stale
   revisions fail with explicit reason codes.
@@ -747,9 +887,9 @@ flowchart LR
 - Detach a local or never-published organisation draft before deletion. Wait
   for retained App runs to complete or fail; their body-free provenance remains
   readable after an eligible hard deletion.
-- Roll back a selective-activation release by keeping existing bindings as
-  `always`; do not drop mode or evidence columns until the team has migrated the
-  data.
+- Roll back a selective-activation release by disabling selective execution,
+  retaining stored modes, and running only `always` bodies as `always_only`; do
+  not drop mode or evidence columns until the team has migrated the data.
 - Pause S2 or the external Marketplace without affecting local pinned Skills.
 
 ## Explicit deferrals
@@ -776,16 +916,19 @@ tests before implementation.
 The sources below inform the plan. They do not override Eneo's accepted runtime
 contract.
 
-| Source                                                                                                                                                                                                                                                    | Useful pattern                                                                                                        | Eneo decision                                                                                                                                   |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Agent Skills specification](https://agentskills.io/specification) and [client guide](https://agentskills.io/client-implementation/adding-skills-support)                                                                                                 | Name/description discovery, full-body activation, and on-demand resources                                             | Follow the core instruction format in S2 and use progressive disclosure in #553. Keep Eneo's database revision and permission model.            |
-| [Agent Skills best practices](https://agentskills.io/skill-creation/best-practices), [description optimisation](https://agentskills.io/skill-creation/optimizing-descriptions), and [evaluation](https://agentskills.io/skill-creation/evaluating-skills) | Focused bodies, clear trigger descriptions, and positive/negative activation tests                                    | Add author guidance and evaluation evidence; do not enforce the 5,000-token recommendation as a hard policy.                                    |
-| [ChatGPT Skills](https://help.openai.com/en/articles/20001066)                                                                                                                                                                                            | Workspace publication, role controls, per-Skill owner/access, users, 30-day invocations, dates, and compliance events | Borrow the governance and oversight shape. Use “entered context” until Eneo can define an honest invocation/outcome metric.                     |
-| [Codex Skills](https://developers.openai.com/codex/skills)                                                                                                                                                                                                | Explicit and implicit activation, progressive disclosure, and a 2% initial-catalogue budget                           | Use 2% as an admin-changeable default. Defer explicit mentions until override and audit semantics are accepted.                                 |
-| [Claude Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) and [Managed Agents Skills](https://platform.claude.com/docs/en/managed-agents/skills)                                                                  | Metadata-first loading, exact version pins, and up to 500 mounted Skills with a startup cost warning                  | Borrow progressive disclosure and exact versions. Use context percentage plus an admin count guard instead of copying 500 as a universal limit. |
-| [Open WebUI Skills](https://docs.openwebui.com/features/workspace/skills/)                                                                                                                                                                                | Lazy `view_skill`, model bindings, `$` mention, per-chat toggles, active state, and user/group access                 | Borrow the clear distinction between Skill and tool. Start with admin/resource bindings; defer user overrides and per-Skill ACLs.               |
-| [AnythingLLM intelligent tool selection](https://docs.anythingllm.com/agent/intelligent-tool-selection)                                                                                                                                                   | Optional reranking above an admin-set tool count, with documented latency overhead                                    | Keep reranking out of the first release. Reconsider only with measured descriptor overflow and explainable selection evidence.                  |
-| [Dify Agent node](https://docs.dify.ai/en/cloud/use-dify/nodes/agent)                                                                                                                                                                                     | Native function calling, explicit iteration limits, tool descriptions, outputs, and structured logs                   | Use a trusted activation tool, a fixed accepted-activation ceiling, and structured evidence. Do not expose hidden chain-of-thought.             |
+| Source                                                                                                                                                                                                                                                    | Useful pattern                                                                                                           | Eneo decision                                                                                                                                   |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Agent Skills specification](https://agentskills.io/specification) and [client guide](https://agentskills.io/client-implementation/adding-skills-support)                                                                                                 | Name/description discovery, full-body activation, and on-demand resources                                                | Follow the core instruction format in S2 and use progressive disclosure in #553. Keep Eneo's database revision and permission model.            |
+| [Agent Skills best practices](https://agentskills.io/skill-creation/best-practices), [description optimisation](https://agentskills.io/skill-creation/optimizing-descriptions), and [evaluation](https://agentskills.io/skill-creation/evaluating-skills) | Focused bodies, clear trigger descriptions, and positive/negative activation tests                                       | Add author guidance and evaluation evidence; do not enforce the 5,000-token recommendation as a hard policy.                                    |
+| [ChatGPT Skills](https://help.openai.com/en/articles/20001066)                                                                                                                                                                                            | Workspace publication, role controls, per-Skill owner/access, users, 30-day invocations, dates, and compliance events    | Borrow the governance and oversight shape. Use “entered context” until Eneo can define an honest invocation/outcome metric.                     |
+| [Codex Skills](https://developers.openai.com/codex/skills)                                                                                                                                                                                                | Explicit and implicit activation, progressive disclosure, and a 2% initial-catalogue budget                              | Borrow the bounded, inspectable discovery principle. Eneo uses a measured 10% total Skill share because the same budget also pays for bodies.   |
+| [Claude Agent Skills](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview) and [Managed Agents Skills](https://platform.claude.com/docs/en/managed-agents/skills)                                                                  | Metadata-first loading, exact version pins, and up to 500 mounted Skills with a startup cost warning                     | Borrow progressive disclosure and exact versions. Use context percentage plus an admin count guard instead of copying 500 as a universal limit. |
+| [Open WebUI Skills](https://docs.openwebui.com/features/workspace/skills/)                                                                                                                                                                                | Lazy `view_skill`, model bindings, `$` mention, per-chat toggles, active state, and user/group access                    | Borrow the clear distinction between Skill and tool. Start with admin/resource bindings; defer user overrides and per-Skill ACLs.               |
+| [LibreChat Skills](https://www.librechat.ai/docs/features/skills) and [Agent settings](https://www.librechat.ai/docs/configuration/librechat_yaml/object_structure/agents)                                                                                | Manual, model-invoked, and always modes; per-Agent allowlists; a model-visible catalogue cap; description-led activation | Borrow the focused allowlist and explicit mode vocabulary. Do not inherit scripts/assets, tool grants, GitHub sync, or user overrides in #553.  |
+| [Onyx Agents](https://docs.onyx.app/overview/core_features/agents) and [Actions](https://docs.onyx.app/overview/core_features/actions)                                                                                                                    | Separates Agent instructions, scoped knowledge, and executable Actions; recommends testing and narrow knowledge          | Preserve Eneo's Skill/tool/knowledge boundaries. Onyx documents no equivalent versioned lazy Skill catalogue, so do not invent one by analogy.  |
+| [Flowise Agentflow](https://docs.flowiseai.com/using-flowise/agentflowv2) and [Agent as Tool](https://docs.flowiseai.com/tutorials/agent-as-tool)                                                                                                         | Explicit graph steps, described agent-as-tool selection, and observable bounded loops                                    | Borrow bounded-loop and traceability questions only. Eneo Skills do not need a workflow graph or multi-agent runtime.                           |
+| [AnythingLLM intelligent tool selection](https://docs.anythingllm.com/agent/intelligent-tool-selection)                                                                                                                                                   | Optional reranking above an admin-set tool count, with documented latency overhead                                       | Keep reranking out of the first release. Reconsider only with measured descriptor overflow and explainable selection evidence.                  |
+| [Dify Agent node](https://docs.dify.ai/en/cloud/use-dify/nodes/agent)                                                                                                                                                                                     | Native function calling, explicit iteration limits, tool descriptions, outputs, and structured logs                      | Use a trusted activation tool, a fixed accepted-activation ceiling, and structured evidence. Do not expose hidden chain-of-thought.             |
 
 ### Patterns we should preserve
 
@@ -812,37 +955,38 @@ These local Codex artifacts contain the planning reviews that shaped this
 roadmap. Their accepted decisions are restated above because `.codex/artifacts`
 is a working-session record, not the product contract.
 
-| Review                                   | Local artifact                                                                                                             | Result used here                                                                                                                           |
-| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Selective activation architecture        | `.codex/artifacts/claude-peer-loop-fable-enterprise-selective-skill-activation-architecture-review-20260721T143724Z.md`    | Replaced eager-all-at-scale with explicit `always` and `on_demand`, a trusted activation effect, and bounded evidence.                     |
-| Organisation budget adjudication         | `.codex/artifacts/claude-peer-loop-fable-organization-admin-skill-budget-final-adjudication-20260721T145646Z.md`           | Made the percentage and attachment guard administrator-owned; kept the model window authoritative.                                         |
-| Selective blueprint verification         | `.codex/artifacts/claude-peer-loop-fable-selective-skill-blueprint-final-verification-20260721T150419Z.md`                 | Confirmed the frozen turn plan, fallback semantics, and explainability language.                                                           |
-| Implementation boundary gate             | `.codex/artifacts/claude-peer-loop-selective-skills-implementation-boundary-verification-20260721T152413Z.md`              | Held #553 until the trusted internal MCP/effect owner is in the branch ancestry.                                                           |
-| Integration train review                 | `.codex/artifacts/claude-peer-loop-eneo-integration-train-before-selective-skills-20260721T165736Z.md`                     | Identified the coupled PR graph and the need to avoid copying #538 into Skills.                                                            |
-| Revised integration train verification   | `.codex/artifacts/claude-peer-loop-revised-eneo-integration-train-verification-20260721T170352Z.md`                        | Accepted Skills-first, split internal MCP core, and file-reference fallback order.                                                         |
-| Admin information architecture           | `.codex/artifacts/claude-peer-loop-eneo-skills-admin-ia-and-permissions-plan-20260721T071004Z.md`                          | Kept one Organisation editor and moved useful adoption/drift data to Skill detail.                                                         |
-| Debug security and reliability           | `.codex/artifacts/claude-peer-loop-debug-mode-security-and-reliability-verification-20260721T133316Z.md`                   | Required one canonical, server-governed debug capability and owner-authorised evidence.                                                    |
-| Skills UI review                         | `.codex/artifacts/claude-peer-loop-eneo-skills-ui-final-ux-review-20260721T094940Z.md`                                     | Retained flat, task-oriented layouts and explicit revision states.                                                                         |
-| Navigation and visual polish             | `.codex/artifacts/claude-peer-loop-eneo-skills-nordic-polish-and-navigation-final-verification-20260721T141118Z.md`        | Reused the organisation navigation and removed route-specific visual duplication.                                                          |
-| Consolidated roadmap challenge           | `.codex/artifacts/claude-peer-loop-enterprise-skills-roadmap-skeptical-review-20260722T115806Z.md`                         | Reconciled token policy with the ADR, restored the dependency graph, and added measurable release calibration.                             |
-| Comparative enterprise challenge         | `.codex/artifacts/claude-peer-loop-enterprise-skills-comparative-blueprint-challenge-20260722T120529Z.md`                  | Added the O1 emergency stop, activation latency, multilingual evaluation, and binding-site drift visibility.                               |
-| Authoritative contract verification      | `.codex/artifacts/claude-peer-loop-enterprise-skills-roadmap-authoritative-contract-verification-20260722T121803Z.md`      | Gave green light at score 8 after both documents agreed on the minimal O1 execution-block contract and test boundary.                      |
-| Two-layer authorization adjudication     | `.codex/artifacts/claude-peer-loop-eneo-skills-two-layer-enterprise-authorization-and-ux-adjudication-20260722T123308Z.md` | Confirmed admin-only Organisation authoring, tenant-plus-Space local management, picker-only published reuse, and no new ACL or dashboard. |
-| Implementation architecture verification | `.codex/artifacts/claude-peer-loop-eneo-skills-implementation-order-and-architecture-verification-20260722T124707Z.md`     | Gave green light at score 8, placed the subtractive correction in #560, and fixed the red-test-first owner and merge sequence.             |
+| Review                                   | Local artifact                                                                                                              | Result used here                                                                                                                           |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Selective activation architecture        | `.codex/artifacts/claude-peer-loop-fable-enterprise-selective-skill-activation-architecture-review-20260721T143724Z.md`     | Replaced eager-all-at-scale with explicit `always` and `on_demand`, a trusted activation effect, and bounded evidence.                     |
+| Organisation budget adjudication         | `.codex/artifacts/claude-peer-loop-fable-organization-admin-skill-budget-final-adjudication-20260721T145646Z.md`            | Made the percentage and attachment guard administrator-owned; kept the model window authoritative.                                         |
+| Selective blueprint verification         | `.codex/artifacts/claude-peer-loop-fable-selective-skill-blueprint-final-verification-20260721T150419Z.md`                  | Confirmed the frozen turn plan, fallback semantics, and explainability language.                                                           |
+| Implementation boundary gate             | `.codex/artifacts/claude-peer-loop-selective-skills-implementation-boundary-verification-20260721T152413Z.md`               | Held #553 until the trusted internal MCP/effect owner is in the branch ancestry.                                                           |
+| Integration train review                 | `.codex/artifacts/claude-peer-loop-eneo-integration-train-before-selective-skills-20260721T165736Z.md`                      | Identified the coupled PR graph and the need to avoid copying #538 into Skills.                                                            |
+| Revised integration train verification   | `.codex/artifacts/claude-peer-loop-revised-eneo-integration-train-verification-20260721T170352Z.md`                         | Accepted Skills-first, split internal MCP core, and file-reference fallback order.                                                         |
+| Admin information architecture           | `.codex/artifacts/claude-peer-loop-eneo-skills-admin-ia-and-permissions-plan-20260721T071004Z.md`                           | Kept one Organisation editor and moved useful adoption/drift data to Skill detail.                                                         |
+| Debug security and reliability           | `.codex/artifacts/claude-peer-loop-debug-mode-security-and-reliability-verification-20260721T133316Z.md`                    | Required one canonical, server-governed debug capability and owner-authorised evidence.                                                    |
+| Skills UI review                         | `.codex/artifacts/claude-peer-loop-eneo-skills-ui-final-ux-review-20260721T094940Z.md`                                      | Retained flat, task-oriented layouts and explicit revision states.                                                                         |
+| Navigation and visual polish             | `.codex/artifacts/claude-peer-loop-eneo-skills-nordic-polish-and-navigation-final-verification-20260721T141118Z.md`         | Reused the organisation navigation and removed route-specific visual duplication.                                                          |
+| Consolidated roadmap challenge           | `.codex/artifacts/claude-peer-loop-enterprise-skills-roadmap-skeptical-review-20260722T115806Z.md`                          | Reconciled token policy with the ADR, restored the dependency graph, and added measurable release calibration.                             |
+| Comparative enterprise challenge         | `.codex/artifacts/claude-peer-loop-enterprise-skills-comparative-blueprint-challenge-20260722T120529Z.md`                   | Added the O1 emergency stop, activation latency, multilingual evaluation, and binding-site drift visibility.                               |
+| Authoritative contract verification      | `.codex/artifacts/claude-peer-loop-enterprise-skills-roadmap-authoritative-contract-verification-20260722T121803Z.md`       | Gave green light at score 8 after both documents agreed on the minimal O1 execution-block contract and test boundary.                      |
+| Two-layer authorization adjudication     | `.codex/artifacts/claude-peer-loop-eneo-skills-two-layer-enterprise-authorization-and-ux-adjudication-20260722T123308Z.md`  | Confirmed admin-only Organisation authoring, tenant-plus-Space local management, picker-only published reuse, and no new ACL or dashboard. |
+| Implementation architecture verification | `.codex/artifacts/claude-peer-loop-eneo-skills-implementation-order-and-architecture-verification-20260722T124707Z.md`      | Gave green light at score 8, placed the subtractive correction in #560, and fixed the red-test-first owner and merge sequence.             |
+| Remaining-roadmap and O2 blueprint       | `.codex/artifacts/claude-peer-loop-enterprise-skills-remaining-roadmap-and-o2-blueprint-20260723T211419Z.md`                | Rejected the copied 2% total budget and #538 merge gate; ordered #553 before O2 and kept T009, S2, and Marketplace behind explicit gates.  |
+| Remaining-roadmap verification           | `.codex/artifacts/claude-peer-loop-enterprise-skills-remaining-roadmap-and-o2-blueprint-verification-20260723T214123Z.md`   | Confirmed the architecture and identified three exact wording gaps in model validation, sibling deferral, and reserved identity.           |
+| Final selective-plan verification        | `.codex/artifacts/claude-peer-loop-enterprise-skills-remaining-roadmap-and-o2-blueprint-verification-3-20260723T220002Z.md` | Gave green light at score 8 after the contracts, admin configuration, slice order, and shared UI ownership agreed with current source.     |
 
 ## Open decisions before implementation
 
 Product and architecture should close these questions at the named gate:
 
-1. **Before O2:** Does install-to-Space preserve the source Skill's display name
-   when that name collides, or require the installer to choose a new name before
-   apply?
-2. **Before Task #553:** How long should per-turn Skill evidence remain available
+1. **Before Task #553:** How long should per-turn Skill evidence remain available
    in ordinary history versus restricted audit storage?
-3. **Before scoped Personal Chat policies:** Which existing group/role owner
+2. **Before scoped Personal Chat policies:** Which existing group/role owner
    supplies the scope and conflict precedence? O1 stays tenant-policy scoped
    until this is defined.
-4. **Before S2:** Which accepted Flow package branch owns the archive mechanics,
-   receipts, and exported Assistant contract?
-5. **Before external Skill distribution:** Which scanner, signature policy,
+3. **Before S2:** Which exact merged Flow package commit owns the archive
+   mechanics that have earned extraction? The active `refactor/flows-clean`
+   branch is evidence, not a stable dependency until it lands on `develop`.
+4. **Before external Skill distribution:** Which scanner, signature policy,
    sandbox, and review workflow can accept scripts, assets, or references?

--- a/docs/goals/enterprise-skills-rollout/state.yaml
+++ b/docs/goals/enterprise-skills-rollout/state.yaml
@@ -4,7 +4,7 @@ goal:
   title: "Enterprise Skills rollout"
   slug: "enterprise-skills-rollout"
   kind: specific
-  tranche: "Complete the O1 general-availability gates on the merged organisation catalogue."
+  tranche: "Close O1 and turn the remaining non-Marketplace Skills roadmap into an ordered implementation blueprint."
   status: active
 
 rules:
@@ -30,12 +30,12 @@ continuity:
   current_thread_id: "019f8f85-2ea6-7030-8c48-6d90143da5e0"
   previous_thread_id: "019f84c4-21db-7a00-b2cd-ae3d294d14ba"
   rotation_count: 1
-  completed_write_tasks_in_thread: 2
+  completed_write_tasks_in_thread: 3
   handoff_note: null
   last_handoff_at: null
-  last_verified_revision: "b186f175d84df3f4c89ef0f244b675f152191934"
+  last_verified_revision: "c642da4953102718c4031c4004e3c6a83d956f4a"
 
-active_task: T007
+active_task: T010
 
 tasks:
   - id: T001
@@ -476,7 +476,7 @@ tasks:
   - id: T007
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Close the O1 deletion and retained-provenance contract before general availability."
     tracking_issue: "https://github.com/eneo-ai/eneo/issues/579"
@@ -501,7 +501,32 @@ tasks:
     stop_if:
       - "Closing the contract requires duplicating App-run lifecycle state."
       - "A behavior proof fails and the fix needs production files outside this contract-lock slice."
-    receipt: null
+    receipt:
+      result: done
+      summary: "Locked the existing deletion/terminal-run recovery contract with PostgreSQL behavior proof and concise operator documentation, without changing production behavior, then squash-merged PR #580."
+      merged_pr: 580
+      source_head: "83be4bef82f40bf79e63d24cbd0402ed5e02289e"
+      merge_commit: "c642da4953102718c4031c4004e3c6a83d956f4a"
+      merged_at: "2026-07-23T21:04:00Z"
+      review_url: "https://github.com/eneo-ai/eneo/pull/580#issuecomment-5063221359"
+      changed_files:
+        - "backend/tests/integration/skills/test_skill_concurrency.py"
+        - "docs/enterprise-skills-roadmap.md"
+        - "docs/goals/enterprise-skills-rollout/state.yaml"
+        - "frontend/apps/docs-site/src/content/guides/skills.mdx"
+      commands:
+        - cmd: "uv run pytest tests/integration/skills/test_skill_concurrency.py tests/unittests/apps/app_runs/test_app_run_provenance.py -q"
+          result: "pass: 21 tests"
+        - cmd: "uv run pytest tests/integration/skills/test_skill_concurrency.py::test_queued_app_run_snapshot_blocks_concurrent_skill_deletion_until_terminal -q"
+          result: "pass: 2 tests after final cleanup"
+        - cmd: "backend Ruff check and format; docs Prettier and production build; Goal Maker checker; git diff --check"
+          result: pass
+        - cmd: "GitHub PR #580 required checks"
+          result: "pass: 17 successful, 3 scope-skipped, 0 failing"
+      verification:
+        - "Complete and failed App runs release an otherwise eligible Skill for hard deletion."
+        - "The Skill and revision rows are deleted while body-free ID/revision/digest/position provenance remains readable."
+        - "The fresh full-coverage review found no current in-scope findings on the merged head."
 
   - id: T008
     type: worker
@@ -538,6 +563,42 @@ tasks:
       - "Keyboard, responsive, loading, empty, and error states"
     stop_if:
       - "There is no measured or observed need beyond the existing source labels and search."
+    receipt: null
+
+  - id: T010
+    type: pm
+    assignee: PM
+    status: active
+    reasoning_hint: high
+    objective: "Adjudicate an implementation-ready, highest-ROI delivery order for Task #553 and the remaining non-Marketplace Enterprise Skills roadmap before any production code changes."
+    inputs:
+      - "origin/develop at c642da4953102718c4031c4004e3c6a83d956f4a"
+      - "Issue #553 and PR #538 at 89694fd450b375b9d3eaed45b9699f38b641f9bf"
+      - "docs/enterprise-skills-roadmap.md"
+      - "docs/adr/marketplace-hub-package-portability-and-skills.md"
+      - "Flow package/export mechanics on refactor/flows-clean at 77202b4f61374a12733fcba1a1f684bb725385c5"
+      - "Official Agent Skills, Codex, Claude Code, Open WebUI, LibreChat, Onyx, Flowise, AnythingLLM, and Dify references"
+    constraints:
+      - "Do not implement production code."
+      - "Use one repo-grounded Fable Max planning review after independently identifying current owners, contradictions, scale limits, failure modes, and the actual remaining roadmap."
+      - "Reconcile Issue #553 with the newer roadmap and ADR; one fallback contract must win before implementation."
+      - "Treat PR #538 as comparison evidence; its loopback FastMCP, identity-token, knowledge, and file stack is not a merge dependency for #553."
+      - "Use the existing completion loop and one concrete frozen Skill plan; do not create a one-method port or generic effect framework."
+      - "Keep Group Chat routing and App on-demand out of scope."
+      - "Plan O2 and S2 only to the reviewable contract and dependency depth needed for ordering; do not implement them in this task."
+      - "Keep external Marketplace implementation last and out of scope."
+      - "Do not add a generic selector, plugin, policy, or multi-tenancy framework."
+    expected_output:
+      - "Canonical owner and dependency decision"
+      - "One explicit no-tool fallback and 100-plus-Skill descriptor/budget contract"
+      - "Small reviewable vertical slices with acceptance, behavior tests, recovery, and stop conditions"
+      - "Evidence-based ROI and dependency order for #553, T008, O2, T009, S2, and Marketplace-last"
+      - "Minimal O2 lifecycle/schema boundary and its explicit separation from S2 package mechanics"
+      - "Updated roadmap, Goal Maker state, and Issue #553 contract"
+    stop_if:
+      - "The plan requires a production edit to prove a disputed behavior."
+      - "The only proposed path is to merge the stacked PR #538 wholesale."
+      - "The review cannot inspect bounded source evidence for the claimed canonical owners."
     receipt: null
 
   - id: T999

--- a/docs/goals/enterprise-skills-rollout/state.yaml
+++ b/docs/goals/enterprise-skills-rollout/state.yaml
@@ -30,12 +30,12 @@ continuity:
   current_thread_id: "019f8f85-2ea6-7030-8c48-6d90143da5e0"
   previous_thread_id: "019f84c4-21db-7a00-b2cd-ae3d294d14ba"
   rotation_count: 1
-  completed_write_tasks_in_thread: 3
+  completed_write_tasks_in_thread: 4
   handoff_note: null
   last_handoff_at: null
   last_verified_revision: "c642da4953102718c4031c4004e3c6a83d956f4a"
 
-active_task: T010
+active_task: T011
 
 tasks:
   - id: T001
@@ -568,7 +568,7 @@ tasks:
   - id: T010
     type: pm
     assignee: PM
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Adjudicate an implementation-ready, highest-ROI delivery order for Task #553 and the remaining non-Marketplace Enterprise Skills roadmap before any production code changes."
     inputs:
@@ -599,6 +599,94 @@ tasks:
       - "The plan requires a production edit to prove a disputed behavior."
       - "The only proposed path is to merge the stacked PR #538 wholesale."
       - "The review cannot inspect bounded source evidence for the claimed canonical owners."
+    receipt:
+      result: done
+      summary: "Reconciled the remaining non-Marketplace roadmap into an implementation-ready #553-first sequence, corrected the copied discovery budget and loopback-MCP dependency, and synced the accepted contract to live Issue #553 without production edits."
+      planning_pr: 581
+      planning_pr_status: "opened for CI and fresh review"
+      issue: "https://github.com/eneo-ai/eneo/issues/553"
+      issue_updated_at: "2026-07-23T22:06:02Z"
+      changed_files:
+        - "docs/enterprise-skills-roadmap.md"
+        - "docs/adr/marketplace-hub-package-portability-and-skills.md"
+        - "docs/goals/enterprise-skills-rollout/state.yaml"
+        - "frontend/apps/docs-site/src/content/guides/skills.mdx"
+      review:
+        session: "eneo-enterprise-skills-o2-blueprint-max"
+        iteration_1: ".codex/artifacts/claude-peer-loop-enterprise-skills-remaining-roadmap-and-o2-blueprint-20260723T211419Z.md; changes required"
+        iteration_2: ".codex/artifacts/claude-peer-loop-enterprise-skills-remaining-roadmap-and-o2-blueprint-verification-20260723T214123Z.md; architecture accepted, three wording blockers"
+        iteration_3: ".codex/artifacts/claude-peer-loop-enterprise-skills-remaining-roadmap-and-o2-blueprint-verification-3-20260723T220002Z.md; green, minimum score 8"
+      evidence:
+        - "Actual LiteLLM counters measured 1/20/50/100 descriptor sets for 128k and 200k model windows; 10% is a measured total Skill-context seed, not a hard-coded model truth."
+        - "PR #538's 21-file, 1,188-change loopback FastMCP stack was verified as comparison evidence rather than a #553 merge dependency."
+        - "refactor/flows-clean at 77202b4f contains the Flow-specific package vertical and must land before S2 extracts mechanics with two consumers."
+        - "Governance Policy owns the union of explicit and provider-selected models; the exact Assistant-versus-policy save condition now matches current resolver semantics."
+        - "The current SettingsRepository is user-bound; the plan reuses Admin Settings as a surface while eneo.skills owns typed organisation runtime policy."
+      validation:
+        - cmd: "bunx prettier@3.9.4 --check docs/enterprise-skills-roadmap.md docs/adr/marketplace-hub-package-portability-and-skills.md frontend/apps/docs-site/src/content/guides/skills.mdx"
+          result: pass
+        - cmd: "node /Users/ccimen/.codex/skills/goal-maker/scripts/check-goal-state.mjs docs/goals/enterprise-skills-rollout/state.yaml"
+          result: pass
+        - cmd: "git diff --check"
+          result: pass
+        - cmd: "bun run --cwd apps/docs-site build"
+          result: "pass; existing Nextra Git timestamp and no-img-element warnings only"
+
+  - id: T011
+    type: worker
+    assignee: Worker
+    status: active
+    reasoning_hint: high
+    objective: "Implement Task #553 slice 1 as a dormant, closed Assistant and Governance Policy binding-mode contract while preserving byte-equivalent all-always behavior."
+    tracking_issue: "https://github.com/eneo-ai/eneo/issues/553"
+    inputs:
+      - "PR #581 after merge into develop"
+      - "docs/enterprise-skills-roadmap.md selective activation boundary and slices"
+      - "docs/adr/marketplace-hub-package-portability-and-skills.md selective activation delivery gate"
+      - "Current Assistant, Governance Policy, Skill binding, migration, and generated-contract owners"
+    allowed_files:
+      - "backend/alembic/versions/"
+      - "backend/src/eneo/assistants/"
+      - "backend/src/eneo/database/tables/skill_table.py"
+      - "backend/src/eneo/governance_policy/"
+      - "backend/src/eneo/skills/"
+      - "backend/tests/integration/assistants/"
+      - "backend/tests/integration/governance_policy/"
+      - "backend/tests/integration/migrations/"
+      - "backend/tests/integration/skills/"
+      - "backend/tests/unittests/assistants/"
+      - "backend/tests/unittests/governance_policy/"
+      - "backend/tests/unittests/skills/"
+      - "docs/enterprise-skills-roadmap.md"
+      - "docs/goals/enterprise-skills-rollout/"
+      - "frontend/apps/docs-site/src/content/guides/skills.mdx"
+      - "frontend/packages/eneo-js/"
+    constraints:
+      - "Do not begin until PR #581 is merged and the new branch is based on that exact develop revision."
+      - "Add a closed internal always | on_demand value only where Assistant and Governance Policy bindings canonically own it; Apps gain no mode."
+      - "Backfill and default every existing row to always."
+      - "Do not accept public on_demand writes, add runtime activation, change provider payloads, or expose mode controls."
+      - "Reuse current binding tables, repositories, parent writes, and generated contracts; create no parallel binding API or generic mode framework."
+      - "Keep schema, domain, persistence, and internal projections typed; add no Any, ignores, or compatibility shim."
+    expected_output:
+      - "One reversible migration and typed closed mode"
+      - "Internal Assistant and Governance Policy binding round-trip with always defaults"
+      - "Byte-equivalent zero-Skill and all-always composition behavior"
+      - "Public request contracts reject or cannot express on_demand"
+      - "Migration, repository, service, schema, and behavior tests"
+      - "Updated concise docs and validation receipt"
+    verify:
+      - "Focused migration round-trip and PostgreSQL constraint tests"
+      - "Assistant and Governance Policy binding repository/service behavior tests"
+      - "Zero-Skill and all-always provider-payload equivalence tests"
+      - "OpenAPI and generated SDK drift checks"
+      - "Backend Ruff, format, strict Pyright, relevant suites, and docs build"
+      - "Required GitHub CI, fresh /review, same-session Claude peer verification, and PM audit"
+    stop_if:
+      - "PR #581 is not merged or develop no longer matches its accepted contract."
+      - "The slice requires provider-loop, token-policy, evidence, or frontend mode-control changes."
+      - "A public generated input can accept on_demand before runtime exists."
+      - "App bindings would gain a mode or require a compatibility branch."
     receipt: null
 
   - id: T999

--- a/frontend/apps/docs-site/src/content/guides/skills.mdx
+++ b/frontend/apps/docs-site/src/content/guides/skills.mdx
@@ -228,6 +228,24 @@ Review the adoption view and update or remove unsafe versions before unblocking.
   automatically.
 - This release has no external Skill marketplace or package installation flow.
 
+## Planned next steps
+
+The next runtime change will let Assistant builders and tenant admins choose
+between **always** and **on demand** for each approved binding. On-demand Skills
+will advertise a compact description and load the exact pinned instructions only
+when a tool-capable model requests them. Apps will remain eager.
+
+Eneo will show the selected model, measured Skill budget, and whether every
+attached Skill is discoverable. Tenant admins will be able to change the seeded
+10% total Skill-context share in **Admin > Overview** without a code change or
+deployment; the model window and platform safety bounds still apply. Eneo will
+reject a new configuration in which an advertised Skill could never be loaded,
+instead of hiding a subset. Models without tool calling will keep only
+**always** Skills and show that limitation.
+
+Editable Space copies with explicit source updates come later. External
+Marketplace distribution remains a separate final phase.
+
 ## FAQ
 
 ### Does editing a Skill immediately change every Assistant that uses it?


### PR DESCRIPTION
## What changed

- reconciled the remaining Enterprise Skills roadmap with current `develop`,
  Issue #553, PR #538, and the active Flow package branch
- made Task #553 the next highest-ROI feature and split it into five deployable
  slices
- defined one administrator-configurable Skill runtime policy, with a seeded
  10% total context share rather than a hard-coded runtime constant
- fixed the trusted activation, model-validation, evidence, App, Group Chat, O2,
  S2, and Marketplace boundaries
- added a concise planned-behaviour section to the docs-site Skills guide
- closed T007 with its merged PR #580 receipt and opened planning task T010

## Why

The previous roadmap mixed a discovery-list percentage with total Skill context,
treated PR #538 as a merge dependency, and left several runtime and delivery
details ambiguous. This plan establishes one reviewable contract before
production implementation begins.

## Developer impact

No production behavior changes. Issue #553 is now the implementation owner. The
first implementation slice is the dormant `always | on_demand` binding contract;
the public mode remains hidden until the trusted runtime and validation paths
exist.

## Validation

- `bunx prettier@3.9.4 --check ...`
- `node /Users/ccimen/.codex/skills/goal-maker/scripts/check-goal-state.mjs docs/goals/enterprise-skills-rollout/state.yaml`
- `git diff --check`
- `bun run --cwd apps/docs-site build`
- Fable Max, same-session final verification: green, minimum score 8

The docs build passed with the existing Nextra Git timestamp and
`@next/next/no-img-element` warnings.

Relates to #553; it does not close the implementation task.
