### PR TITLE
fix(ci): avoid QEMU in native amd64 build

### DIFF
--- a/.github/workflows/build_and_push_images.yml
+++ b/.github/workflows/build_and_push_images.yml
@@ -329,7 +329,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up QEMU
+      - name: Set up QEMU for the emulated arm64 build
+        if: matrix.platform == 'linux/arm64'
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
         with:
           image: ${{ env.QEMU_IMAGE }}


### PR DESCRIPTION
## Summary

- Skips QEMU setup for the native `linux/amd64` SeaweedFS build.
- Keeps the digest-pinned QEMU path unchanged for the emulated `linux/arm64` build.
- Adds no retry, timeout increase, or relaxed supply-chain gate.

## Why

The amd64 job in [develop run 30099837888](https://github.com/eneo-ai/eneo/actions/runs/30099837888/job/89503247725) failed before Eneo code ran because Docker Hub's token endpoint timed out while QEMU was being initialized. The same commit passed on rerun, but amd64 does not need emulation at all. Removing that unnecessary dependency is more reliable than masking the outage with retries.

## What changed

The existing SeaweedFS platform matrix now runs the QEMU setup step only when `matrix.platform` is `linux/arm64`.

## What was deliberately not changed

- No image, digest, registry, attestation, SBOM, vulnerability, or license policy changed.
- No object-content product behavior, API, deployment configuration, docs, or Flow code changed.
- The arm64 build and its trust boundary remain unchanged.

## Deletion / consolidation

The native amd64 job no longer performs an unnecessary emulation setup.

## Risk and rollback

Risk is limited to one GitHub Actions condition. Revert the single commit to restore the previous unconditional setup; arm64 continues to execute the same pinned action and image.

## Validation

- Workflow YAML parse: passed.
- Developer-tooling tests: 19 passed.
- Project workflow self-tests: passed.
- Commit hooks and pre-push gate: passed.
- `git diff --check`: passed.
