### PR TITLE
fix(spaces): keep application lists fast with attached files

### DIFF
--- a/backend/src/eneo/actors/actor_factory.py
+++ b/backend/src/eneo/actors/actor_factory.py
@@ -1,13 +1,12 @@
 from typing import TYPE_CHECKING
 
-from eneo.actors.actors.space_actor import SpaceActor
+from eneo.actors.actors.space_actor import SpaceAccessFacts, SpaceActor
 
 if TYPE_CHECKING:
-    from eneo.spaces.space import Space
     from eneo.users.user import UserInDB
 
 
 class ActorFactory:
     @staticmethod
-    def create_space_actor(user: "UserInDB", space: "Space"):
+    def create_space_actor(user: "UserInDB", space: SpaceAccessFacts):
         return SpaceActor(user=user, space=space)

--- a/backend/src/eneo/actors/actor_manager.py
+++ b/backend/src/eneo/actors/actor_manager.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from eneo.actors import ActorFactory
+    from eneo.actors.actors.space_actor import SpaceAccessFacts
     from eneo.spaces.space import Space
     from eneo.users.user import UserInDB
 
@@ -13,4 +14,9 @@ class ActorManager:
         self.factory = factory
 
     def get_space_actor_from_space(self, space: "Space"):
+        from eneo.actors.actors.space_actor import SpaceAccessFacts
+
+        return self.get_space_actor(SpaceAccessFacts.from_space(space))
+
+    def get_space_actor(self, space: "SpaceAccessFacts"):
         return self.factory.create_space_actor(user=self.user, space=space)

--- a/backend/src/eneo/actors/actors/space_actor.py
+++ b/backend/src/eneo/actors/actors/space_actor.py
@@ -1,5 +1,9 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Optional, Union
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from uuid import UUID
 
 from eneo.authentication.auth_models import is_service_api_key
 from eneo.main.models import ResourcePermission
@@ -7,11 +11,81 @@ from eneo.modules.module import Modules
 from eneo.roles.permissions import Permission
 
 if TYPE_CHECKING:
-    from eneo.apps.apps.app import App
-    from eneo.assistants.assistant import Assistant
-    from eneo.group_chat.domain.entities.group_chat import GroupChat
     from eneo.spaces.space import Space
     from eneo.users.user import UserInDB
+
+
+class PublishableResource(Protocol):
+    @property
+    def id(self) -> UUID | None: ...
+
+    @property
+    def published(self) -> bool: ...
+
+
+@runtime_checkable
+class InsightResource(PublishableResource, Protocol):
+    @property
+    def insight_enabled(self) -> bool: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SpaceRoleFact:
+    id: UUID
+    role: str
+
+
+@dataclass(frozen=True, slots=True)
+class SpaceAccessFacts:
+    id: UUID | None
+    user_id: UUID | None
+    tenant_space_id: UUID | None
+    members: Mapping[UUID, SpaceRoleFact]
+    group_members: Mapping[UUID, SpaceRoleFact]
+    default_assistant_id: UUID | None
+    assistant_ids: frozenset[UUID]
+    app_ids: frozenset[UUID]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "members",
+            MappingProxyType(dict(self.members)),
+        )
+        object.__setattr__(
+            self,
+            "group_members",
+            MappingProxyType(dict(self.group_members)),
+        )
+
+    @classmethod
+    def from_space(cls, space: "Space") -> "SpaceAccessFacts":
+        return cls(
+            id=space.id,
+            user_id=space.user_id,
+            tenant_space_id=space.tenant_space_id,
+            members={
+                member.id: SpaceRoleFact(id=member.id, role=member.role)
+                for member in space.members.values()
+            },
+            group_members={
+                member.id: SpaceRoleFact(id=member.id, role=member.role)
+                for member in space.group_members.values()
+            },
+            default_assistant_id=(
+                space.default_assistant.id
+                if space.default_assistant is not None
+                else None
+            ),
+            assistant_ids=frozenset(assistant.id for assistant in space.assistants),
+            app_ids=frozenset(app.id for app in space.apps if app.id is not None),
+        )
+
+    def is_personal(self) -> bool:
+        return self.user_id is not None
+
+    def is_organization(self) -> bool:
+        return self.user_id is None and self.tenant_space_id is None
 
 
 class SpaceAction(str, Enum):
@@ -418,7 +492,7 @@ class SpaceActor:
     def __init__(
         self,
         user: "UserInDB",
-        space: "Space",
+        space: SpaceAccessFacts,
         shared_space_permissions: AccessControlList = SHARED_SPACE_PERMISSIONS,
         personal_space_permissions: AccessControlList = PERSONAL_SPACE_PERMISSIONS,
         org_space_permissions: AccessControlList = ORG_SPACE_PERMISSIONS,
@@ -500,11 +574,11 @@ class SpaceActor:
             if key.scope_id != self.space.id:
                 return None
         elif scope_type in ("assistant", "app"):
-            resource_ids: set[object] = set()
-            if scope_type == "assistant":
-                resource_ids = {a.id for a in (self.space.assistants or [])}
-            elif scope_type == "app":
-                resource_ids = {a.id for a in (self.space.apps or [])}
+            resource_ids = (
+                self.space.assistant_ids
+                if scope_type == "assistant"
+                else self.space.app_ids
+            )
             if key.scope_id not in resource_ids:
                 return None
         else:
@@ -533,10 +607,12 @@ class SpaceActor:
             return None
 
         highest = None
-        for group_member in self.space.group_members.values():
-            if group_member.id in user_group_ids:
-                group_role = SpaceRole(group_member.role)
-                highest = self._get_highest_role(highest, group_role)
+        for group_id in user_group_ids:
+            group_member = self.space.group_members.get(group_id)
+            if group_member is None:
+                continue
+            group_role = SpaceRole(group_member.role)
+            highest = self._get_highest_role(highest, group_role)
 
         return highest
 
@@ -619,7 +695,7 @@ class SpaceActor:
         self,
         action: SpaceAction,
         resource_type: SpaceResourceType,
-        resource: Optional[Union["Assistant", "GroupChat", "App"]] = None,
+        resource: PublishableResource | None = None,
     ):
         role = self._get_role()
         permissions = self._get_permissions(role=role)
@@ -669,7 +745,9 @@ class SpaceActor:
                 return False
 
         if resource_type in INSIGHT_RESOURCES and action == SpaceAction.INSIGHT_VIEW:
-            if resource is not None and not resource.insight_enabled:  # type: ignore[attr-defined]
+            if resource is not None and not isinstance(resource, InsightResource):
+                return False
+            if resource is not None and not resource.insight_enabled:
                 return False
 
         allowed_actions = permissions.get(resource_type, set())
@@ -747,7 +825,7 @@ class SpaceActor:
             resource_type=SpaceResourceType.ASSISTANT,
         )
 
-    def can_read_assistant(self, assistant: "Assistant"):
+    def can_read_assistant(self, assistant: PublishableResource):
         return self.can_perform_action(
             action=SpaceAction.READ,
             resource_type=SpaceResourceType.ASSISTANT,
@@ -805,7 +883,7 @@ class SpaceActor:
             resource_type=SpaceResourceType.GROUP_CHAT,
         )
 
-    def can_read_group_chat(self, group_chat: "GroupChat"):
+    def can_read_group_chat(self, group_chat: PublishableResource):
         return self.can_perform_action(
             action=SpaceAction.READ,
             resource_type=SpaceResourceType.GROUP_CHAT,
@@ -832,7 +910,7 @@ class SpaceActor:
             resource_type=SpaceResourceType.APP,
         )
 
-    def can_read_app(self, app: "App"):
+    def can_read_app(self, app: PublishableResource):
         return self.can_perform_action(
             action=SpaceAction.READ,
             resource_type=SpaceResourceType.APP,
@@ -897,14 +975,14 @@ class SpaceActor:
             resource_type=SpaceResourceType.ASSISTANT,
         )
 
-    def can_access_insight_group_chat(self, group_chat: "GroupChat"):
+    def can_access_insight_group_chat(self, group_chat: InsightResource):
         return self.can_perform_action(
             action=SpaceAction.INSIGHT_VIEW,
             resource_type=SpaceResourceType.GROUP_CHAT,
             resource=group_chat,
         )
 
