### PR TITLE
refactor(object-content): keep attachment reads fast at scale

### DIFF
--- a/backend/src/eneo/object_content/content_repository.py
+++ b/backend/src/eneo/object_content/content_repository.py
@@ -505,26 +505,6 @@ class ObjectContentRepository:
         self._clear_lease(row)
         await self._session.flush()
 
-    async def get_readable(
-        self,
-        *,
-        content_id: UUID,
-        tenant_id: UUID,
-        access_class: ContentAccessClass,
-    ) -> ReadableContent:
-        row = (
-            await self._session.scalars(
-                select(ObjectContents).where(
-                    ObjectContents.id == content_id,
-                    ObjectContents.tenant_id == tenant_id,
-                    ObjectContents.access_class == access_class.value,
-                )
-            )
-        ).one_or_none()
-        if row is None or row.state != ContentState.AVAILABLE.value:
-            raise ObjectContentStateError("Object content is not available")
-        return self._readable(row)
-
     async def get_readable_sources(
         self,
         grants: Sequence[ContentReadGrant],
@@ -623,22 +603,6 @@ class ObjectContentRepository:
             row.failure_detail = "durable object bytes are unavailable or untrusted"
             row.next_attempt_at = None
             await self._session.flush()
-
-    async def get_inline_payload(self, content_id: UUID) -> bytes:
-        payload = await self._session.get(InlineContentPayloads, content_id)
-        if payload is None:
-            raise ObjectContentStateError("Inline content payload is missing")
-        return payload.payload
-
-    async def get_object_store_descriptor(
-        self,
-        content_id: UUID,
-    ) -> ObjectStoreDescriptor:
-        descriptor = await self._object_store_descriptor(content_id)
-        return ObjectStoreDescriptor(
-            content_id=descriptor.content_id,
-            object_key=descriptor.object_key,
-        )
 
     async def apply_hold(
         self,

--- a/backend/src/eneo/object_content/content_repository.py
+++ b/backend/src/eneo/object_content/content_repository.py
@@ -57,15 +57,16 @@ class ReadableContent:
 
 
 @dataclass(frozen=True, slots=True)
-class ReadableContentSource:
-    content: ReadableContent
-    inline_payload: bytes | None
-
-
-@dataclass(frozen=True, slots=True)
 class ObjectStoreDescriptor:
     content_id: UUID
     object_key: str
+
+
+@dataclass(frozen=True, slots=True)
+class ReadableContentSource:
+    content: ReadableContent
+    inline_payload: bytes | None
+    object_store_descriptor: ObjectStoreDescriptor | None
 
 
 class ObjectContentRepository:
@@ -528,7 +529,7 @@ class ObjectContentRepository:
         self,
         grants: Sequence[ContentReadGrant],
     ) -> dict[UUID, ReadableContentSource]:
-        """Read access-validated controls and inline payloads in one query."""
+        """Read access-validated controls and byte-source facts in one query."""
         if not grants:
             return {}
 
@@ -542,10 +543,18 @@ class ObjectContentRepository:
         }
         rows = (
             await self._session.execute(
-                select(ObjectContents, InlineContentPayloads.payload)
+                select(
+                    ObjectContents,
+                    InlineContentPayloads.payload,
+                    ObjectStoreObjects.object_key,
+                )
                 .outerjoin(
                     InlineContentPayloads,
                     InlineContentPayloads.content_id == ObjectContents.id,
+                )
+                .outerjoin(
+                    ObjectStoreObjects,
+                    ObjectStoreObjects.content_id == ObjectContents.id,
                 )
                 .where(
                     tuple_(
@@ -559,16 +568,26 @@ class ObjectContentRepository:
         ).all()
 
         sources: dict[UUID, ReadableContentSource] = {}
-        for row, inline_payload in rows:
+        for row, inline_payload, object_key in rows:
             content = self._readable(row)
             if (
                 content.storage_kind is StorageKind.POSTGRES_INLINE
                 and inline_payload is None
             ):
                 raise ObjectContentStateError("Inline content payload is missing")
+            if content.storage_kind is StorageKind.OBJECT_STORE and object_key is None:
+                raise ObjectContentStateError("Object-store descriptor is missing")
             sources[content.content_id] = ReadableContentSource(
                 content=content,
                 inline_payload=inline_payload,
+                object_store_descriptor=(
+                    ObjectStoreDescriptor(
+                        content_id=content.content_id,
+                        object_key=object_key,
+                    )
+                    if object_key is not None
+                    else None
+                ),
             )
 
         requested_ids = {grant.content_id for grant in grants}

--- a/backend/src/eneo/object_content/content_service.py
+++ b/backend/src/eneo/object_content/content_service.py
@@ -377,35 +377,39 @@ class ObjectContentService:
         range_header: str | None = None,
     ) -> AsyncGenerator[ContentRead]:
         async with self._database.session() as session, session.begin():
-            repository = ObjectContentRepository(session)
-            content = await repository.get_readable(
-                content_id=grant.content_id,
-                tenant_id=grant.tenant_id,
-                access_class=grant.access_class,
+            sources = await ObjectContentRepository(session).get_readable_sources(
+                [grant]
             )
-            inline_payload = (
-                await repository.get_inline_payload(content.content_id)
-                if content.storage_kind is StorageKind.POSTGRES_INLINE
-                else None
-            )
-            object_store_descriptor = (
-                await repository.get_object_store_descriptor(content.content_id)
-                if content.storage_kind is StorageKind.OBJECT_STORE
-                else None
-            )
+        source = sources[grant.content_id]
         byte_range = (
             None
             if range_header is None
-            else ByteRange.parse(range_header, size_bytes=content.size_bytes)
+            else ByteRange.parse(
+                range_header,
+                size_bytes=source.content.size_bytes,
+            )
         )
+        async with self._open_readable_source(
+            source,
+            byte_range=byte_range,
+        ) as opened:
+            yield opened
 
+    @asynccontextmanager
+    async def _open_readable_source(
+        self,
+        source: ReadableContentSource,
+        *,
+        byte_range: ByteRange | None = None,
+    ) -> AsyncGenerator[ContentRead]:
+        content = source.content
         match content.storage_kind:
             case StorageKind.POSTGRES_INLINE:
-                if inline_payload is None:
+                if source.inline_payload is None:
                     raise RuntimeError("Inline content dispatch lost its payload")
                 try:
                     async with self._inline_store.open_verified_read(
-                        inline_payload,
+                        source.inline_payload,
                         expected_sha256=content.sha256,
                         expected_size_bytes=content.size_bytes,
                         expected_media_type=content.media_type,
@@ -419,14 +423,14 @@ class ObjectContentService:
                     )
                     raise
             case StorageKind.OBJECT_STORE:
-                if object_store_descriptor is None:
+                if source.object_store_descriptor is None:
                     raise RuntimeError(
                         "Object-store content dispatch lost its descriptor"
                     )
                 _settings, store = self._require_object_store()
                 try:
                     async with store.open_verified_read(
-                        object_store_descriptor.object_key,
+                        source.object_store_descriptor.object_key,
                         expected_sha256=content.sha256,
                         expected_size_bytes=content.size_bytes,
                         expected_media_type=content.media_type,
@@ -458,11 +462,11 @@ class ObjectContentService:
         self,
         grants: Sequence[ContentReadGrant],
     ) -> dict[UUID, bytes]:
-        """Materialize authorized content with one inline query per bounded page.
+        """Materialize authorized content with one source query per bounded page.
 
-        PostgreSQL-inline controls and payloads are loaded and access-validated
-        together. Object-store content keeps the verified streaming path behind
-        ``open_content``; callers do not branch on storage placement.
+        Controls plus inline payloads or private object-store descriptors are
+        loaded and access-validated together. Both storage kinds then use the
+        same verified backend dispatch; callers do not branch on placement.
         """
         unique_grants: dict[UUID, ContentReadGrant] = {}
         for grant in grants:
@@ -485,37 +489,16 @@ class ObjectContentService:
             for grant in page:
                 source = sources[grant.content_id]
                 payloads[grant.content_id] = await self._read_source_bytes(
-                    grant,
                     source,
                 )
         return payloads
 
     async def _read_source_bytes(
         self,
-        grant: ContentReadGrant,
         source: ReadableContentSource,
     ) -> bytes:
-        content = source.content
-        if content.storage_kind is StorageKind.OBJECT_STORE:
-            async with self.open_content(grant) as opened:
-                return b"".join([chunk async for chunk in opened.chunks])
-
-        if source.inline_payload is None:
-            raise ObjectContentStateError("Inline content payload is missing")
-        try:
-            async with self._inline_store.open_verified_read(
-                source.inline_payload,
-                expected_sha256=content.sha256,
-                expected_size_bytes=content.size_bytes,
-                expected_media_type=content.media_type,
-            ) as opened:
-                return b"".join([chunk async for chunk in opened.chunks])
-        except ObjectContentIntegrityError:
-            await self._mark_backend_failure(
-                content.content_id,
-                ContentFailureCode.BACKEND_CORRUPT,
-            )
-            raise
+        async with self._open_readable_source(source) as opened:
+            return b"".join([chunk async for chunk in opened.chunks])
 
     async def apply_hold(
         self,

--- a/backend/tests/integration/object_content/test_content_service.py
+++ b/backend/tests/integration/object_content/test_content_service.py
@@ -12,7 +12,7 @@ import pytest
 from botocore.config import Config
 from botocore.exceptions import ReadTimeoutError
 from botocore.session import get_session
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, event, func, select
 
 from eneo.database.database import DatabaseSessionManager
 from eneo.database.tables.files_table import Files
@@ -579,6 +579,108 @@ async def test_service_owns_real_upload_read_and_final_delete_lifecycle(
         await real_object_store.store.head(
             await _object_key(object_content_database, prepared.id)
         )
+
+
+@pytest.mark.asyncio
+async def test_batch_object_store_reads_use_one_source_query(
+    object_content_database: DatabaseSessionManager,
+    real_object_store: RealObjectStore,
+) -> None:
+    service = _service(
+        real_object_store.settings,
+        real_object_store.store,
+        object_content_database,
+    )
+    grants: list[ContentReadGrant] = []
+    expected: dict[UUID, bytes] = {}
+    object_keys: list[str] = []
+
+    async with object_content_database.session() as session, session.begin():
+        tenant_id = (await session.scalars(select(Tenants.id))).one()
+        user_id = (await session.scalars(select(Users.id))).one()
+        assert session.bind is not None
+        sync_engine = session.bind.sync_engine
+
+    for index in range(3):
+        payload = f"remote attachment {index}".encode()
+        async with capture_content(
+            _payload_bytes(payload),
+            declared_media_type="application/octet-stream",
+            verified_media_type="application/octet-stream",
+            maximum_size_bytes=len(payload),
+            spool_memory_bytes=real_object_store.settings.spool_memory_bytes,
+            multipart_part_bytes=real_object_store.settings.multipart_part_bytes,
+        ) as captured:
+            async with object_content_database.session() as session, session.begin():
+                owner = Files(
+                    name=f"batch-{index}.bin",
+                    mimetype=captured.verified_media_type,
+                    file_type="text",
+                    tenant_id=tenant_id,
+                    user_id=user_id,
+                    parent_file_id=None,
+                )
+                session.add(owner)
+                await session.flush()
+                prepared = await service.prepare_in_transaction(
+                    session,
+                    intent=ContentIntent(
+                        tenant_id=tenant_id,
+                        created_by_user_id=user_id,
+                        access_class=ContentAccessClass.PRIVATE_RESOURCE,
+                        idempotency_key=uuid4().hex,
+                        producer_receipt=f"file:{owner.id}:original:0",
+                    ),
+                    content=captured,
+                    storage_kind=StorageKind.OBJECT_STORE,
+                )
+                session.add(
+                    FileContentReferences(
+                        file_id=owner.id,
+                        content_id=prepared.id,
+                        variant="original",
+                        ordinal=0,
+                    )
+                )
+                await session.flush()
+
+            await service.store_and_verify(
+                content_id=prepared.id,
+                content=captured,
+            )
+            grant = ContentReadGrant(
+                content_id=prepared.id,
+                tenant_id=tenant_id,
+                access_class=ContentAccessClass.PRIVATE_RESOURCE,
+            )
+            grants.append(grant)
+            expected[prepared.id] = payload
+            object_keys.append(await _object_key(object_content_database, prepared.id))
+
+    source_queries: list[str] = []
+
+    def capture_source_query(
+        _connection,
+        _cursor,
+        statement,
+        _parameters,
+        _context,
+        _executemany,
+    ) -> None:
+        normalized = statement.lower()
+        if "object_contents" in normalized or "object_store_objects" in normalized:
+            source_queries.append(statement)
+
+    event.listen(sync_engine, "before_cursor_execute", capture_source_query)
+    try:
+        materialized = await service.read_content_bytes(grants)
+    finally:
+        event.remove(sync_engine, "before_cursor_execute", capture_source_query)
+        for object_key in object_keys:
+            await real_object_store.store.delete_and_confirm(object_key)
+
+    assert materialized == expected
+    assert len(source_queries) == 1
 
 
 @pytest.mark.asyncio

--- a/docs/goals/file-read-contract/state.yaml
+++ b/docs/goals/file-read-contract/state.yaml
@@ -4,7 +4,7 @@ goal:
   title: "Efficient file views and explicit original downloads"
   slug: "file-read-contract"
   kind: specific
-  tranche: "Add an explicit authorized original-file download contract; leave metadata-only projections for the next #586 slice."
+  tranche: "Remove per-object database rereads from bounded attachment hydration; leave metadata-only aggregate projections for the next #586 slice."
   status: active
 
 rules:
@@ -35,7 +35,7 @@ continuity:
   last_handoff_at: null
   last_verified_revision: "00aaa9dd2e296456bdadbb549aca14daf91e5754"
 
-active_task: T007
+active_task: T009
 
 tasks:
   - id: T001
@@ -394,7 +394,7 @@ tasks:
   - id: T007
     type: worker
     assignee: PM
-    status: active
+    status: done
     reasoning_hint: low
     objective: "Publish the immutable reviewed source as a ready PR, request a fresh review, and verify all required GitHub checks."
     allowed_files:
@@ -409,7 +409,16 @@ tasks:
       - "Pre-push, CI, or fresh review exposes a current defect."
       - "The branch contains unrelated changes."
       - "The PR would imply that all of #586 is complete."
-    receipt: null
+    receipt:
+      result: done
+      summary: "Published and merged PR #589 with exact-original recovery, purpose-separated signed access, attributable link audit, and PostgreSQL-inline/compatible-store parity."
+      source_commit: "369e574600dcc3e07b5f35cd90e798ebdf55179a"
+      merge_commit: "a97c8a9b0f7fb7dbb35b2ca757c30bc73badc261"
+      pull_request: "https://github.com/eneo-ai/eneo/pull/589"
+      validation:
+        - "All required GitHub checks passed on the immutable source head."
+        - "Backend tests passed in 32m49s; frontend, E2E, Docker, schema, coverage, dependency, and policy checks passed."
+        - "Task #588 closed through the merged PR; #586 remains open for read-performance work."
 
   - id: T008
     type: worker
@@ -513,11 +522,51 @@ tasks:
           - ".codex/artifacts/claude-peer-loop-pr-589-original-download-architecture-and-api-dx-review-20260724T130152Z.md"
           - ".codex/artifacts/claude-peer-loop-pr-589-original-download-verification-20260724T131537Z.md"
 
+  - id: T009
+    type: worker
+    assignee: PM
+    status: active
+    reasoning_hint: high
+    objective: "Eliminate per-object database transactions from bounded object-store attachment hydration without changing File or storage-provider contracts."
+    allowed_files:
+      - "backend/src/eneo/object_content/content_repository.py"
+      - "backend/src/eneo/object_content/content_service.py"
+      - "backend/tests/integration/object_content/test_content_service.py"
+      - "frontend/apps/docs-site/src/content/guides/object-content-storage.mdx"
+      - "docs/goals/file-read-contract/state.yaml"
+    verify:
+      - "Multiple object-store grants are access-validated with one bounded relational source query per page."
+      - "No object-store item re-enters open_content or opens a per-item database transaction."
+      - "Single reads and batch reads share one private verified backend-dispatch implementation."
+      - "Bytes, authorization, failure-state transitions, integrity checks, ordering, deduplication, and PostgreSQL-inline behavior remain unchanged."
+      - "Focused real compatible-store tests, Ruff, format, strict Pyright, docs-site build, and repository gates pass."
+    stop_if:
+      - "The fix requires a provider-specific branch outside the private S3-compatible adapter."
+      - "The fix requires public API, schema, migration, placement, worker, or retention changes."
+      - "A bounded source page cannot preserve tenant and access-class validation."
+
+  - id: T010
+    type: worker
+    assignee: PM
+    status: queued
+    reasoning_hint: high
+    objective: "Give metadata-only File, Assistant, App, and Space views an explicit projection that performs no payload reads while preserving execution-time hydration."
+    allowed_files:
+      - "Freeze after T009 from current source and public-contract evidence."
+    verify:
+      - "Zero payload reads for metadata-only views."
+      - "Execution, prompt, history, and transcription consumers keep explicit verified hydration."
+      - "No partially hydrated File domain object or storage-provider branch."
+      - "docs.eneo.ai explains metadata versus content reads."
+    stop_if:
+      - "The public transcription contract cannot be preserved or changed additively."
+      - "The slice requires a boolean hydration mode or a broad repository framework."
+
 checks:
   dirty_fingerprint: "Only the new Goal Maker charter and board are tracked before T001."
   last_verification:
     result: pass
-    task: T008
+    task: T007
     commands:
       - "118 focused backend and integration tests passed"
       - "3825 backend non-integration tests passed"
@@ -525,3 +574,4 @@ checks:
       - "Strict Pyright 0/0 and changed-path Ruff/format passed"
       - "SDK tests/lint, web check/lint, docs-site build, schema parity, and diff check passed"
       - "Fable high pass 1 changes_required at 8; pass 2 green at 8 with no blockers"
+      - "PR #589 required GitHub checks passed and squash merge produced a97c8a9b"

--- a/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
+++ b/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
@@ -101,6 +101,11 @@ bytes are stored inline in PostgreSQL or in an optional configured
 S3-compatible endpoint. Callers do not receive bucket, object-key, or provider
 details, and Eneo does not require S3-compatible storage.
 
+When a view genuinely needs several attachment payloads, Eneo validates their
+database records as a bounded batch and then verifies each byte stream. Remote
+objects still require one content read each, but they do not add one database
+transaction per attachment.
+
 ## What happens when a File is deleted?
 
 Eneo first checks the File and its generated derivatives against concrete


### PR DESCRIPTION
## Summary

- Reads access-validated object-store descriptors in the existing bounded database query.
- Reuses one verified byte-read path for both single files and attachment batches.
- Removes the extra database transaction per remote attachment without changing APIs or storage choice.

## Why

Assistant, App, and Space views that genuinely need attachment bytes should not create database load proportional to the number of remotely stored files. PostgreSQL remains the complete default; optional S3-compatible storage keeps the same product behavior.

## What changed

`ObjectContentRepository` now returns the authorized byte-source facts for each bounded page. `ObjectContentService` verifies both PostgreSQL-inline and object-store reads through one canonical dispatch. A real PostgreSQL/SeaweedFS query-count test proves three remote attachments use one source query instead of seven. docs.eneo.ai now explains this behavior.

## What was deliberately not changed

- No public API, schema, migration, storage policy, provider branch, cache, or fallback.
- Metadata-only File/Assistant/App/Space projections remain a separate final #586 slice.
- Knowledge ingestion, retention, cleanup, and Flow storage remain outside this PR.

## Deletion / consolidation

The duplicate inline-read dispatch and the object-store batch re-entry through `open_content()` were consolidated into the existing object-content owner.

## Risk and rollback

Risk is limited to private read dispatch. Access-class and tenant validation, integrity checks, ordering, deduplication, failure transitions, and bounded page size are unchanged. Revert the single commit to restore the previous query pattern.

## Validation

- Focused PostgreSQL + real SeaweedFS integration: 8 passed.
- Backend non-integration: 3,858 passed.
- Full backend integration: 1,128 passed, 78 skipped, 1 expected xfail.
- Ruff/format: passed.
- Strict Pyright: 0 errors, 0 warnings.
- docs-site production build: passed.
- Repository pre-push/schema drift: passed.

Refs #586
Parent: #549