### PR TITLE
docs(skills): record T012 receipt and activate T013

### DIFF
--- a/docs/enterprise-skills-roadmap.md
+++ b/docs/enterprise-skills-roadmap.md
@@ -109,6 +109,7 @@ The delivery graph was last verified on 2026-07-23:
 | [#580](https://github.com/eneo-ai/eneo/pull/580)         | O1 deletion and retained-provenance closure     | Merged as `c642da49`; PostgreSQL behavior proof, documentation, required CI, and final full-coverage review passed. |
 | [#581](https://github.com/eneo-ai/eneo/pull/581)         | Selective activation planning blueprint         | Merged as `677c54ca`; required CI passed and the final review found no current findings.                            |
 | [#582](https://github.com/eneo-ai/eneo/pull/582)         | Task #553 slice 1: dormant binding mode         | Merged as `80b5f377`; required CI passed and the final review found no current findings.                            |
+| [#583](https://github.com/eneo-ai/eneo/pull/583)         | Task #553 slice 2: typed runtime policy         | Merged as `e681171f`; required CI passed and the final review found no current findings.                            |
 | [Issue #551](https://github.com/eneo-ai/eneo/issues/551) | File, InfoBlob, and Icon object-content cutover | Open. This gates the fallback file-reference path, not the preferred internal-MCP core split.                       |
 | [#464](https://github.com/eneo-ai/eneo/pull/464)         | MCP file references                             | Open and conflict-marked. It belongs to the object-content/file track.                                              |
 | [#538](https://github.com/eneo-ai/eneo/pull/538)         | Loopback internal MCP and on-demand knowledge   | Open and coupled to #464. It is useful comparison evidence, not a merge dependency for selective Skills.            |
@@ -879,27 +880,27 @@ flowchart LR
 
 ## Risks and edge cases
 
-| Risk or case                                    | Required handling                                                                                                           |
-| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| A Skill changes after attachment                | Exact revision pin stays unchanged; UI shows update drift.                                                                  |
-| Published revision changes                      | Existing resources do not advance. A builder approves each update.                                                          |
-| Skill is unpublished                            | New attachments stop; retained exact pins keep running.                                                                     |
-| Published Skill is found harmful                | Tenant admin blocks the Skill identity. New turns and not-started App runs stop; pins and audit evidence remain.            |
+| Risk or case                                    | Required handling                                                                                                                                                         |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A Skill changes after attachment                | Exact revision pin stays unchanged; UI shows update drift.                                                                                                                |
+| Published revision changes                      | Existing resources do not advance. A builder approves each update.                                                                                                        |
+| Skill is unpublished                            | New attachments stop; retained exact pins keep running.                                                                                                                   |
+| Published Skill is found harmful                | Tenant admin blocks the Skill identity. New turns and not-started App runs stop; pins and audit evidence remain.                                                          |
 | Blocked source has installed local copies       | Copies keep their independent identity. Admins see affected copies, block each unsafe local identity explicitly, and install/update from the blocked source fails closed. |
-| Skill deletion could invalidate a queued run    | Bindings and retained queued/running App-run evidence block deletion; terminal runs retain body-free IDs and digests.       |
-| Author loses permission during a draft          | Parent save reauthorises and commits atomically or fails without partial bindings.                                          |
-| End user lacks catalogue permission             | Parent-resource access still runs its approved pins.                                                                        |
-| Two Skills contradict each other                | Saved order is visible. The author resolves the conflict; Eneo does not invent semantic precedence.                         |
-| Two Skills share a display name                 | Stable IDs and revision IDs govern activation; UI includes owner/Space context.                                             |
-| Descriptor matches too broadly                  | Task #553 evaluation catches false positives; admins can set the binding to `always`, remove it, or revise the description. |
-| Descriptor language differs from the user query | Evaluate trigger cases in the languages the Assistant serves. Record the model used for the test.                           |
-| Descriptor budget is exceeded                   | Preserve required content, disable optional catalogue for the turn, and record the reason.                                  |
-| Model cannot call tools                         | Run `always_only`; never change `on_demand` into eager loading.                                                             |
-| Model requests an unbound or blocked Skill      | Reject it and record a bounded reason code.                                                                                 |
-| Policy changes during a stream                  | The frozen turn plan completes; the next turn sees the new policy.                                                          |
-| Analytics could expose instructions             | Store IDs, counts, digests, and reason codes. Keep bodies and prompts out of aggregate rows.                                |
-| Admin raises limits beyond useful values        | Show measured impact and warnings; the selected model's hard context validation remains final.                              |
-| Imported Skill contains code or tools           | S1/O1 stay instruction-only. S2 rejects executable content until a separate security contract exists.                       |
+| Skill deletion could invalidate a queued run    | Bindings and retained queued/running App-run evidence block deletion; terminal runs retain body-free IDs and digests.                                                     |
+| Author loses permission during a draft          | Parent save reauthorises and commits atomically or fails without partial bindings.                                                                                        |
+| End user lacks catalogue permission             | Parent-resource access still runs its approved pins.                                                                                                                      |
+| Two Skills contradict each other                | Saved order is visible. The author resolves the conflict; Eneo does not invent semantic precedence.                                                                       |
+| Two Skills share a display name                 | Stable IDs and revision IDs govern activation; UI includes owner/Space context.                                                                                           |
+| Descriptor matches too broadly                  | Task #553 evaluation catches false positives; admins can set the binding to `always`, remove it, or revise the description.                                               |
+| Descriptor language differs from the user query | Evaluate trigger cases in the languages the Assistant serves. Record the model used for the test.                                                                         |
+| Descriptor budget is exceeded                   | Preserve required content, disable optional catalogue for the turn, and record the reason.                                                                                |
+| Model cannot call tools                         | Run `always_only`; never change `on_demand` into eager loading.                                                                                                           |
+| Model requests an unbound or blocked Skill      | Reject it and record a bounded reason code.                                                                                                                               |
+| Policy changes during a stream                  | The frozen turn plan completes; the next turn sees the new policy.                                                                                                        |
+| Analytics could expose instructions             | Store IDs, counts, digests, and reason codes. Keep bodies and prompts out of aggregate rows.                                                                              |
+| Admin raises limits beyond useful values        | Show measured impact and warnings; the selected model's hard context validation remains final.                                                                            |
+| Imported Skill contains code or tools           | S1/O1 stay instruction-only. S2 rejects executable content until a separate security contract exists.                                                                     |
 
 ### Recovery and rollback
 

--- a/docs/goals/enterprise-skills-rollout/state.yaml
+++ b/docs/goals/enterprise-skills-rollout/state.yaml
@@ -35,7 +35,7 @@ continuity:
   last_handoff_at: null
   last_verified_revision: "c642da4953102718c4031c4004e3c6a83d956f4a"
 
-active_task: T012
+active_task: T013
 
 tasks:
   - id: T001
@@ -731,7 +731,7 @@ tasks:
   - id: T012
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Task #553 slice 2: the typed organisation Skill runtime policy with admin management, audit, and read-only per-model projections, without exposing binding modes or changing runtime behavior."
     tracking_issue: "https://github.com/eneo-ai/eneo/issues/553"
@@ -782,10 +782,14 @@ tasks:
       - "The design requires provider-loop, frozen-plan, or UI mode-control changes owned by later slices."
       - "Policy storage cannot avoid the user-bound settings row without a generic settings framework."
     receipt:
-      result: implemented
-      summary: "Stored the typed tenant Skill runtime policy in eneo.skills with migration backfill from SKILL_MAX_BINDINGS, moved binding-limit enforcement to the stored value, removed the obsolete runtime environment interface, and exposed admin-only get/replace/reset plus per-model allowance projections with typed audit. PR #583 opened for CI and fresh review; merge pending."
-      pr: 583
-      pr_status: "opened for CI and fresh review"
+      result: done
+      summary: "Stored the typed tenant Skill runtime policy in eneo.skills with migration backfill from SKILL_MAX_BINDINGS, moved binding-limit enforcement to the stored value, removed the obsolete runtime environment interface, exposed admin-only get/replace/reset plus per-model allowance projections with typed audit, and serialized binding writes against concurrent policy changes. Squash-merged PR #583."
+      merged_pr: 583
+      source_head: "f1fe73f62b9e72668b00ebe69fc8d48f1bce51e9"
+      merge_commit: "e681171f691b70801b8059435906ff3f0d96f7d8"
+      merged_at: "2026-07-24T03:24:07Z"
+      github_checks: "All 16 required checks passed on f1fe73f after one rerun of an unrelated object_content PostgreSQL-restart flake"
+      final_review: "Review 2 on f1fe73f confirmed F1 (superseded attachment limit race) resolved with no current findings: https://github.com/eneo-ai/eneo/pull/583#issuecomment-5065538134"
       base_commit: "80b5f377d537f81d6da0bb4f600a464e59bf63b3"
       changed_files:
         - "backend/.env.template"
@@ -816,6 +820,48 @@ tasks:
         iteration_2: "commit gate changes_required: SELECT-only reads, env-interface removal, typed audit; all applied"
         iteration_3: ".codex/artifacts/codex-peer-loop-t012-runtime-policy-peer-gap-fixes-20260724T014046Z.md; changes_required: ADR closure + concurrency proofs; applied"
         iteration_4: "final gate green, GREEN_LIGHT yes, score 8"
+
+  - id: T013
+    type: worker
+    assignee: Worker
+    status: active
+    reasoning_hint: high
+    objective: "Implement Task #553 slice 3: route every eager turn through one immutable SkillTurnPlan and persist typed, body-free activation evidence while behavior remains all-always."
+    tracking_issue: "https://github.com/eneo-ai/eneo/issues/553"
+    inputs:
+      - "develop at e681171f691b70801b8059435906ff3f0d96f7d8 (merged PR #583)"
+      - "docs/enterprise-skills-roadmap.md slice 3 contract and evidence section"
+      - "Issue #553 evidence section (Question.skill_provenance stays; one nullable skill_activation JSONB via a strict versioned model)"
+      - "Existing completion context, streaming and non-streaming provider loops, placeholder/success/failure/stream-abort finalisation owners"
+    allowed_files:
+      - "backend/alembic/versions/"
+      - "backend/src/eneo/assistants/"
+      - "backend/src/eneo/completion_models/"
+      - "backend/src/eneo/database/tables/"
+      - "backend/src/eneo/questions/"
+      - "backend/src/eneo/sessions/"
+      - "backend/src/eneo/skills/"
+      - "backend/tests/"
+      - "docs/enterprise-skills-roadmap.md"
+      - "docs/goals/enterprise-skills-rollout/"
+      - "frontend/packages/eneo-js/"
+    constraints:
+      - "Do not begin until a bounded plan with file:line evidence exists and the Codex plan gate has run."
+      - "Preserve all-always runtime behavior; streaming and non-streaming paths use the same frozen plan and evidence."
+      - "Exact revision IDs and digests are retained; instruction bodies and prompts never enter analytics evidence."
+      - "Reuse the canonical audit/history/debug owners; no event table."
+      - "Do not add the activation tool, public on_demand writes, or UI controls."
+      - "Settle the roadmap's open retention decision with current product owners or stop and ask the user; do not invent a second retention system."
+    verify:
+      - "Byte-equivalent all-always payloads through the frozen plan"
+      - "Evidence finalisation across success, failure, timeout, cancellation, and client disconnect"
+      - "Strict versioned round-trip of the skill_activation value"
+      - "Focused suites, migration round-trip if schema changes, Ruff, Pyright, generated contracts"
+      - "Required GitHub CI, fresh /review, same-session Codex verification"
+    stop_if:
+      - "The design requires the reserved activation function or provider-loop dispatch owned by slice 4."
+      - "The retention decision cannot be settled without user product authority."
+    receipt: null
 
   - id: T999
     type: judge


### PR DESCRIPTION
## Changes

- completes the T012 goal-board receipt with the verified PR #583 merge facts
  (source head, merge commit, checks, final review)
- marks T012 done and activates T013 — the #553 slice-3 frozen-plan and
  evidence task — with its contract, allowed files, and stop conditions
- adds the #583 row to the roadmap's merged-delivery table

Documentation only; no production behavior changes.

## Why

The goal board is the machine truth for task status and receipts. Recording
the merge evidence and the next active task keeps the next implementation
session traceable without re-deriving state from GitHub.

## Planning

- Task: part of #553 (board bookkeeping between slices 2 and 3)
- Parent epic: #545

## Testing

- `node ~/.codex/skills/goal-maker/scripts/check-goal-state.mjs docs/goals/enterprise-skills-rollout/state.yaml` — ok: true
- `npx prettier --check docs/enterprise-skills-roadmap.md` — pass
- `git diff --check` — pass

## Screenshots

Not applicable; documentation only.