### PR TITLE
fix(roadmap): expose sponsor in public JSON

### DIFF
--- a/.github/PROJECT_WORKFLOW.md
+++ b/.github/PROJECT_WORKFLOW.md
@@ -288,8 +288,8 @@ or an internal exporter field never adds it to public JSON automatically.
 Schema version 1 exposes these item fields:
 
 - `number`, `url`, `title`, and the complete Epic `Summary`;
-- Project `status`, `roadmapVersion`, `area`, `priority`, `startDate`, and
-  `targetDate`;
+- Project `status`, `roadmapVersion`, `area`, `priority`, `sponsor`,
+  `startDate`, and `targetDate`;
 - `group`: `in_progress`, `next`, `later`, or `delivered`.
 
 The envelope also exposes `unpublishedItemCount`. It counts epic-level Project

--- a/scripts/export_github_roadmap.mjs
+++ b/scripts/export_github_roadmap.mjs
@@ -210,6 +210,7 @@ function renderPublicJson(epics, context) {
       priority: epic.priority,
       startDate: epic.startDate,
       targetDate: epic.targetDate,
+      sponsor: epic.sponsor,
       group: publicRoadmapGroup(epic, nextVersionRank),
     }))
     .sort((left, right) => (
@@ -1173,6 +1174,7 @@ function runSelfTest() {
     "number",
     "priority",
     "roadmapVersion",
+    "sponsor",
     "startDate",
     "status",
     "summary",
@@ -1203,6 +1205,10 @@ function runSelfTest() {
   assert.equal(publicJson.items.find((epic) => epic.number === 103).group, "later");
   assert.equal(publicJson.items.find((epic) => epic.number === 105).group, "delivered");
   assert.equal(publicJson.items.find((epic) => epic.number === 106).group, "later");
+  assert.equal(
+    publicJson.items.find((epic) => epic.number === 101).sponsor,
+    "Sundsvalls kommun verksamhetsstod",
+  );
   assert.equal(
     publicJson.items.find((epic) => epic.number === 101).summary,
     "People can use a safer personal chat.\n\nThe rollout remains controlled by administrators.",


### PR DESCRIPTION
## Summary

- Expose the already extracted Project 5 sponsor value as `sponsor` in each public roadmap JSON item.
- Extend the public allowlist self-test to require the field and preserve its value.
- Document `sponsor` in the schema 1 public feed contract.

## Why

The eneo.ai roadmap consumer needs Sponsor / Municipality for labels and
filtering. `scripts/export_github_roadmap.mjs` already owns extraction and uses
the value in existing exports, so the public JSON projection is the canonical
place to expose it without duplicating Project parsing in the website.

## What changed

- `scripts/export_github_roadmap.mjs`: add `sponsor: epic.sponsor` to the
  allowlisted public item projection and its self-test contract.
- `.github/PROJECT_WORKFLOW.md`: include `sponsor` in the documented schema 1
  item fields.

## What was deliberately not changed

- No new sponsor extraction or fallback logic.
- No Markdown, Mermaid, or SVG behavior changes.
- No website code or Project 5 mutation.
- `schemaVersion` remains `1`; the field is additive and its value may be
  empty.

## Deletion / consolidation

No duplicate path was added. The public feed reuses the existing `epic.sponsor`
owner.

## Risk and rollback

Risk is limited to an additive public JSON item field. Existing consumers can
ignore it. Reverting this commit removes the field without affecting the
existing extraction or other export formats.

## Planning

Small additive follow-up to #570. No equivalent open task or pull request was
found.

## Validation

- RED: `node scripts/export_github_roadmap.mjs --self-test` failed because the
  public allowlist required `sponsor` before the projection exposed it.
- PASS: `node --check scripts/export_github_roadmap.mjs`
- PASS: `node scripts/export_github_roadmap.mjs --self-test`
- PASS: live Project 5 JSON export with the unchanged schema 1 envelope and
  exact item allowlist.
- PASS: every live public item contains a string `sponsor`.
- PASS: live epics #545 and #549 both export `Sundsvalls kommun`.
- PASS: `npx prettier --check .github/PROJECT_WORKFLOW.md`
- PASS: `git diff --check`
- PASS: commit hooks and pre-push checks.

## Screenshots

Not applicable; no UI changes.