-    def can_access_insight_assistant(self, assistant: "Assistant"):
+    def can_access_insight_assistant(self, assistant: InsightResource):
         return self.can_perform_action(
             action=SpaceAction.INSIGHT_VIEW,
             resource_type=SpaceResourceType.ASSISTANT,
@@ -1053,15 +1131,15 @@ class SpaceActor:
         return permissions
 
     def get_assistant_permissions(
-        self, assistant: "Assistant"
+        self, assistant: InsightResource
     ) -> list[ResourcePermission]:
         permissions: list[ResourcePermission] = []
 
         # TODO: Getting permissions should be revisited after
         # Space is the aggregate root
         if (
-            self.space.default_assistant is not None
-            and assistant.id == self.space.default_assistant.id
+            self.space.default_assistant_id is not None
+            and assistant.id == self.space.default_assistant_id
         ):
             if self.can_read_default_assistant():
                 permissions.append(ResourcePermission.READ)
@@ -1080,7 +1158,7 @@ class SpaceActor:
         )
 
     def get_group_chat_permissions(
-        self, group_chat: "GroupChat"
+        self, group_chat: InsightResource
     ) -> list[ResourcePermission]:
         return self._get_resource_permissions(
             can_edit=self.can_edit_group_chats(),

--- a/backend/src/eneo/spaces/api/space_assembler.py
+++ b/backend/src/eneo/spaces/api/space_assembler.py
@@ -1,4 +1,6 @@
+from datetime import datetime
 from typing import TYPE_CHECKING, cast
+from uuid import UUID
 
 from eneo.assistants.api.assistant_models import (
     AssistantSparse,
@@ -38,19 +40,24 @@ from eneo.spaces.api.space_models import (
     UpdateSpaceDryRunResponse,
 )
 from eneo.spaces.space import Space
+from eneo.spaces.space_applications_projection import (
+    AppApplicationsProjection,
+    AssistantApplicationsProjection,
+    GroupChatApplicationsProjection,
+    ServiceApplicationsProjection,
+    SpaceApplicationsProjection,
+)
 from eneo.spaces.space_service import SpaceSecurityClassificationImpactAnalysis
 from eneo.transcription_models.presentation import TranscriptionModelPublic
 from eneo.users.user import UserInDB
 from eneo.websites.presentation.website_models import WebsitePublic
 
 if TYPE_CHECKING:
-    from eneo.actors import ActorManager
-    from eneo.apps.apps.app import App
+    from eneo.actors import ActorManager, SpaceActor
     from eneo.assistants.api.assistant_assembler import AssistantAssembler
     from eneo.assistants.assistant import Assistant
     from eneo.completion_models.presentation import CompletionModelAssembler
     from eneo.governance_policy.domain.policy_resolver import EffectiveConfig
-    from eneo.group_chat.domain.entities.group_chat import GroupChat
 
 
 class SpaceAssembler:
@@ -67,22 +74,97 @@ class SpaceAssembler:
         self.completion_model_assembler = completion_model_assembler
         self.actor_manager = actor_manager
 
+    @staticmethod
+    def _required_datetime(value: datetime | None) -> datetime:
+        assert value is not None
+        return value
+
+    @staticmethod
+    def _assistant_user_id(assistant: "Assistant") -> UUID:
+        assert assistant.user is not None
+        return assistant.user.id
+
+    @staticmethod
+    def _applications_projection_from_space(
+        space: Space,
+    ) -> SpaceApplicationsProjection:
+        from eneo.actors.actors.space_actor import SpaceAccessFacts
+
+        return SpaceApplicationsProjection(
+            access=SpaceAccessFacts.from_space(space),
+            assistants=tuple(
+                AssistantApplicationsProjection(
+                    id=assistant.id,
+                    created_at=SpaceAssembler._required_datetime(assistant.created_at),
+                    updated_at=SpaceAssembler._required_datetime(assistant.updated_at),
+                    name=assistant.name,
+                    completion_model_kwargs=assistant.completion_model_kwargs,
+                    logging_enabled=assistant.logging_enabled,
+                    user_id=SpaceAssembler._assistant_user_id(assistant),
+                    published=assistant.published,
+                    description=assistant.description,
+                    metadata_json=assistant.metadata_json,
+                    icon_id=assistant.icon_id,
+                    completion_model_id=(
+                        assistant.completion_model.id
+                        if assistant.completion_model is not None
+                        else None
+                    ),
+                    insight_enabled=assistant.insight_enabled,
+                )
+                for assistant in space.assistants
+            ),
+            group_chats=tuple(
+                GroupChatApplicationsProjection(
+                    id=group_chat.id,
+                    created_at=SpaceAssembler._required_datetime(group_chat.created_at),
+                    updated_at=SpaceAssembler._required_datetime(group_chat.updated_at),
+                    name=group_chat.name,
+                    user_id=group_chat.user_id,
+                    published=group_chat.published,
+                    metadata_json=group_chat.metadata_json,
+                    icon_id=group_chat.icon_id,
+                    insight_enabled=group_chat.insight_enabled,
+                )
+                for group_chat in space.group_chats
+            ),
+            apps=tuple(
+                AppApplicationsProjection(
+                    id=app.id,
+                    created_at=SpaceAssembler._required_datetime(app.created_at),
+                    updated_at=SpaceAssembler._required_datetime(app.updated_at),
+                    name=app.name,
+                    description=app.description,
+                    published=app.published,
+                    user_id=app.user_id,
+                    icon_id=app.icon_id,
+                )
+                for app in space.apps
+                if app.id is not None
+            ),
+            services=tuple(
+                ServiceApplicationsProjection(
+                    id=service.id,
+                    created_at=SpaceAssembler._required_datetime(service.created_at),
+                    updated_at=SpaceAssembler._required_datetime(service.updated_at),
+                    name=service.name,
+                    prompt=service.prompt,
+                    completion_model_kwargs=service.completion_model_kwargs,
+                    user_id=service.user_id,
+                )
+                for service in space.services
+            ),
+        )
+
+    def from_applications_projection(
+        self, projection: SpaceApplicationsProjection
+    ) -> Applications:
+        applications = self._get_applications_model(projection)
+        self._apply_api_key_applications_caps(applications)
+        return applications
+
     def _set_permissions_on_resources(self, space: Space) -> None:
         actor = self.actor_manager.get_space_actor_from_space(space=space)
-
-        for assistant in space.assistants:
-            assistant.permissions = actor.get_assistant_permissions(assistant=assistant)
-
-        for group_chat in space.group_chats or []:
-            group_chat.permissions = actor.get_group_chat_permissions(
-                group_chat=group_chat
-            )
-
-        for app in space.apps:
-            app.permissions = actor.get_app_permissions()  # type: ignore[attr-defined]
-
-        for service in space.services:
-            service.permissions = actor.get_service_permissions()
 
         for collection in space.collections:
             collection.permissions = actor.get_collection_permissions()
@@ -150,6 +232,30 @@ class SpaceAssembler:
 
         cap = self._cap_permissions
 
+        self._apply_api_key_applications_caps(applications)
+
+        knowledge.groups.permissions = cap(
+            knowledge.groups.permissions, rp.knowledge.value
+        )
+        knowledge.websites.permissions = cap(
+            knowledge.websites.permissions, rp.knowledge.value
+        )
+        knowledge.integration_knowledge_list.permissions = cap(
+            knowledge.integration_knowledge_list.permissions, rp.knowledge.value
+        )
+
+        for collection in knowledge.groups.items:
+            if hasattr(collection, "permissions"):
+                collection.permissions = cap(collection.permissions, rp.knowledge.value)
+        for website in knowledge.websites.items:
+            if hasattr(website, "permissions"):
+                website.permissions = cap(website.permissions, rp.knowledge.value)
+
+    def _apply_api_key_applications_caps(self, applications: Applications) -> None:
+        rp = self._get_api_key_resource_permissions()
+        if rp is None:
+            return
+        cap = self._cap_permissions
         applications.assistants.permissions = cap(
             applications.assistants.permissions, rp.assistants.value
         )
@@ -162,18 +268,6 @@ class SpaceAssembler:
         applications.services.permissions = cap(
             applications.services.permissions, rp.apps.value
         )
-
-        knowledge.groups.permissions = cap(
-            knowledge.groups.permissions, rp.knowledge.value
-        )
-        knowledge.websites.permissions = cap(
-            knowledge.websites.permissions, rp.knowledge.value
-        )
-        knowledge.integration_knowledge_list.permissions = cap(
-            knowledge.integration_knowledge_list.permissions, rp.knowledge.value
-        )
-
-        # Also cap per-item permissions
         for assistant in applications.assistants.items:
             assistant.permissions = cap(assistant.permissions, rp.assistants.value)
         for group_chat in applications.group_chats.items:
@@ -182,13 +276,6 @@ class SpaceAssembler:
             app.permissions = cap(app.permissions, rp.apps.value)
         for service in applications.services.items:
             service.permissions = cap(service.permissions, rp.apps.value)
-
-        for collection in knowledge.groups.items:
-            if hasattr(collection, "permissions"):
-                collection.permissions = cap(collection.permissions, rp.knowledge.value)
-        for website in knowledge.websites.items:
-            if hasattr(website, "permissions"):
-                website.permissions = cap(website.permissions, rp.knowledge.value)
 
     def _cap_space_permissions(
         self, permissions: list[ResourcePermission]
@@ -201,6 +288,12 @@ class SpaceAssembler:
 
     def _get_assistant_permissions(self, space: Space) -> list[ResourcePermission]:
         actor = self.actor_manager.get_space_actor_from_space(space=space)
+        return self._get_assistant_permissions_from_actor(actor)
+
+    @staticmethod
+    def _get_assistant_permissions_from_actor(
+        actor: "SpaceActor",
+    ) -> list[ResourcePermission]:
         permissions: list[ResourcePermission] = []
 
         if actor.can_read_assistants():
@@ -214,7 +307,12 @@ class SpaceAssembler:
 
     def _get_group_chat_permissions(self, space: Space) -> list[ResourcePermission]:
         actor = self.actor_manager.get_space_actor_from_space(space=space)
+        return self._get_group_chat_permissions_from_actor(actor)
 
+    @staticmethod
+    def _get_group_chat_permissions_from_actor(
+        actor: "SpaceActor",
+    ) -> list[ResourcePermission]:
         permissions: list[ResourcePermission] = []
         if actor.can_read_group_chats():
             permissions.append(ResourcePermission.READ)
@@ -227,6 +325,12 @@ class SpaceAssembler:
 
     def _get_app_permissions(self, space: Space) -> list[ResourcePermission]:
         actor = self.actor_manager.get_space_actor_from_space(space=space)
+        return self._get_app_permissions_from_actor(actor)
+
+    @staticmethod
+    def _get_app_permissions_from_actor(
+        actor: "SpaceActor",
+    ) -> list[ResourcePermission]:
         permissions: list[ResourcePermission] = []
 
         if actor.can_read_apps():
@@ -240,6 +344,12 @@ class SpaceAssembler:
 
     def _get_service_permissions(self, space: Space) -> list[ResourcePermission]:
         actor = self.actor_manager.get_space_actor_from_space(space=space)
+        return self._get_service_permissions_from_actor(actor)
+
+    @staticmethod
+    def _get_service_permissions_from_actor(
+        actor: "SpaceActor",
+    ) -> list[ResourcePermission]:
         permissions: list[ResourcePermission] = []
 
         if actor.can_read_services():
@@ -381,8 +491,11 @@ class SpaceAssembler:
             member for member in space.members.values() if member.id != self.user.id
         ]
 
-    def _get_assistant_model(self, assistant: "Assistant") -> AssistantSparse:
-        assert assistant.user is not None
+    def _get_assistant_model(
+        self,
+        assistant: AssistantApplicationsProjection,
+        permissions: list[ResourcePermission],
+    ) -> AssistantSparse:
         return AssistantSparse(
             created_at=assistant.created_at,
             updated_at=assistant.updated_at,
@@ -390,21 +503,21 @@ class SpaceAssembler:
             name=assistant.name,
             completion_model_kwargs=assistant.completion_model_kwargs,
             logging_enabled=assistant.logging_enabled,
-            user_id=assistant.user.id,
+            user_id=assistant.user_id,
             published=assistant.published,
-            permissions=assistant.permissions,
+            permissions=permissions,
             description=assistant.description,
             type=AssistantType.ASSISTANT,
             metadata_json=assistant.metadata_json,
             icon_id=assistant.icon_id,
-            completion_model_id=assistant.completion_model.id
-            if assistant.completion_model
-            else None,
+            completion_model_id=assistant.completion_model_id,
         )
 
-    def _get_group_chat_model(self, group_chat: "GroupChat") -> GroupChatSparse:
-        assert group_chat.created_at is not None
-        assert group_chat.updated_at is not None
+    def _get_group_chat_model(
+        self,
+        group_chat: GroupChatApplicationsProjection,
+        permissions: list[ResourcePermission],
+    ) -> GroupChatSparse:
         return GroupChatSparse(
             created_at=group_chat.created_at,
             updated_at=group_chat.updated_at,
@@ -412,14 +525,17 @@ class SpaceAssembler:
             id=group_chat.id,
             user_id=group_chat.user_id,
             published=group_chat.published,
-            permissions=group_chat.permissions,
+            permissions=permissions,
             type="group-chat",
             metadata_json=group_chat.metadata_json,
             icon_id=group_chat.icon_id,
         )
 
-    def _get_app_model(self, app: "App") -> AppSparse:
-        assert app.id is not None
+    def _get_app_model(
+        self,
+        app: AppApplicationsProjection,
+        permissions: list[ResourcePermission],
+    ) -> AppSparse:
         return AppSparse(
             created_at=app.created_at,
             updated_at=app.updated_at,
@@ -428,55 +544,70 @@ class SpaceAssembler:
             description=app.description,
             published=app.published,
             user_id=app.user_id,
-            permissions=app.permissions,  # type: ignore[attr-defined]
+            permissions=permissions,
             icon_id=app.icon_id,
         )
 
     def _get_applications_model(
-        self, space: Space, only_published: bool = False
+        self,
+        projection: SpaceApplicationsProjection,
+        only_published: bool = False,
     ) -> Applications:
-        actor = self.actor_manager.get_space_actor_from_space(space=space)
+        actor = self.actor_manager.get_space_actor(projection.access)
         return Applications(
             assistants=PaginatedPermissions[AssistantSparse](
                 items=[
-                    self._get_assistant_model(assistant)
-                    for assistant in space.assistants
+                    self._get_assistant_model(
+                        assistant,
+                        actor.get_assistant_permissions(assistant),
+                    )
+                    for assistant in projection.assistants
                     if actor.can_read_assistant(assistant=assistant)
                     and (not only_published or assistant.published)
                 ],
-                permissions=self._get_assistant_permissions(space),
+                permissions=self._get_assistant_permissions_from_actor(actor),
             ),
             group_chats=PaginatedPermissions[GroupChatSparse](
                 items=[
-                    self._get_group_chat_model(group_chat=group_chat)
-                    for group_chat in (space.group_chats or [])
+                    self._get_group_chat_model(
+                        group_chat,
+                        actor.get_group_chat_permissions(group_chat),
+                    )
+                    for group_chat in projection.group_chats
                     if actor.can_read_group_chat(group_chat=group_chat)
                     and (not only_published or group_chat.published)
                 ],
-                permissions=self._get_group_chat_permissions(space=space),
+                permissions=self._get_group_chat_permissions_from_actor(actor),
             ),
             apps=PaginatedPermissions[AppSparse](
                 items=[
-                    self._get_app_model(app)
-                    for app in space.apps
+                    self._get_app_model(app, actor.get_app_permissions())
+                    for app in projection.apps
                     if actor.can_read_app(app=app)
                     and (not only_published or app.published)
                 ],
-                permissions=self._get_app_permissions(space),
+                permissions=self._get_app_permissions_from_actor(actor),
             ),
             services=PaginatedPermissions[ServiceSparse](
                 items=[
-                    self._get_service_model(service)
-                    for service in space.services
+                    self._get_service_model(
+                        service,
+                        actor.get_service_permissions(),
+                    )
+                    for service in projection.services
                     if actor.can_read_services()
                 ]
                 if not only_published
                 else [],
-                permissions=self._get_service_permissions(space),
+                permissions=self._get_service_permissions_from_actor(actor),
             ),
         )
 
-    def _get_service_model(self, service: Service) -> ServiceSparse:
+    def _get_service_model(
+        self,
+        service: ServiceApplicationsProjection,
+        permissions: list[ResourcePermission],
+    ) -> ServiceSparse:
         return ServiceSparse(
             created_at=service.created_at,
             updated_at=service.updated_at,
@@ -485,7 +616,7 @@ class SpaceAssembler:
             prompt=service.prompt,
             completion_model_kwargs=service.completion_model_kwargs,
             user_id=service.user_id,
-            permissions=service.permissions,
+            permissions=permissions,
         )
 
     def _get_knowledge_model(self, space: Space) -> Knowledge:
@@ -534,7 +665,9 @@ class SpaceAssembler:
     ) -> SpacePublic:
         actor = self.actor_manager.get_space_actor_from_space(space=space)
         self._set_permissions_on_resources(space)
-        applications = self._get_applications_model(space)
+        applications = self._get_applications_model(
+            self._applications_projection_from_space(space)
+        )
         knowledge = self._get_knowledge_model(space)
         self._apply_api_key_resource_caps(applications, knowledge)
         members = PaginatedPermissions[SpaceMember](
@@ -656,7 +789,10 @@ class SpaceAssembler:
                         permissions=self._get_default_assistant_permissions(space),
                     )
                 )
-            applications = self._get_applications_model(space, only_published=True)
+            applications = self._get_applications_model(
+                self._applications_projection_from_space(space),
+                only_published=True,
+            )
             space_sparse.applications = applications
             space_sparse.default_assistant = default_assistant
 
@@ -667,7 +803,8 @@ class SpaceAssembler:
     ) -> SpaceDashboard:
         self._set_permissions_on_resources(space)
         applications = self._get_applications_model(
-            space=space, only_published=only_published
+            self._applications_projection_from_space(space),
+            only_published=only_published,
         )
 
         default_assistant = None

