### PR TITLE
feat(skills): add dormant binding activation mode

### DIFF
--- a/backend/alembic/versions/202607240115_add_skill_binding_activation_mode.py
+++ b/backend/alembic/versions/202607240115_add_skill_binding_activation_mode.py
@@ -1,0 +1,107 @@
+"""add Assistant and Governance Policy Skill binding activation mode
+
+Revision ID: 202607240115
+Revises: 202607231730
+Create Date: 2026-07-24 01:15:00.000000
+"""
+
+from collections.abc import Sequence
+from time import monotonic, sleep
+
+from sqlalchemy.exc import DBAPIError
+
+from alembic import op
+
+revision: str = "202607240115"
+down_revision: str | None = "202607231730"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_MODE_TABLES = ("assistant_skill_bindings", "governance_policy_skill_bindings")
+_LOCK_NOT_AVAILABLE_SQLSTATE = "55P03"
+_METADATA_LOCK_RETRY_SECONDS = 5.0
+_METADATA_LOCK_RETRY_INTERVAL_SECONDS = 0.025
+
+
+def _constraint_name(table: str) -> str:
+    return f"ck_{table}_activation_mode"
+
+
+def _execute_with_immediate_table_lock(
+    *,
+    table: str,
+    statements: tuple[str, ...],
+) -> None:
+    """Run one short metadata phase without joining PostgreSQL's lock queue."""
+    bind = op.get_bind()
+    deadline = monotonic() + _METADATA_LOCK_RETRY_SECONDS
+
+    while True:
+        bind.exec_driver_sql("BEGIN")
+        try:
+            bind.exec_driver_sql(f"LOCK TABLE {table} IN ACCESS EXCLUSIVE MODE NOWAIT")
+            for statement in statements:
+                bind.exec_driver_sql(statement)
+            bind.exec_driver_sql("COMMIT")
+            return
+        except DBAPIError as error:
+            bind.exec_driver_sql("ROLLBACK")
+            sqlstate = getattr(error.orig, "sqlstate", None) or getattr(
+                error.orig, "pgcode", None
+            )
+            if sqlstate != _LOCK_NOT_AVAILABLE_SQLSTATE or monotonic() >= deadline:
+                raise
+            sleep(_METADATA_LOCK_RETRY_INTERVAL_SECONDS)
+        except Exception:
+            bind.exec_driver_sql("ROLLBACK")
+            raise
+
+
+def upgrade() -> None:
+    # Each phase commits independently so a bounded lock retry never holds one
+    # table's exclusive lock while touching the other, and the populated-table
+    # CHECK scan happens under the weaker validation lock, not the metadata one.
+    with op.get_context().autocommit_block():
+        for table in _MODE_TABLES:
+            _execute_with_immediate_table_lock(
+                table=table,
+                statements=(
+                    f"""
+                    ALTER TABLE {table}
+                        ADD COLUMN IF NOT EXISTS activation_mode TEXT
+                            NOT NULL DEFAULT 'always'
+                    """,
+                    f"""
+                    ALTER TABLE {table}
+                        DROP CONSTRAINT IF EXISTS {_constraint_name(table)}
+                    """,
+                    f"""
+                    ALTER TABLE {table}
+                        ADD CONSTRAINT {_constraint_name(table)}
+                        CHECK (activation_mode IN ('always', 'on_demand'))
+                        NOT VALID
+                    """,
+                ),
+            )
+        for table in _MODE_TABLES:
+            op.execute(
+                f"ALTER TABLE {table} VALIDATE CONSTRAINT {_constraint_name(table)}"
+            )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        for table in _MODE_TABLES:
+            _execute_with_immediate_table_lock(
+                table=table,
+                statements=(
+                    f"""
+                    ALTER TABLE {table}
+                        DROP CONSTRAINT IF EXISTS {_constraint_name(table)}
+                    """,
+                    f"""
+                    ALTER TABLE {table}
+                        DROP COLUMN IF EXISTS activation_mode
+                    """,
+                ),
+            )

--- a/backend/src/eneo/database/tables/skill_table.py
+++ b/backend/src/eneo/database/tables/skill_table.py
@@ -194,6 +194,7 @@ class AssistantSkillBindings(BaseCrossReference):
     skill_id: Mapped[UUID] = mapped_column()
     skill_revision_id: Mapped[UUID] = mapped_column()
     position: Mapped[int] = mapped_column()
