### PR TITLE
fix(ci): make frontend E2E failures diagnosable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,8 +410,6 @@ jobs:
         env:
           SVELTE_KIT_OUT_DIR: .svelte-kit-e2e
           NODE_OPTIONS: --max-old-space-size=6144
-          ENEO_BACKEND_URL: http://localhost:8124
-          PUBLIC_ENEO_BACKEND_URL: http://localhost:8124
         run: bun run build
 
       - name: Run E2E tests
@@ -419,16 +417,29 @@ jobs:
         env:
           # The workflow owns the stack lifecycle, so Playwright must not manage it.
           E2E_MANAGE_STACK: "0"
-          E2E_BACKEND_URL: http://localhost:8124
+          # Keep SSR and direct API helpers on one deterministic loopback path.
+          E2E_BACKEND_URL: http://127.0.0.1:8124
           E2E_JWT_SECRET: ci-test-jwt-secret-not-for-production-0123456789 # matches the e2e-backend JWT_SECRET
         run: bun run test:e2e
+
+      - name: Capture E2E stack diagnostics
+        if: ${{ failure() }}
+        run: |
+          mkdir -p e2e-artifacts
+          docker compose -f docker-compose.e2e.ci.yml ps --all \
+            > e2e-artifacts/compose-ps.txt
+          docker compose -f docker-compose.e2e.ci.yml logs \
+            --no-color --timestamps \
+            > e2e-artifacts/compose.log
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report
-          path: frontend/apps/web/playwright-report
+          path: |
+            frontend/apps/web/playwright-report
+            e2e-artifacts
           retention-days: 7
           if-no-files-found: ignore
 

--- a/frontend/apps/web/playwright.config.ts
+++ b/frontend/apps/web/playwright.config.ts
@@ -9,7 +9,7 @@ import { defineConfig, devices } from "@playwright/test";
 // (SVELTE_KIT_OUT_DIR=.svelte-kit-e2e, see below), so it no longer touches a live
 // `vite dev`'s `.svelte-kit` — you can run the E2E suite while developing.
 const PORT = 4173;
-const BACKEND_URL = process.env.E2E_BACKEND_URL ?? "http://localhost:8124";
+const BACKEND_URL = process.env.E2E_BACKEND_URL ?? "http://127.0.0.1:8124";
 
 // Reused login session, produced once by auth.setup.ts.
 export const STORAGE_STATE = "playwright/.auth/user.json";
@@ -31,7 +31,9 @@ export default defineConfig({
     : [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: `http://localhost:${PORT}`,
-    trace: "on-first-retry"
+    // There are no automatic E2E retries. Retain the original failure trace so
+    // backend connectivity and response failures remain diagnosable.
+    trace: "retain-on-failure"
   },
   projects: [
     // 1) Authenticate once and persist the session.

--- a/frontend/apps/web/tests/chat.spec.ts
+++ b/frontend/apps/web/tests/chat.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { askChatQuestion, uniqueName } from "./helpers";
 
 // Central flow #4: the core product loop. A logged-in user sends a message in the
 // personal chat and gets the assistant's streamed answer. The seeded model points
@@ -8,12 +9,8 @@ import { expect, test } from "@playwright/test";
 test("a streamed answer is saved and can be reopened from history", async ({ page }) => {
   await page.goto("/spaces/personal/chat");
 
-  const question = "e2e persistence ping";
-  const input = page.locator('[contenteditable="true"]').first();
-  await input.click();
-  await input.pressSequentially(question);
-
-  await page.locator('button[name="ask"]').click();
+  const question = uniqueName("e2e persistence ping");
+  await askChatQuestion(page, question);
 
   await expect(page.getByText(question, { exact: true })).toBeVisible();
   await expect(page.getByText("E2E mock completion: pong")).toBeVisible({ timeout: 20_000 });

--- a/frontend/apps/web/tests/helpers.ts
+++ b/frontend/apps/web/tests/helpers.ts
@@ -1,6 +1,6 @@
 import { expect, type APIRequestContext, type Page } from "@playwright/test";
 
-export const BACKEND_URL = process.env.E2E_BACKEND_URL ?? "http://localhost:8124";
+export const BACKEND_URL = process.env.E2E_BACKEND_URL ?? "http://127.0.0.1:8124";
 export const MOCK_REPLY = "E2E mock completion: pong";
 
 let counter = 0;


### PR DESCRIPTION
## Summary

- pins the isolated E2E backend to one deterministic IPv4 loopback path;
- retains the original Playwright trace instead of waiting for a retry that never runs;
- uploads Compose status and timestamped service logs when E2E fails;
- gives persisted chat fixtures unique names so repeated runs cannot select stale conversations.

## Why

Two separate CI runs failed on different pages but rendered the same SvelteKit `fetch failed` error. The old job discarded backend logs and configured traces only for a retry even though E2E has zero retries. The historical artifacts therefore do not prove the transport root cause.

This PR removes one connection variable and, more importantly, preserves enough evidence to diagnose any recurrence without adding retries, increasing timeouts, or weakening assertions.

## What changed

- `.github/workflows/ci.yml` owns the host-side backend address and failure artifacts.
- `playwright.config.ts` retains the initial failed trace.
- the shared E2E backend helper defaults to the same address.
- `chat.spec.ts` reuses the existing input helper and unique-name convention.

## What was deliberately not changed

- no production frontend or backend behavior;
- no browser retry or timeout increase;
- no health/readiness redesign;
- no claim that IPv6 was the proven historical root cause.

## Deletion / consolidation

The chat test now reuses the existing `askChatQuestion` helper, and two no-op build-time backend URL assignments were removed because the SvelteKit environment is runtime-resolved.

## Risk and rollback

Risk is limited to the isolated E2E workflow and tests. Revert commit `d6f90161c` to restore the prior runner behavior. Failure artifacts contain only the repository's synthetic E2E stack; a local scan found no JWT secret, test password, provider key, or Authorization value in the captured logs.

## Validation

- Playwright 1.61.1/Linux full suite, three iterations, two workers: **34 passed**
- normal Playwright E2E run on a fresh stack: **12 passed**
- forced backend outage: initial failure trace retained; Compose status/log files non-empty
- `bun run lint`: **passed**
- `bun run check`: **0 errors, 0 warnings**
- production web build without backend build-time env: **passed**
- workflow YAML parse and `git diff --check`: **passed**
- normal commit and pre-push hooks: **passed**