--- a/backend/src/eneo/spaces/api/space_router.py
+++ b/backend/src/eneo/spaces/api/space_router.py
@@ -435,9 +435,8 @@ async def get_space_applications(
     service = container.space_service()
     assembler = container.space_assembler()
 
-    space = await service.get_space(id)
-
-    return assembler.from_space_to_model(space).applications
+    projection = await service.get_applications_projection(id)
+    return assembler.from_applications_projection(projection)
 
 
 @router.post(

--- a/backend/src/eneo/spaces/space_applications_projection.py
+++ b/backend/src/eneo/spaces/space_applications_projection.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from eneo.actors.actors.space_actor import SpaceAccessFacts
+from eneo.ai_models.completion_models.completion_model import ModelKwargs
+
+
+# This response projection validates only fields published by Applications.
+# Omitted aggregate-only state must not force full-domain or file hydration.
+@dataclass(frozen=True, slots=True)
+class AssistantApplicationsProjection:
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+    name: str
+    completion_model_kwargs: ModelKwargs
+    logging_enabled: bool
+    user_id: UUID
+    published: bool
+    description: str | None
+    metadata_json: dict[str, object] | None
+    icon_id: UUID | None
+    completion_model_id: UUID | None
+    insight_enabled: bool
+
+
+@dataclass(frozen=True, slots=True)
+class GroupChatApplicationsProjection:
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+    name: str
+    user_id: UUID
+    published: bool
+    metadata_json: dict[str, object] | None
+    icon_id: UUID | None
+    insight_enabled: bool
+
+
+@dataclass(frozen=True, slots=True)
+class AppApplicationsProjection:
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+    name: str
+    description: str | None
+    published: bool
+    user_id: UUID
+    icon_id: UUID | None
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceApplicationsProjection:
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+    name: str
+    prompt: str
+    completion_model_kwargs: ModelKwargs
+    user_id: UUID
+
+
+@dataclass(frozen=True, slots=True)
+class SpaceApplicationsProjection:
+    access: SpaceAccessFacts
+    assistants: tuple[AssistantApplicationsProjection, ...]
+    group_chats: tuple[GroupChatApplicationsProjection, ...]
+    apps: tuple[AppApplicationsProjection, ...]
+    services: tuple[ServiceApplicationsProjection, ...]

--- a/backend/src/eneo/spaces/space_factory.py
+++ b/backend/src/eneo/spaces/space_factory.py
@@ -4,6 +4,8 @@ from uuid import UUID
 
 from pydantic import ValidationError
 
+from eneo.actors.actors.space_actor import SpaceAccessFacts, SpaceRoleFact
+from eneo.ai_models.completion_models.completion_model import ModelKwargs
 from eneo.apps.apps.app_factory import AppFactory
 from eneo.collections.domain.collection import Collection
 from eneo.database.tables.app_table import Apps
@@ -25,6 +27,13 @@ from eneo.security_classifications.domain.entities.security_classification impor
 from eneo.services.service import Service
 from eneo.spaces.api.space_models import SpaceGroupMember, SpaceMember, SpaceRoleValue
 from eneo.spaces.space import Space
+from eneo.spaces.space_applications_projection import (
+    AppApplicationsProjection,
+    AssistantApplicationsProjection,
+    GroupChatApplicationsProjection,
+    ServiceApplicationsProjection,
+    SpaceApplicationsProjection,
+)
 from eneo.user_groups.user_group import UserGroupState
 from eneo.users.user import UserInDBBase, UserSparse
 from eneo.websites.domain.website import Website
@@ -134,6 +143,146 @@ class SpaceFactory:
             collections=[],
             members={},
             group_members={},
+        )
+
+    def create_applications_projection(
+        self,
+        *,
+        space_in_db: Spaces,
+        member_roles: Mapping[UUID, str],
+        group_member_roles: Mapping[UUID, str],
+        assistants_in_db: Sequence[Assistants],
+        group_chats_in_db: Sequence[GroupChatsTable],
+        apps_in_db: Sequence[Apps],
+        services_in_db: Sequence[Services],
+        completion_models: Sequence["CompletionModel"],
+    ) -> SpaceApplicationsProjection:
+        completion_models_by_id = {model.id: model for model in completion_models}
+
+        def _assistant_projection(
+            assistant: Assistants,
+        ) -> AssistantApplicationsProjection:
+            kwargs = (
+                ModelKwargs()
+                if assistant.completion_model_kwargs is None
+                else ModelKwargs.model_validate(assistant.completion_model_kwargs)
+            )
+            completion_model = (
+                completion_models_by_id.get(assistant.completion_model_id)
+                if assistant.completion_model_id is not None
+                else None
+            )
+            if completion_model is not None:
+                kwargs = kwargs.filter_unsupported(
+                    completion_model.get_supported_model_kwargs()
+                )
+            return AssistantApplicationsProjection(
+                id=assistant.id,
+                created_at=assistant.created_at,
+                updated_at=assistant.updated_at,
+                name=assistant.name,
+                completion_model_kwargs=kwargs,
+                logging_enabled=assistant.logging_enabled,
+                user_id=assistant.user_id,
+                published=assistant.published,
+                description=assistant.description,
+                metadata_json=assistant.metadata_json,
+                icon_id=assistant.icon_id,
+                completion_model_id=(
+                    completion_model.id if completion_model is not None else None
+                ),
+                insight_enabled=assistant.insight_enabled,
+            )
+
+        all_assistants = _build_or_skip(
+            assistants_in_db,
+            item_kind="assistant_applications_projection",
+            build_fn=_assistant_projection,
+        )
+        default_assistant_row = next(
+            (assistant for assistant in assistants_in_db if assistant.is_default),
+            None,
+        )
+        assistants = tuple(
+            assistant
+            for assistant in all_assistants
+            if default_assistant_row is None or assistant.id != default_assistant_row.id
+        )
+
+        def _service_projection(service: Services) -> ServiceApplicationsProjection:
+            kwargs = (
+                ModelKwargs()
+                if service.completion_model_kwargs is None
+                else ModelKwargs.model_validate(service.completion_model_kwargs)
+            )
+            return ServiceApplicationsProjection(
+                id=service.id,
+                created_at=service.created_at,
+                updated_at=service.updated_at,
+                name=service.name,
+                prompt=service.prompt,
+                completion_model_kwargs=kwargs,
+                user_id=service.user_id,
+            )
+
+        services = tuple(
+            _build_or_skip(
+                services_in_db,
+                item_kind="service_applications_projection",
+                build_fn=_service_projection,
+            )
+        )
+        apps = tuple(
+            AppApplicationsProjection(
+                id=app.id,
+                created_at=app.created_at,
+                updated_at=app.updated_at,
+                name=app.name,
+                description=app.description,
+                published=app.published,
+                user_id=app.user_id,
+                icon_id=app.icon_id,
+            )
+            for app in apps_in_db
+        )
+        return SpaceApplicationsProjection(
+            access=SpaceAccessFacts(
+                id=space_in_db.id,
+                user_id=space_in_db.user_id,
+                tenant_space_id=space_in_db.tenant_space_id,
+                members={
+                    user_id: SpaceRoleFact(id=user_id, role=role)
+                    for user_id, role in member_roles.items()
+                },
+                group_members={
+                    group_id: SpaceRoleFact(id=group_id, role=role)
+                    for group_id, role in group_member_roles.items()
+                },
+                default_assistant_id=(
+                    default_assistant_row.id
+                    if default_assistant_row is not None
+                    else None
+                ),
+                assistant_ids=frozenset(item.id for item in assistants),
+                app_ids=frozenset(item.id for item in apps),
+            ),
+            assistants=assistants,
+            group_chats=tuple(
+                GroupChatApplicationsProjection(
+                    id=group_chat.id,
+                    created_at=group_chat.created_at,
+                    updated_at=group_chat.updated_at,
+                    name=group_chat.name,
+                    user_id=group_chat.user_id,
+                    published=group_chat.published,
+                    metadata_json=group_chat.metadata_json,
+                    icon_id=group_chat.icon_id,
+                    insight_enabled=group_chat.insight_enabled,
+                )
+                for group_chat in group_chats_in_db
+            ),
+            apps=apps,
+            services=services,
         )
 
     def create_space_from_db(

--- a/backend/src/eneo/spaces/space_repo.py
+++ b/backend/src/eneo/spaces/space_repo.py
@@ -64,6 +64,7 @@ from eneo.database.tables.spaces_table import (
     SpacesUsers,
 )
 from eneo.database.tables.user_groups_table import UserGroups
+from eneo.database.tables.users_table import Users
 from eneo.database.tables.websites_spaces_table import WebsitesSpaces
 from eneo.database.tables.websites_table import CrawlRuns as CrawlRunsTable
 from eneo.database.tables.websites_table import Websites as WebsitesTable
@@ -77,7 +78,9 @@ from eneo.main.exceptions import (
 from eneo.main.logging import get_logger
 from eneo.spaces.api.space_models import SpaceGroupMember, SpaceMember
 from eneo.spaces.space import Space
+from eneo.spaces.space_applications_projection import SpaceApplicationsProjection
 from eneo.spaces.space_factory import SpaceFactory
+from eneo.user_groups.user_group import UserGroupState
 
 logger = get_logger(__name__)
 
@@ -1443,6 +1446,85 @@ class SpaceRepository:
             raise NotFoundException()
 
         return space
+
+    async def get_applications_projection(
+        self, id: UUID
+    ) -> SpaceApplicationsProjection:
+        space_in_db = await self.session.scalar(
+            sa.select(Spaces).where(Spaces.id == id)
+        )
+        if space_in_db is None:
+            raise NotFoundException()
+
+        member_roles = dict(
+            (
+                await self.session.execute(
+                    sa.select(SpacesUsers.user_id, SpacesUsers.role)
+                    .join(Users, Users.id == SpacesUsers.user_id)
+                    .where(SpacesUsers.space_id == id)
+                    .where(Users.deleted_at.is_(None))
+                )
+            )
+            .tuples()
+            .all()
+        )
+        group_member_roles = dict(
+            (
+                await self.session.execute(
+                    sa.select(
+                        SpacesUserGroups.user_group_id,
+                        SpacesUserGroups.role,
+                    )
+                    .join(
+                        UserGroups,
+                        UserGroups.id == SpacesUserGroups.user_group_id,
+                    )
+                    .where(SpacesUserGroups.space_id == id)
+                    .where(
+                        sa.or_(
+                            UserGroups.state.is_(None),
+                            UserGroups.state != UserGroupState.DELETED.value,
+                        )
+                    )
+                )
+            )
+            .tuples()
+            .all()
+        )
+        assistants = (
+            await self.session.scalars(
+                sa.select(Assistants)
+                .where(Assistants.space_id == id)
+                .order_by(Assistants.created_at)
+            )
+        ).all()
+        group_chats = (
+            await self.session.scalars(
+                sa.select(GroupChatsTable).where(GroupChatsTable.space_id == id)
+            )
+        ).all()
+        apps = (
+            await self.session.scalars(
+                sa.select(Apps).where(Apps.space_id == id).order_by(Apps.created_at)
+            )
+        ).all()
+        services = (
+            await self.session.scalars(
+                sa.select(Services).where(Services.space_id == id)
+            )
+        ).all()
+        completion_models = await self.completion_model_repo.all(with_deprecated=True)
+
+        return self.factory.create_applications_projection(
+            space_in_db=space_in_db,
+            member_roles=member_roles,
+            group_member_roles=group_member_roles,
+            assistants_in_db=assistants,
+            group_chats_in_db=group_chats,
+            apps_in_db=apps,
+            services_in_db=services,
+            completion_models=completion_models,
+        )
 
     async def update(
         self, space: Space, mcp_tool_settings: list[tuple[UUID, bool]] | None = None

--- a/backend/src/eneo/spaces/space_service.py
+++ b/backend/src/eneo/spaces/space_service.py
@@ -29,6 +29,7 @@ from eneo.main.models import NOT_PROVIDED, ModelId, NotProvided, is_provided
 from eneo.mcp_servers.domain.entities.mcp_server import MCPServer
 from eneo.spaces.api.space_models import SpaceGroupMember, SpaceMember, SpaceRoleValue
 from eneo.spaces.space import Space
+from eneo.spaces.space_applications_projection import SpaceApplicationsProjection
 from eneo.spaces.space_factory import SpaceFactory
 from eneo.spaces.space_repo import SpaceRepository
 from eneo.transcription_models.application.transcription_model_crud_service import (
@@ -244,6 +245,23 @@ class SpaceService:
             )
 
         return space
+
+    async def get_applications_projection(
+        self, id: UUID
+    ) -> SpaceApplicationsProjection:
+        projection = await self.repo.get_applications_projection(id)
+        actor = self.actor_manager.get_space_actor(projection.access)
+        if not actor.can_read_space():
+            raise UnauthorizedException(
+                "You do not have permission to read this space.",
+                code="forbidden_action",
+                context={
+                    "resource_type": "space",
+                    "action": "read",
+                    "auth_layer": "domain_policy",
+                },
+            )
+        return projection
 
     async def update_space(
         self,

--- a/backend/tests/integration/object_content/test_file_aggregate_hydration.py
+++ b/backend/tests/integration/object_content/test_file_aggregate_hydration.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import re
 from uuid import UUID, uuid4
 
 import pytest
+import sqlalchemy as sa
+
+from eneo.database.tables.group_chats_table import GroupChatsTable
+from eneo.database.tables.spaces_table import SpacesCompletionModels
+from eneo.files.file_content_loader import FileContentLoader
 
 
 async def _create_space(client, headers: dict[str, str]) -> str:
@@ -106,3 +112,190 @@ async def test_persisted_aggregate_files_reload_through_object_content(
     assert reloaded_session.questions[0].files[0].text == "durable policy"
     assert reloaded_question is not None
     assert reloaded_question.files[0].text == "durable policy"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_space_applications_view_does_not_read_attachment_content(
+    client,
+    db_container,
+    admin_user_api_key,
+    admin_user,
+    completion_model_factory,
+    service_factory,
+    transcription_model_factory,
+    monkeypatch,
+) -> None:
+    headers = {"X-API-Key": admin_user_api_key.key}
+    space_id = await _create_space(client, headers)
+
+    audio_upload = await client.post(
+        "/api/v1/files/",
+        files={"upload_file": ("meeting.mp3", b"audio", "audio/mpeg")},
+        headers=headers,
+    )
+    assert audio_upload.status_code == 200, audio_upload.text
+    audio_file_id = UUID(audio_upload.json()["id"])
+
+    async with db_container() as container:
+        saved = await container.file_service().save_transcription(
+            audio_file_id,
+            "persisted sparse transcript",
+        )
+        assert saved == "persisted sparse transcript"
+
+    reloaded_file = await client.get(f"/api/v1/files/{audio_file_id}/", headers=headers)
+    assert reloaded_file.status_code == 200, reloaded_file.text
+    assert reloaded_file.json()["transcription"] == "persisted sparse transcript"
+
+    attachment_upload = await client.post(
+        "/api/v1/files/",
+        files={"upload_file": ("policy.txt", b"durable policy", "text/plain")},
+        headers=headers,
+    )
+    assert attachment_upload.status_code == 200, attachment_upload.text
+    attachment = [{"id": attachment_upload.json()["id"]}]
+
+    assistant = await client.post(
+        "/api/v1/assistants/",
+        json={"name": "Sparse assistant", "space_id": space_id},
+        headers=headers,
+    )
+    assert assistant.status_code == 200, assistant.text
+    assistant_id = assistant.json()["id"]
+    updated_assistant = await client.post(
+        f"/api/v1/assistants/{assistant_id}/",
+        json={"attachments": attachment},
+        headers=headers,
+    )
+    assert updated_assistant.status_code == 200, updated_assistant.text
+
+    async with db_container() as container:
+        await transcription_model_factory(
+            container.session(),
+            "sparse-fixture-whisper",
+            is_default=True,
+        )
+
+    app = await client.post(
+        f"/api/v1/spaces/{space_id}/applications/apps/",
+        json={"name": "Sparse app"},
+        headers=headers,
+    )
+    assert app.status_code == 201, app.text
+    app_id = app.json()["id"]
+    updated_app = await client.patch(
+        f"/api/v1/apps/{app_id}/",
+        json={"attachments": attachment},
+        headers=headers,
+    )
+    assert updated_app.status_code == 200, updated_app.text
+
+    async with db_container() as container:
+        session = container.session()
+        completion_model = await completion_model_factory(
+            session,
+            f"sparse-completion-{uuid4().hex[:8]}",
+            is_default=True,
+        )
+        session.add(
+            SpacesCompletionModels(
+                space_id=UUID(space_id),
+                completion_model_id=completion_model.id,
+            )
+        )
+        for number in range(2):
+            session.add(
+                GroupChatsTable(
+                    name=f"Sparse group chat {number}",
+                    space_id=UUID(space_id),
+                    user_id=admin_user.id,
+                )
+            )
+            await service_factory(
+                session,
+                f"Sparse service {number}",
+                completion_model.id,
+                space_id=UUID(space_id),
+            )
+        await session.flush()
+
+    async with db_container() as container:
+        session = container.session()
+        assert session.bind is not None
+        sync_engine = session.bind.sync_engine
+
+    byte_loads = 0
+    original_load_attachment_groups = FileContentLoader.load_attachment_groups
+
+    async def count_attachment_byte_loads(self, groups):
+        nonlocal byte_loads
+        byte_loads += 1
+        return await original_load_attachment_groups(self, groups)
+
+    monkeypatch.setattr(
+        FileContentLoader,
+        "load_attachment_groups",
+        count_attachment_byte_loads,
+    )
+
+    attachment_queries: list[str] = []
+    matched_attachment_tables: set[str] = set()
+    attachment_tables = (
+        "files",
+        "assistants_files",
+        "apps_files",
+        "file_content_references",
+        "object_contents",
+        "inline_content_payloads",
+        "object_store_objects",
+    )
+
+    def capture_attachment_query(
+        _connection,
+        _cursor,
+        statement,
+        _parameters,
+        _context,
+        _executemany,
+    ) -> None:
+        normalized = statement.lower()
+        matched = {
+            table
+            for table in attachment_tables
+            if re.search(rf"\b{re.escape(table)}\b", normalized)
+        }
+        if matched:
+            matched_attachment_tables.update(matched)
+            attachment_queries.append(statement)
+
+    sa.event.listen(sync_engine, "before_cursor_execute", capture_attachment_query)
+    try:
+        full_space = await client.get(
+            f"/api/v1/spaces/{space_id}/",
+            headers=headers,
+        )
+        assert full_space.status_code == 200, full_space.text
+        expected_applications = full_space.json()["applications"]
+        assert byte_loads > 0
+        assert attachment_queries
+        assert "files" in matched_attachment_tables
+        assert len(expected_applications["group_chats"]["items"]) == 2
+
+        byte_loads = 0
+        attachment_queries.clear()
+        matched_attachment_tables.clear()
+        applications = await client.get(
+            f"/api/v1/spaces/{space_id}/applications/",
+            headers=headers,
+        )
+    finally:
+        sa.event.remove(
+            sync_engine,
+            "before_cursor_execute",
+            capture_attachment_query,
+        )
+
+    assert applications.status_code == 200, applications.text
+    assert applications.json() == expected_applications
+    assert (byte_loads, attachment_queries, matched_attachment_tables) == (0, [], set())

--- a/backend/tests/unittests/actors/test_space_actor.py
+++ b/backend/tests/unittests/actors/test_space_actor.py
@@ -1,8 +1,18 @@
+from collections.abc import MutableMapping
+from typing import cast
 from unittest.mock import MagicMock
+from uuid import UUID, uuid4
 
 import pytest
 
-from eneo.actors import SpaceAction, SpaceActor, SpaceResourceType
+from eneo.actors import (
+    ActorFactory,
+    ActorManager,
+    SpaceAction,
+    SpaceActor,
+    SpaceResourceType,
+)
+from eneo.actors.actors.space_actor import SpaceAccessFacts, SpaceRoleFact
 from eneo.modules.module import Modules
 from eneo.roles.permissions import Permission
 
@@ -78,6 +88,119 @@ class MockPermission:
     SERVICES = "services"
 
 
+def _actor(user, space: MockSpace) -> SpaceActor:
+    facts = SpaceAccessFacts(
+        id=space.id,
+        user_id=space.user_id,
+        tenant_space_id=space.tenant_space_id,
+        members={
+            member.id: SpaceRoleFact(id=member.id, role=member.role)
+            for member in space.members.values()
+        },
+        group_members={
+            member.id: SpaceRoleFact(id=member.id, role=member.role)
+            for member in space.group_members.values()
+        },
+        default_assistant_id=None,
+        assistant_ids=frozenset(
+            assistant.id for assistant in getattr(space, "assistants", ())
+        ),
+        app_ids=frozenset(app.id for app in getattr(space, "apps", ())),
+    )
+    return SpaceActor(user, facts)
+
+
+def test_space_access_facts_seal_member_snapshots() -> None:
+    member_id = uuid4()
+    source_members = {member_id: SpaceRoleFact(id=member_id, role=MockSpaceRole.VIEWER)}
+    facts = SpaceAccessFacts(
+        id=uuid4(),
+        user_id=None,
+        tenant_space_id=uuid4(),
+        members=source_members,
+        group_members={},
+        default_assistant_id=None,
+        assistant_ids=frozenset(),
+        app_ids=frozenset(),
+    )
+
+    source_members[member_id] = SpaceRoleFact(
+        id=member_id,
+        role=MockSpaceRole.ADMIN,
+    )
+
+    assert facts.members[member_id].role == MockSpaceRole.VIEWER
+    mutable_view = cast(MutableMapping[UUID, SpaceRoleFact], facts.members)
+    with pytest.raises(TypeError):
+        mutable_view[member_id] = SpaceRoleFact(
+            id=member_id,
+            role=MockSpaceRole.ADMIN,
+        )
+
+
+def test_space_access_facts_from_space_preserves_authorization_inputs() -> None:
+    space_id = uuid4()
+    user_id = uuid4()
+    tenant_space_id = uuid4()
+    member_id = uuid4()
+    group_id = uuid4()
+    default_assistant_id = uuid4()
+    assistant_id = uuid4()
+    app_id = uuid4()
+    space = MagicMock(
+        id=space_id,
+        user_id=user_id,
+        tenant_space_id=tenant_space_id,
+        members={
+            member_id: MagicMock(id=member_id, role=MockSpaceRole.ADMIN),
+        },
+        group_members={
+            group_id: MagicMock(id=group_id, role=MockSpaceRole.EDITOR),
+        },
+        default_assistant=MagicMock(id=default_assistant_id),
+        assistants=[
+            MagicMock(id=default_assistant_id),
+            MagicMock(id=assistant_id),
+        ],
+        apps=[MagicMock(id=app_id), MagicMock(id=None)],
+    )
+
+    facts = SpaceAccessFacts.from_space(space)
+
+    assert facts.id == space_id
+    assert facts.user_id == user_id
+    assert facts.tenant_space_id == tenant_space_id
+    assert facts.members[member_id].role == MockSpaceRole.ADMIN
+    assert facts.group_members[group_id].role == MockSpaceRole.EDITOR
+    assert facts.default_assistant_id == default_assistant_id
+    assert facts.assistant_ids == frozenset({default_assistant_id, assistant_id})
+    assert facts.app_ids == frozenset({app_id})
+
+
+def test_actor_manager_adapts_full_space_to_canonical_access_facts() -> None:
+    user = MockUser(id=uuid4())
+    space = MagicMock(
+        id=uuid4(),
+        user_id=user.id,
+        tenant_space_id=uuid4(),
+        members={},
+        group_members={},
+        default_assistant=None,
+        assistants=[],
+        apps=[],
+    )
+    manager = ActorManager(user, ActorFactory())
+
+    actor_from_space = manager.get_space_actor_from_space(space)
+    direct_facts = SpaceAccessFacts.from_space(space)
+    actor_from_facts = manager.get_space_actor(direct_facts)
+
+    assert actor_from_space.space == direct_facts
+    assert actor_from_facts.space is direct_facts
+    assert actor_from_space.can_read_space()
+    assert actor_from_facts.can_read_space()
+
+
 @pytest.fixture()
 def owner_user():
     return MockUser(id=1)
@@ -125,7 +248,7 @@ def shared_space(organization_space, viewer_user, editor_user, admin_user):
 
 
 def test_owner_can_read_personal_space(owner_user: MockUser, personal_space: MockSpace):
-    actor = SpaceActor(owner_user, personal_space)
+    actor = _actor(owner_user, personal_space)
     assert actor.can_perform_action(
         action=SpaceAction.READ, resource_type=SpaceResourceType.SPACE
     )
@@ -134,7 +257,7 @@ def test_owner_can_read_personal_space(owner_user: MockUser, personal_space: Moc
 def test_owner_cannot_edit_personal_space(
     owner_user: MockUser, personal_space: MockSpace
 ):
-    actor = SpaceActor(owner_user, personal_space)
+    actor = _actor(owner_user, personal_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.EDIT, resource_type=SpaceResourceType.SPACE
@@ -144,7 +267,7 @@ def test_owner_cannot_edit_personal_space(
 
 
 def test_admin_can_edit_shared_space(admin_user: MockUser, shared_space: MockSpace):
-    actor = SpaceActor(admin_user, shared_space)
+    actor = _actor(admin_user, shared_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.EDIT, resource_type=SpaceResourceType.SPACE
@@ -156,7 +279,7 @@ def test_admin_can_edit_shared_space(admin_user: MockUser, shared_space: MockSpa
 def test_editor_cannot_edit_shared_space(
     editor_user: MockUser, shared_space: MockSpace
 ):
-    actor = SpaceActor(editor_user, shared_space)
+    actor = _actor(editor_user, shared_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.EDIT, resource_type=SpaceResourceType.SPACE
@@ -168,7 +291,7 @@ def test_editor_cannot_edit_shared_space(
 def test_viewer_cannot_edit_shared_space(
     editor_user: MockUser, shared_space: MockSpace
 ):
-    actor = SpaceActor(editor_user, shared_space)
+    actor = _actor(editor_user, shared_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.EDIT, resource_type=SpaceResourceType.SPACE
@@ -181,7 +304,7 @@ def test_owner_can_not_create_services_without_services_permission(
     owner_user: MockUser, personal_space: MockSpace
 ):
     owner_user.modules.append(Modules.ENEO_APPLICATIONS)
-    actor = SpaceActor(owner_user, personal_space)
+    actor = _actor(owner_user, personal_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.CREATE, resource_type=SpaceResourceType.SERVICE
@@ -190,7 +313,7 @@ def test_owner_can_not_create_services_without_services_permission(
     )
 
     owner_user.permissions.add(MockPermission.SERVICES)
-    actor = SpaceActor(owner_user, personal_space)
+    actor = _actor(owner_user, personal_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.CREATE, resource_type=SpaceResourceType.SERVICE
@@ -203,7 +326,7 @@ def test_owner_can_not_create_services_without_applications_modules(
     owner_user: MockUser, personal_space: MockSpace
 ):
     owner_user.permissions.add(MockPermission.SERVICES)
-    actor = SpaceActor(owner_user, personal_space)
+    actor = _actor(owner_user, personal_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.CREATE, resource_type=SpaceResourceType.SERVICE
@@ -215,7 +338,7 @@ def test_owner_can_not_create_services_without_applications_modules(
 def test_no_one_can_publish_apps_in_personal_space(
     owner_user: MockUser, personal_space: MockSpace
 ):
-    actor = SpaceActor(owner_user, personal_space)
+    actor = _actor(owner_user, personal_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.PUBLISH, resource_type=SpaceResourceType.APP
@@ -228,7 +351,7 @@ def test_no_one_can_publish_services_in_personal_space(
     owner_user: MockUser, personal_space: MockSpace
 ):
     owner_user.modules.append(Modules.ENEO_APPLICATIONS)
-    actor = SpaceActor(owner_user, personal_space)
+    actor = _actor(owner_user, personal_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.PUBLISH, resource_type=SpaceResourceType.SERVICE
@@ -242,7 +365,7 @@ def test_viewers_can_only_read_published_resources(
 ):
     resource = MagicMock(published=False)
     viewer_user.modules.append(Modules.ENEO_APPLICATIONS)
-    viewer = SpaceActor(viewer_user, shared_space)
+    viewer = _actor(viewer_user, shared_space)
 
     assert (
         viewer.can_perform_action(
@@ -357,7 +480,7 @@ def test_user_can_access_space_via_group_membership(
     group_member_user: MockUser, space_with_group_admin: MockSpace
 ):
     """Test that a user can access a space through group membership."""
-    actor = SpaceActor(group_member_user, space_with_group_admin)
+    actor = _actor(group_member_user, space_with_group_admin)
     assert actor.can_perform_action(
         action=SpaceAction.READ, resource_type=SpaceResourceType.SPACE
     )
@@ -367,7 +490,7 @@ def test_group_admin_can_edit_space(
     group_member_user: MockUser, space_with_group_admin: MockSpace
 ):
     """Test that a user with admin role via group can edit the space."""
-    actor = SpaceActor(group_member_user, space_with_group_admin)
+    actor = _actor(group_member_user, space_with_group_admin)
     assert actor.can_perform_action(
         action=SpaceAction.EDIT, resource_type=SpaceResourceType.SPACE
     )
@@ -377,7 +500,7 @@ def test_group_editor_cannot_edit_space(
     group_member_user: MockUser, space_with_group_editor: MockSpace
 ):
     """Test that a user with editor role via group cannot edit the space."""
-    actor = SpaceActor(group_member_user, space_with_group_editor)
+    actor = _actor(group_member_user, space_with_group_editor)
     assert (
         actor.can_perform_action(
             action=SpaceAction.EDIT, resource_type=SpaceResourceType.SPACE
@@ -390,7 +513,7 @@ def test_group_viewer_can_only_read(
     group_member_user: MockUser, space_with_group_viewer: MockSpace
 ):
     """Test that a user with viewer role via group can only read."""
-    actor = SpaceActor(group_member_user, space_with_group_viewer)
+    actor = _actor(group_member_user, space_with_group_viewer)
 
     # Can read the space
     assert actor.can_perform_action(
@@ -411,7 +534,7 @@ def test_highest_role_is_used_with_multiple_groups(
 ):
     """Test that when a user is in multiple groups, the highest role is used."""
     # User is in groups 100 (viewer), 200 (editor), 300 (admin)
-    actor = SpaceActor(multi_group_user, space_with_multiple_groups)
+    actor = _actor(multi_group_user, space_with_multiple_groups)
 
     # Should have admin privileges (highest role)
     assert actor.can_perform_action(
@@ -435,7 +558,7 @@ def test_direct_membership_overrides_group_membership(organization_space):
         id="space-mixed",
     )
 
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
 
     # Should have admin privileges (highest from group)
     assert actor.can_perform_action(
@@ -448,7 +571,7 @@ def test_user_without_membership_cannot_access(
 ):
     """Test that a user without any membership cannot access the space."""
     # User is only in group 100, but shared_space has no group members
-    actor = SpaceActor(group_member_user, shared_space)
+    actor = _actor(group_member_user, shared_space)
 
     # Should not have any access (user 10 is not a direct member or in any group)
     assert (
@@ -463,7 +586,7 @@ def test_group_admin_can_manage_group_members(
     group_member_user: MockUser, space_with_group_admin: MockSpace
 ):
     """Test that admin via group can manage group members."""
-    actor = SpaceActor(group_member_user, space_with_group_admin)
+    actor = _actor(group_member_user, space_with_group_admin)
 
     assert actor.can_perform_action(
         action=SpaceAction.READ, resource_type=SpaceResourceType.GROUP_MEMBER
@@ -483,7 +606,7 @@ def test_group_editor_cannot_manage_group_members(
     group_member_user: MockUser, space_with_group_editor: MockSpace
 ):
     """Test that editor via group cannot manage group members."""
-    actor = SpaceActor(group_member_user, space_with_group_editor)
+    actor = _actor(group_member_user, space_with_group_editor)
 
     # Editors have no group member permissions
     assert (
@@ -542,7 +665,7 @@ def test_service_key_tenant_scoped_grants_viewer():
     key = MockServiceKey("tenant", None, "read")
     user = MockServiceUser(id=99, active_api_key=key)
     space = MockSpace(user_id=None, personal=False, tenant_space_id="org-1", id="s1")
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert actor.can_read_space()
 
 
@@ -550,7 +673,7 @@ def test_service_key_tenant_scoped_admin_grants_edit():
     key = MockServiceKey("tenant", None, "admin")
     user = MockServiceUser(id=99, active_api_key=key)
     space = MockSpace(user_id=None, personal=False, tenant_space_id="org-1", id="s1")
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert actor.can_edit_space()
 
 
@@ -558,7 +681,7 @@ def test_service_key_space_scoped_matching():
     key = MockServiceKey("space", "s1", "read")
     user = MockServiceUser(id=99, active_api_key=key)
     space = MockSpace(user_id=None, personal=False, tenant_space_id="org-1", id="s1")
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert actor.can_read_space()
 
 
@@ -566,7 +689,7 @@ def test_service_key_space_scoped_non_matching():
     key = MockServiceKey("space", "s1", "read")
     user = MockServiceUser(id=99, active_api_key=key)
     space = MockSpace(user_id=None, personal=False, tenant_space_id="org-1", id="other")
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert not actor.can_read_space()
 
 
@@ -580,7 +703,7 @@ def test_service_key_assistant_scoped_matching():
         id="s1",
         assistants=[MockAssistant("asst-1")],
     )
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert actor.can_read_space()
     assert actor.can_read_assistants()
 
@@ -595,7 +718,7 @@ def test_service_key_assistant_scoped_non_matching():
         id="s1",
         assistants=[MockAssistant("asst-1")],
     )
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert not actor.can_read_space()
 
 
@@ -604,7 +727,7 @@ def test_service_key_tenant_scoped_write_grants_editor():
     key = MockServiceKey("tenant", None, "write")
     user = MockServiceUser(id=99, active_api_key=key)
     space = MockSpace(user_id=None, personal=False, tenant_space_id="org-1", id="s1")
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert actor.can_read_space()
     assert actor.can_read_assistants()
     assert actor.can_create_assistants()
@@ -624,7 +747,7 @@ def test_service_key_app_scoped_matching():
         id="s1",
         apps=[MockApp("app-1")],
     )
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert actor.can_read_space()
     assert actor.can_read_apps()
 
@@ -639,7 +762,7 @@ def test_service_key_app_scoped_non_matching():
         id="s1",
         apps=[MockApp("app-1")],
     )
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert not actor.can_read_space()
 
 
@@ -649,7 +772,7 @@ def test_user_key_does_not_trigger_service_role():
     key = MockServiceKey("tenant", None, "admin", ownership="user")
     user = MockServiceUser(id=99, active_api_key=key)
     space = MockSpace(user_id=None, personal=False, tenant_space_id="org-1", id="s1")
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     # User has no membership → should be denied even though key has admin
     assert not actor.can_read_space()
 
@@ -658,7 +781,7 @@ def test_service_key_no_key_returns_none():
     """Regular user without active_api_key — actor should fall through."""
     user = MockUser(id=99)
     space = MockSpace(user_id=None, personal=False, tenant_space_id="org-1", id="s1")
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     # No membership, no service key → can_read_space should be False
     assert not actor.can_read_space()
 
@@ -681,7 +804,7 @@ def test_user_key_read_caps_admin_member_to_viewer():
         members={admin_user.id: admin_user},
     )
     space.members = {user.id: MockUser(id=user.id, role="admin")}
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert actor.can_read_space()
     assert not actor.can_edit_space()
     assert not actor.can_delete_space()
@@ -701,7 +824,7 @@ def test_user_key_admin_does_not_upgrade_viewer_member():
         id="s1",
         members={user.id: MockUser(id=user.id, role="viewer")},
     )
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert actor.can_read_space()
     assert not actor.can_edit_space()
     assert not actor.can_create_assistants()
@@ -718,7 +841,7 @@ def test_user_key_admin_matches_admin_member():
         id="s1",
         members={user.id: MockUser(id=user.id, role="admin")},
     )
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert actor.can_read_space()
     assert actor.can_edit_space()
     assert actor.can_delete_space()
@@ -737,7 +860,7 @@ def test_user_key_scope_not_covering_space_denies_access():
         id="space-A",
         members={user.id: MockUser(id=user.id, role="admin")},
     )
-    actor = SpaceActor(user, space_a)
+    actor = _actor(user, space_a)
     assert not actor.can_read_space()
 
 
@@ -751,7 +874,7 @@ def test_bearer_user_without_key_keeps_full_membership_role():
         id="s1",
         members={user.id: MockUser(id=user.id, role="admin")},
     )
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert actor.can_read_space()
     assert actor.can_edit_space()
     assert actor.can_delete_space()
@@ -772,7 +895,7 @@ def test_personal_space_owner_with_read_key_can_still_read():
         ],
     )
     space = MockSpace(user_id=42, personal=True, id="personal-s1")
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert actor.can_read_space()
     assert actor.can_read_assistants()
     assert actor.can_read_apps()
@@ -798,7 +921,7 @@ def test_personal_space_owner_with_write_key_can_edit_but_not_delete():
         ],
     )
     space = MockSpace(user_id=42, personal=True, id="personal-s1")
-    actor = SpaceActor(user, space)
+    actor = _actor(user, space)
     assert actor.can_read_assistants()
     assert actor.can_create_assistants()
     assert actor.can_edit_assistants()
@@ -812,7 +935,7 @@ def test_viewer_cannot_create_integration_knowledge_in_shared_space(
     viewer_user: MockUser, shared_space: MockSpace
 ):
     """Viewers should only be able to read integration knowledge, not create."""
-    actor = SpaceActor(viewer_user, shared_space)
+    actor = _actor(viewer_user, shared_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.CREATE,
@@ -825,7 +948,7 @@ def test_viewer_cannot_create_integration_knowledge_in_shared_space(
 def test_viewer_cannot_edit_integration_knowledge_in_shared_space(
     viewer_user: MockUser, shared_space: MockSpace
 ):
-    actor = SpaceActor(viewer_user, shared_space)
+    actor = _actor(viewer_user, shared_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.EDIT,
@@ -838,7 +961,7 @@ def test_viewer_cannot_edit_integration_knowledge_in_shared_space(
 def test_viewer_cannot_delete_integration_knowledge_in_shared_space(
     viewer_user: MockUser, shared_space: MockSpace
 ):
-    actor = SpaceActor(viewer_user, shared_space)
+    actor = _actor(viewer_user, shared_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.DELETE,
@@ -851,7 +974,7 @@ def test_viewer_cannot_delete_integration_knowledge_in_shared_space(
 def test_viewer_can_read_integration_knowledge_in_shared_space(
     viewer_user: MockUser, shared_space: MockSpace
 ):
-    actor = SpaceActor(viewer_user, shared_space)
+    actor = _actor(viewer_user, shared_space)
     assert actor.can_perform_action(
         action=SpaceAction.READ,
         resource_type=SpaceResourceType.INTEGRATION_KNOWLEDGE,
@@ -861,7 +984,7 @@ def test_viewer_can_read_integration_knowledge_in_shared_space(
 def test_editor_can_create_integration_knowledge_in_shared_space(
     editor_user: MockUser, shared_space: MockSpace
 ):
-    actor = SpaceActor(editor_user, shared_space)
+    actor = _actor(editor_user, shared_space)
     assert actor.can_perform_action(
         action=SpaceAction.CREATE,
         resource_type=SpaceResourceType.INTEGRATION_KNOWLEDGE,
@@ -871,7 +994,7 @@ def test_editor_can_create_integration_knowledge_in_shared_space(
 def test_editor_can_delete_integration_knowledge_in_shared_space(
     editor_user: MockUser, shared_space: MockSpace
 ):
-    actor = SpaceActor(editor_user, shared_space)
+    actor = _actor(editor_user, shared_space)
     assert actor.can_perform_action(
         action=SpaceAction.DELETE,
         resource_type=SpaceResourceType.INTEGRATION_KNOWLEDGE,
@@ -881,7 +1004,7 @@ def test_editor_can_delete_integration_knowledge_in_shared_space(
 def test_admin_can_create_integration_knowledge_in_shared_space(
     admin_user: MockUser, shared_space: MockSpace
 ):
-    actor = SpaceActor(admin_user, shared_space)
+    actor = _actor(admin_user, shared_space)
     assert actor.can_perform_action(
         action=SpaceAction.CREATE,
         resource_type=SpaceResourceType.INTEGRATION_KNOWLEDGE,
@@ -891,7 +1014,7 @@ def test_admin_can_create_integration_knowledge_in_shared_space(
 def test_admin_can_delete_integration_knowledge_in_shared_space(
     admin_user: MockUser, shared_space: MockSpace
 ):
-    actor = SpaceActor(admin_user, shared_space)
+    actor = _actor(admin_user, shared_space)
     assert actor.can_perform_action(
         action=SpaceAction.DELETE,
         resource_type=SpaceResourceType.INTEGRATION_KNOWLEDGE,
@@ -905,7 +1028,7 @@ def test_viewer_cannot_create_integration_knowledge_in_org_space(
     viewer_user: MockUser, organization_space: MockSpace
 ):
     organization_space.members = {viewer_user.id: viewer_user}
-    actor = SpaceActor(viewer_user, organization_space)
+    actor = _actor(viewer_user, organization_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.CREATE,
@@ -919,7 +1042,7 @@ def test_viewer_cannot_delete_integration_knowledge_in_org_space(
     viewer_user: MockUser, organization_space: MockSpace
 ):
     organization_space.members = {viewer_user.id: viewer_user}
-    actor = SpaceActor(viewer_user, organization_space)
+    actor = _actor(viewer_user, organization_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.DELETE,
@@ -934,7 +1057,7 @@ def test_viewer_cannot_read_integration_knowledge_in_org_space(
 ):
     """Org spaces only grant permissions to admins, not viewers."""
     organization_space.members = {viewer_user.id: viewer_user}
-    actor = SpaceActor(viewer_user, organization_space)
+    actor = _actor(viewer_user, organization_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.READ,
@@ -948,7 +1071,7 @@ def test_admin_can_read_integration_knowledge_in_org_space(
     admin_user: MockUser, organization_space: MockSpace
 ):
     organization_space.members = {admin_user.id: admin_user}
-    actor = SpaceActor(admin_user, organization_space)
+    actor = _actor(admin_user, organization_space)
     assert actor.can_perform_action(
         action=SpaceAction.READ,
         resource_type=SpaceResourceType.INTEGRATION_KNOWLEDGE,
@@ -959,7 +1082,7 @@ def test_admin_can_create_integration_knowledge_in_org_space(
     admin_user: MockUser, organization_space: MockSpace
 ):
     organization_space.members = {admin_user.id: admin_user}
-    actor = SpaceActor(admin_user, organization_space)
+    actor = _actor(admin_user, organization_space)
     assert actor.can_perform_action(
         action=SpaceAction.CREATE,
         resource_type=SpaceResourceType.INTEGRATION_KNOWLEDGE,
@@ -973,7 +1096,7 @@ def test_group_viewer_cannot_create_integration_knowledge(
     group_member_user: MockUser, space_with_group_viewer: MockSpace
 ):
     """Viewer via group membership should not be able to create integration knowledge."""
-    actor = SpaceActor(group_member_user, space_with_group_viewer)
+    actor = _actor(group_member_user, space_with_group_viewer)
     assert (
         actor.can_perform_action(
             action=SpaceAction.CREATE,
@@ -987,7 +1110,7 @@ def test_group_editor_can_create_integration_knowledge(
     group_member_user: MockUser, space_with_group_editor: MockSpace
 ):
     """Editor via group membership should be able to create integration knowledge."""
-    actor = SpaceActor(group_member_user, space_with_group_editor)
+    actor = _actor(group_member_user, space_with_group_editor)
     assert actor.can_perform_action(
         action=SpaceAction.CREATE,
         resource_type=SpaceResourceType.INTEGRATION_KNOWLEDGE,
@@ -998,7 +1121,7 @@ def test_group_admin_can_create_integration_knowledge(
     group_member_user: MockUser, space_with_group_admin: MockSpace
 ):
     """Admin via group membership should be able to create integration knowledge."""
-    actor = SpaceActor(group_member_user, space_with_group_admin)
+    actor = _actor(group_member_user, space_with_group_admin)
     assert actor.can_perform_action(
         action=SpaceAction.CREATE,
         resource_type=SpaceResourceType.INTEGRATION_KNOWLEDGE,
@@ -1025,7 +1148,7 @@ def test_member_without_shared_spaces_can_read_shared_space(
         permissions=_permissions_without_shared_spaces(),
     )
     shared_space.members = {user.id: user}
-    actor = SpaceActor(user, shared_space)
+    actor = _actor(user, shared_space)
     assert actor.can_perform_action(
         action=SpaceAction.READ, resource_type=SpaceResourceType.SPACE
     )
@@ -1041,7 +1164,7 @@ def test_non_member_without_shared_spaces_has_no_role_on_shared_space(
         role=MockSpaceRole.ADMIN,
         permissions=_permissions_without_shared_spaces(),
     )
-    actor = SpaceActor(user, shared_space)
+    actor = _actor(user, shared_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.READ, resource_type=SpaceResourceType.SPACE
@@ -1061,7 +1184,7 @@ def test_admin_without_shared_spaces_retains_org_space_access(
         permissions=_permissions_without_shared_spaces(),
     )
     organization_space.members = {admin.id: admin}
-    actor = SpaceActor(admin, organization_space)
+    actor = _actor(admin, organization_space)
     assert actor.can_perform_action(
         action=SpaceAction.READ, resource_type=SpaceResourceType.SPACE
     )
@@ -1077,7 +1200,7 @@ def test_viewer_without_shared_spaces_has_no_org_space_access(
         permissions=_permissions_without_shared_spaces(),
     )
     organization_space.members = {viewer.id: viewer}
-    actor = SpaceActor(viewer, organization_space)
+    actor = _actor(viewer, organization_space)
     assert (
         actor.can_perform_action(
             action=SpaceAction.READ, resource_type=SpaceResourceType.SPACE
@@ -1106,7 +1229,7 @@ def test_editor_without_websites_cannot_create_website_in_shared_space(
         permissions=_permissions_without_websites(),
     )
     shared_space.members = {user.id: user}
-    actor = SpaceActor(user, shared_space)
+    actor = _actor(user, shared_space)
     assert actor.can_create_websites() is False
 
 
@@ -1119,7 +1242,7 @@ def test_admin_without_websites_cannot_create_website_in_shared_space(
         permissions=_permissions_without_websites(),
     )
     shared_space.members = {user.id: user}
-    actor = SpaceActor(user, shared_space)
+    actor = _actor(user, shared_space)
     assert actor.can_create_websites() is False
     assert actor.can_edit_websites() is False
     assert actor.can_delete_websites() is False
@@ -1136,7 +1259,7 @@ def test_editor_without_websites_can_still_read_websites_in_shared_space(
         permissions=_permissions_without_websites(),
     )
     shared_space.members = {user.id: user}
-    actor = SpaceActor(user, shared_space)
+    actor = _actor(user, shared_space)
     assert actor.can_read_websites() is True
 
 
@@ -1151,7 +1274,7 @@ def test_editor_with_websites_can_create_website_in_shared_space(
         permissions=ALL_PERMISSIONS,
     )
     shared_space.members = {user.id: user}
-    actor = SpaceActor(user, shared_space)
+    actor = _actor(user, shared_space)
     assert actor.can_create_websites() is True
 
 
@@ -1161,7 +1284,7 @@ def test_owner_without_websites_cannot_create_website_in_personal_space(
     """The same tenant gate also covers personal spaces."""
     owner = MockUser(id=54, permissions=_permissions_without_websites())
     personal_space.user_id = owner.id
-    actor = SpaceActor(owner, personal_space)
+    actor = _actor(owner, personal_space)
     assert actor.can_create_websites() is False
 
 
@@ -1176,7 +1299,7 @@ def test_owner_cannot_read_personal_default_assistant_without_personal_chat(
 ):
     owner = MockUser(id=60, permissions={Permission.ASSISTANTS})
     personal_space.user_id = owner.id
-    actor = SpaceActor(owner, personal_space)
+    actor = _actor(owner, personal_space)
     assert actor.can_read_default_assistant() is False
     assert actor.can_edit_default_assistant() is False
 
@@ -1186,7 +1309,7 @@ def test_owner_can_read_personal_default_assistant_with_personal_chat(
 ):
     owner = MockUser(id=61, permissions={Permission.PERSONAL_CHAT})
     personal_space.user_id = owner.id
-    actor = SpaceActor(owner, personal_space)
+    actor = _actor(owner, personal_space)
     assert actor.can_read_default_assistant() is True
     assert actor.can_edit_default_assistant() is True
 
@@ -1195,7 +1318,7 @@ def test_personal_chat_is_decoupled_from_assistants(personal_space: MockSpace):
     """PERSONAL_CHAT alone unlocks the chat; ASSISTANTS is not required."""
     owner = MockUser(id=62, permissions={Permission.PERSONAL_CHAT})
     personal_space.user_id = owner.id
-    actor = SpaceActor(owner, personal_space)
+    actor = _actor(owner, personal_space)
     assert actor.can_read_default_assistant() is True
     assert actor.can_read_assistants() is False
 
@@ -1206,7 +1329,7 @@ def test_assistants_permission_does_not_grant_personal_chat(
     """ASSISTANTS manages assistants but does not unlock the personal chat."""
     owner = MockUser(id=63, permissions={Permission.ASSISTANTS})
     personal_space.user_id = owner.id
-    actor = SpaceActor(owner, personal_space)
+    actor = _actor(owner, personal_space)
     assert actor.can_read_assistants() is True
     assert actor.can_read_default_assistant() is False
 
@@ -1219,7 +1342,7 @@ def test_personal_chat_does_not_gate_shared_space_default_assistant(
     of the PERSONAL_CHAT permission."""
     member = MockUser(id=64, role=MockSpaceRole.EDITOR, permissions=set())
     shared_space.members = {member.id: member}
-    actor = SpaceActor(member, shared_space)
+    actor = _actor(member, shared_space)
     assert actor.can_read_default_assistant() is True
 
 
@@ -1318,7 +1441,7 @@ def test_skill_actions_follow_space_role(
             members={user.id: user},
         )
 
-    assert _skill_actions(SpaceActor(user, space)) == expected
+    assert _skill_actions(_actor(user, space)) == expected
 
 
 @pytest.mark.parametrize(
@@ -1348,4 +1471,4 @@ def test_skill_actions_require_tenant_skill_permission(
             members={user.id: user},
         )
 
-    assert _skill_actions(SpaceActor(user, space)) == _NO_SKILL_ACTIONS
+    assert _skill_actions(_actor(user, space)) == _NO_SKILL_ACTIONS

--- a/backend/tests/unittests/spaces/api/test_space_assembler.py
+++ b/backend/tests/unittests/spaces/api/test_space_assembler.py
@@ -1,8 +1,10 @@
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
 
+from eneo.actors.actors.space_actor import SpaceAccessFacts
 from eneo.ai_models.completion_models.completion_model import ModelKwargs
 from eneo.assistants.api.assistant_models import AssistantType, DefaultAssistant
 from eneo.files.file_models import FileRestrictions, Limit
@@ -11,6 +13,10 @@ from eneo.questions.question import UseTools
 from eneo.spaces.api.space_assembler import SpaceAssembler
 from eneo.spaces.api.space_models import SpaceMember, SpaceRoleValue
 from eneo.spaces.space import Space
+from eneo.spaces.space_applications_projection import (
+    AssistantApplicationsProjection,
+    SpaceApplicationsProjection,
+)
 from tests.fixtures import (
     TEST_EMBEDDING_MODEL,
     TEST_MODEL_CHATGPT,
@@ -190,3 +196,55 @@ def test_applications_included_in_space_sparse(
     )
 
     assert space_sparse.applications != None
+
+
+def test_from_applications_projection_maps_authorized_sparse_items(
+    space_assembler: SpaceAssembler,
+):
+    assistant_id = uuid4()
+    now = datetime.now(UTC)
+    projection = SpaceApplicationsProjection(
+        access=SpaceAccessFacts(
+            id=uuid4(),
+            user_id=None,
+            tenant_space_id=uuid4(),
+            members={},
+            group_members={},
+            default_assistant_id=None,
+            assistant_ids=frozenset({assistant_id}),
+            app_ids=frozenset(),
+        ),
+        assistants=(
+            AssistantApplicationsProjection(
+                id=assistant_id,
+                created_at=now,
+                updated_at=now,
+                name="Sparse assistant",
+                completion_model_kwargs=ModelKwargs(),
+                logging_enabled=True,
+                user_id=uuid4(),
+                published=True,
+                description=None,
+                metadata_json=None,
+                icon_id=None,
+                completion_model_id=None,
+                insight_enabled=False,
+            ),
+        ),
+        group_chats=(),
+        apps=(),
+        services=(),
+    )
+    actor = space_assembler.actor_manager.get_space_actor.return_value
+    actor.can_read_assistant.return_value = True
+    actor.get_assistant_permissions.return_value = [ResourcePermission.READ]
+
+    applications = space_assembler.from_applications_projection(projection)
+
+    assert [assistant.id for assistant in applications.assistants.items] == [
+        assistant_id
+    ]
+    assert applications.assistants.items[0].permissions == [ResourcePermission.READ]
+    space_assembler.actor_manager.get_space_actor.assert_called_once_with(
+        projection.access
+    )

--- a/backend/tests/unittests/spaces/test_space_factory.py
+++ b/backend/tests/unittests/spaces/test_space_factory.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -6,6 +7,10 @@ from uuid import uuid4
 import pytest
 from pydantic import BaseModel, ValidationError
 
+from eneo.completion_models.domain.model_kwargs_capabilities import (
+    ModelKwargCapability,
+    SupportedModelKwargs,
+)
 from eneo.spaces import space_factory
 from eneo.spaces.space_factory import SpaceFactory, _build_or_skip
 
@@ -146,6 +151,150 @@ def test_create_space_from_request():
     assert created_space.completion_models == []
     assert created_space.tenant_id is not None
     assert created_space.members == {}
+
+
+def test_create_applications_projection_preserves_sparse_response_contract(factory):
+    now = datetime.now(UTC)
+    space_id = uuid4()
+    user_id = uuid4()
+    member_id = uuid4()
+    group_id = uuid4()
+    completion_model_id = uuid4()
+    default_assistant_id = uuid4()
+    assistant_id = uuid4()
+    missing_model_assistant_id = uuid4()
+    invalid_assistant_id = uuid4()
+    app_id = uuid4()
+    group_chat_ids = [uuid4(), uuid4()]
+    service_ids = [uuid4(), uuid4()]
+
+    space_in_db = MagicMock()
+    space_in_db.id = space_id
+    space_in_db.user_id = None
+    space_in_db.tenant_space_id = uuid4()
+
+    completion_model = MagicMock()
+    completion_model.id = completion_model_id
+    completion_model.is_deprecated = True
+    completion_model.get_supported_model_kwargs.return_value = SupportedModelKwargs(
+        temperature=ModelKwargCapability(supported=True)
+    )
+
+    def assistant(
+        *,
+        id,
+        is_default=False,
+        model_id=completion_model_id,
+        kwargs=None,
+    ):
+        row = MagicMock()
+        row.id = id
+        row.created_at = now
+        row.updated_at = now
+        row.name = f"assistant-{id}"
+        row.completion_model_kwargs = kwargs
+        row.logging_enabled = True
+        row.user_id = user_id
+        row.published = True
+        row.description = None
+        row.metadata_json = None
+        row.icon_id = None
+        row.completion_model_id = model_id
+        row.insight_enabled = False
+        row.is_default = is_default
+        return row
+
+    default_assistant = assistant(id=default_assistant_id, is_default=True)
+    supported_assistant = assistant(
+        id=assistant_id,
+        kwargs={"temperature": 0.4, "top_p": 0.8},
+    )
+    missing_model_assistant = assistant(
+        id=missing_model_assistant_id,
+        model_id=uuid4(),
+        kwargs=None,
+    )
+    invalid_assistant = assistant(
+        id=invalid_assistant_id,
+        kwargs={"temperature": "not-a-number"},
+    )
+
+    app = MagicMock()
+    app.id = app_id
+    app.created_at = now
+    app.updated_at = now
+    app.name = "app"
+    app.description = None
+    app.published = True
+    app.user_id = user_id
+    app.icon_id = None
+    # The Applications response deliberately ignores aggregate-only app state.
+    # Corruption there must not force full-domain hydration or hide metadata.
+    app.completion_model_kwargs = {"temperature": "not-a-number"}
+
+    group_chats = []
+    for group_chat_id in group_chat_ids:
+        group_chat = MagicMock()
+        group_chat.id = group_chat_id
+        group_chat.created_at = now
+        group_chat.updated_at = now
+        group_chat.name = f"group-chat-{group_chat_id}"
+        group_chat.user_id = user_id
+        group_chat.published = True
+        group_chat.metadata_json = None
+        group_chat.icon_id = None
+        group_chat.insight_enabled = False
+        group_chats.append(group_chat)
+
+    services = []
+    for service_id in service_ids:
+        service = MagicMock()
+        service.id = service_id
+        service.created_at = now
+        service.updated_at = now
+        service.name = f"service-{service_id}"
+        service.prompt = ""
+        service.completion_model_kwargs = None
+        service.user_id = user_id
+        services.append(service)
+
+    projection = factory.create_applications_projection(
+        space_in_db=space_in_db,
+        member_roles={member_id: "admin"},
+        group_member_roles={group_id: "viewer"},
+        assistants_in_db=[
+            default_assistant,
+            supported_assistant,
+            missing_model_assistant,
+            invalid_assistant,
+        ],
+        group_chats_in_db=group_chats,
+        apps_in_db=[app],
+        services_in_db=services,
+        completion_models=[completion_model],
+    )
+
+    assert [item.id for item in projection.assistants] == [
+        assistant_id,
+        missing_model_assistant_id,
+    ]
+    assert projection.assistants[0].completion_model_id == completion_model_id
+    assert projection.assistants[0].completion_model_kwargs.temperature == 0.4
+    assert projection.assistants[0].completion_model_kwargs.top_p is None
+    assert projection.assistants[1].completion_model_id is None
+    assert (
+        projection.assistants[1].completion_model_kwargs.model_dump(exclude_none=True)
+        == {}
+    )
+    assert projection.access.default_assistant_id == default_assistant_id
+    assert projection.access.assistant_ids == frozenset(
+        {assistant_id, missing_model_assistant_id}
+    )
+    assert projection.access.app_ids == frozenset({app_id})
+    assert projection.access.members[member_id].role == "admin"
+    assert projection.access.group_members[group_id].role == "viewer"
+    assert [item.id for item in projection.group_chats] == group_chat_ids
+    assert [item.id for item in projection.services] == service_ids
 
 
 def test_create_space_from_db_maps_integration_knowledge_fields(factory):

--- a/backend/tests/unittests/spaces/test_space_service.py
+++ b/backend/tests/unittests/spaces/test_space_service.py
@@ -19,6 +19,7 @@ def actor():
 def service(actor: MagicMock):
     actor_manager = MagicMock()
     actor_manager.get_space_actor_from_space.return_value = actor
+    actor_manager.get_space_actor.return_value = actor
 
     # Mock the repo with proper session.execute chain for MCP servers query
     repo = AsyncMock()
@@ -70,6 +71,31 @@ async def test_raise_not_found_if_user_not_member_of_space(
 
     with pytest.raises(UnauthorizedException):
         await service.get_space(uuid4())
+
+
+async def test_get_applications_projection_authorizes_sparse_access_facts(
+    service: SpaceService, actor: MagicMock
+):
+    projection = MagicMock()
+    service.repo.get_applications_projection.return_value = projection
+    actor.can_read_space.return_value = True
+    space_id = uuid4()
+
+    result = await service.get_applications_projection(space_id)
+
+    assert result is projection
+    service.repo.get_applications_projection.assert_awaited_once_with(space_id)
+    service.actor_manager.get_space_actor.assert_called_once_with(projection.access)
+
+
+async def test_get_applications_projection_rejects_unauthorized_access(
+    service: SpaceService, actor: MagicMock
+):
+    service.repo.get_applications_projection.return_value = MagicMock()
+    actor.can_read_space.return_value = False
+
+    with pytest.raises(UnauthorizedException):
+        await service.get_applications_projection(uuid4())
 
 
 async def test_raise_unauthorized_if_user_can_not_edit(

--- a/docs/goals/file-read-contract/notes/T010-lease-revision.md
+++ b/docs/goals/file-read-contract/notes/T010-lease-revision.md
@@ -1,0 +1,45 @@
+# T010 lease revision
+
+Source revision: `a8418c40f28650238fa7a421bdb8d0ff9bb300ef`
+
+The first Claude plan review returned `changes_required` at MIN_SCORE 5. It
+confirmed that the original lease could not both reuse `SpaceActor` and prohibit
+partial `Space` objects. It also identified the existing `SpaceFactory`
+attachment hydration fence as a deliberate invariant that must not be weakened.
+
+The Goal Maker Judge selected a typed authorization seam, then explicitly
+approved scope amendment B′ after source review found a duplicate mapper:
+
+- `SpaceActor` authorizes immutable `SpaceAccessFacts` instead of depending on a
+  complete `Space` aggregate.
+- Complete Space reads and the new sparse applications projection adapt into the
+  same actor policy.
+- `SpaceRepository` owns only the sparse queries, active-row filtering, ordering,
+  and one factory call.
+- `SpaceFactory` owns the additive DB-row-to-projection mapping and reuses the
+  existing `_build_or_skip` validation belt. It may not change
+  `create_space_from_db`, the hydration fence, or aggregate construction.
+- Completion-model parity uses
+  `completion_model_repo.all(with_deprecated=True)` plus a local O(1) id map;
+  current AssistantSparse behavior does not use Space model mappings here.
+- `SpaceAssembler` keeps one implementation for response mapping, ordering,
+  filtering, item/list permissions, and API-key caps.
+- `SpaceService` remains the endpoint authorization boundary.
+- Every public schema, sibling route, aggregate factory behavior, and real byte
+  consumer remains unchanged.
+
+The unloaded-attachment alternative was rejected: representing persisted
+attachments as an empty list would create false domain state.
+
+The paused source-thread draft was accepted only as untrusted input. It had
+already fixed deleted user/group query filtering and moved mapping into the
+factory, but it must still restore `create_space_from_db`, remove the incorrect
+Space completion-model filter from the sparse mapper, seal role mappings for
+immutable O(1) lookup, and add focused factory/human-membership parity tests.
+
+The current integration RED draft is untrusted until it also proves persisted
+transcription, installs an independent byte-read tripwire, uses a full-Space
+positive control for the SQL listener, resets observations, and compares the
+complete `Applications` JSON. Its initial unchanged run did fail on source in
+13.07 seconds and captured six forbidden queries beginning with
+`assistants_files`, so the underlying performance defect is verified.

--- a/docs/goals/file-read-contract/notes/T011-metadata-projection-map.md
+++ b/docs/goals/file-read-contract/notes/T011-metadata-projection-map.md
@@ -1,0 +1,62 @@
+# T011 metadata-projection map
+
+## Public view evidence
+
+- Direct File GET/list deliberately use `FileService._project_public_files` and
+  read persisted transcription bytes into `FilePublic.transcription`.
+- Assistant and App public assemblers convert hydrated `File` attachments to
+  `FilePublic`, so they also expose transcription even though text/blob are
+  discarded.
+- Full Space responses discard non-default Assistant/App attachments, but the
+  default Assistant can still expose transcription. Sparse Space application
+  responses contain `AssistantSparse`/`AppSparse` and discard attachments
+  completely.
+- Execution, prompt/context-fit, history/replay, transcription, and download
+  paths genuinely require verified content and must retain explicit hydration.
+
+Key evidence:
+
+- `backend/src/eneo/files/file_models.py:97`
+- `backend/src/eneo/files/file_models.py:121`
+- `backend/src/eneo/files/file_service.py:494`
+- `backend/src/eneo/assistants/api/assistant_assembler.py:73`
+- `backend/src/eneo/assistants/api/assistant_models.py:318`
+- `backend/src/eneo/apps/apps/api/app_assembler.py:129`
+- `backend/src/eneo/apps/apps/api/app_models.py:54`
+- `backend/src/eneo/spaces/space_factory.py:150`
+- `backend/src/eneo/spaces/api/space_assembler.py:384`
+- `backend/src/eneo/spaces/api/space_router.py:151`
+
+## Canonical ownership
+
+Keep `FileRepository` plus `project_file_info` as the byte-free File projection
+owner. Keep `FileContentLoader` as the one authorized grouped byte-hydration
+interface. Reuse `FileInfo`; never construct a `File` without its required
+text/blob.
+
+The smallest candidate interface is an explicitly named grouped metadata
+projection returning ordered `FileInfo`, alongside the existing grouped content
+loader returning ordered hydrated `File`. Share tenant validation, reference
+selection, deduplication, and ordering internally. Do not add a boolean mode,
+provider branch, generic projection framework, cache, or fallback.
+
+## Compatibility decision
+
+`FilePublic.transcription` is optional in the schema but is populated today in
+direct File, Assistant, App, and default-Assistant Space responses. A Judge must
+decide whether nested aggregate transcription may become `null` while direct
+File GET/list remains unchanged, or whether byte-free aggregate behavior needs
+a separately named additive response/route. Existing sources do not authorize
+silently changing that runtime value.
+
+## Candidate T010 proof
+
+- Corrupt or remove inline and real compatible-store attachment bytes, then
+  prove chosen metadata-only views return unchanged metadata and execute zero
+  payload queries/remote reads.
+- Preserve direct File transcription byte-for-byte.
+- Preserve Assistant/App execution, prompt preflight, history/replay, and both
+  download contracts through existing focused suites.
+- Stop if compatibility requires changing or removing public fields, execution
+  receives `FileInfo`, a metadata path reads bytes, or the slice requires a flag,
+  partial `File`, provider branch, #569/#571, or Flow work.

--- a/docs/goals/file-read-contract/notes/T012-projection-compatibility.md
+++ b/docs/goals/file-read-contract/notes/T012-projection-compatibility.md
@@ -1,0 +1,44 @@
+# T012 projection compatibility decision
+
+## Decision
+
+Fail closed. Existing Assistant, App, default-Assistant Space, dashboard, and
+`include_applications` responses currently populate persisted
+`FilePublic.transcription`. Its optional type permits a genuinely absent
+transcription; it does not authorize silently replacing a populated runtime
+value with `null`.
+
+Any attachment-bearing metadata response therefore needs a separately named,
+additive public contract and a concrete migration consumer. That product work is
+deferred. Direct File GET/list and all existing hydrated aggregate responses
+remain unchanged.
+
+## T010 contract
+
+Narrow T010 to `GET /api/v1/spaces/{id}/applications/`. Its existing
+`Applications` response contains `AssistantSparse` and `AppSparse` without
+attachment fields, yet the current route loads a full Space and discards the
+hydrated attachment bytes.
+
+Implement one explicit sparse applications read projection that:
+
+- returns the exact existing JSON, ordering, published filtering, permissions,
+  collection permissions, tenant authorization, and scoped-key behavior;
+- performs zero File, File-reference, object-content, payload, descriptor, or
+  object-store reads;
+- reuses current actor/authorization ownership instead of copying policy;
+- never creates partially hydrated File, Assistant, App, or Space objects.
+
+## Proof and stop conditions
+
+First make the current waste observable: attach content with persisted
+transcription, make byte reads fail, and prove the sparse route still needs
+hydration today. The green behavior must return the unchanged response with zero
+File/content SQL and zero remote adapter calls. Preserve direct File
+transcription and current Assistant/App/full-Space, dashboard, execution,
+history, transcription, and download behavior through focused regressions.
+
+Stop if the implementation needs a public value change, duplicated actor policy,
+a partial domain object, boolean hydration flag, generic projection framework,
+new route, provider branch, cache, fallback, a file outside the frozen lease,
+#569, #571, or Flow.

--- a/docs/goals/file-read-contract/state.yaml
+++ b/docs/goals/file-read-contract/state.yaml
@@ -4,7 +4,7 @@ goal:
   title: "Efficient file views and explicit original downloads"
   slug: "file-read-contract"
   kind: specific
-  tranche: "Remove per-object database rereads from bounded attachment hydration; leave metadata-only aggregate projections for the next #586 slice."
+  tranche: "Make the existing sparse Space applications view explicitly byte-free without changing any public response value or execution-time hydration."
   status: active
 
 rules:
@@ -27,15 +27,15 @@ continuity:
   rotate_after_completed_write_tasks: 2
   rotate_after_hours: 6
   rotate_when_slow: true
-  current_thread_id: "019f64db-c1fa-7250-97d3-e4c12a889f71"
-  previous_thread_id: null
+  current_thread_id: "019f949b-c0c8-70c1-8c1a-be21e689b811"
+  previous_thread_id: "019f64db-c1fa-7250-97d3-e4c12a889f71"
   rotation_count: 0
-  completed_write_tasks_in_thread: 0
+  completed_write_tasks_in_thread: 1
   handoff_note: notes/handoff.md
   last_handoff_at: null
-  last_verified_revision: "00aaa9dd2e296456bdadbb549aca14daf91e5754"
+  last_verified_revision: "a8418c40f28650238fa7a421bdb8d0ff9bb300ef"
 
-active_task: T009
+active_task: T010
 
 tasks:
   - id: T001
@@ -412,6 +412,10 @@ tasks:
     receipt:
       result: done
       summary: "Published and merged PR #589 with exact-original recovery, purpose-separated signed access, attributable link audit, and PostgreSQL-inline/compatible-store parity."
+      changed_files: []
+      commands:
+        - "Repository pre-push and all required GitHub checks on the immutable source head"
+        - "Fresh /review and merge-state verification"
       source_commit: "369e574600dcc3e07b5f35cd90e798ebdf55179a"
       merge_commit: "a97c8a9b0f7fb7dbb35b2ca757c30bc73badc261"
       pull_request: "https://github.com/eneo-ai/eneo/pull/589"
@@ -525,7 +529,7 @@ tasks:
   - id: T009
     type: worker
     assignee: PM
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Eliminate per-object database transactions from bounded object-store attachment hydration without changing File or storage-provider contracts."
     allowed_files:
@@ -544,34 +548,220 @@ tasks:
       - "The fix requires a provider-specific branch outside the private S3-compatible adapter."
       - "The fix requires public API, schema, migration, placement, worker, or retention changes."
       - "A bounded source page cannot preserve tenant and access-class validation."
+    receipt:
+      result: done
+      summary: "Merged PR #592 after consolidating single and batch byte reads behind one access-validated source query and deleting the three superseded repository read entry points."
+      changed_files:
+        - "backend/src/eneo/object_content/content_repository.py"
+        - "backend/src/eneo/object_content/content_service.py"
+        - "backend/tests/integration/object_content/test_content_service.py"
+        - "frontend/apps/docs-site/src/content/guides/object-content-storage.mdx"
+        - "docs/goals/file-read-contract/state.yaml"
+      source_head: "158be7abdb51d69abb4967912c142dfe17cd4c54"
+      merge_commit: "a7f6494eb2da319f3ae3ec2f49e46ee47b8f8339"
+      pull_request: "https://github.com/eneo-ai/eneo/pull/592"
+      behavior:
+        - "Each bounded page access-validates controls plus inline payloads or remote descriptors in one relational query."
+        - "Remote items no longer re-enter open_content or open one database transaction per attachment."
+        - "Single and batch reads reuse one private verified backend dispatch without provider-specific product behavior."
+        - "Three orphaned repository getters, including two unvalidated byte-source doors, were deleted after peer review proved they had no remaining caller."
+      validation:
+        - "Original full local gates: 3,858 non-integration tests and 1,128 integration tests passed; 78 skipped and 1 expected xfail."
+        - "Follow-up deletion: 7 focused PostgreSQL/real SeaweedFS tests, Ruff, format, strict Pyright 0/0, docs-site build, schema drift, commit hooks, and pre-push passed."
+        - "GitHub: Backend tests passed in 25m52s, Frontend E2E in 5m54s, and every required CI, Docker, docs, dependency, schema, coverage, and policy check passed on the exact source head."
+        - "Fresh Review 2 covered all five paths at 158be7abd and found no in-scope issue; no review threads remained."
+        - "Separate develop reruns 30099837888 and 30099837843 completed successfully without retry/timeout or unrelated source changes."
+      commands:
+        - "Focused PostgreSQL and real SeaweedFS object-content integration tests"
+        - "Whole backend non-integration and integration test suites"
+        - "Changed-path Ruff and format; strict whole-backend Pyright"
+        - "Docs-site production build and repository pre-push/schema drift"
+        - "GitHub required checks and fresh /review on source head 158be7abd"
+      peer_review:
+        session: "eneo-pr592-remote-hydration"
+        iteration_1:
+          verdict: changes_required
+          minimum_score: 7
+          accepted: "Delete three repository methods orphaned by the shared source query."
+        iteration_2:
+          verdict: green
+          green_light: true
+          minimum_score: 8
+          blockers: none
+      planning:
+        - "Task #586 remains open; its bounded-hydration acceptance criterion is checked."
+        - "Epic #549 remains open with #586 explicitly marked as partially delivered."
+        - "Canonical Project #5 keeps both #586 and #549 In Progress."
+
+  - id: T011
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: high
+    objective: "Freeze the smallest explicit byte-free projection for metadata-only File, Assistant, App, and Space views from current develop source and public-contract evidence."
+    inputs:
+      - "Task #586 and epic #549"
+      - "T001 and T009 receipts"
+      - "backend/src/eneo/files/"
+      - "backend/src/eneo/assistants/"
+      - "backend/src/eneo/apps/"
+      - "backend/src/eneo/spaces/"
+      - "Current assemblers, response models, repository queries, and behavior tests"
+      - "frontend/apps/docs-site/src/content/guides/object-content-storage.mdx"
+    constraints:
+      - "Read-only."
+      - "File keeps identity, filename, authorization, and public behavior."
+      - "eneo.object_content keeps verified bytes, placement, integrity, and lifecycle."
+      - "Preserve PostgreSQL-inline as the complete default and optional object storage as provider-neutral."
+      - "Preserve execution, prompt, history, transcription, and byte-download hydration."
+      - "Do not use a boolean hydration mode, partially hydrated File domain object, provider branch, generic projection framework, cache, or fallback."
+      - "Do not start #569, #571, or Flow work."
+    expected_output:
+      - "Exact metadata-only HTTP/view paths and genuine byte consumers"
+      - "Current and proposed canonical owner"
+      - "Smallest additive projection type/interface"
+      - "Exact T010 allowed_files, behavior-first RED tests, verification commands, and stop conditions"
+      - "Public compatibility and docs impact"
+    receipt:
+      result: done
+      summary: "Current source cannot make every existing File/Assistant/App/default-Space response byte-free without deciding the runtime compatibility of optional FilePublic.transcription; Space application sparse views already discard attachments completely."
+      note: "notes/T011-metadata-projection-map.md"
+      evidence:
+        - "backend/src/eneo/files/file_service.py:494"
+        - "backend/src/eneo/assistants/api/assistant_models.py:318"
+        - "backend/src/eneo/apps/apps/api/app_models.py:54"
+        - "backend/src/eneo/spaces/api/space_assembler.py:384"
+        - "backend/src/eneo/spaces/api/space_router.py:151"
+      spawned_tasks:
+        - "T012"
+        - "T010"
+
+  - id: T012
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Decide aggregate transcription compatibility and freeze the smallest public-compatible T010 metadata projection."
+    inputs:
+      - "T011 receipt and notes/T011-metadata-projection-map.md"
+      - "Task #586 and epic #549"
+      - "Current FilePublic, AssistantPublic, AppPublic, SpacePublic, sparse application, and dashboard contracts"
+      - "Current assemblers, repository read paths, execution consumers, and behavior tests"
+    constraints:
+      - "Read-only."
+      - "Preserve direct File GET/list transcription unless current product evidence explicitly permits an additive contract."
+      - "Prefer deepening File-owned projection and hydration interfaces over adding routes, flags, or generic frameworks."
+      - "Do not construct partially hydrated File objects."
+      - "Do not change storage placement, providers, retry/fallback, #569, #571, or Flow."
+    expected_output:
+      - "Decision on nested aggregate FilePublic.transcription compatibility"
+      - "Exact existing views that become byte-free and byte consumers that remain hydrated"
+      - "Exact T010 allowed_files"
+      - "Behavior-first RED tests and validation commands"
+      - "Stop conditions and deferred work"
+    receipt:
+      result: done
+      decision: "Fail closed on existing Assistant/App/default-Space transcription values; narrow T010 to GET /api/v1/spaces/{id}/applications/, whose Applications schema already excludes attachments."
+      next_allowed_task: T010
+      note: "notes/T012-projection-compatibility.md"
+      evidence:
+        - "backend/src/eneo/assistants/api/assistant_assembler.py:73"
+        - "backend/src/eneo/apps/apps/api/app_assembler.py:129"
+        - "backend/src/eneo/spaces/api/space_assembler.py:648"
+        - "backend/src/eneo/spaces/api/space_router.py:427"
+        - "backend/tests/integration/object_content/test_file_public_routes.py:97"
+      blocked_tasks:
+        - "Broad conversion of existing AssistantPublic, AppPublic, default-Assistant Space, dashboard, and include_applications responses."
+        - "Changing populated nested FilePublic.transcription to null."
+        - "Adding a public metadata route without a product-approved response and migration consumer."
 
   - id: T010
     type: worker
     assignee: PM
+    status: active
+    reasoning_hint: high
+    objective: "Make GET /api/v1/spaces/{id}/applications/ use an explicit sparse applications read projection with zero File/reference/payload/object-store reads and no response change."
+    inputs:
+      - "T012 receipt"
+      - "notes/T010-lease-revision.md"
+      - ".codex/artifacts/claude-peer-loop-t010-sparse-applications-plan-review-20260724T160737Z.md"
+    contract:
+      - "SpaceActor authorizes immutable typed SpaceAccessFacts; complete Space construction and the sparse projection are adapters to the same actor policy."
+      - "SpaceRepository owns only sparse queries, active-row filtering, ordering, and the factory call; it does not map projection fields or authorization state."
+      - "SpaceFactory is the canonical DB-row-to-SpaceApplicationsProjection mapper; this additive method constructs frozen projection values, never partial domain objects."
+      - "create_space_from_db, _build_or_skip, and the attachment hydration fence retain their existing behavior; the sparse mapper reuses _build_or_skip without modifying it."
+      - "Assistant completion-model parity reuses completion_model_repo.all(with_deprecated=True), an O(1) local id map, and existing CompletionModel capability logic; Space completion-model mappings do not affect current AssistantSparse values."
+      - "SpaceAssembler remains the single owner of Applications mapping, ordering, filtering, permissions, and API-key caps for both full Space and sparse projection inputs."
+      - "SpaceService remains the endpoint authorization boundary; only GET /api/v1/spaces/{id}/applications/ adopts the new projection."
+    allowed_files:
+      - "backend/src/eneo/actors/actors/space_actor.py"
+      - "backend/src/eneo/actors/actor_factory.py"
+      - "backend/src/eneo/actors/actor_manager.py"
+      - "backend/src/eneo/spaces/space_applications_projection.py"
+      - "backend/src/eneo/spaces/space_factory.py"
+      - "backend/src/eneo/spaces/space_repo.py"
+      - "backend/src/eneo/spaces/space_service.py"
+      - "backend/src/eneo/spaces/api/space_assembler.py"
+      - "backend/src/eneo/spaces/api/space_router.py"
+      - "backend/tests/unittests/actors/test_space_actor.py"
+      - "backend/tests/unittests/spaces/test_space_factory.py"
+      - "backend/tests/unittests/spaces/test_space_service.py"
+      - "backend/tests/unittests/spaces/api/test_space_assembler.py"
+      - "backend/tests/integration/object_content/test_file_aggregate_hydration.py"
+    tdd:
+      - "First strengthen the dirty RED draft: persist and re-read non-null transcription, add an independent FileContentLoader byte-read tripwire, and prove SQL capture with a full-Space positive control before resetting observations."
+      - "Record two independent failures on source revision a8418c40f: the byte tripwire fires and the applications request observes forbidden File/reference/content/payload SQL."
+      - "Compare complete Applications JSON with the unchanged full-Space applications response, not only resource ids."
+      - "Protect ordering, null and populated completion_model_id, published filtering, item/list permissions, API-key caps, and tenant/space/assistant/app/service-key authorization matrices."
+      - "Protect O(1) direct-membership maps, direct/group human authorization, deleted-user/deleted-group exclusion, default-assistant exclusion, completion-model capability/deprecated/absent parity, null kwargs, and invalid-row skip semantics."
+    verify:
+      - "Applications response values, ordering, filtering, list/item permissions, authorization failures, and scoped-key caps are exactly unchanged."
+      - "The route queries none of files, assistants_files, apps_files, file_content_references, object_contents, inline_content_payloads, or object_store_objects; FileContentLoader/object-content/object-store byte seams are not invoked."
+      - "No partial File, Assistant, App, GroupChat, Service, or Space domain object is constructed; SpaceFactory changes are additive outside imports and create_space_from_db plus its hydration fence remain unchanged."
+      - "Focused object-content integration, factory/actor/service/assembler unit, human membership and API-key scope/service-key integration tests, Ruff, format, strict whole-backend Pyright, and diff check pass."
+      - "The same Opus 5 session verifies the revised slice; if external authentication remains unavailable, a fresh repository review must find no current issue before merge."
+    stop_if:
+      - "Any file outside allowed_files is required."
+      - "create_space_from_db, _build_or_skip semantics, the attachment hydration fence, Space, public response models/OpenAPI, DB tables/migrations, container wiring, or another route must change."
+      - "Any File/reference/content/payload/object-store read remains."
+      - "Any partial domain object, unloaded-relationship special case, boolean flag, cast, Any, type ignore, fake type, provider branch, cache, fallback, or generic projection framework is proposed."
+      - "Authorization, published filtering, response mapping, ordering, or API-key cap logic would be duplicated."
+      - "Repository and factory both map the same projection field or completion-model rule."
+      - "Role inputs are not concrete O(1) mappings or deleted users/groups remain eligible."
+      - "Deprecated, inaccessible, absent, or capability-filtered Assistant completion-model output differs from the current full-Space response."
+      - "Complete-Space and SpaceAccessFacts actor adapters differ for any existing role/scope case."
+      - "A public response/status/error value changes or a mandatory verification fails twice without explanation."
+      - "Work expands to include_applications, dashboard, other routes, public schemas, #569, #571, or Flow."
+
+  - id: T013
+    type: judge
+    assignee: Judge
     status: queued
     reasoning_hint: high
-    objective: "Give metadata-only File, Assistant, App, and Space views an explicit projection that performs no payload reads while preserving execution-time hydration."
-    allowed_files:
-      - "Freeze after T009 from current source and public-contract evidence."
-    verify:
-      - "Zero payload reads for metadata-only views."
-      - "Execution, prompt, history, and transcription consumers keep explicit verified hydration."
-      - "No partially hydrated File domain object or storage-provider branch."
-      - "docs.eneo.ai explains metadata versus content reads."
-    stop_if:
-      - "The public transcription contract cannot be preserved or changed additively."
-      - "The slice requires a boolean hydration mode or a broad repository framework."
+    objective: "Audit the byte-free sparse applications slice, its public compatibility, and the remaining #586 gap before any additive metadata contract is proposed."
+    inputs:
+      - "T010 receipt"
+      - "Current diff and verification"
+      - "Task #586 and epic #549"
+    constraints:
+      - "Read-only."
+      - "Do not call the broad File/Assistant/App/Space projection complete."
+      - "Do not start an additive public contract, #569, #571, or Flow."
+    expected_output:
+      - "complete | not_complete for the narrowed T010 slice"
+      - "Evidence mapped to the frozen contract"
+      - "Exact remaining #586 work and product decision"
+    receipt: null
 
 checks:
-  dirty_fingerprint: "Only the new Goal Maker charter and board are tracked before T001."
+  dirty_fingerprint: "T010 begins with PM-owned state/notes plus an untrusted RED draft in backend/tests/integration/object_content/test_file_aggregate_hydration.py; production is unchanged."
   last_verification:
     result: pass
-    task: T007
+    task: T009
     commands:
-      - "118 focused backend and integration tests passed"
-      - "3825 backend non-integration tests passed"
-      - "Prior full integration: 1125 passed; 77 skipped; 1 expected xfail"
-      - "Strict Pyright 0/0 and changed-path Ruff/format passed"
-      - "SDK tests/lint, web check/lint, docs-site build, schema parity, and diff check passed"
-      - "Fable high pass 1 changes_required at 8; pass 2 green at 8 with no blockers"
-      - "PR #589 required GitHub checks passed and squash merge produced a97c8a9b"
+      - "PR #592 source head 158be7abd merged as a7f6494eb after all checks passed"
+      - "3,858 non-integration and 1,128 integration tests passed; 78 skipped and 1 expected xfail"
+      - "Focused PostgreSQL/real SeaweedFS regression tests passed after the peer-review deletion"
+      - "Strict Pyright 0/0, Ruff/format, schema drift, docs-site build, commit hooks, pre-push, and diff checks passed"
+      - "Fresh Review 2 found no issue on all five paths; Claude session eneo-pr592-remote-hydration finished green at MIN_SCORE 8"
+      - "Develop reruns 30099837888 and 30099837843 passed without speculative fixes"

--- a/docs/goals/file-read-contract/state.yaml
+++ b/docs/goals/file-read-contract/state.yaml
@@ -678,7 +678,7 @@ tasks:
   - id: T010
     type: worker
     assignee: PM
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Make GET /api/v1/spaces/{id}/applications/ use an explicit sparse applications read projection with zero File/reference/payload/object-store reads and no response change."
     inputs:
@@ -732,11 +732,45 @@ tasks:
       - "Complete-Space and SpaceAccessFacts actor adapters differ for any existing role/scope case."
       - "A public response/status/error value changes or a mandatory verification fails twice without explanation."
       - "Work expands to include_applications, dashboard, other routes, public schemas, #569, #571, or Flow."
+    receipt:
+      result: done
+      summary: "GET /api/v1/spaces/{id}/applications/ now returns the unchanged Applications contract from a typed, authorized sparse projection without reading File or object-content bytes."
+      source_commit: "8e3053bf1ba6bab1cae0d0d79e477636a12de639"
+      changed_owners:
+        - "SpaceAccessFacts is the immutable authorization input shared by complete Space reads and the sparse projection."
+        - "SpaceRepository performs a fixed set of sparse queries; SpaceFactory maps rows; SpaceService authorizes; SpaceAssembler remains the one response and permission owner."
+      behavior:
+        - "The existing response, ordering, published filtering, item/list permissions, and API-key caps remain unchanged."
+        - "The route performs no File, reference, object-content, inline-payload, object-descriptor, or object-store read."
+        - "Complete Space and genuine byte consumers retain their existing hydration behavior."
+        - "Storage placement remains transparent: PostgreSQL-inline is still the default and compatible object storage remains optional."
+      complexity:
+        - "A fixed seven relational statements plus the existing completion-model list read replace full aggregate hydration."
+        - "Projection and response mapping are O(resources + models); model, membership, and scoped-resource checks use O(1) maps or sets."
+        - "No cache, generic projection framework, provider branch, partially hydrated domain object, or new fallback was added."
+      validation:
+        - "114 focused actor/factory/service/assembler unit tests passed after rebasing onto develop."
+        - "31 focused PostgreSQL authorization and zero-byte-read integration tests passed; 14 opt-in matrix tests skipped."
+        - "Whole backend: 3,877 non-integration tests passed."
+        - "Whole backend integration: 1,133 passed, 78 skipped, and 1 expected xfail in 15m31s."
+        - "Changed-path Ruff/format passed; strict whole-backend Pyright reported 0 errors and 0 warnings."
+        - "Repository pre-push route metadata and schema drift passed."
+        - "Docs-site production build passed and Pagefind indexed 28 pages."
+      peer_review:
+        session: "eneo-t010-sparse-applications-projection"
+        model: "Claude Opus 5"
+        effort: "xhigh"
+        prior_verdict: "changes_required at score 7; every concrete finding was independently verified and addressed."
+        final_verification: "Attempted twice in the same resumable session but the Claude CLI rejected its logged-in OAuth token as revoked; no final verdict is claimed."
+        merge_gate: "A fresh repository review must find no current issue before merge."
+        artifacts:
+          - ".codex/artifacts/claude-peer-loop-t010-sparse-applications-plan-review-20260724T184151Z.md"
+          - ".codex/artifacts/claude-peer-loop-t010-sparse-applications-plan-review-20260724T190531Z.md"
 
   - id: T013
     type: judge
     assignee: Judge
-    status: queued
+    status: done
     reasoning_hint: high
     objective: "Audit the byte-free sparse applications slice, its public compatibility, and the remaining #586 gap before any additive metadata contract is proposed."
     inputs:
@@ -751,7 +785,18 @@ tasks:
       - "complete | not_complete for the narrowed T010 slice"
       - "Evidence mapped to the frozen contract"
       - "Exact remaining #586 work and product decision"
-    receipt: null
+    receipt:
+      result: done
+      decision: "The narrowed T010 slice is complete and public-compatible. The broader #586 metadata-projection outcome is not complete."
+      evidence:
+        - "The integration test compares the complete sparse Applications JSON with the prior full-Space response and proves zero byte/content SQL."
+        - "The full backend regression suites protect complete-Space, execution, authorization, File, and object-content consumers."
+        - "No public response model, OpenAPI schema, storage placement, model-selection behavior, or provider contract changed."
+      remaining:
+        - "Direct File GET/list and existing Assistant/App/default-Assistant Space responses intentionally retain persisted transcription behavior."
+        - "Making those views byte-free requires an additive product-approved response with a concrete migration consumer; populated transcription may not silently become null."
+        - "Placement policy (#569), lifecycle cleanup (#571), InfoBlob/knowledge generations, and Flow remain separate roadmap work."
+      next_step: "Publish T010 as the reviewable #586 partial slice; do not start another public metadata contract without a product decision."
 
 checks:
   dirty_fingerprint: "T010 begins with PM-owned state/notes plus an untrusted RED draft in backend/tests/integration/object_content/test_file_aggregate_hydration.py; production is unchanged."

--- a/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
+++ b/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
@@ -80,9 +80,9 @@ For a download button, keep the File ID and mint the URL when the user clicks:
 const { url, expires_at } = await eneo.files.generateOriginalSignedUrl({
   fileId,
   contentDisposition: "attachment",
-})
+});
 
-window.location.assign(url)
+window.location.assign(url);
 ```
 
 Do not persist the returned URL or send it to analytics. It is a temporary
@@ -105,6 +105,11 @@ When a view genuinely needs several attachment payloads, Eneo validates their
 database records as a bounded batch and then verifies each byte stream. Remote
 objects still require one content read each, but they do not add one database
 transaction per attachment.
+
+Views that only show names, icons, publication state, and permissions do not
+retrieve attachment bodies. For example, the Space applications list reads
+metadata without opening PostgreSQL-inline or object-store bytes. This reduces
+storage work without changing the response or requiring object storage.
 
 ## What happens when a File is deleted?
 


### PR DESCRIPTION
## Changes

- Space application lists now read only the names, icons, publication state, model metadata, and permissions they return.
- Complete Space reads and the new metadata path reuse the same authorization policy and response mapping.
- The API response is unchanged, but the list no longer opens attached File, PostgreSQL payload, or optional object-store bytes.
- docs.eneo.ai now explains that metadata-only views do not retrieve attachment bodies.

```mermaid
flowchart LR
  Request["Open Space applications"] --> Metadata["Read metadata and permissions"]
  Metadata --> Response["Return the same applications list"]
  Metadata -. "does not open" .-> Bytes["File content"]
```

## Why

The endpoint previously loaded the complete Space, including attached file content that it immediately discarded. This made a metadata list slower as attachments grew and coupled it unnecessarily to the configured byte backend.

The new path works identically for PostgreSQL-only installations and deployments using optional compatible object storage.

## Deliberately not changed

- No public API schema changed.
- No model selection or model-provider behavior changed.
- No storage placement or S3 configuration changed.
- Full Space, File, chat, Assistant, App, download, and other genuine byte consumers keep their current behavior.
- Broader File, Assistant, and App metadata improvements remain in #586.

## Risk and rollback

The primary risk is authorization or response drift when using the smaller read model. Exact-response, role, API-key, deleted-membership, ordering, and full backend regression tests cover this boundary.

Reverting the three commits restores the previous full-Space read without requiring a data migration.

## Planning

- Task: Fixes #597
- Related task: #586
- Epic: #549

## Testing

- Focused Space and authorization tests: 114 passed.
- Focused PostgreSQL authorization and zero-byte-read tests: 31 passed.
- Whole backend non-integration suite: 3,877 passed.
- Whole backend integration suite: 1,133 passed, 78 skipped, 1 expected xfail.
- Ruff and formatting passed.
- Whole-backend Pyright: 0 errors and 0 warnings.
- Repository pre-push route metadata and schema drift passed.
- docs-site production build passed; Pagefind indexed 28 pages.

## Screenshots

No UI change.