+    activation_mode: Mapped[str] = mapped_column(Text, server_default="always")
 
     __table_args__ = (
         PrimaryKeyConstraint(
@@ -209,6 +210,10 @@ class AssistantSkillBindings(BaseCrossReference):
         CheckConstraint(
             "position >= 0",
             name="ck_assistant_skill_bindings_position_nonnegative",
+        ),
+        CheckConstraint(
+            "activation_mode IN ('always', 'on_demand')",
+            name="ck_assistant_skill_bindings_activation_mode",
         ),
         ForeignKeyConstraint(
             ["space_id", "assistant_id"],
@@ -331,6 +336,7 @@ class GovernancePolicySkillBindings(BaseCrossReference):
     skill_id: Mapped[UUID] = mapped_column()
     skill_revision_id: Mapped[UUID] = mapped_column()
     position: Mapped[int] = mapped_column()
+    activation_mode: Mapped[str] = mapped_column(Text, server_default="always")
 
     __table_args__ = (
         PrimaryKeyConstraint(
@@ -346,6 +352,10 @@ class GovernancePolicySkillBindings(BaseCrossReference):
         CheckConstraint(
             "position >= 0",
             name="ck_governance_policy_skill_bindings_position_nonnegative",
+        ),
+        CheckConstraint(
+            "activation_mode IN ('always', 'on_demand')",
+            name="ck_governance_policy_skill_bindings_activation_mode",
         ),
         ForeignKeyConstraint(
             ["tenant_id", "policy_id"],

--- a/backend/src/eneo/skills/application/skill_service.py
+++ b/backend/src/eneo/skills/application/skill_service.py
@@ -437,21 +437,6 @@ class SkillService:
             raise BadRequestException(
                 "One or more existing Skill bindings are no longer available"
             )
-        # Re-resolution rebuilds bindings from catalogue state, which would
-        # silently reset a stored activation mode; a retained binding must
-        # keep the mode the parent already saved.
-        existing_by_reference = {
-            self._binding_reference(binding): binding for binding in existing
-        }
-        retained = [
-            replace(
-                binding,
-                activation_mode=existing_by_reference[
-                    self._binding_reference(binding)
-                ].activation_mode,
-            )
-            for binding in retained
-        ]
         return (
             {self._binding_reference(binding): binding for binding in retained},
             [
@@ -467,6 +452,7 @@ class SkillService:
         *,
         references: list[SkillBindingReference],
         resolved_groups: tuple[list[ResolvedSkillBinding], ...],
+        existing: list[ResolvedSkillBinding],
         missing_error: Exception,
     ) -> list[ResolvedSkillBinding]:
         resolved_by_reference = {
@@ -476,8 +462,23 @@ class SkillService:
         }
         if any(reference not in resolved_by_reference for reference in references):
             raise missing_error
+        # Re-resolution rebuilds bindings from catalogue state, which would
+        # silently reset a stored activation mode. A parent carries at most one
+        # binding per Skill, so a Skill already bound to the parent keeps its
+        # saved mode even when the request pins a different revision; only a
+        # genuinely new Skill takes the resolver default.
+        existing_mode_by_skill_id = {
+            binding.skill_id: binding.activation_mode for binding in existing
+        }
         return [
-            replace(resolved_by_reference[reference], position=position)
+            replace(
+                resolved_by_reference[reference],
+                position=position,
+                activation_mode=existing_mode_by_skill_id.get(
+                    reference.skill_id,
+                    resolved_by_reference[reference].activation_mode,
+                ),
+            )
             for position, reference in enumerate(references)
         ]
 
@@ -528,6 +529,7 @@ class SkillService:
                 local,
                 published,
             ),
+            existing=existing,
             missing_error=NotFoundException(
                 "One or more Skill revisions are unavailable for this resource"
             ),
@@ -558,6 +560,7 @@ class SkillService:
         return self._order_resolved_bindings(
             references=references,
             resolved_groups=(list(retained_by_reference.values()), published),
+            existing=existing,
             missing_error=BadRequestException(
                 "Personal Chat can only use published organisation Skill versions"
             ),

--- a/backend/src/eneo/skills/application/skill_service.py
+++ b/backend/src/eneo/skills/application/skill_service.py
@@ -437,6 +437,21 @@ class SkillService:
             raise BadRequestException(
                 "One or more existing Skill bindings are no longer available"
             )
+        # Re-resolution rebuilds bindings from catalogue state, which would
+        # silently reset a stored activation mode; a retained binding must
+        # keep the mode the parent already saved.
+        existing_by_reference = {
+            self._binding_reference(binding): binding for binding in existing
+        }
+        retained = [
+            replace(
+                binding,
+                activation_mode=existing_by_reference[
+                    self._binding_reference(binding)
+                ].activation_mode,
+            )
+            for binding in retained
+        ]
         return (
             {self._binding_reference(binding): binding for binding in retained},
             [

--- a/backend/src/eneo/skills/domain/skill.py
+++ b/backend/src/eneo/skills/domain/skill.py
@@ -247,6 +247,14 @@ class SkillBindingSource(str, Enum):
     ORGANIZATION = "organization"
 
 
+class SkillActivationMode(str, Enum):
+    """Closed Assistant/Governance Policy binding mode; Apps compose eagerly
+    and carry the fixed ALWAYS value without a persisted column."""
+
+    ALWAYS = "always"
+    ON_DEMAND = "on_demand"
+
+
 def derive_skill_publication_state(
     *,
     current_revision_number: int,
@@ -520,6 +528,7 @@ class ResolvedSkillBinding:
     is_active: bool = True
     attachable_revision_id: UUID | None = None
     attachable_revision_number: int | None = None
+    activation_mode: SkillActivationMode = SkillActivationMode.ALWAYS
 
 
 @dataclass(frozen=True)

--- a/backend/src/eneo/skills/infrastructure/skill_repo_impl.py
+++ b/backend/src/eneo/skills/infrastructure/skill_repo_impl.py
@@ -29,6 +29,7 @@ from eneo.skills.domain.skill import (
     PublishedSkillSummary,
     ResolvedSkillBinding,
     Skill,
+    SkillActivationMode,
     SkillAdoptionCursor,
     SkillAdoptionDrift,
     SkillAdoptionPersonalChat,
@@ -1480,6 +1481,8 @@ class SkillRepoImpl:
         attachable_revision_id: UUID | None,
         attachable_revision_number: int | None,
         position: int,
+        *,
+        activation_mode: SkillActivationMode = SkillActivationMode.ALWAYS,
     ) -> ResolvedSkillBinding:
         return ResolvedSkillBinding(
             skill_id=skill.id,
@@ -1502,6 +1505,7 @@ class SkillRepoImpl:
             is_active=skill.is_active,
             attachable_revision_id=attachable_revision_id,
             attachable_revision_number=attachable_revision_number,
+            activation_mode=activation_mode,
         )
 
     async def _resolve_references(
@@ -1738,6 +1742,7 @@ class SkillRepoImpl:
                 attachable_revision_id,
                 attachable_revision_number,
                 binding.position,
+                activation_mode=SkillActivationMode(binding.activation_mode),
             )
             for (
                 binding,
@@ -1786,6 +1791,7 @@ class SkillRepoImpl:
                         "skill_id": binding.skill_id,
                         "skill_revision_id": binding.skill_revision_id,
                         "position": position,
+                        "activation_mode": binding.activation_mode.value,
                     }
                     for position, binding in enumerate(bindings)
                 ],
@@ -1893,6 +1899,7 @@ class SkillRepoImpl:
                 attachable_revision_id,
                 attachable_revision_number,
                 binding.position,
+                activation_mode=SkillActivationMode(binding.activation_mode),
             )
             for (
                 binding,
@@ -1929,6 +1936,7 @@ class SkillRepoImpl:
                         "skill_id": binding.skill_id,
                         "skill_revision_id": binding.skill_revision_id,
                         "position": position,
+                        "activation_mode": binding.activation_mode.value,
                     }
                     for position, binding in enumerate(bindings)
                 ],

--- a/backend/tests/integration/migrations/test_skills_schema_round_trip.py
+++ b/backend/tests/integration/migrations/test_skills_schema_round_trip.py
@@ -37,6 +37,7 @@ PRE_PERMISSION_CONVERGENCE_REVISION = "202607221600"
 SKILLS_HEAD_REVISION = "202607221700"
 PRE_SKILL_EXECUTION_BLOCK_REVISION = "202607231330"
 SKILL_EXECUTION_BLOCK_REVISION = "202607231730"
+BINDING_ACTIVATION_MODE_REVISION = "202607240115"
 
 
 @dataclass(frozen=True)
@@ -1873,3 +1874,128 @@ def test_skill_execution_block_migration_enforces_active_lifecycle_and_round_tri
         cursor.execute("SELECT to_regclass('skill_execution_blocks')")
         assert cursor.fetchone() == (None,)
     command.upgrade(config, SKILL_EXECUTION_BLOCK_REVISION)
+
+
+def _activation_mode_column_exists(connection: PgConnection, table: str) -> bool:
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT count(*)
+            FROM information_schema.columns
+            WHERE table_name = %s AND column_name = 'activation_mode'
+            """,
+            (table,),
+        )
+        return cursor.fetchone()[0] == 1
+
+
+def test_binding_activation_mode_migration_backfills_and_round_trips(
+    pre_skills_database: MigrationDatabase,
+):
+    connection = pre_skills_database.connection
+    config = pre_skills_database.alembic_config
+    command.upgrade(config, SKILL_EXECUTION_BLOCK_REVISION)
+
+    tenant_id = _insert_tenant(connection, "activation-mode")
+    user_id = _insert_user(connection, tenant_id, "activation-mode")
+    space_id = _insert_space(connection, tenant_id, "activation-mode")
+    skill_id, revision_id = _insert_skill(
+        connection,
+        space_id=space_id,
+        created_by_user_id=user_id,
+        label="activation-mode",
+    )
+    assistant_id = _insert_assistant(connection, user_id=user_id, space_id=space_id)
+    policy_id = _insert_policy(connection, tenant_id)
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO assistant_skill_bindings (
+                assistant_id, tenant_id, space_id, skill_space_id,
+                skill_id, skill_revision_id, position
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, 0)
+            """,
+            (assistant_id, tenant_id, space_id, space_id, skill_id, revision_id),
+        )
+        cursor.execute(
+            """
+            INSERT INTO governance_policy_skill_bindings (
+                policy_id, tenant_id, skill_space_id,
+                skill_id, skill_revision_id, position
+            )
+            VALUES (%s, %s, %s, %s, %s, 0)
+            """,
+            (policy_id, tenant_id, space_id, skill_id, revision_id),
+        )
+
+    command.upgrade(config, BINDING_ACTIVATION_MODE_REVISION)
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT activation_mode FROM assistant_skill_bindings "
+            "WHERE assistant_id = %s",
+            (assistant_id,),
+        )
+        assert cursor.fetchone() == ("always",)
+        cursor.execute(
+            "SELECT activation_mode FROM governance_policy_skill_bindings "
+            "WHERE policy_id = %s",
+            (policy_id,),
+        )
+        assert cursor.fetchone() == ("always",)
+
+    assert not _activation_mode_column_exists(connection, "app_skill_bindings")
+
+    _assert_constraint(
+        connection,
+        expected="ck_assistant_skill_bindings_activation_mode",
+        statement="""
+            UPDATE assistant_skill_bindings
+            SET activation_mode = 'sometimes'
+            WHERE assistant_id = %s
+        """,
+        parameters=(assistant_id,),
+    )
+    _assert_constraint(
+        connection,
+        expected="ck_governance_policy_skill_bindings_activation_mode",
+        statement="""
+            UPDATE governance_policy_skill_bindings
+            SET activation_mode = 'sometimes'
+            WHERE policy_id = %s
+        """,
+        parameters=(policy_id,),
+    )
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            UPDATE governance_policy_skill_bindings
+            SET activation_mode = 'on_demand'
+            WHERE policy_id = %s
+            """,
+            (policy_id,),
+        )
+        cursor.execute(
+            "SELECT activation_mode FROM governance_policy_skill_bindings "
+            "WHERE policy_id = %s",
+            (policy_id,),
+        )
+        assert cursor.fetchone() == ("on_demand",)
+
+    command.downgrade(config, SKILL_EXECUTION_BLOCK_REVISION)
+    assert not _activation_mode_column_exists(connection, "assistant_skill_bindings")
+    assert not _activation_mode_column_exists(
+        connection, "governance_policy_skill_bindings"
+    )
+
+    command.upgrade(config, BINDING_ACTIVATION_MODE_REVISION)
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT activation_mode FROM assistant_skill_bindings "
+            "WHERE assistant_id = %s",
+            (assistant_id,),
+        )
+        assert cursor.fetchone() == ("always",)

--- a/backend/tests/integration/skills/test_skill_catalogue_repo.py
+++ b/backend/tests/integration/skills/test_skill_catalogue_repo.py
@@ -1,16 +1,20 @@
+from dataclasses import replace
 from uuid import uuid4
 
 import pytest
 import sqlalchemy as sa
 
 from eneo.database.tables.app_table import AppRuns
+from eneo.database.tables.governance_policy_table import GovernancePolicies
 from eneo.database.tables.job_table import Jobs
 from eneo.database.tables.spaces_table import Spaces, SpacesUsers
+from eneo.governance_policy.domain.governance_policy import PolicyScope
 from eneo.jobs.job_models import Task
 from eneo.main.exceptions import NameCollisionException, NotFoundException
 from eneo.main.models import Status
 from eneo.skills.domain.skill import (
     PublishedSkillDeletionError,
+    SkillActivationMode,
     SkillBindingReference,
     SkillBindingSource,
     SkillExecutionReference,
@@ -610,3 +614,138 @@ async def test_publication_mutations_are_stale_safe_and_idempotent(
         assert republished.previous_is_active is False
         assert republished.skill.publication_state is SkillPublicationState.PUBLISHED
         assert republished.skill.is_active is True
+
+
+async def test_binding_activation_mode_round_trips_for_assistant_and_policy_only(
+    db_container,
+    admin_user,
+    completion_model_factory,
+    space_factory,
+    assistant_factory,
+    app_factory,
+):
+    async with db_container() as container:
+        session = container.session()
+        organization = await _organization_space(
+            session,
+            tenant_id=admin_user.tenant_id,
+        )
+        assert organization is not None
+        model = await completion_model_factory(session, "activation-mode-model")
+        space = await space_factory(session, "Activation mode space", [model.id])
+        session.add(SpacesUsers(space_id=space.id, user_id=admin_user.id, role="admin"))
+        assistant = await assistant_factory(
+            session,
+            "Activation mode Assistant",
+            model.id,
+            space_id=space.id,
+        )
+        app = await app_factory(
+            session,
+            "Activation mode App",
+            model.id,
+            space_id=space.id,
+        )
+        policy = GovernancePolicies(
+            tenant_id=admin_user.tenant_id,
+            scope=PolicyScope.PERSONAL_DEFAULT_ASSISTANT.value,
+        )
+        session.add(policy)
+        await session.flush()
+
+        repo = container.skill_repo()
+        local = await repo.create(
+            space_id=space.id,
+            slug=f"activation-mode-{uuid4().hex[:8]}",
+            display_name="Activation mode",
+            description="Round-trips the closed binding mode",
+            instructions="Use the activation-mode instructions.",
+            content_digest="a" * 64,
+            created_by_user_id=admin_user.id,
+        )
+        published = await repo.create(
+            space_id=organization.id,
+            slug=f"activation-mode-org-{uuid4().hex[:8]}",
+            display_name="Activation mode org",
+            description="Round-trips the closed policy binding mode",
+            instructions="Use the approved activation-mode instructions.",
+            content_digest="b" * 64,
+            created_by_user_id=admin_user.id,
+        )
+        await repo.publish_organization(
+            tenant_id=admin_user.tenant_id,
+            skill_id=published.id,
+            expected_revision_id=published.current_revision.id,
+        )
+
+        resolved = await repo.resolve_local_references_for_binding_update(
+            space_id=space.id,
+            references=[
+                SkillBindingReference(
+                    skill_id=local.id,
+                    skill_revision_id=local.current_revision.id,
+                )
+            ],
+        )
+        assert [binding.activation_mode for binding in resolved] == [
+            SkillActivationMode.ALWAYS
+        ]
+
+        on_demand = [
+            replace(binding, activation_mode=SkillActivationMode.ON_DEMAND)
+            for binding in resolved
+        ]
+        await repo.replace_assistant_bindings(
+            assistant_id=assistant.id,
+            tenant_id=admin_user.tenant_id,
+            space_id=space.id,
+            bindings=on_demand,
+        )
+        assistant_bindings = await repo.list_assistant_bindings(
+            assistant_id=assistant.id
+        )
+        assert [binding.activation_mode for binding in assistant_bindings] == [
+            SkillActivationMode.ON_DEMAND
+        ]
+
+        approved = await repo.resolve_published_references_for_binding_update(
+            tenant_id=admin_user.tenant_id,
+            references=[
+                SkillBindingReference(
+                    skill_id=published.id,
+                    skill_revision_id=published.current_revision.id,
+                )
+            ],
+        )
+        await repo.replace_policy_bindings(
+            policy_id=policy.id,
+            tenant_id=admin_user.tenant_id,
+            skill_space_id=organization.id,
+            bindings=[
+                replace(binding, activation_mode=SkillActivationMode.ON_DEMAND)
+                for binding in approved
+            ],
+        )
+        policy_bindings = await repo.list_policy_bindings(policy_id=policy.id)
+        assert [binding.activation_mode for binding in policy_bindings] == [
+            SkillActivationMode.ON_DEMAND
+        ]
+
+        # Apps stay eager: the table has no mode column, so even an internal
+        # ON_DEMAND value cannot persist and reads come back as ALWAYS.
+        await repo.replace_app_bindings(
+            app_id=app.id,
+            tenant_id=admin_user.tenant_id,
+            space_id=space.id,
+            bindings=on_demand,
+        )
+        app_bindings = await repo.list_app_bindings(app_id=app.id)
+        assert [binding.activation_mode for binding in app_bindings] == [
+            SkillActivationMode.ALWAYS
+        ]
+        execution_plan_bindings = await repo.list_app_bindings_for_execution_plan(
+            app_id=app.id
+        )
+        assert [binding.activation_mode for binding in execution_plan_bindings] == [
+            SkillActivationMode.ALWAYS
+        ]

--- a/backend/tests/unittests/skills/test_skill.py
+++ b/backend/tests/unittests/skills/test_skill.py
@@ -18,6 +18,7 @@ from eneo.skills.application.skill_service import SkillService
 from eneo.skills.domain.skill import (
     NormalizedSkillContent,
     Skill,
+    SkillActivationMode,
     SkillBindingReference,
     SkillBindingSource,
     SkillExecutionBlock,
@@ -234,6 +235,20 @@ def test_zero_skills_returns_base_prompt_byte_for_byte():
     composition = compose_skill_instructions(base_instructions=base, bindings=[])
     assert composition.prompt == base
     assert composition.provenance == ()
+
+
+def test_activation_mode_is_dormant_in_composition():
+    always = [_binding(position=0, name="Payroll"), _binding(position=1, name="Leave")]
+    on_demand = [
+        replace(binding, activation_mode=SkillActivationMode.ON_DEMAND)
+        for binding in always
+    ]
+
+    assert compose_skill_instructions(
+        base_instructions="Base instructions", bindings=on_demand
+    ) == compose_skill_instructions(
+        base_instructions="Base instructions", bindings=always
+    )
 
 
 def test_composition_orders_skills_and_builds_matching_provenance():

--- a/backend/tests/unittests/skills/test_skill_presentation_contract.py
+++ b/backend/tests/unittests/skills/test_skill_presentation_contract.py
@@ -14,6 +14,7 @@ from eneo.skills.application.skill_service import SkillService
 from eneo.skills.domain.skill import (
     ResolvedSkillBinding,
     Skill,
+    SkillBindingReference,
     SkillBindingSource,
     SkillCatalogEntry,
     SkillCatalogPage,
@@ -579,3 +580,27 @@ async def test_lost_delete_race_does_not_emit_a_second_delete_audit():
         )
 
     audit_service.log_async.assert_not_awaited()
+
+
+def test_public_binding_contracts_cannot_express_activation_mode():
+    """Slice 1 keeps the mode dormant: a client-supplied activation_mode is
+    dropped by the closed input model and no read model advertises one, so
+    the generated OpenAPI/SDK contracts stay unchanged."""
+    payload = {
+        "skill_id": str(uuid4()),
+        "skill_revision_id": str(uuid4()),
+        "activation_mode": "on_demand",
+    }
+    parsed = SkillBindingReferenceInput.model_validate(payload)
+    references = skill_binding_references_from_input([parsed])
+
+    assert not hasattr(parsed, "activation_mode")
+    assert references[0] == SkillBindingReference(
+        skill_id=parsed.skill_id,
+        skill_revision_id=parsed.skill_revision_id,
+    )
+    for public_model in (
+        skill_models.SkillBindingReferenceInput,
+        skill_models.SkillBindingSummary,
+    ):
+        assert "activation_mode" not in public_model.model_json_schema()["properties"]

--- a/backend/tests/unittests/skills/test_skill_service.py
+++ b/backend/tests/unittests/skills/test_skill_service.py
@@ -1244,3 +1244,61 @@ async def test_new_binding_defaults_to_always_activation_mode():
     assert [binding.activation_mode for binding in result] == [
         SkillActivationMode.ALWAYS
     ]
+
+
+async def test_assistant_revision_upgrade_keeps_activation_mode():
+    space = _space()
+    existing = replace(_binding(), activation_mode=SkillActivationMode.ON_DEMAND)
+    upgraded = replace(
+        _binding(skill_id=existing.skill_id),
+        activation_mode=SkillActivationMode.ALWAYS,
+    )
+    repo = AsyncMock()
+    repo.list_assistant_bindings.return_value = [existing]
+    repo.resolve_local_references_for_binding_update.return_value = [upgraded]
+    service = _service(space=space, repo=repo)
+
+    result = await service.replace_assistant_bindings(
+        space_id=space.id,
+        assistant_id=space.assistant.id,
+        references=[_binding_reference(upgraded)],
+    )
+
+    assert [binding.activation_mode for binding in result] == [
+        SkillActivationMode.ON_DEMAND
+    ]
+    persisted = repo.replace_assistant_bindings.await_args.kwargs["bindings"]
+    assert [binding.activation_mode for binding in persisted] == [
+        SkillActivationMode.ON_DEMAND
+    ]
+
+
+async def test_governance_revision_upgrade_keeps_activation_mode():
+    space = _space(organization=True)
+    existing = replace(_binding(), activation_mode=SkillActivationMode.ON_DEMAND)
+    upgraded = replace(
+        _binding(skill_id=existing.skill_id),
+        activation_mode=SkillActivationMode.ALWAYS,
+    )
+    repo = AsyncMock()
+    repo.list_policy_bindings.return_value = [existing]
+    repo.resolve_published_references_for_binding_update.return_value = [upgraded]
+    service = _service(
+        space=space,
+        repo=repo,
+        permissions={Permission.ADMIN, Permission.SKILLS},
+    )
+
+    result = await service.replace_governance_bindings(
+        policy_id=uuid4(),
+        organization_space_id=space.id,
+        references=[_binding_reference(upgraded)],
+    )
+
+    assert [binding.activation_mode for binding in result] == [
+        SkillActivationMode.ON_DEMAND
+    ]
+    persisted = repo.replace_policy_bindings.await_args.kwargs["bindings"]
+    assert [binding.activation_mode for binding in persisted] == [
+        SkillActivationMode.ON_DEMAND
+    ]

--- a/backend/tests/unittests/skills/test_skill_service.py
+++ b/backend/tests/unittests/skills/test_skill_service.py
@@ -16,6 +16,7 @@ from eneo.roles.permissions import Permission
 from eneo.skills.application.skill_service import SkillService
 from eneo.skills.domain.skill import (
     ResolvedSkillBinding,
+    SkillActivationMode,
     SkillBindingReference,
     SkillBindingSource,
     SkillCatalogEntry,
@@ -1176,3 +1177,70 @@ async def test_governance_bindings_require_organization_space_in_same_tenant():
             organization_space_id=space.id,
             references=[],
         )
+
+
+async def test_retained_assistant_binding_keeps_activation_mode_on_resave():
+    space = _space()
+    existing = replace(_binding(), activation_mode=SkillActivationMode.ON_DEMAND)
+    freshly_resolved = replace(existing, activation_mode=SkillActivationMode.ALWAYS)
+    repo = AsyncMock()
+    repo.list_assistant_bindings.return_value = [existing]
+    repo.resolve_bound_references_for_binding_update.return_value = [freshly_resolved]
+    service = _service(space=space, repo=repo)
+
+    result = await service.replace_assistant_bindings(
+        space_id=space.id,
+        assistant_id=space.assistant.id,
+        references=[_binding_reference(existing)],
+    )
+
+    assert result[0].activation_mode is SkillActivationMode.ON_DEMAND
+    persisted = repo.replace_assistant_bindings.await_args.kwargs["bindings"]
+    assert [binding.activation_mode for binding in persisted] == [
+        SkillActivationMode.ON_DEMAND
+    ]
+
+
+async def test_retained_governance_binding_keeps_activation_mode_on_resave():
+    space = _space(organization=True)
+    existing = replace(_binding(), activation_mode=SkillActivationMode.ON_DEMAND)
+    freshly_resolved = replace(existing, activation_mode=SkillActivationMode.ALWAYS)
+    repo = AsyncMock()
+    repo.list_policy_bindings.return_value = [existing]
+    repo.resolve_bound_references_for_binding_update.return_value = [freshly_resolved]
+    service = _service(
+        space=space,
+        repo=repo,
+        permissions={Permission.ADMIN, Permission.SKILLS},
+    )
+
+    result = await service.replace_governance_bindings(
+        policy_id=uuid4(),
+        organization_space_id=space.id,
+        references=[_binding_reference(existing)],
+    )
+
+    assert result[0].activation_mode is SkillActivationMode.ON_DEMAND
+    persisted = repo.replace_policy_bindings.await_args.kwargs["bindings"]
+    assert [binding.activation_mode for binding in persisted] == [
+        SkillActivationMode.ON_DEMAND
+    ]
+
+
+async def test_new_binding_defaults_to_always_activation_mode():
+    space = _space()
+    added = _binding()
+    repo = AsyncMock()
+    repo.list_assistant_bindings.return_value = []
+    repo.resolve_local_references_for_binding_update.return_value = [added]
+    service = _service(space=space, repo=repo)
+
+    result = await service.replace_assistant_bindings(
+        space_id=space.id,
+        assistant_id=space.assistant.id,
+        references=[_binding_reference(added)],
+    )
+
+    assert [binding.activation_mode for binding in result] == [
+        SkillActivationMode.ALWAYS
+    ]

--- a/docs/goals/enterprise-skills-rollout/state.yaml
+++ b/docs/goals/enterprise-skills-rollout/state.yaml
@@ -691,7 +691,37 @@ tasks:
       - "The slice requires provider-loop, token-policy, evidence, or frontend mode-control changes."
       - "A public generated input can accept on_demand before runtime exists."
       - "App bindings would gain a mode or require a compatibility branch."
-    receipt: null
+    receipt:
+      result: implemented
+      summary: "Added the dormant closed always|on_demand binding mode to Assistant and Governance Policy bindings with always backfill, retained-mode preservation on parent saves, byte-equivalent composition, and unchanged public contracts. PR #582 opened for CI and fresh review; merge pending."
+      pr: 582
+      pr_status: "opened for CI and fresh review"
+      base_commit: "677c54ca4aa0a244f51bbe77de8890ca23807536"
+      changed_files:
+        - "backend/alembic/versions/202607240115_add_skill_binding_activation_mode.py"
+        - "backend/src/eneo/database/tables/skill_table.py"
+        - "backend/src/eneo/skills/application/skill_service.py"
+        - "backend/src/eneo/skills/domain/skill.py"
+        - "backend/src/eneo/skills/infrastructure/skill_repo_impl.py"
+        - "backend/tests/integration/migrations/test_skills_schema_round_trip.py"
+        - "backend/tests/integration/skills/test_skill_catalogue_repo.py"
+        - "backend/tests/unittests/skills/"
+        - "docs/goals/enterprise-skills-rollout/state.yaml"
+      commands:
+        - cmd: "uv run pytest -n 2 -m 'not integration' tests/"
+          result: "pass: 3798 tests"
+        - cmd: "uv run pytest tests/integration/skills/"
+          result: "pass: 38 tests"
+        - cmd: "uv run pytest -m migration_isolation tests/integration/migrations/test_skills_schema_round_trip.py::test_binding_activation_mode_migration_backfills_and_round_trips -v"
+          result: "pass: PostgreSQL backfill, CHECK rejection, App-column absence, downgrade, re-upgrade"
+        - cmd: "uv run ruff check src/eneo; uv run ruff format --check src/eneo; uv run pyright; uv lock --check"
+          result: pass
+        - cmd: "app.openapi() dump + openapi-typescript regen of eneo-js schema.d.ts"
+          result: "pass: no activation_mode anywhere in the spec; zero generated-SDK drift"
+      review:
+        session: "eneo-t011-binding-modes"
+        iteration_1: ".codex/artifacts/codex-peer-loop-t011-dormant-skill-binding-activation-mode-plan-20260723T224841Z.md; changes_required, both P1 findings verified and applied"
+        iteration_2: ".codex/artifacts/codex-peer-loop-t011-dormant-skill-binding-activation-mode-implementation-20260723T234717Z.md; green, GREEN_LIGHT yes, score 8"
 
   - id: T999
     type: judge

--- a/docs/goals/enterprise-skills-rollout/state.yaml
+++ b/docs/goals/enterprise-skills-rollout/state.yaml
@@ -603,7 +603,11 @@ tasks:
       result: done
       summary: "Reconciled the remaining non-Marketplace roadmap into an implementation-ready #553-first sequence, corrected the copied discovery budget and loopback-MCP dependency, and synced the accepted contract to live Issue #553 without production edits."
       planning_pr: 581
-      planning_pr_status: "opened for CI and fresh review"
+      planning_pr_status: "squash-merged into develop"
+      planning_pr_source_head: "73beee9e9731a8444bea22d3718a61f0e279541a"
+      planning_pr_merge_commit: "677c54ca4aa0a244f51bbe77de8890ca23807536"
+      planning_pr_merged_at: "2026-07-23T22:43:40Z"
+      planning_pr_final_review: "Review 2 on 73beee9 confirmed F1 resolved with no current findings: https://github.com/eneo-ai/eneo/pull/581#issuecomment-5064240636"
       issue: "https://github.com/eneo-ai/eneo/issues/553"
       issue_updated_at: "2026-07-23T22:06:02Z"
       changed_files:


### PR DESCRIPTION
## Changes

- adds a closed internal `always | on_demand` activation mode to Assistant and
  Governance Policy Skill bindings, backfilled and defaulting to `always`;
  Apps gain no mode and a behavior test pins their eager-only projection
- preserves a retained binding's stored mode when a parent save re-resolves
  its bindings, so a later `on_demand` row cannot be silently reset by a
  reorder or unchanged save
- migrates both binding tables in short NOWAIT-bounded metadata phases with
  `CHECK ... NOT VALID` plus separate validation, following the repository's
  online-migration precedent, with a tested downgrade
- keeps every public contract unchanged: a client-supplied `activation_mode`
  is dropped by the closed input model, no read model exposes the field, and
  regenerating the SDK schema from the live OpenAPI spec produces zero drift
- proves dormancy at the composition seam: an `on_demand` binding composes
  byte-identically to the same binding marked `always`

## Why

Task #553 needs a persisted, typed binding mode before policy, frozen-plan,
and runtime slices can build on it. Landing the contract dormant keeps this
PR small and riskless: existing rows migrate to `always`, provider payloads
stay byte-equivalent, and nothing public can express `on_demand` until the
runtime exists.

## Planning

- Task: part of #553 (delivery slice 1 of 5 — do not close the task)
- Parent epic: #545
- Goal board: T011 in `docs/goals/enterprise-skills-rollout/state.yaml`

## Testing

- `uv run pytest -n 2 -m "not integration" tests/` — 3798 passed
- `uv run pytest tests/integration/skills/` — 38 passed
- `uv run pytest -m migration_isolation tests/integration/migrations/test_skills_schema_round_trip.py::test_binding_activation_mode_migration_backfills_and_round_trips -v` — 1 passed (PostgreSQL backfill, CHECK rejection on both tables, App-table absence, downgrade, re-upgrade)
- `uv run ruff check src/eneo`, `uv run ruff format --check src/eneo`, `uv run pyright`, `uv lock --check` — all clean
- OpenAPI dump contains no `activation_mode`; `openapi-typescript` regen of
  `frontend/packages/eneo-js/src/types/schema.d.ts` — zero diff
- Codex peer loop (gpt-5.6-sol, same session as the plan gate): iteration 1
  `changes_required` applied, iteration 2 commit gate — green, `GREEN_LIGHT:
  yes`, score 8

## Screenshots

Not applicable; no product UI changed.
