### PR TITLE
fix(files): prevent deleting files that are still in use

### DIFF
--- a/backend/alembic/versions/202607241000_add_file_usage_indexes.py
+++ b/backend/alembic/versions/202607241000_add_file_usage_indexes.py
@@ -1,0 +1,45 @@
+"""add reverse indexes for File usage checks
+
+Revision ID: 202607241000
+Revises: 202607231700
+Create Date: 2026-07-24 10:00:00.000000
+
+Each junction-table primary key starts with its product owner ID. File deletion
+preview instead filters by ``file_id``, so these reverse indexes keep usage
+checks proportional to matching relations. They are built concurrently to
+avoid blocking attachment writes during an upgrade.
+
+If a concurrent build fails, rerun the migration. The explicit drop removes
+any invalid index left by PostgreSQL before the build is retried.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "202607241000"
+down_revision: str | None = "202607231700"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEXES = (
+    ("ix_questions_files_file_id", "questions_files"),
+    ("ix_assistants_files_file_id", "assistants_files"),
+    ("ix_apps_files_file_id", "apps_files"),
+    ("ix_app_runs_files_file_id", "app_runs_files"),
+)
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        for index_name, table_name in _INDEXES:
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}")
+            op.execute(
+                f"CREATE INDEX CONCURRENTLY {index_name} ON {table_name} (file_id)"
+            )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        for index_name, _table_name in reversed(_INDEXES):
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {index_name}")

--- a/backend/src/eneo/database/tables/app_table.py
+++ b/backend/src/eneo/database/tables/app_table.py
@@ -118,6 +118,8 @@ class AppsFiles(BaseCrossReference):
     # Relationships
     file: Mapped[Files] = relationship()
 
+    __table_args__ = (Index("ix_apps_files_file_id", "file_id"),)
+
 
 class AppsPrompts(BaseCrossReference):
     prompt_id: Mapped[UUID] = mapped_column(
@@ -139,3 +141,5 @@ class AppRunsFiles(BaseCrossReference):
 
     # Relationships
     file: Mapped[Files] = relationship()
+
+    __table_args__ = (Index("ix_app_runs_files_file_id", "file_id"),)

--- a/backend/src/eneo/database/tables/assistant_table.py
+++ b/backend/src/eneo/database/tables/assistant_table.py
@@ -125,6 +125,8 @@ class AssistantsFiles(BaseCrossReference):
     # Relationships
     file: Mapped[Files] = relationship()
 
+    __table_args__ = (Index("ix_assistants_files_file_id", "file_id"),)
+
 
 class AssistantIntegrationKnowledge(BasePublic):
     __tablename__ = "assistant_integration_knowledge"  # type: ignore[assignment]

--- a/backend/src/eneo/database/tables/questions_table.py
+++ b/backend/src/eneo/database/tables/questions_table.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Optional
 from uuid import UUID
 
-from sqlalchemy import ForeignKey
+from sqlalchemy import ForeignKey, Index
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -99,3 +99,5 @@ class QuestionsFiles(BaseCrossReference):
     type: Mapped[str] = mapped_column()
 
     file: Mapped[Files] = relationship()
+
+    __table_args__ = (Index("ix_questions_files_file_id", "file_id"),)

--- a/backend/src/eneo/files/file_models.py
+++ b/backend/src/eneo/files/file_models.py
@@ -29,6 +29,34 @@ class FileContentVariant(StrEnum):
     PREVIEW = "preview"
 
 
+class FileUsageKind(StrEnum):
+    CHAT_ATTACHMENT = "chat_attachment"
+    ASSISTANT_ATTACHMENT = "assistant_attachment"
+    APP_ATTACHMENT = "app_attachment"
+    APP_RUN_INPUT = "app_run_input"
+
+
+class FileUsageSummary(BaseModel):
+    kind: FileUsageKind
+    count: int
+
+
+class FileDeletionPreview(BaseModel):
+    file_id: UUID
+    can_delete: bool
+    affected_file_count: int
+    blockers: list[FileUsageSummary]
+
+
+class FileInUseError(Exception):
+    code = "file_in_use"
+
+    def __init__(self, preview: FileDeletionPreview) -> None:
+        self.preview = preview
+        self.details = preview.model_dump(mode="json")
+        super().__init__("File is still used and cannot be deleted.")
+
+
 class FileBase(BaseModel):
     name: str
     checksum: str

--- a/backend/src/eneo/files/file_router.py
+++ b/backend/src/eneo/files/file_router.py
@@ -13,6 +13,7 @@ from eneo.authentication.auth_dependencies import require_user_for_creation
 from eneo.authentication.signed_urls import generate_signed_token, verify_signed_token
 from eneo.files.file_models import (
     ContentDisposition,
+    FileDeletionPreview,
     FilePublic,
     SignedURLRequest,
     SignedURLResponse,
@@ -116,7 +117,7 @@ async def get_file(
         204: {
             "description": "File deleted successfully. No response body is returned."
         },
-        **responses.get_responses([403, 404]),
+        **responses.get_responses([403, 404, 409]),
     },
 )
 async def delete_file(
@@ -156,6 +157,23 @@ async def delete_file(
             extra=extra,
         ),
     )
+
+
+@router.get(
+    "/{id}/deletion-preview/",
+    response_model=FileDeletionPreview,
+    status_code=200,
+    responses=responses.get_responses([403, 404]),
+    description=(
+        "Preview whether deleting this File would remove active chat, Assistant, "
+        "App, or App-run attachments."
+    ),
+)
+async def get_file_deletion_preview(
+    id: UUID,
+    container: Annotated[Container, Depends(get_container(with_user=True))],
+) -> FileDeletionPreview:
+    return await container.file_service().get_deletion_preview(id)
 
 
 @router.post(

--- a/backend/src/eneo/files/file_service.py
+++ b/backend/src/eneo/files/file_service.py
@@ -10,11 +10,15 @@ from eneo.files.file_content_loader import FileContentLoader
 from eneo.files.file_models import (
     File,
     FileContentVariant,
+    FileDeletionPreview,
     FileInfo,
+    FileInUseError,
     FileMetadata,
     FileMetadataCreate,
     FilePublic,
     FileType,
+    FileUsageKind,
+    FileUsageSummary,
 )
 from eneo.files.file_protocol import (
     FileProtocol,
@@ -27,6 +31,7 @@ from eneo.files.file_repo import (
     project_file_info,
     select_primary_file_reference,
 )
+from eneo.files.file_usage import FileUsageRepository
 from eneo.main.exceptions import (
     BadRequestException,
     NotFoundException,
@@ -75,6 +80,7 @@ class FileService:
         self.protocol = protocol
         self._object_content = object_content
         self._content_loader = FileContentLoader(repo, object_content)
+        self._usage = FileUsageRepository(repo.session)
 
     @asynccontextmanager
     async def _write_transaction(self) -> AsyncGenerator[None]:
@@ -238,24 +244,80 @@ class FileService:
         by_file = self._references_by_file(references)
         return [project_file_info(file, by_file[file.id]) for file in metadata]
 
-    async def delete_file(self, id: UUID) -> FileInfo:
+    async def get_deletion_preview(self, file_id: UUID) -> FileDeletionPreview:
         user = self._authenticated_user()
         metadata = await self.repo.get_by_id_and_owner(
-            file_id=id,
+            file_id=file_id,
             user_id=user.id,
             tenant_id=user.tenant_id,
         )
         if metadata is None:
             raise NotFoundException()
-        info = await self._file_info(metadata)
-        deleted = await self.repo.delete_by_owner(
-            id=id,
-            user_id=user.id,
+        family_ids = await self._usage.list_family(
+            root_file_id=file_id,
             tenant_id=user.tenant_id,
         )
-        if deleted is None:
+        if not family_ids:
             raise NotFoundException()
-        return info
+        return await self._deletion_preview(
+            file_id=file_id,
+            family_ids=family_ids,
+        )
+
+    async def delete_file(self, id: UUID) -> FileInfo:
+        user = self._authenticated_user()
+        async with self._write_transaction():
+            metadata = await self.repo.get_by_id_and_owner(
+                file_id=id,
+                user_id=user.id,
+                tenant_id=user.tenant_id,
+            )
+            if metadata is None:
+                raise NotFoundException()
+            family_ids = await self._usage.lock_family(
+                root_file_id=id,
+                tenant_id=user.tenant_id,
+            )
+            if not family_ids:
+                raise NotFoundException()
+            preview = await self._deletion_preview(
+                file_id=id,
+                family_ids=family_ids,
+            )
+            if not preview.can_delete:
+                raise FileInUseError(preview)
+
+            info = await self._file_info(metadata)
+            deleted = await self.repo.delete_by_owner(
+                id=id,
+                user_id=user.id,
+                tenant_id=user.tenant_id,
+            )
+            if deleted is None:
+                raise NotFoundException()
+            return info
+
+    async def _deletion_preview(
+        self,
+        *,
+        file_id: UUID,
+        family_ids: list[UUID],
+    ) -> FileDeletionPreview:
+        usage = {
+            item.kind: item.count
+            for item in await self._usage.count_product_usage(family_ids)
+        }
+        blockers = [
+            FileUsageSummary(kind=kind, count=usage[kind])
+            for kind in FileUsageKind
+            if kind in usage
+        ]
+        return FileDeletionPreview(
+            file_id=file_id,
+            can_delete=not blockers,
+            affected_file_count=len(family_ids),
+            blockers=blockers,
+        )
 
     async def get_file_content(self, file_id: UUID) -> File:
         metadata = await self.repo.get_by_id(file_id=file_id)

--- a/backend/src/eneo/files/file_usage.py
+++ b/backend/src/eneo/files/file_usage.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.dialects.postgresql import UUID as PostgreSQLUUID
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import InstrumentedAttribute
+from sqlalchemy.sql.elements import BindParameter
+from sqlalchemy.sql.selectable import Select
+
+from eneo.database.tables.app_table import AppRunsFiles, AppsFiles
+from eneo.database.tables.assistant_table import AssistantsFiles
+from eneo.database.tables.files_table import Files
+from eneo.database.tables.questions_table import QuestionsFiles
+from eneo.files.file_models import FileUsageKind
+
+
+class FileFamilyTenantMismatchError(RuntimeError):
+    """A derived File points across the root File's tenant boundary."""
+
+
+@dataclass(frozen=True, slots=True)
+class FileUsageCount:
+    kind: FileUsageKind
+    count: int
+
+
+class FileUsageRepository:
+    """Derive usage that fences user-initiated File deletion.
+
+    User and tenant offboarding intentionally keep their database-owned cascade
+    behavior. Advisory previews use a recursive CTE, while deletion locks base
+    File rows level by level because PostgreSQL 13 does not propagate an outer
+    ``FOR UPDATE`` through a recursive CTE.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_family(
+        self,
+        *,
+        root_file_id: UUID,
+        tenant_id: UUID,
+    ) -> list[UUID]:
+        family = (
+            sa.select(Files.id, Files.parent_file_id, Files.tenant_id)
+            .where(Files.id == root_file_id)
+            .cte("file_family", recursive=True)
+        )
+        descendants = sa.select(
+            Files.id,
+            Files.parent_file_id,
+            Files.tenant_id,
+        ).join(family, Files.parent_file_id == family.c.id)
+        family = family.union(descendants)
+
+        rows = (
+            await self._session.execute(
+                sa.select(family.c.id, family.c.tenant_id).order_by(family.c.id)
+            )
+        ).all()
+        self._require_tenant(
+            (row.tenant_id for row in rows),
+            tenant_id=tenant_id,
+        )
+        return [row.id for row in rows]
+
+    async def lock_family(
+        self,
+        *,
+        root_file_id: UUID,
+        tenant_id: UUID,
+    ) -> list[UUID]:
+        root = (
+            await self._session.execute(
+                sa.select(Files.id, Files.tenant_id)
+                .where(Files.id == root_file_id)
+                .with_for_update(of=Files)
+            )
+        ).one_or_none()
+        if root is None:
+            return []
+        self._require_tenant([root.tenant_id], tenant_id=tenant_id)
+
+        family_ids = [root.id]
+        visited = {root.id}
+        frontier = [root.id]
+        while frontier:
+            rows = (
+                await self._session.execute(
+                    sa.select(Files.id, Files.tenant_id)
+                    .where(Files.parent_file_id.in_(frontier))
+                    .order_by(Files.id)
+                    .with_for_update(of=Files)
+                )
+            ).all()
+            self._require_tenant(
+                (row.tenant_id for row in rows),
+                tenant_id=tenant_id,
+            )
+            frontier = [row.id for row in rows if row.id not in visited]
+            visited.update(frontier)
+            family_ids.extend(frontier)
+
+        return family_ids
+
+    async def count_product_usage(
+        self,
+        file_ids: list[UUID],
+    ) -> list[FileUsageCount]:
+        if not file_ids:
+            return []
+
+        file_ids_parameter = sa.bindparam(
+            "file_usage_ids",
+            type_=ARRAY(PostgreSQLUUID(as_uuid=True)),
+        )
+        usage = sa.union_all(
+            self._usage_select(
+                FileUsageKind.CHAT_ATTACHMENT,
+                QuestionsFiles.file_id,
+                file_ids_parameter,
+            ),
+            self._usage_select(
+                FileUsageKind.ASSISTANT_ATTACHMENT,
+                AssistantsFiles.file_id,
+                file_ids_parameter,
+            ),
+            self._usage_select(
+                FileUsageKind.APP_ATTACHMENT,
+                AppsFiles.file_id,
+                file_ids_parameter,
+            ),
+            self._usage_select(
+                FileUsageKind.APP_RUN_INPUT,
+                AppRunsFiles.file_id,
+                file_ids_parameter,
+            ),
+        ).subquery("file_product_usage")
+        rows = (
+            await self._session.execute(
+                sa.select(
+                    usage.c.kind,
+                    sa.func.count().label("usage_count"),
+                )
+                .group_by(usage.c.kind)
+                .order_by(usage.c.kind),
+                {"file_usage_ids": file_ids},
+            )
+        ).all()
+        return [
+            FileUsageCount(
+                kind=FileUsageKind(row.kind),
+                count=row.usage_count,
+            )
+            for row in rows
+        ]
+
+    @staticmethod
+    def _usage_select(
+        kind: FileUsageKind,
+        file_id_column: InstrumentedAttribute[UUID],
+        file_ids_parameter: BindParameter[Sequence[UUID]],
+    ) -> Select[tuple[str, UUID]]:
+        return sa.select(
+            sa.literal(kind.value).label("kind"),
+            file_id_column.label("file_id"),
+        ).where(file_id_column == sa.any_(file_ids_parameter))
+
+    @staticmethod
+    def _require_tenant(
+        tenant_ids: Iterable[UUID],
+        *,
+        tenant_id: UUID,
+    ) -> None:
+        if any(row_tenant_id != tenant_id for row_tenant_id in tenant_ids):
+            raise FileFamilyTenantMismatchError(
+                "Derived File family crosses a tenant boundary."
+            )

--- a/backend/src/eneo/main/exceptions.py
+++ b/backend/src/eneo/main/exceptions.py
@@ -66,6 +66,7 @@ class ErrorCodes(int, Enum):
     # Deployment configuration errors
     ENCRYPTION_NOT_CONFIGURED = 9042
     SKILL_REVISION_CONFLICT = 9043
+    FILE_IN_USE = 9044
 
 
 class NotFoundException(Exception):

--- a/backend/src/eneo/server/exception_handlers.py
+++ b/backend/src/eneo/server/exception_handlers.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.exc import IntegrityError
 
+from eneo.files.file_models import FileInUseError
 from eneo.main.exceptions import EXCEPTION_MAP, ErrorCodes, UnauthorizedException
 from eneo.main.models import GeneralError
 from eneo.main.request_context import get_request_context
@@ -115,6 +116,7 @@ def add_exception_handlers(app: FastAPI):
         ),
         ObjectContentStateError: (409, None, ErrorCodes.BAD_REQUEST),
         ObjectContentBusyError: (409, None, ErrorCodes.RESOURCE_NOT_READY),
+        FileInUseError: (409, None, ErrorCodes.FILE_IN_USE),
         ContentTooLargeError: (413, None, ErrorCodes.FILE_TOO_LARGE),
         InvalidContentRangeError: (416, None, ErrorCodes.BAD_REQUEST),
     }

--- a/backend/tests/integration/migrations/test_file_usage_indexes.py
+++ b/backend/tests/integration/migrations/test_file_usage_indexes.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import psycopg2
+import pytest
+from testcontainers.postgres import PostgresContainer
+
+from alembic import command
+from alembic.config import Config
+
+pytestmark = [pytest.mark.integration, pytest.mark.migration_isolation]
+
+_POSTGRES_13_IMAGE = (
+    "pgvector/pgvector:pg13@"
+    "sha256:751a89c96f7c32cb8133472f711c274853378fb5f8b55dd9fa0e9d3f1471bfc3"
+)
+_PREVIOUS_REVISION = "202607231700"
+_INDEX_REVISION = "202607241000"
+_INDEXES = (
+    "ix_questions_files_file_id",
+    "ix_assistants_files_file_id",
+    "ix_apps_files_file_id",
+    "ix_app_runs_files_file_id",
+)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def override_settings_for_session() -> Generator[None, None, None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def cleanup_database() -> Generator[None, None, None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def seed_default_models() -> Generator[None, None, None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def encryption_service() -> Generator[None, None, None]:
+    yield
+
+
+def _alembic_config(database_url: str) -> Config:
+    backend_dir = Path(__file__).resolve().parents[3]
+    config = Config(str(backend_dir / "alembic.ini"))
+    config.set_main_option("script_location", str(backend_dir / "alembic"))
+    config.set_main_option("sqlalchemy.url", database_url)
+    return config
+
+
+def _index_state(database_url: str) -> dict[str, bool]:
+    with (
+        psycopg2.connect(database_url.replace("+psycopg2", "")) as connection,
+        connection.cursor() as cursor,
+    ):
+        cursor.execute(
+            """
+            SELECT indexrelid::regclass::text, indisvalid
+            FROM pg_index
+            WHERE indexrelid::regclass::text = ANY(%s)
+            ORDER BY indexrelid::regclass::text
+            """,
+            (list(_INDEXES),),
+        )
+        return dict(cursor.fetchall())
+
+
+def test_file_usage_indexes_upgrade_downgrade_and_reupgrade() -> None:
+    postgres = PostgresContainer(
+        image=_POSTGRES_13_IMAGE,
+        username="file_usage_indexes",
+        password="file_usage_indexes_password",
+        dbname="file_usage_indexes",
+    )
+    with postgres:
+        database_url = postgres.get_connection_url()
+        config = _alembic_config(database_url)
+
+        command.upgrade(config, _PREVIOUS_REVISION)
+        assert _index_state(database_url) == {}
+
+        command.upgrade(config, _INDEX_REVISION)
+        assert _index_state(database_url) == dict.fromkeys(_INDEXES, True)
+
+        command.downgrade(config, _PREVIOUS_REVISION)
+        assert _index_state(database_url) == {}
+
+        command.upgrade(config, _INDEX_REVISION)
+        assert _index_state(database_url) == dict.fromkeys(_INDEXES, True)

--- a/backend/tests/integration/object_content/test_file_public_routes.py
+++ b/backend/tests/integration/object_content/test_file_public_routes.py
@@ -13,6 +13,8 @@ from eneo.database.tables.object_content_table import (
     FileContentReferences,
     InlineContentPayloads,
 )
+from eneo.database.tables.questions_table import Questions, QuestionsFiles
+from eneo.database.tables.sessions_table import Sessions
 
 
 def _opaque_png(*, width: int, height: int) -> bytes:
@@ -22,6 +24,74 @@ def _opaque_png(*, width: int, height: int) -> bytes:
         format="PNG",
     )
     return buffer.getvalue()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_used_file_delete_returns_the_typed_preview_before_mutation(
+    client,
+    db_container,
+    admin_user_api_key,
+) -> None:
+    headers = {"X-API-Key": admin_user_api_key.key}
+    upload = await client.post(
+        "/api/v1/files/",
+        files={"upload_file": ("policy.txt", b"durable policy", "text/plain")},
+        headers=headers,
+    )
+    assert upload.status_code == 200, upload.text
+    file_id = UUID(upload.json()["id"])
+
+    async with db_container() as container:
+        user = container.user()
+        session = container.session()
+        chat_session = Sessions(user_id=user.id, name="Deletion preview")
+        session.add(chat_session)
+        await session.flush()
+        question = Questions(
+            question="Use the policy",
+            answer="",
+            num_tokens_question=0,
+            num_tokens_answer=0,
+            tenant_id=user.tenant_id,
+            session_id=chat_session.id,
+        )
+        session.add(question)
+        await session.flush()
+        question_id = question.id
+        session.add(
+            QuestionsFiles(
+                question_id=question_id,
+                file_id=file_id,
+                type="user",
+            )
+        )
+
+    expected_preview = {
+        "file_id": str(file_id),
+        "can_delete": False,
+        "affected_file_count": 1,
+        "blockers": [{"kind": "chat_attachment", "count": 1}],
+    }
+    preview = await client.get(
+        f"/api/v1/files/{file_id}/deletion-preview/",
+        headers=headers,
+    )
+    deletion = await client.delete(
+        f"/api/v1/files/{file_id}/",
+        headers=headers,
+    )
+
+    assert preview.status_code == 200, preview.text
+    assert preview.json() == expected_preview
+    assert deletion.status_code == 409, deletion.text
+    assert deletion.json()["code"] == "file_in_use"
+    assert deletion.json()["eneo_error_code"] == 9044
+    assert deletion.json()["details"] == expected_preview
+
+    async with db_container() as container:
+        session = container.session()
+        assert await session.get(QuestionsFiles, (question_id, file_id)) is not None
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/object_content/test_file_usage_deletion.py
+++ b/backend/tests/integration/object_content/test_file_usage_deletion.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+
+from eneo.database.database import DatabaseSessionManager
+from eneo.database.tables.files_table import Files
+from eneo.database.tables.questions_table import Questions, QuestionsFiles
+from eneo.database.tables.sessions_table import Sessions
+from eneo.database.tables.users_table import Users
+from eneo.files.file_models import FileInUseError, FileType, FileUsageKind
+from eneo.files.file_repo import FileRepository
+from eneo.files.file_service import FileService
+from eneo.files.file_usage import FileUsageRepository
+from eneo.users.user import UserInDB
+
+
+async def _owner_ids(database: DatabaseSessionManager) -> tuple[UUID, UUID]:
+    async with database.session() as session, session.begin():
+        row = (await session.execute(sa.select(Users.tenant_id, Users.id))).one()
+        return row.tenant_id, row.id
+
+
+async def _add_file(
+    session,
+    *,
+    tenant_id: UUID,
+    user_id: UUID,
+    name: str,
+    parent_file_id: UUID | None = None,
+) -> Files:
+    file = Files(
+        name=name,
+        mimetype="text/plain",
+        file_type=FileType.TEXT.value,
+        tenant_id=tenant_id,
+        user_id=user_id,
+        parent_file_id=parent_file_id,
+    )
+    session.add(file)
+    await session.flush()
+    return file
+
+
+async def _add_question_file(
+    session,
+    *,
+    tenant_id: UUID,
+    user_id: UUID,
+    file_id: UUID,
+) -> QuestionsFiles:
+    chat_session = Sessions(user_id=user_id, name="File usage test")
+    session.add(chat_session)
+    await session.flush()
+    question = Questions(
+        question="Use this attachment",
+        answer="",
+        num_tokens_question=0,
+        num_tokens_answer=0,
+        tenant_id=tenant_id,
+        session_id=chat_session.id,
+    )
+    session.add(question)
+    await session.flush()
+    relation = QuestionsFiles(
+        question_id=question.id,
+        file_id=file_id,
+        type="user",
+    )
+    session.add(relation)
+    await session.flush()
+    return relation
+
+
+def _service(
+    *,
+    session,
+    tenant_id: UUID,
+    user_id: UUID,
+) -> FileService:
+    return FileService(
+        user=UserInDB.model_construct(id=user_id, tenant_id=tenant_id),
+        repo=FileRepository(session),
+        protocol=AsyncMock(),
+        object_content=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_used_depth_two_descendant_blocks_root_deletion(
+    object_content_database: DatabaseSessionManager,
+) -> None:
+    tenant_id, user_id = await _owner_ids(object_content_database)
+    async with object_content_database.session() as session, session.begin():
+        root = await _add_file(
+            session,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            name="root.txt",
+        )
+        child = await _add_file(
+            session,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            name="child.txt",
+            parent_file_id=root.id,
+        )
+        grandchild = await _add_file(
+            session,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            name="grandchild.txt",
+            parent_file_id=child.id,
+        )
+        relation = await _add_question_file(
+            session,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            file_id=grandchild.id,
+        )
+        root_id = root.id
+        relation_key = (relation.question_id, relation.file_id)
+
+    async with object_content_database.session() as session, session.begin():
+        service = _service(
+            session=session,
+            tenant_id=tenant_id,
+            user_id=user_id,
+        )
+        preview = await service.get_deletion_preview(root_id)
+        assert preview.can_delete is False
+        assert preview.affected_file_count == 3
+        assert [(blocker.kind, blocker.count) for blocker in preview.blockers] == [
+            (FileUsageKind.CHAT_ATTACHMENT, 1)
+        ]
+
+        with pytest.raises(FileInUseError) as exc_info:
+            await service.delete_file(root_id)
+        assert exc_info.value.preview == preview
+
+    async with object_content_database.session() as session, session.begin():
+        assert (
+            await session.scalar(
+                sa.select(sa.func.count())
+                .select_from(Files)
+                .where(Files.id.in_([root_id, relation_key[1]]))
+            )
+        ) == 2
+        assert await session.get(QuestionsFiles, relation_key) is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_first_prevents_a_late_attachment_without_losing_a_use(
+    object_content_database: DatabaseSessionManager,
+) -> None:
+    tenant_id, user_id = await _owner_ids(object_content_database)
+    async with object_content_database.session() as session, session.begin():
+        root = await _add_file(
+            session,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            name="root.txt",
+        )
+        child = await _add_file(
+            session,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            name="child.txt",
+            parent_file_id=root.id,
+        )
+        grandchild = await _add_file(
+            session,
+            tenant_id=tenant_id,
+            user_id=user_id,
+            name="grandchild.txt",
+            parent_file_id=child.id,
+        )
+        chat_session = Sessions(user_id=user_id, name="Concurrent attachment")
+        session.add(chat_session)
+        await session.flush()
+        question = Questions(
+            question="Attach concurrently",
+            answer="",
+            num_tokens_question=0,
+            num_tokens_answer=0,
+            tenant_id=tenant_id,
+            session_id=chat_session.id,
+        )
+        session.add(question)
+        await session.flush()
+        root_id = root.id
+        grandchild_id = grandchild.id
+        question_id = question.id
+
+    family_locked = asyncio.Event()
+    allow_delete = asyncio.Event()
+    attach_started = asyncio.Event()
+
+    async def delete_family() -> None:
+        async with object_content_database.session() as session, session.begin():
+            usage = FileUsageRepository(session)
+            family_ids = await usage.lock_family(
+                root_file_id=root_id,
+                tenant_id=tenant_id,
+            )
+            family_locked.set()
+            await allow_delete.wait()
+            assert await usage.count_product_usage(family_ids) == []
+            await session.execute(sa.delete(Files).where(Files.id == root_id))
+
+    async def attach_file() -> None:
+        await family_locked.wait()
+        async with object_content_database.session() as session, session.begin():
+            session.add(
+                QuestionsFiles(
+                    question_id=question_id,
+                    file_id=grandchild_id,
+                    type="user",
+                )
+            )
+            attach_started.set()
+            await session.flush()
+
+    delete_task = asyncio.create_task(delete_family())
+    attach_task = asyncio.create_task(attach_file())
+    await attach_started.wait()
+    await asyncio.sleep(0.1)
+    assert attach_task.done() is False
+    allow_delete.set()
+
+    await delete_task
+    with pytest.raises(IntegrityError):
+        await attach_task
+
+    async with object_content_database.session() as session, session.begin():
+        assert await session.get(Files, root_id) is None
+        assert await session.get(QuestionsFiles, (question_id, grandchild_id)) is None

--- a/backend/tests/integration/test_file_usage_relations.py
+++ b/backend/tests/integration/test_file_usage_relations.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from eneo.database.tables.app_table import AppRuns, AppRunsFiles, AppsFiles
+from eneo.database.tables.assistant_table import AssistantsFiles
+from eneo.database.tables.files_table import Files
+from eneo.database.tables.questions_table import Questions, QuestionsFiles
+from eneo.database.tables.sessions_table import Sessions
+from eneo.files.file_models import FileType, FileUsageKind
+from eneo.files.file_usage import FileUsageRepository
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_file_usage_groups_every_current_product_relation(
+    async_session: AsyncSession,
+    admin_user,
+    test_tenant,
+    completion_model_factory,
+    assistant_factory,
+    app_factory,
+) -> None:
+    completion_model = await completion_model_factory(async_session, "gpt-4")
+    assistant = await assistant_factory(
+        async_session,
+        "Usage Assistant",
+        completion_model.id,
+    )
+    app = await app_factory(
+        async_session,
+        "Usage App",
+        completion_model.id,
+    )
+    app_run = AppRuns(
+        tenant_id=test_tenant.id,
+        app_id=app.id,
+        user_id=admin_user.id,
+        completion_model_id=completion_model.id,
+        input_text="Use the attachment",
+        output_text="",
+    )
+    chat_session = Sessions(user_id=admin_user.id, name="Usage chat")
+    file = Files(
+        name="shared.txt",
+        mimetype="text/plain",
+        file_type=FileType.TEXT.value,
+        tenant_id=test_tenant.id,
+        user_id=admin_user.id,
+    )
+    async_session.add_all([app_run, chat_session, file])
+    await async_session.flush()
+
+    question = Questions(
+        question="Use the attachment",
+        answer="",
+        num_tokens_question=0,
+        num_tokens_answer=0,
+        tenant_id=test_tenant.id,
+        session_id=chat_session.id,
+    )
+    async_session.add(question)
+    await async_session.flush()
+    async_session.add_all(
+        [
+            QuestionsFiles(
+                question_id=question.id,
+                file_id=file.id,
+                type="user",
+            ),
+            AssistantsFiles(
+                assistant_id=assistant.id,
+                file_id=file.id,
+            ),
+            AppsFiles(
+                app_id=app.id,
+                file_id=file.id,
+            ),
+            AppRunsFiles(
+                app_run_id=app_run.id,
+                file_id=file.id,
+            ),
+        ]
+    )
+    await async_session.flush()
+
+    counts = await FileUsageRepository(async_session).count_product_usage([file.id])
+
+    assert {item.kind: item.count for item in counts} == {
+        FileUsageKind.CHAT_ATTACHMENT: 1,
+        FileUsageKind.ASSISTANT_ATTACHMENT: 1,
+        FileUsageKind.APP_ATTACHMENT: 1,
+        FileUsageKind.APP_RUN_INPUT: 1,
+    }

--- a/backend/tests/unit/test_file_service.py
+++ b/backend/tests/unit/test_file_service.py
@@ -19,6 +19,7 @@ def _service() -> tuple[FileService, AsyncMock, SimpleNamespace]:
         protocol=AsyncMock(),
         object_content=AsyncMock(),
     )
+    service._usage = AsyncMock()
     return service, repo, user
 
 
@@ -30,17 +31,39 @@ async def test_delete_non_owned_and_missing_files_share_the_404_path() -> None:
     with pytest.raises(NotFoundException):
         await service.delete_file(uuid4())
 
+    service._usage.lock_family.assert_not_awaited()
     repo.delete_by_owner.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_delete_uses_one_owner_bound_lookup_and_delete() -> None:
+async def test_deletion_preview_returns_404_if_the_file_disappears_during_read() -> (
+    None
+):
+    service, repo, user = _service()
+    file_id = uuid4()
+    repo.get_by_id_and_owner.return_value = SimpleNamespace(id=file_id)
+    service._usage.list_family.return_value = []
+
+    with pytest.raises(NotFoundException):
+        await service.get_deletion_preview(file_id)
+
+    service._usage.list_family.assert_awaited_once_with(
+        root_file_id=file_id,
+        tenant_id=user.tenant_id,
+    )
+    service._usage.count_product_usage.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_rechecks_usage_under_the_family_lock() -> None:
     service, repo, user = _service()
     file_id = uuid4()
     metadata = SimpleNamespace(id=file_id)
     public_info = SimpleNamespace(id=file_id)
     repo.get_by_id_and_owner.return_value = metadata
     repo.delete_by_owner.return_value = metadata
+    service._usage.lock_family.return_value = [file_id]
+    service._usage.count_product_usage.return_value = []
     service._file_info = AsyncMock(return_value=public_info)
 
     result = await service.delete_file(file_id)
@@ -51,6 +74,11 @@ async def test_delete_uses_one_owner_bound_lookup_and_delete() -> None:
         user_id=user.id,
         tenant_id=user.tenant_id,
     )
+    service._usage.lock_family.assert_awaited_once_with(
+        root_file_id=file_id,
+        tenant_id=user.tenant_id,
+    )
+    service._usage.count_product_usage.assert_awaited_once_with([file_id])
     repo.delete_by_owner.assert_awaited_once_with(
         id=file_id,
         user_id=user.id,

--- a/frontend/apps/docs-site/src/content/docs/object-content-architecture.mdx
+++ b/frontend/apps/docs-site/src/content/docs/object-content-architecture.mdx
@@ -84,6 +84,29 @@ stateDiagram-v2
   tombstoned --> [*]: purge horizon passed
 ```
 
+### Product usage fence
+
+File deletion has a product-level fence before the object-content lifecycle
+starts. A bounded File-owned query counts four concrete relations:
+
+- chat questions;
+- Assistant attachments;
+- App attachments;
+- App-run inputs.
+
+The advisory preview uses a recursive read to include generated derivatives.
+The authoritative delete path locks the root and descendants
+parent-before-child, repeats the same grouped query, and returns a typed `409
+file_in_use` response when any relation remains. PostgreSQL 13 does not lock
+the underlying File rows through an outer `FOR UPDATE` on a recursive CTE, so
+the delete path deliberately locks base rows one level at a time. Reverse
+`file_id` indexes keep each relation lookup proportional to matching uses.
+
+This fence covers user-initiated File deletion. User and organization
+offboarding intentionally retain their existing database-owned cascades.
+Object-content holds and minimum retention protect bytes after the final
+product reference disappears; they are not duplicated as File-identity rules.
+
 ## Crash recovery and reconciliation
 
 Inline creation has no database/object-store crash gap: payload and intent share

--- a/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
+++ b/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
@@ -21,13 +21,13 @@ import { Callout, Steps, Tabs } from "nextra/components";
 
 ## How content flows
 
-File and Icon own the product meaning: filename, purpose, authorization, and
-which variant is needed. The shared object-content module owns durable bytes,
-SHA-256, exact size and media type, placement, lifecycle, and deletion.
+File and Icon own the product meaning: filename, authorization, and where the
+content is used. The shared object-content module owns durable bytes, SHA-256,
+exact size and media type, placement, lifecycle, and physical deletion.
 
 ```mermaid
 flowchart LR
-  upload["File or Icon"] --> owner["Product owner\nname · purpose · access"]
+  upload["File or Icon"] --> owner["Product owner\nname · use · access"]
   owner --> control["PostgreSQL control\nidentity · digest · references · lifecycle"]
   control --> bytes{"One byte authority"}
   bytes --> inline["PostgreSQL inline\ndefault"]
@@ -58,6 +58,27 @@ Object storage and RAG solve different problems:
 
 Enabling an endpoint makes the optional byte plane available; it does not move
 existing content or change producer placement by itself.
+
+## What happens when a File is deleted?
+
+Eneo first checks the File and its generated derivatives against concrete
+product relations. A File cannot be deleted while it is attached to a chat,
+Assistant, App, or App run. The preview returns a short count for each blocking
+use; it never exposes storage keys or endpoint details.
+
+```mermaid
+flowchart LR
+  request["Delete File"] --> preview["Check current uses"]
+  preview -->|still used| blocked["Keep File\nexplain what blocks deletion"]
+  preview -->|unused| delete["Delete File identity"]
+  delete --> lifecycle["Object content handles\nfinal byte deletion"]
+```
+
+Preview is advisory. Eneo repeats the same check while holding database locks
+before deletion, so a concurrent attachment cannot be silently removed.
+Removing a File from a chat or Assistant only removes that use; the reusable
+File remains until its owner deletes it. Organization or user offboarding keeps
+its existing database-cascade behavior.
 
 ## Choose the right deployment
 
@@ -262,6 +283,12 @@ content item live either inline or in the configured endpoint.
 
 No. Placement changes require an explicit copy, full verification, authority
 switch, and cleanup workflow.
+
+### Why can I not delete an uploaded File?
+
+The File is still used by a chat, Assistant, App, or App run. Check its deletion
+preview, remove those uses deliberately, and try again. Eneo blocks the delete
+instead of silently breaking those resources.
 
 ### What happens when an endpoint is down?
 

--- a/frontend/packages/eneo-js/src/types/schema.d.ts
+++ b/frontend/packages/eneo-js/src/types/schema.d.ts
@@ -3836,6 +3836,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/files/{id}/deletion-preview/": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get File Deletion Preview
+     * @description Preview whether deleting this File would remove active chat, Assistant, App, or App-run attachments.
+     */
+    get: operations["get_file_deletion_preview_api_v1_files__id__deletion_preview__get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/files/{id}/signed-url/": {
     parameters: {
       query?: never;
@@ -11464,7 +11484,8 @@ export interface components {
       | 9040
       | 9041
       | 9042
-      | 9043;
+      | 9043
+      | 9044;
     /**
      * ExpiringKeySummaryItem
      * @description Lightweight summary of a single expiring API key.
@@ -11718,6 +11739,20 @@ export interface components {
        */
       status?: string;
     };
+    /** FileDeletionPreview */
+    FileDeletionPreview: {
+      /**
+       * File Id
+       * Format: uuid
+       */
+      file_id: string;
+      /** Can Delete */
+      can_delete: boolean;
+      /** Affected File Count */
+      affected_file_count: number;
+      /** Blockers */
+      blockers: components["schemas"]["FileUsageSummary"][];
+    };
     /** FilePublic */
     FilePublic: {
       /** Created At */
@@ -11745,6 +11780,17 @@ export interface components {
       /** Accepted File Types */
       accepted_file_types: components["schemas"]["AcceptedFileType"][];
       limit: components["schemas"]["Limit"];
+    };
+    /**
+     * FileUsageKind
+     * @enum {string}
+     */
+    FileUsageKind: "chat_attachment" | "assistant_attachment" | "app_attachment" | "app_run_input";
+    /** FileUsageSummary */
+    FileUsageSummary: {
+      kind: components["schemas"]["FileUsageKind"];
+      /** Count */
+      count: number;
     };
     /** FormatLimit */
     FormatLimit: {
@@ -33343,6 +33389,64 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_file_deletion_preview_api_v1_files__id__deletion_preview__get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["FileDeletionPreview"];
+        };
       };
       /** @description Forbidden */
       403: {


### PR DESCRIPTION
## TL;DR

Eneo now refuses to delete a File while a chat, Assistant, App, or App run still
uses it. Users can preview the blocking uses first, and the final check runs
under database locks so a concurrent attachment cannot disappear silently.

The rule belongs to `File` and works the same whether the bytes live in
PostgreSQL or optional S3-compatible storage.

## Changes

- Add one File-owned usage query for the four concrete product relations.
- Check the root File and every generated descendant before deletion.
- Return a typed `409 file_in_use` response with bounded reason counts.
- Add reverse indexes that keep usage checks fast as relation tables grow.
- Update OpenAPI/generated types and docs.eneo.ai.

```mermaid
flowchart LR
  delete["Delete File"] --> check["Check current uses"]
  check -->|used| keep["Keep it and explain why"]
  check -->|unused| remove["Delete File identity"]
  remove --> bytes["Existing content lifecycle removes final bytes"]
```

## Why

Deleting a File previously let PostgreSQL cascade away active attachments
without warning. That could break chats and configured resources while looking
like a successful delete.

This change makes deletion explicit without adding a purpose flag, a generic
usage registry, a storage-provider branch, or a second cleanup system.

## What changed

- `FileUsageRepository` owns family traversal, database locking, and the
  grouped usage query.
- `FileService` owns the preview and the safe-delete decision.
- File models own the public usage and conflict contracts.
- The existing object-content lifecycle still owns byte retention and physical
  deletion after the final File reference disappears.

## What was deliberately not changed

- User and organization offboarding keep their existing cascade behavior.
- No automatic TTL, force-delete flow, storage migration, admin inventory, or
  knowledge-generation schema is included.
- PostgreSQL remains the complete default; object storage remains optional.

## Risk and rollback

The intentional behavior change is that an in-use File returns `409` instead of
silently deleting its relations. The authoritative check locks the File family
parent-before-child and rechecks usage in the same transaction.

Rollback reverts this commit and downgrades the index migration. No File or
object-content data is rewritten.

## Planning

- Task: Fixes #578
- Epic: #549
- Next read-contract slice: #586

## Testing

- `uv run pytest -q -n 2 -m "not integration" tests/` — 3,807 passed.
- `uv run pytest -q -n 2 -m integration tests/integration/` — 1,119 passed,
  77 skipped, 1 known xfailed.
- PostgreSQL 13 index migration upgrade → downgrade → re-upgrade — passed.
- Focused API, lock-race, all-relation, and route-audit tests — 61 passed.
- `uv run ruff check src/eneo` and `uv run ruff format --check src/eneo` —
  passed.
- `uv run pyright` — 0 errors, 0 warnings.
- OpenAPI regeneration and `@eneo/eneo-js` lint — passed.
- docs-site production build and search index — passed.
- `python3 scripts/pre_push_check.py` — passed with the tracked template
  environment.

## Screenshots

No product UI changed.
