### PR TITLE
Activate on-demand Skills during chat turns

### DIFF
--- a/backend/src/eneo/ai_models/completion_models/completion_model.py
+++ b/backend/src/eneo/ai_models/completion_models/completion_model.py
@@ -56,6 +56,22 @@ class FunctionDefinition:
     schema: dict[str, object]
 
 
+def function_definition_to_tool(
+    definition: FunctionDefinition,
+) -> dict[str, object]:
+    """Serialize one built-in function exactly as it is sent to providers."""
+
+    return {
+        "type": "function",
+        "function": {
+            "name": definition.name,
+            "description": definition.description,
+            "parameters": definition.schema,
+            "strict": True,
+        },
+    }
+
+
 @dataclass
 class FunctionCall:
     name: Optional[str] = None

--- a/backend/src/eneo/ai_models/completion_models/completion_model.py
+++ b/backend/src/eneo/ai_models/completion_models/completion_model.py
@@ -138,6 +138,9 @@ class Completion:
     error: Optional[str] = None
     error_code: Optional[int] = None
     usage: Optional[TokenUsage] = None
+    # Cumulative request-payload count when at least one provider round omitted
+    # prompt usage. Provider-reported usage remains separate and authoritative.
+    input_token_estimate: Optional[int] = None
 
 
 class CompletionModelBase(BaseModel):

--- a/backend/src/eneo/assistants/assistant.py
+++ b/backend/src/eneo/assistants/assistant.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     )
     from eneo.assistants.references import ReferencesService
     from eneo.collections.domain.collection import Collection
+    from eneo.completion_models.domain.skill_activation import SkillActivationRuntime
     from eneo.completion_models.infrastructure.web_search import WebSearchResult
     from eneo.integration.domain.entities.integration_knowledge import (
         IntegrationKnowledge,
@@ -359,6 +360,7 @@ class Assistant(Entity):
         mcp_servers_override: Optional[list["MCPServer"]] = None,
         prompt_override: str | None = None,
         completion_prompt_files: list["File"] | None = None,
+        skill_runtime: "SkillActivationRuntime | None" = None,
     ) -> tuple["CompletionModelResponse", DatastoreResult]:
         # Overrides come from the orchestrating service (personal assistant
         # governance). When set, they take precedence over the values stored on
@@ -432,6 +434,7 @@ class Assistant(Entity):
             web_search_results=list(web_search_results or []),
             mcp_servers=[] if self.has_knowledge() else effective_mcp_servers,
             require_tool_approval=require_tool_approval,
+            skill_runtime=skill_runtime,
         )
 
         return response, datastore_result

--- a/backend/src/eneo/assistants/assistant_service.py
+++ b/backend/src/eneo/assistants/assistant_service.py
@@ -19,7 +19,6 @@ from eneo.assistants.assistant_factory import AssistantFactory
 from eneo.assistants.assistant_repo import AssistantRepository
 from eneo.authentication.api_key_scope_revoker import ApiKeyScopeRevoker
 from eneo.authentication.auth_models import ApiKeyScopeType, ApiKeyStateReasonCode
-from eneo.completion_models.domain.skill_context import measure_skill_context
 from eneo.completion_models.infrastructure.context_builder import (
     count_tokens,
 )
@@ -63,8 +62,10 @@ from eneo.roles.permissions import (
 from eneo.services.service import DatastoreResult
 from eneo.services.service_repo import ServiceRepository
 from eneo.skills.domain.skill import (
+    SkillActivationEvidenceV1,
     SkillBindingReference,
     SkillComposition,
+    SkillExecutionReference,
     SkillRuntimeResolution,
     SkillTurnPlan,
     compose_skill_instructions,
@@ -92,6 +93,9 @@ if TYPE_CHECKING:
     from eneo.assistants.references import ReferencesService
     from eneo.completion_models.application import CompletionModelCRUDService
     from eneo.completion_models.domain.completion_model import CompletionModel
+    from eneo.completion_models.domain.skill_activation import (
+        SkillActivationRuntime,
+    )
     from eneo.completion_models.infrastructure.completion_service import (
         CompletionService,
     )
@@ -1308,6 +1312,10 @@ class AssistantService:
         stream: bool,
         assistant_id: UUID,
         question_id: UUID,
+        skill_plan: SkillTurnPlan,
+        skill_runtime: "SkillActivationRuntime",
+        selected_model_route: str,
+        initial_skill_context_tokens: int,
         version: int = 1,
         web_search_results: Sequence["WebSearchResult"] | None = None,
         assistant_selector_tokens: int = 0,
@@ -1315,6 +1323,22 @@ class AssistantService:
         # Capture tenant_id outside the generator so the abort-path background save
         # doesn't depend on self.user being safely accessible during teardown.
         tenant_id = self.user.tenant_id
+
+        def _final_skill_runtime_state() -> tuple[
+            tuple[SkillExecutionReference, ...],
+            SkillActivationEvidenceV1,
+        ]:
+            assert completion_model is not None
+            snapshot = skill_runtime.snapshot()
+            return (
+                skill_plan.active_provenance(snapshot),
+                skill_plan.activation_evidence(
+                    selected_model_id=completion_model.id,
+                    selected_model_route=selected_model_route,
+                    snapshot=snapshot,
+                ),
+            )
+
         if stream:
 
             async def response_stream() -> AsyncGenerator[Completion, None]:
@@ -1524,8 +1548,14 @@ class AssistantService:
                             actual=stream_usage.prompt_tokens,
                         )
                     else:
+                        final_skill_tokens = skill_runtime.snapshot().measurement.tokens
                         num_tokens_question = (
-                            response.total_token_count + assistant_selector_tokens
+                            response.total_token_count
+                            + max(
+                                final_skill_tokens - initial_skill_context_tokens,
+                                0,
+                            )
+                            + assistant_selector_tokens
                         )
                         input_source = "litellm"
 
@@ -1546,6 +1576,7 @@ class AssistantService:
                         f"output={num_tokens_answer} ({output_source})"
                     )
 
+                    skill_provenance, skill_activation = _final_skill_runtime_state()
                     await self.session_service.complete_question_with_answer(
                         question_id=question_id,
                         answer=response_string,
@@ -1560,6 +1591,8 @@ class AssistantService:
                         tool_calls=tool_calls if tool_calls else None,
                         mcp_tool_references=mcp_tool_references or None,
                         reasoning=reasoning_string or None,
+                        skill_provenance=skill_provenance,
+                        skill_activation=skill_activation,
                     )
                     completed = True
 
@@ -1581,7 +1614,11 @@ class AssistantService:
                     # abort) must be saved via a fresh DB session because the
                     # request-scoped AsyncSession may already be torn down and
                     # `await` across GeneratorExit is fragile.
-                    if not completed and (response_string or reasoning_string):
+                    if not completed and (
+                        response_string
+                        or reasoning_string
+                        or skill_runtime.snapshot().changed
+                    ):
                         from eneo.sessions.session_service import (
                             persist_partial_question_answer,
                             safe_count_tokens,
@@ -1597,6 +1634,9 @@ class AssistantService:
                             safe_count_tokens(response_string, model_name)
                             + reasoning_token_count
                         )
+                        skill_provenance, skill_activation = (
+                            _final_skill_runtime_state()
+                        )
                         schedule_background_save(
                             persist_partial_question_answer(
                                 tenant_id=tenant_id,
@@ -1604,6 +1644,8 @@ class AssistantService:
                                 answer=response_string,
                                 num_tokens_answer=partial_tokens_answer,
                                 reasoning=reasoning_string or None,
+                                skill_provenance=skill_provenance,
+                                skill_activation=skill_activation,
                             )
                         )
                         logger.info(
@@ -1667,6 +1709,7 @@ class AssistantService:
                 f"output={num_tokens_answer} ({output_source})"
             )
 
+            skill_provenance, skill_activation = _final_skill_runtime_state()
             await self.session_service.complete_question_with_answer(
                 question_id=question_id,
                 answer=final_answer,
@@ -1680,6 +1723,8 @@ class AssistantService:
                 web_search_results=list(web_search_results or []),
                 mcp_tool_references=non_streaming_mcp_refs or None,
                 reasoning=final_reasoning,
+                skill_provenance=skill_provenance,
+                skill_activation=skill_activation,
             )
 
             return final_answer
@@ -1903,23 +1948,23 @@ class AssistantService:
             effective_config=effective_config,
             space_is_personal=space.is_personal(),
         )
-        skill_composition = skill_plan.composition
-        if skill_composition.provenance:
-            prompt_override = skill_composition.prompt
         model_route = effective_completion_model.get_model_route()
-        skill_context = measure_skill_context(
-            base_instructions=skill_plan.base_instructions,
-            composed_instructions=skill_composition.prompt,
-            model_name=model_route,
+        skill_runtime = skill_plan.to_activation_runtime(
+            selected_model_route=model_route,
             max_input_tokens=effective_completion_model.max_input_tokens,
-            context_share_percent=skill_plan.policy.context_share_percent,
+            supports_tool_calling=effective_completion_model.supports_tool_calling,
         )
+        initial_skill_snapshot = skill_runtime.snapshot()
+        skill_composition = SkillComposition(
+            prompt=skill_runtime.prompt,
+            provenance=skill_plan.active_provenance(initial_skill_snapshot),
+        )
+        if skill_runtime.prompt != skill_plan.base_instructions:
+            prompt_override = skill_runtime.prompt
         skill_activation = skill_plan.activation_evidence(
             selected_model_id=effective_completion_model.id,
             selected_model_route=model_route,
-            skill_context_tokens=skill_context.tokens,
-            skill_context_token_limit=skill_context.limit,
-            token_count_source=skill_context.source.value,
+            snapshot=initial_skill_snapshot,
         )
 
         # Per-request MCP opt-out from the composer toolbar: narrow whatever set
@@ -2036,21 +2081,42 @@ class AssistantService:
         else:
             web_search_results = []
 
-        response, datastore_result = await assistant_to_ask.ask(
-            question=cleaned_question,
-            completion_service=self.completion_service,
-            references_service=self.references_service,
-            session=session,
-            files=completion_file_inputs.completion_message_files,
-            stream=stream,
-            version=version,
-            web_search_results=web_search_results,
-            require_tool_approval=require_tool_approval,
-            completion_model_override=completion_model_override,
-            mcp_servers_override=mcp_servers_override,
-            prompt_override=prompt_override,
-            completion_prompt_files=completion_file_inputs.completion_prompt_files,
-        )
+        try:
+            response, datastore_result = await assistant_to_ask.ask(
+                question=cleaned_question,
+                completion_service=self.completion_service,
+                references_service=self.references_service,
+                session=session,
+                files=completion_file_inputs.completion_message_files,
+                stream=stream,
+                version=version,
+                web_search_results=web_search_results,
+                require_tool_approval=require_tool_approval,
+                completion_model_override=completion_model_override,
+                mcp_servers_override=mcp_servers_override,
+                prompt_override=prompt_override,
+                completion_prompt_files=completion_file_inputs.completion_prompt_files,
+                skill_runtime=skill_runtime,
+            )
+        except Exception:
+            failed_snapshot = skill_runtime.snapshot()
+            if failed_snapshot.changed:
+                try:
+                    await self.session_service.update_question_skill_runtime_state(
+                        question_id=question_id,
+                        skill_provenance=skill_plan.active_provenance(failed_snapshot),
+                        skill_activation=skill_plan.activation_evidence(
+                            selected_model_id=effective_completion_model.id,
+                            selected_model_route=model_route,
+                            snapshot=failed_snapshot,
+                        ),
+                    )
+                except Exception:
+                    logger.exception(
+                        "Could not persist final Skill activation evidence after "
+                        "completion failure"
+                    )
+            raise
 
         # TODO: Separate the response based on stream true or false
 
@@ -2064,6 +2130,10 @@ class AssistantService:
             stream=stream,
             assistant_id=assistant_to_ask.id,
             question_id=question_id,
+            skill_plan=skill_plan,
+            skill_runtime=skill_runtime,
+            selected_model_route=model_route,
+            initial_skill_context_tokens=(initial_skill_snapshot.measurement.tokens),
             version=version,
             web_search_results=web_search_results,
             assistant_selector_tokens=assistant_selector_tokens,

--- a/backend/src/eneo/assistants/assistant_service.py
+++ b/backend/src/eneo/assistants/assistant_service.py
@@ -1353,6 +1353,7 @@ class AssistantService:
                 # that legitimately share a URI.
                 mcp_ref_seen: set[UUID] = set()
                 stream_usage: TokenUsage | None = None
+                stream_input_token_estimate: int | None = None
                 completed = False
 
                 try:
@@ -1364,6 +1365,8 @@ class AssistantService:
                         reasoning_token_count = chunk.reasoning_token_count
                         if chunk.usage:
                             stream_usage = chunk.usage
+                        if chunk.input_token_estimate is not None:
+                            stream_input_token_estimate = chunk.input_token_estimate
 
                         if chunk.response_type == ResponseType.TEXT:
                             response_string = f"{response_string}{chunk.text}"
@@ -1549,13 +1552,17 @@ class AssistantService:
                         )
                     else:
                         final_skill_tokens = skill_runtime.snapshot().measurement.tokens
-                        num_tokens_question = (
-                            response.total_token_count
+                        base_input_tokens = (
+                            stream_input_token_estimate
+                            if stream_input_token_estimate is not None
+                            else response.total_token_count
                             + max(
                                 final_skill_tokens - initial_skill_context_tokens,
                                 0,
                             )
-                            + assistant_selector_tokens
+                        )
+                        num_tokens_question = (
+                            base_input_tokens + assistant_selector_tokens
                         )
                         input_source = "litellm"
 
@@ -2102,7 +2109,12 @@ class AssistantService:
             failed_snapshot = skill_runtime.snapshot()
             if failed_snapshot.changed:
                 try:
-                    await self.session_service.update_question_skill_runtime_state(
+                    from eneo.sessions.session_service import (
+                        persist_final_skill_runtime_state,
+                    )
+
+                    await persist_final_skill_runtime_state(
+                        tenant_id=self.user.tenant_id,
                         question_id=question_id,
                         skill_provenance=skill_plan.active_provenance(failed_snapshot),
                         skill_activation=skill_plan.activation_evidence(

--- a/backend/src/eneo/completion_models/domain/skill_activation.py
+++ b/backend/src/eneo/completion_models/domain/skill_activation.py
@@ -666,8 +666,35 @@ class SkillActivationRuntime:
             )
         selection_started_at = perf_counter_ns()
         self._validate_provider_calls(calls)
-        previous_prompt = self.prompt
         requests = tuple(self._request_from_provider_call(call) for call in internal)
+        if self.tool_definition is None:
+            staged = self._fork()
+            result = staged._apply_round(
+                requests,
+                forced_rejections={
+                    request.activation_key or "": (
+                        SkillActivationRejectionReason.ACTIVATION_UNAVAILABLE
+                    )
+                    for request in requests
+                },
+            )
+            external, deferred = self._append_provider_round(
+                messages=messages,
+                calls=calls,
+                assistant_content=assistant_content,
+                result=result,
+            )
+            staged._selection_latency_ms = self._selection_latency_ms + (
+                (perf_counter_ns() - selection_started_at) // 1_000_000
+            )
+            self._commit(staged)
+            return SkillToolCallApplication(
+                external_calls=external,
+                deferred_calls=deferred,
+                assistant_message_appended=True,
+            )
+
+        previous_prompt = self.prompt
         bounded_requests = requests[:MAX_SKILL_ACTIVATIONS_PER_TURN]
         overflow_requests = requests[MAX_SKILL_ACTIVATIONS_PER_TURN:]
         forced_rejections: dict[str, SkillActivationRejectionReason] = {}

--- a/backend/src/eneo/completion_models/domain/skill_activation.py
+++ b/backend/src/eneo/completion_models/domain/skill_activation.py
@@ -1,0 +1,842 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from time import perf_counter_ns
+from typing import Any, cast
+
+from eneo.ai_models.completion_models.completion_model import (
+    FunctionDefinition,
+    function_definition_to_tool,
+)
+from eneo.completion_models.domain.skill_context import (
+    SkillContextMeasurement,
+    measure_skill_context,
+)
+from eneo.skills.domain.skill import (
+    MAX_RETAINED_SKILL_ACTIVATION_REJECTIONS,
+    MAX_SKILL_ACTIVATIONS_PER_TURN,
+    ResolvedSkillBinding,
+    SkillActivationFallbackReason,
+    SkillActivationRejectionReason,
+    SkillTurnEffectiveMode,
+    compose_skill_instructions,
+)
+from eneo.tokens.token_utils import (
+    TokenCountSource,
+    measure_provider_input_tokens,
+)
+
+SKILL_ACTIVATION_TOOL_NAME = "eneo_activate_skill"
+
+
+class SkillPromptOwnershipError(RuntimeError):
+    """The rendered prompt no longer belongs to the frozen Skill plan."""
+
+
+class InvalidSkillToolCallError(RuntimeError):
+    """Provider tool-call identifiers cannot form a valid transcript."""
+
+
+@dataclass(frozen=True)
+class FrozenSkillInstruction:
+    """Provider-safe, exact per-turn Skill candidate."""
+
+    activation_key: str
+    binding: ResolvedSkillBinding
+    initially_active: bool
+
+    @property
+    def display_name(self) -> str:
+        return self.binding.display_name
+
+    @property
+    def description(self) -> str:
+        return self.binding.description
+
+    @property
+    def position(self) -> int:
+        return self.binding.position
+
+
+@dataclass(frozen=True)
+class SkillActivationSnapshot:
+    effective_mode: SkillTurnEffectiveMode
+    fallback_reason: SkillActivationFallbackReason | None
+    initially_active: tuple[str, ...]
+    active: tuple[str, ...]
+    accepted: tuple[str, ...]
+    repeated: tuple[str, ...]
+    rejected: tuple[SkillActivationRejectionSnapshot, ...]
+    measurement: SkillContextMeasurement
+    activation_rounds: int
+    selection_latency_ms: int
+
+    @property
+    def changed(self) -> bool:
+        return bool(
+            self.activation_rounds or self.accepted or self.repeated or self.rejected
+        )
+
+
+@dataclass(frozen=True)
+class SkillActivationRejectionSnapshot:
+    activation_key: str
+    reason: SkillActivationRejectionReason
+
+
+@dataclass(frozen=True)
+class SkillActivationRequest:
+    call_id: str
+    activation_key: str | None
+
+
+@dataclass(frozen=True)
+class SkillActivationDecision:
+    call_id: str
+    provider_payload: dict[str, bool]
+
+
+@dataclass(frozen=True)
+class SkillActivationRoundResult:
+    decisions: tuple[SkillActivationDecision, ...]
+    accepted_any: bool
+
+
+@dataclass(frozen=True)
+class ProviderToolCall:
+    call_id: str
+    name: str
+    arguments: str
+
+
+@dataclass(frozen=True)
+class SkillToolCallApplication:
+    external_calls: tuple[ProviderToolCall, ...]
+    deferred_calls: tuple[ProviderToolCall, ...]
+    assistant_message_appended: bool
+
+
+def _compose_prompt(
+    *,
+    base_instructions: str,
+    skills: tuple[FrozenSkillInstruction, ...],
+) -> str:
+    return compose_skill_instructions(
+        base_instructions=base_instructions,
+        bindings=[skill.binding for skill in skills],
+    ).prompt
+
+
+def _activation_tool(
+    skills: tuple[FrozenSkillInstruction, ...],
+) -> FunctionDefinition:
+    catalogue = "\n".join(
+        f"- {skill.activation_key}: {skill.display_name} — {skill.description}"
+        for skill in skills
+    )
+    return FunctionDefinition(
+        name=SKILL_ACTIVATION_TOOL_NAME,
+        description=(
+            "Load the full instructions for one available Skill when they are "
+            "needed for the current request.\n\nAvailable Skills:\n"
+            f"{catalogue}"
+        ),
+        schema={
+            "type": "object",
+            "properties": {
+                "skill_key": {
+                    "type": "string",
+                    "enum": [skill.activation_key for skill in skills],
+                }
+            },
+            "required": ["skill_key"],
+            "additionalProperties": False,
+        },
+    )
+
+
+class SkillActivationRuntime:
+    """Concrete mutable state for one frozen selective-Skill turn."""
+
+    def __init__(
+        self,
+        *,
+        base_instructions: str,
+        prompt: str,
+        tool_definition: FunctionDefinition | None,
+        effective_mode: SkillTurnEffectiveMode,
+        fallback_reason: SkillActivationFallbackReason | None,
+        skills: tuple[FrozenSkillInstruction, ...],
+        blocked_keys: frozenset[str],
+        max_activations_per_turn: int,
+        context_share_percent: int,
+        model_route: str,
+        max_input_tokens: int,
+        measurement: SkillContextMeasurement,
+    ) -> None:
+        self._base_instructions = base_instructions
+        self.prompt = prompt
+        self.tool_definition = tool_definition
+        self._effective_mode = effective_mode
+        self._fallback_reason = fallback_reason
+        self._skills = skills
+        self._skills_by_key = {skill.activation_key: skill for skill in skills}
+        self._blocked_keys = blocked_keys
+        self._max_activations_per_turn = max_activations_per_turn
+        self._context_share_percent = context_share_percent
+        self._model_route = model_route
+        self._max_input_tokens = max_input_tokens
+        self._measurement = measurement
+        self._active_keys = {
+            skill.activation_key for skill in skills if skill.initially_active
+        }
+        self._accepted: list[str] = []
+        self._repeated: list[str] = []
+        self._rejected: list[SkillActivationRejectionSnapshot] = []
+        self._rejected_keys: set[tuple[str, SkillActivationRejectionReason]] = set()
+        self._activation_rounds = 0
+        self._selection_latency_ms = 0
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        base_instructions: str,
+        skills: tuple[FrozenSkillInstruction, ...],
+        blocked_keys: frozenset[str],
+        selective_activation_enabled: bool,
+        max_activations_per_turn: int,
+        context_share_percent: int,
+        model_route: str,
+        max_input_tokens: int,
+        supports_tool_calling: bool,
+    ) -> SkillActivationRuntime:
+        ordered = tuple(sorted(skills, key=lambda skill: skill.position))
+        initially_active = tuple(skill for skill in ordered if skill.initially_active)
+        on_demand = tuple(skill for skill in ordered if not skill.initially_active)
+        required_prompt = _compose_prompt(
+            base_instructions=base_instructions,
+            skills=initially_active,
+        )
+
+        fallback_reason: SkillActivationFallbackReason | None = None
+        tool: FunctionDefinition | None = None
+        if not selective_activation_enabled:
+            fallback_reason = (
+                SkillActivationFallbackReason.SELECTIVE_ACTIVATION_DISABLED
+            )
+        elif not supports_tool_calling:
+            fallback_reason = SkillActivationFallbackReason.MODEL_LACKS_TOOL_CALLING
+        elif on_demand:
+            candidate_tool = _activation_tool(on_demand)
+            selective_measurement = measure_skill_context(
+                base_instructions=base_instructions,
+                composed_instructions=required_prompt,
+                model_name=model_route,
+                max_input_tokens=max_input_tokens,
+                context_share_percent=context_share_percent,
+                tools=[function_definition_to_tool(candidate_tool)],
+            )
+            if selective_measurement.source is TokenCountSource.FALLBACK_ESTIMATE:
+                fallback_reason = (
+                    SkillActivationFallbackReason.TOKEN_MEASUREMENT_UNAVAILABLE
+                )
+            elif selective_measurement.tokens <= selective_measurement.limit:
+                return cls(
+                    base_instructions=base_instructions,
+                    prompt=required_prompt,
+                    tool_definition=candidate_tool,
+                    effective_mode=SkillTurnEffectiveMode.SELECTIVE,
+                    fallback_reason=None,
+                    skills=ordered,
+                    blocked_keys=blocked_keys,
+                    max_activations_per_turn=max_activations_per_turn,
+                    context_share_percent=context_share_percent,
+                    model_route=model_route,
+                    max_input_tokens=max_input_tokens,
+                    measurement=selective_measurement,
+                )
+            else:
+                fallback_reason = SkillActivationFallbackReason.CATALOG_BUDGET_EXCEEDED
+
+        measurement = measure_skill_context(
+            base_instructions=base_instructions,
+            composed_instructions=required_prompt,
+            model_name=model_route,
+            max_input_tokens=max_input_tokens,
+            context_share_percent=context_share_percent,
+        )
+        return cls(
+            base_instructions=base_instructions,
+            prompt=required_prompt,
+            tool_definition=tool,
+            effective_mode=SkillTurnEffectiveMode.ALWAYS_ONLY,
+            fallback_reason=fallback_reason,
+            skills=ordered,
+            blocked_keys=blocked_keys,
+            max_activations_per_turn=max_activations_per_turn,
+            context_share_percent=context_share_percent,
+            model_route=model_route,
+            max_input_tokens=max_input_tokens,
+            measurement=measurement,
+        )
+
+    def _active_skills(
+        self, extra_key: str | None = None
+    ) -> tuple[FrozenSkillInstruction, ...]:
+        keys = set(self._active_keys)
+        if extra_key is not None:
+            keys.add(extra_key)
+        return tuple(skill for skill in self._skills if skill.activation_key in keys)
+
+    def _measure(
+        self, skills: tuple[FrozenSkillInstruction, ...]
+    ) -> tuple[str, SkillContextMeasurement]:
+        prompt = _compose_prompt(
+            base_instructions=self._base_instructions,
+            skills=skills,
+        )
+        tools = (
+            [function_definition_to_tool(self.tool_definition)]
+            if self.tool_definition is not None
+            else []
+        )
+        return (
+            prompt,
+            measure_skill_context(
+                base_instructions=self._base_instructions,
+                composed_instructions=prompt,
+                model_name=self._model_route,
+                max_input_tokens=self._max_input_tokens,
+                context_share_percent=self._context_share_percent,
+                tools=tools,
+            ),
+        )
+
+    @staticmethod
+    def _provider_unavailable() -> dict[str, bool]:
+        return {"activated": False, "unavailable": True}
+
+    @staticmethod
+    def _evidence_key(activation_key: str | None) -> str:
+        if not activation_key:
+            return "<invalid>"
+        if len(activation_key) <= 128:
+            return activation_key
+        digest = hashlib.sha256(activation_key.encode()).hexdigest()[:16]
+        return f"{activation_key[:110]}-{digest}"
+
+    def _reject(
+        self,
+        *,
+        activation_key: str | None,
+        reason: SkillActivationRejectionReason,
+    ) -> None:
+        evidence_key = self._evidence_key(activation_key)
+        identity = (evidence_key, reason)
+        if (
+            identity in self._rejected_keys
+            or len(self._rejected) >= MAX_RETAINED_SKILL_ACTIVATION_REJECTIONS
+        ):
+            return
+        self._rejected_keys.add(identity)
+        self._rejected.append(
+            SkillActivationRejectionSnapshot(
+                activation_key=evidence_key,
+                reason=reason,
+            )
+        )
+
+    def _fork(self) -> SkillActivationRuntime:
+        staged = SkillActivationRuntime(
+            base_instructions=self._base_instructions,
+            prompt=self.prompt,
+            tool_definition=self.tool_definition,
+            effective_mode=self._effective_mode,
+            fallback_reason=self._fallback_reason,
+            skills=self._skills,
+            blocked_keys=self._blocked_keys,
+            max_activations_per_turn=self._max_activations_per_turn,
+            context_share_percent=self._context_share_percent,
+            model_route=self._model_route,
+            max_input_tokens=self._max_input_tokens,
+            measurement=self._measurement,
+        )
+        staged._active_keys = set(self._active_keys)
+        staged._accepted = list(self._accepted)
+        staged._repeated = list(self._repeated)
+        staged._rejected = list(self._rejected)
+        staged._rejected_keys = set(self._rejected_keys)
+        staged._activation_rounds = self._activation_rounds
+        staged._selection_latency_ms = self._selection_latency_ms
+        return staged
+
+    def _commit(self, staged: SkillActivationRuntime) -> None:
+        self.prompt = staged.prompt
+        self._measurement = staged._measurement
+        self._active_keys = staged._active_keys
+        self._accepted = staged._accepted
+        self._repeated = staged._repeated
+        self._rejected = staged._rejected
+        self._rejected_keys = staged._rejected_keys
+        self._activation_rounds = staged._activation_rounds
+        self._selection_latency_ms = staged._selection_latency_ms
+
+    def record_reserved_tool_collision(self) -> None:
+        self._reject(
+            activation_key=SKILL_ACTIVATION_TOOL_NAME,
+            reason=SkillActivationRejectionReason.RESERVED_TOOL_COLLISION,
+        )
+
+    def _apply_round(
+        self,
+        requests: tuple[SkillActivationRequest, ...],
+        *,
+        forced_rejections: dict[str, SkillActivationRejectionReason],
+    ) -> SkillActivationRoundResult:
+        decisions: list[SkillActivationDecision] = []
+        accepted_any = False
+        if requests:
+            self._activation_rounds += 1
+
+        for request in requests:
+            key = request.activation_key
+            forced_reason = forced_rejections.get(key or "")
+            if forced_reason is not None:
+                self._reject(
+                    activation_key=key,
+                    reason=forced_reason,
+                )
+                decisions.append(
+                    SkillActivationDecision(
+                        call_id=request.call_id,
+                        provider_payload=self._provider_unavailable(),
+                    )
+                )
+                continue
+
+            if key in self._active_keys:
+                if key not in self._repeated:
+                    self._repeated.append(key)
+                decisions.append(
+                    SkillActivationDecision(
+                        call_id=request.call_id,
+                        provider_payload={
+                            "activated": True,
+                            "already_active": True,
+                        },
+                    )
+                )
+                continue
+
+            if key in self._blocked_keys:
+                self._reject(
+                    activation_key=key,
+                    reason=SkillActivationRejectionReason.BLOCKED,
+                )
+                decisions.append(
+                    SkillActivationDecision(
+                        call_id=request.call_id,
+                        provider_payload=self._provider_unavailable(),
+                    )
+                )
+                continue
+
+            candidate = self._skills_by_key.get(key) if key is not None else None
+            if candidate is None:
+                self._reject(
+                    activation_key=key,
+                    reason=SkillActivationRejectionReason.UNKNOWN_KEY,
+                )
+                decisions.append(
+                    SkillActivationDecision(
+                        call_id=request.call_id,
+                        provider_payload=self._provider_unavailable(),
+                    )
+                )
+                continue
+
+            assert key is not None
+            if len(self._accepted) >= self._max_activations_per_turn:
+                self._reject(
+                    activation_key=key,
+                    reason=SkillActivationRejectionReason.ACTIVATION_LIMIT_EXCEEDED,
+                )
+                decisions.append(
+                    SkillActivationDecision(
+                        call_id=request.call_id,
+                        provider_payload=self._provider_unavailable(),
+                    )
+                )
+                continue
+
+            candidate_prompt, candidate_measurement = self._measure(
+                self._active_skills(key)
+            )
+            if candidate_measurement.source is TokenCountSource.FALLBACK_ESTIMATE:
+                self._reject(
+                    activation_key=key,
+                    reason=(
+                        SkillActivationRejectionReason.TOKEN_MEASUREMENT_UNAVAILABLE
+                    ),
+                )
+                decisions.append(
+                    SkillActivationDecision(
+                        call_id=request.call_id,
+                        provider_payload=self._provider_unavailable(),
+                    )
+                )
+                continue
+            if candidate_measurement.tokens > candidate_measurement.limit:
+                self._reject(
+                    activation_key=key,
+                    reason=SkillActivationRejectionReason.CONTEXT_LIMIT_EXCEEDED,
+                )
+                decisions.append(
+                    SkillActivationDecision(
+                        call_id=request.call_id,
+                        provider_payload=self._provider_unavailable(),
+                    )
+                )
+                continue
+
+            self._active_keys.add(key)
+            self._accepted.append(key)
+            self.prompt = candidate_prompt
+            self._measurement = candidate_measurement
+            accepted_any = True
+            decisions.append(
+                SkillActivationDecision(
+                    call_id=request.call_id,
+                    provider_payload={"activated": True},
+                )
+            )
+
+        return SkillActivationRoundResult(
+            decisions=tuple(decisions),
+            accepted_any=accepted_any,
+        )
+
+    @staticmethod
+    def _request_from_provider_call(
+        call: ProviderToolCall,
+    ) -> SkillActivationRequest:
+        try:
+            payload: object = json.loads(call.arguments)
+        except (TypeError, ValueError):
+            payload = None
+        activation_key = None
+        if isinstance(payload, dict):
+            candidate_key = cast("dict[object, object]", payload).get("skill_key")
+            if isinstance(candidate_key, str):
+                activation_key = candidate_key
+        return SkillActivationRequest(
+            call_id=call.call_id,
+            activation_key=activation_key,
+        )
+
+    @staticmethod
+    def _capture_rendered_suffix(
+        messages: list[dict[str, object]],
+        *,
+        previous_prompt: str,
+    ) -> tuple[bool, str]:
+        if messages and messages[0].get("role") == "system":
+            rendered_prompt = messages[0].get("content")
+            if not isinstance(rendered_prompt, str) or not rendered_prompt.startswith(
+                previous_prompt
+            ):
+                raise SkillPromptOwnershipError(
+                    "The rendered system prompt no longer starts with the frozen "
+                    "Skill prompt"
+                )
+            return True, rendered_prompt[len(previous_prompt) :]
+        return False, ""
+
+    @staticmethod
+    def _replace_system_prompt(
+        messages: list[dict[str, object]],
+        *,
+        prompt: str,
+        previous_prompt: str,
+        had_system_prompt: bool,
+        rendered_suffix: str,
+    ) -> None:
+        separator = "\n\n" if not previous_prompt and rendered_suffix else ""
+        replacement: dict[str, object] = {
+            "role": "system",
+            "content": f"{prompt}{separator}{rendered_suffix}",
+        }
+        if had_system_prompt:
+            messages[0] = replacement
+        else:
+            messages.insert(0, replacement)
+
+    @staticmethod
+    def _validate_provider_calls(calls: tuple[ProviderToolCall, ...]) -> None:
+        call_ids = [call.call_id for call in calls]
+        if any(not call_id for call_id in call_ids) or len(call_ids) != len(
+            set(call_ids)
+        ):
+            raise InvalidSkillToolCallError(
+                "The model produced an invalid tool call identifier"
+            )
+
+    @staticmethod
+    def _append_provider_round(
+        *,
+        messages: list[dict[str, object]],
+        calls: tuple[ProviderToolCall, ...],
+        assistant_content: str | None,
+        result: SkillActivationRoundResult,
+    ) -> tuple[tuple[ProviderToolCall, ...], tuple[ProviderToolCall, ...]]:
+        internal = tuple(
+            call for call in calls if call.name == SKILL_ACTIVATION_TOOL_NAME
+        )
+        external = tuple(
+            call for call in calls if call.name != SKILL_ACTIVATION_TOOL_NAME
+        )
+        messages.append(
+            {
+                "role": "assistant",
+                "content": assistant_content,
+                "tool_calls": [
+                    {
+                        "id": call.call_id,
+                        "type": "function",
+                        "function": {
+                            "name": call.name,
+                            "arguments": call.arguments,
+                        },
+                    }
+                    for call in calls
+                ],
+            }
+        )
+        decision_by_call_id = {
+            decision.call_id: decision for decision in result.decisions
+        }
+        for call in internal:
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.call_id,
+                    "content": json.dumps(
+                        decision_by_call_id[call.call_id].provider_payload
+                    ),
+                }
+            )
+        deferred = external if result.accepted_any else ()
+        for call in deferred:
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.call_id,
+                    "content": json.dumps(
+                        {
+                            "deferred": True,
+                            "reason": "skill_context_updated",
+                            "retryable": True,
+                        }
+                    ),
+                }
+            )
+        return (() if deferred else external), deferred
+
+    def apply_provider_tool_calls(
+        self,
+        *,
+        calls: tuple[ProviderToolCall, ...],
+        messages: list[dict[str, object]],
+        provider_tools: list[dict[str, object]] | None = None,
+        assistant_content: str | None = None,
+    ) -> SkillToolCallApplication:
+        """Close internal calls and return external calls safe to dispatch."""
+
+        internal = tuple(
+            call for call in calls if call.name == SKILL_ACTIVATION_TOOL_NAME
+        )
+        if not internal:
+            return SkillToolCallApplication(
+                external_calls=calls,
+                deferred_calls=(),
+                assistant_message_appended=False,
+            )
+        selection_started_at = perf_counter_ns()
+        self._validate_provider_calls(calls)
+        previous_prompt = self.prompt
+        requests = tuple(self._request_from_provider_call(call) for call in internal)
+        bounded_requests = requests[:MAX_SKILL_ACTIVATIONS_PER_TURN]
+        overflow_requests = requests[MAX_SKILL_ACTIVATIONS_PER_TURN:]
+        forced_rejections: dict[str, SkillActivationRejectionReason] = {}
+
+        def stage_round(
+            rejections: dict[str, SkillActivationRejectionReason],
+        ) -> tuple[
+            SkillActivationRuntime,
+            list[dict[str, object]],
+            tuple[ProviderToolCall, ...],
+            tuple[ProviderToolCall, ...],
+            tuple[str, ...],
+        ]:
+            staged = self._fork()
+            result = staged._apply_round(
+                bounded_requests,
+                forced_rejections=rejections,
+            )
+            overflow_decisions = tuple(
+                SkillActivationDecision(
+                    call_id=request.call_id,
+                    provider_payload=(
+                        {
+                            "activated": True,
+                            "already_active": True,
+                        }
+                        if request.activation_key in staged._active_keys
+                        else self._provider_unavailable()
+                    ),
+                )
+                for request in overflow_requests
+            )
+            result = SkillActivationRoundResult(
+                decisions=(*result.decisions, *overflow_decisions),
+                accepted_any=result.accepted_any,
+            )
+            staged_messages = [message.copy() for message in messages]
+            if result.accepted_any:
+                had_system_prompt, rendered_suffix = self._capture_rendered_suffix(
+                    messages,
+                    previous_prompt=previous_prompt,
+                )
+                self._replace_system_prompt(
+                    staged_messages,
+                    prompt=staged.prompt,
+                    previous_prompt=previous_prompt,
+                    had_system_prompt=had_system_prompt,
+                    rendered_suffix=rendered_suffix,
+                )
+            external, deferred = self._append_provider_round(
+                messages=staged_messages,
+                calls=calls,
+                assistant_content=assistant_content,
+                result=result,
+            )
+            newly_accepted = tuple(
+                key for key in staged._accepted if key not in self._accepted
+            )
+            return (
+                staged,
+                staged_messages,
+                external,
+                deferred,
+                newly_accepted,
+            )
+
+        while True:
+            staged, staged_messages, external, deferred, newly_accepted = stage_round(
+                forced_rejections
+            )
+            if not newly_accepted:
+                break
+
+            provider_measurement = measure_provider_input_tokens(
+                cast("list[dict[str, Any]]", staged_messages),
+                cast("list[dict[str, Any]]", provider_tools or []),
+                self._model_route,
+            )
+            if provider_measurement.source is TokenCountSource.FALLBACK_ESTIMATE:
+                forced_rejections.update(
+                    {
+                        key: (
+                            SkillActivationRejectionReason.TOKEN_MEASUREMENT_UNAVAILABLE
+                        )
+                        for key in newly_accepted
+                    }
+                )
+                continue
+            if provider_measurement.tokens > self._max_input_tokens:
+                overflow_key = newly_accepted[-1]
+                for index, candidate_key in enumerate(newly_accepted[:-1]):
+                    probe_rejections = {
+                        **forced_rejections,
+                        **{
+                            later_key: (
+                                SkillActivationRejectionReason.MODEL_CONTEXT_LIMIT_EXCEEDED
+                            )
+                            for later_key in newly_accepted[index + 1 :]
+                        },
+                    }
+                    (
+                        _probe,
+                        probe_messages,
+                        _probe_external,
+                        _probe_deferred,
+                        _probe_accepted,
+                    ) = stage_round(probe_rejections)
+                    probe_measurement = measure_provider_input_tokens(
+                        cast("list[dict[str, Any]]", probe_messages),
+                        cast("list[dict[str, Any]]", provider_tools or []),
+                        self._model_route,
+                    )
+                    if probe_measurement.source is TokenCountSource.FALLBACK_ESTIMATE:
+                        forced_rejections.update(
+                            {
+                                key: (
+                                    SkillActivationRejectionReason.TOKEN_MEASUREMENT_UNAVAILABLE
+                                )
+                                for key in newly_accepted
+                            }
+                        )
+                        overflow_key = None
+                        break
+                    if probe_measurement.tokens > self._max_input_tokens:
+                        overflow_key = candidate_key
+                        break
+
+                if overflow_key is not None:
+                    forced_rejections[overflow_key] = (
+                        SkillActivationRejectionReason.MODEL_CONTEXT_LIMIT_EXCEEDED
+                    )
+                continue
+            break
+
+        for request in overflow_requests:
+            if request.activation_key in staged._active_keys:
+                continue
+            staged._reject(
+                activation_key=request.activation_key,
+                reason=SkillActivationRejectionReason.ACTIVATION_LIMIT_EXCEEDED,
+            )
+        staged._selection_latency_ms = self._selection_latency_ms + (
+            (perf_counter_ns() - selection_started_at) // 1_000_000
+        )
+        self._commit(staged)
+        messages[:] = staged_messages
+        return SkillToolCallApplication(
+            external_calls=external,
+            deferred_calls=deferred,
+            assistant_message_appended=True,
+        )
+
+    def snapshot(self) -> SkillActivationSnapshot:
+        initially_active = tuple(
+            skill.activation_key for skill in self._skills if skill.initially_active
+        )
+        return SkillActivationSnapshot(
+            effective_mode=self._effective_mode,
+            fallback_reason=self._fallback_reason,
+            initially_active=initially_active,
+            active=tuple(
+                skill.activation_key
+                for skill in self._skills
+                if skill.activation_key in self._active_keys
+            ),
+            accepted=tuple(self._accepted),
+            repeated=tuple(self._repeated),
+            rejected=tuple(self._rejected),
+            measurement=self._measurement,
+            activation_rounds=self._activation_rounds,
+            selection_latency_ms=self._selection_latency_ms,
+        )

--- a/backend/src/eneo/completion_models/domain/skill_context.py
+++ b/backend/src/eneo/completion_models/domain/skill_context.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from eneo.tokens.token_utils import (
     TokenCountSource,
     measure_message_token_delta,
+    measure_tool_tokens,
 )
 
 
@@ -26,16 +27,24 @@ def measure_skill_context(
     model_name: str,
     max_input_tokens: int,
     context_share_percent: int,
+    tools: list[dict[str, object]] | None = None,
 ) -> SkillContextMeasurement:
-    """Measure the prompt cost added by Skills using the completion counter."""
+    """Measure the complete Skill-owned prompt and tool-schema cost."""
 
-    delta = measure_message_token_delta(
+    message_delta = measure_message_token_delta(
         _system_message(base_instructions),
         _system_message(composed_instructions),
         model_name,
     )
+    tool_delta = measure_tool_tokens(tools or [], model_name)
+    source = (
+        TokenCountSource.FALLBACK_ESTIMATE
+        if TokenCountSource.FALLBACK_ESTIMATE
+        in (message_delta.source, tool_delta.source)
+        else TokenCountSource.LITELLM
+    )
     return SkillContextMeasurement(
-        tokens=delta.tokens,
+        tokens=message_delta.tokens + tool_delta.tokens,
         limit=max_input_tokens * context_share_percent // 100,
-        source=delta.source,
+        source=source,
     )

--- a/backend/src/eneo/completion_models/infrastructure/adapters/base_adapter.py
+++ b/backend/src/eneo/completion_models/infrastructure/adapters/base_adapter.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
         Context,
         ModelKwargs,
     )
+    from eneo.completion_models.domain.skill_activation import SkillActivationRuntime
     from eneo.logging.logging import LoggingDetails
 
 
@@ -37,6 +38,7 @@ class CompletionModelAdapter(ABC):
         context: "Context",
         model_kwargs: "ModelKwargs | dict[str, Any] | None",
         mcp_proxy: Any | None = None,
+        skill_runtime: "SkillActivationRuntime | None" = None,
         **kwargs: Any,
     ) -> "Completion":
         raise NotImplementedError()
@@ -61,6 +63,7 @@ class CompletionModelAdapter(ABC):
         context: "Context",
         model_kwargs: "ModelKwargs | dict[str, Any] | None" = None,
         mcp_proxy: Any | None = None,
+        skill_runtime: "SkillActivationRuntime | None" = None,
         **kwargs: Any,
     ) -> Any:
         """

--- a/backend/src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py
+++ b/backend/src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py
@@ -28,6 +28,15 @@ from eneo.ai_models.completion_models.completion_model import (
     ResponseType,
     TokenUsage,
     ToolCallMetadata,
+    function_definition_to_tool,
+)
+from eneo.completion_models.domain.skill_activation import (
+    SKILL_ACTIVATION_TOOL_NAME,
+    InvalidSkillToolCallError,
+    ProviderToolCall,
+    SkillActivationRuntime,
+    SkillPromptOwnershipError,
+    SkillToolCallApplication,
 )
 from eneo.completion_models.infrastructure.adapters.base_adapter import (
     CompletionModelAdapter,
@@ -310,6 +319,7 @@ class PreparedModelStream:
     kwargs: dict[str, Any]
     mcp_proxy: "MCPProxySession | None"
     has_tools: bool
+    skill_runtime: SkillActivationRuntime | None = None
     # Eneo built-in tools (web search, etc.) kept so iterate_stream can
     # re-merge with refreshed MCP tools after a tools/list_changed without
     # recomputing the built-ins.
@@ -512,6 +522,35 @@ class TenantModelAdapter(CompletionModelAdapter):
             )
         return cast(dict[str, Any], parsed)
 
+    @staticmethod
+    def _apply_skill_activation_tool_calls(
+        *,
+        runtime: SkillActivationRuntime | None,
+        calls: tuple[ProviderToolCall, ...],
+        messages: list[dict[str, object]],
+        provider_tools: list[dict[str, object]],
+        assistant_content: str | None,
+    ) -> SkillToolCallApplication | None:
+        if runtime is None:
+            return None
+        try:
+            return runtime.apply_provider_tool_calls(
+                calls=calls,
+                messages=messages,
+                provider_tools=provider_tools,
+                assistant_content=assistant_content,
+            )
+        except SkillPromptOwnershipError as error:
+            raise OpenAIException(
+                str(error),
+                code="skill_prompt_ownership",
+            ) from error
+        except InvalidSkillToolCallError as error:
+            raise OpenAIException(
+                str(error),
+                code="invalid_tool_call",
+            ) from error
+
     def _extract_usage(self, response: _LiteLLMHasUsage) -> TokenUsage | None:
         """Extract token usage from a LiteLLM response."""
         usage = getattr(response, "usage", None)
@@ -564,27 +603,16 @@ class TenantModelAdapter(CompletionModelAdapter):
         if not context.function_definitions:
             return []
 
-        # Use OpenAI format (compatible with most providers via LiteLLM)
-        tools: list[dict[str, Any]] = []
-        for func_def in context.function_definitions:
-            func_def_any = cast(Any, func_def)
-            tools.append(
-                {
-                    "type": "function",
-                    "function": {
-                        "name": func_def_any.name,
-                        "description": func_def_any.description,
-                        "parameters": cast(dict[str, Any], func_def_any.schema),
-                        "strict": True,
-                    },
-                }
-            )
-        return tools
+        return [
+            cast(dict[str, Any], function_definition_to_tool(func_def))
+            for func_def in context.function_definitions
+        ]
 
     def _merge_mcp_tools(
         self,
         eneo_tools: list[dict[str, Any]],
         mcp_proxy: "MCPProxySession | None",
+        skill_runtime: SkillActivationRuntime | None = None,
     ) -> list[dict[str, Any]]:
         """Merge Eneo built-in tools with MCP proxy tools.
 
@@ -600,7 +628,26 @@ class TenantModelAdapter(CompletionModelAdapter):
                 )
             return []
         mcp_tools = mcp_proxy.get_tools_for_llm() if mcp_proxy else []
-        return eneo_tools + mcp_tools
+        built_in_names = {
+            tool.get("function", {}).get("name")
+            for tool in eneo_tools
+            if isinstance(tool.get("function"), dict)
+        }
+        filtered_mcp_tools = [
+            tool
+            for tool in mcp_tools
+            if not (
+                isinstance(tool.get("function"), dict)
+                and tool["function"].get("name") in built_in_names
+            )
+        ]
+        if skill_runtime is not None and any(
+            isinstance(tool.get("function"), dict)
+            and tool["function"].get("name") == SKILL_ACTIVATION_TOOL_NAME
+            for tool in mcp_tools
+        ):
+            skill_runtime.record_reserved_tool_collision()
+        return eneo_tools + filtered_mcp_tools
 
     async def _refresh_mcp_tools_after_round(
         self,
@@ -609,6 +656,7 @@ class TenantModelAdapter(CompletionModelAdapter):
         tool_names: list[str],
         litellm_kwargs: dict[str, Any],
         allowed_tools: set[str],
+        skill_runtime: SkillActivationRuntime | None = None,
     ) -> set[str]:
         """Re-list MCP tools after a tool round; update the advertised set if changed.
 
@@ -629,7 +677,11 @@ class TenantModelAdapter(CompletionModelAdapter):
         if not tools_changed:
             return allowed_tools
 
-        refreshed_tools = self._merge_mcp_tools(eneo_tools, mcp_proxy)
+        refreshed_tools = self._merge_mcp_tools(
+            eneo_tools,
+            mcp_proxy,
+            skill_runtime,
+        )
         if refreshed_tools:
             litellm_kwargs["tools"] = refreshed_tools
         return mcp_proxy.get_allowed_tool_names()
@@ -743,6 +795,7 @@ class TenantModelAdapter(CompletionModelAdapter):
         context: "Context",
         model_kwargs: ModelKwargs | dict[str, Any] | None,
         mcp_proxy: "MCPProxySession | None" = None,
+        skill_runtime: SkillActivationRuntime | None = None,
         **kwargs: Any,
     ) -> Completion:
         """
@@ -769,7 +822,11 @@ class TenantModelAdapter(CompletionModelAdapter):
 
         # Build combined tools (Eneo built-in + MCP)
         eneo_tools = self._build_tools_from_context(context)
-        all_tools = self._merge_mcp_tools(eneo_tools, mcp_proxy)
+        all_tools = self._merge_mcp_tools(
+            eneo_tools,
+            mcp_proxy,
+            skill_runtime,
+        )
         if all_tools:
             litellm_kwargs["tools"] = all_tools
 
@@ -809,7 +866,11 @@ class TenantModelAdapter(CompletionModelAdapter):
                 tool_round = 0
                 seen_prefixes: set[str] = set()
                 captured_refs: list[McpToolReference] = []
-                while msg.tool_calls and mcp_proxy:
+                activation_available = (
+                    skill_runtime is not None
+                    and skill_runtime.tool_definition is not None
+                )
+                while msg.tool_calls and (mcp_proxy or activation_available):
                     if tool_round >= self.MAX_TOOL_ROUNDS:
                         raise OpenAIException(
                             "The model exceeded the maximum number of tool rounds.",
@@ -817,44 +878,75 @@ class TenantModelAdapter(CompletionModelAdapter):
                         )
                     tool_round += 1
 
-                    allowed_tools = mcp_proxy.get_allowed_tool_names()
-                    for tc in msg.tool_calls:
-                        if tc.function.name not in allowed_tools:
-                            raise OpenAIException(
-                                "The model requested an unauthorized tool.",
-                                code="unauthorized_tool",
-                            )
-
-                    messages.append(
-                        {
-                            "role": "assistant",
-                            "content": msg.content,
-                            "tool_calls": [
-                                {
-                                    "id": tc.id,
-                                    "type": "function",
-                                    "function": {
-                                        "name": tc.function.name,
-                                        "arguments": tc.function.arguments,
-                                    },
-                                }
-                                for tc in msg.tool_calls
-                            ],
-                        }
+                    provider_calls = tuple(
+                        ProviderToolCall(
+                            call_id=tc.id,
+                            name=tc.function.name,
+                            arguments=tc.function.arguments,
+                        )
+                        for tc in msg.tool_calls
                     )
+                    activation = self._apply_skill_activation_tool_calls(
+                        runtime=skill_runtime,
+                        calls=provider_calls,
+                        messages=cast("list[dict[str, object]]", messages),
+                        provider_tools=cast(
+                            "list[dict[str, object]]",
+                            litellm_kwargs.get("tools") or [],
+                        ),
+                        assistant_content=msg.content,
+                    )
+                    external_calls = (
+                        activation.external_calls
+                        if activation is not None
+                        else provider_calls
+                    )
+                    if external_calls and mcp_proxy is None:
+                        break
+                    if not activation or not activation.assistant_message_appended:
+                        messages.append(
+                            {
+                                "role": "assistant",
+                                "content": msg.content,
+                                "tool_calls": [
+                                    {
+                                        "id": call.call_id,
+                                        "type": "function",
+                                        "function": {
+                                            "name": call.name,
+                                            "arguments": call.arguments,
+                                        },
+                                    }
+                                    for call in provider_calls
+                                ],
+                            }
+                        )
 
-                    proxy_calls: list[tuple[str, dict[str, Any]]] = []
-                    for tc in msg.tool_calls:
-                        arguments = self._parse_tool_arguments(tc.function.arguments)
-                        proxy_calls.append((tc.function.name, arguments))
-                    results = await mcp_proxy.call_tools_parallel(proxy_calls)
+                    results: list[dict[str, Any]] = []
+                    if external_calls:
+                        assert mcp_proxy is not None
+                        allowed_tools = mcp_proxy.get_allowed_tool_names()
+                        for call in external_calls:
+                            if call.name not in allowed_tools:
+                                raise OpenAIException(
+                                    "The model requested an unauthorized tool.",
+                                    code="unauthorized_tool",
+                                )
+                        proxy_calls = [
+                            (
+                                call.name,
+                                self._parse_tool_arguments(call.arguments),
+                            )
+                            for call in external_calls
+                        ]
+                        results = await mcp_proxy.call_tools_parallel(proxy_calls)
 
                     # Add tool results to messages. Resource content blocks are
                     # captured as McpToolReferences (buffered on completion for
                     # later persistence) and woven into the LLM-facing text via
                     # a structured MCP source context so the model can emit
                     # <inref/> markers without relying on server-specific shapes.
-                    for tc, result in zip(msg.tool_calls, results):
+                    for call, result in zip(external_calls, results):
                         content_list = cast(
                             list[dict[str, Any]], result.get("content") or []
                         )
@@ -864,8 +956,8 @@ class TenantModelAdapter(CompletionModelAdapter):
                             refs_for_call,
                         ) = _build_tool_result_with_references(
                             content_list=content_list,
-                            tool_call_id=tc.id,
-                            mcp_tool_name=tc.function.name,
+                            tool_call_id=call.call_id,
+                            mcp_tool_name=call.name,
                             existing_prefixes=seen_prefixes,
                         )
                         captured_refs.extend(refs_for_call)
@@ -876,7 +968,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                         messages.append(
                             {
                                 "role": "tool",
-                                "tool_call_id": tc.id,
+                                "tool_call_id": call.call_id,
                                 "content": llm_text,
                             }
                         )
@@ -932,6 +1024,7 @@ class TenantModelAdapter(CompletionModelAdapter):
         context: "Context",
         model_kwargs: ModelKwargs | dict[str, Any] | None = None,
         mcp_proxy: "MCPProxySession | None" = None,
+        skill_runtime: SkillActivationRuntime | None = None,
         **kwargs: Any,
     ) -> PreparedModelStream:
         """
@@ -959,7 +1052,11 @@ class TenantModelAdapter(CompletionModelAdapter):
 
         # Build combined tools (Eneo built-in + MCP)
         eneo_tools = self._build_tools_from_context(context)
-        all_tools = self._merge_mcp_tools(eneo_tools, mcp_proxy)
+        all_tools = self._merge_mcp_tools(
+            eneo_tools,
+            mcp_proxy,
+            skill_runtime,
+        )
         if all_tools:
             litellm_kwargs["tools"] = all_tools
 
@@ -995,6 +1092,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                 messages=messages,
                 kwargs=litellm_kwargs,
                 mcp_proxy=mcp_proxy,
+                skill_runtime=skill_runtime,
                 has_tools=bool(all_tools),
                 eneo_tools=eneo_tools,
             )
@@ -1059,6 +1157,10 @@ class TenantModelAdapter(CompletionModelAdapter):
                 else cast(AsyncIterator[_LiteLLMStreamChunk], stream)
             )
             mcp_proxy = prepared.mcp_proxy if prepared else None
+            skill_runtime = prepared.skill_runtime if prepared else None
+            activation_available = (
+                skill_runtime is not None and skill_runtime.tool_definition is not None
+            )
             mcp_tools_active = bool(mcp_proxy and prepared and prepared.has_tools)
             pending_allowed_tools: set[str] = (
                 mcp_proxy.get_allowed_tool_names()
@@ -1081,6 +1183,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                     super().__init__()
                     self.has_tool_calls: bool = False
                     self.tool_calls_acc: dict[int, _AccumulatedToolCall] = {}
+                    self.assistant_content: list[str] = []
                     self.usage: TokenUsage | None = None
 
             result = _StreamResult()
@@ -1095,6 +1198,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                 pending_emitted: set[int] = set()
                 res.has_tool_calls = False
                 res.tool_calls_acc = {}
+                res.assistant_content = []
 
                 async for chunk in s:
                     logger.debug(f"[DEBUG] Raw chunk: {chunk}")
@@ -1191,6 +1295,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                     content = delta.content or ""
 
                     if content:
+                        res.assistant_content.append(content)
                         buffer += content
 
                         if "<think>" in buffer and not inside_thinking:
@@ -1228,12 +1333,21 @@ class TenantModelAdapter(CompletionModelAdapter):
             async for comp in _drain_stream(source_stream, result):
                 yield comp
 
-            # --- MCP tool call loop ---
-            if result.has_tool_calls and mcp_proxy and prepared and prepared.has_tools:
+            # --- Built-in activation and MCP tool call loop ---
+            if (
+                result.has_tool_calls
+                and prepared
+                and prepared.has_tools
+                and (mcp_proxy or activation_available)
+            ):
                 messages = prepared.messages
                 litellm_kwargs = prepared.kwargs
                 eneo_tools: list[dict[str, Any]] = prepared.eneo_tools
-                allowed_tools = mcp_proxy.get_allowed_tool_names()
+                allowed_tools: set[str] = (
+                    mcp_proxy.get_allowed_tool_names()
+                    if mcp_proxy is not None
+                    else set()
+                )
 
                 max_rounds = self.MAX_TOOL_ROUNDS
                 tool_round = 0
@@ -1247,8 +1361,92 @@ class TenantModelAdapter(CompletionModelAdapter):
                         result.tool_calls_acc[idx]
                         for idx in sorted(result.tool_calls_acc.keys())
                     ]
+                    if any(
+                        not tool_call["id"] or not tool_call["function"]["name"]
+                        for tool_call in tool_calls
+                    ):
+                        raise OpenAIException(
+                            "The model produced an invalid tool call.",
+                            code="invalid_tool_call",
+                        )
+
+                    provider_calls = tuple(
+                        ProviderToolCall(
+                            call_id=cast(str, tool_call["id"]),
+                            name=tool_call["function"]["name"],
+                            arguments=tool_call["function"]["arguments"],
+                        )
+                        for tool_call in tool_calls
+                    )
+                    activation = self._apply_skill_activation_tool_calls(
+                        runtime=skill_runtime,
+                        calls=provider_calls,
+                        messages=cast("list[dict[str, object]]", messages),
+                        provider_tools=cast(
+                            "list[dict[str, object]]",
+                            litellm_kwargs.get("tools") or [],
+                        ),
+                        assistant_content="".join(result.assistant_content) or None,
+                    )
+                    external_calls = (
+                        activation.external_calls
+                        if activation is not None
+                        else provider_calls
+                    )
+                    external_call_ids = {call.call_id for call in external_calls}
+                    tool_calls = [
+                        tool_call
+                        for tool_call in tool_calls
+                        if tool_call["id"] in external_call_ids
+                    ]
+                    if tool_calls and mcp_proxy is None:
+                        break
+
+                    if not tool_calls:
+                        if activation and activation.deferred_calls:
+                            deferred_metadata: list[ToolCallMetadata] = []
+                            for call in activation.deferred_calls:
+                                server_name, tool_name, title = _resolve_tool_names(
+                                    call.name
+                                )
+                                deferred_metadata.append(
+                                    ToolCallMetadata(
+                                        server_name=server_name,
+                                        tool_name=tool_name,
+                                        title=title,
+                                        tool_call_id=call.call_id,
+                                        result_status="deferred",
+                                        result=json.dumps(
+                                            {
+                                                "deferred": True,
+                                                "reason": "skill_context_updated",
+                                                "retryable": True,
+                                            }
+                                        ),
+                                        mcp_tool_name=call.name,
+                                    )
+                                )
+                            yield Completion(
+                                response_type=ResponseType.TOOL_CALL,
+                                tool_calls_metadata=deferred_metadata,
+                            )
+                        follow_up = cast(
+                            AsyncIterator[_LiteLLMStreamChunk],
+                            await _acompletion_call(
+                                model=self.litellm_model,
+                                messages=messages,
+                                stream=True,
+                                drop_params=True,
+                                stream_options={"include_usage": True},
+                                **litellm_kwargs,
+                            ),
+                        )
+                        async for comp in _drain_stream(follow_up, result):
+                            yield comp
+                        continue
 
                     # Security validation
+                    assert mcp_proxy is not None
                     for tc in tool_calls:
                         name = tc["function"]["name"]
                         if name not in allowed_tools:
@@ -1409,23 +1607,24 @@ class TenantModelAdapter(CompletionModelAdapter):
                         denied_tcs: list[_AccumulatedToolCall] = []
 
                     # Add assistant message with tool calls to conversation
-                    messages.append(
-                        {
-                            "role": "assistant",
-                            "content": None,
-                            "tool_calls": [
-                                {
-                                    "id": tc["id"],
-                                    "type": "function",
-                                    "function": {
-                                        "name": tc["function"]["name"],
-                                        "arguments": tc["function"]["arguments"],
-                                    },
-                                }
-                                for tc in tool_calls
-                            ],
-                        }
-                    )
+                    if not activation or not activation.assistant_message_appended:
+                        messages.append(
+                            {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": [
+                                    {
+                                        "id": tc["id"],
+                                        "type": "function",
+                                        "function": {
+                                            "name": tc["function"]["name"],
+                                            "arguments": tc["function"]["arguments"],
+                                        },
+                                    }
+                                    for tc in tool_calls
+                                ],
+                            }
+                        )
 
                     # Execute approved tools
                     if approved_tcs:
@@ -1571,6 +1770,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                         tool_names=[tc["function"]["name"] for tc in tool_calls],
                         litellm_kwargs=litellm_kwargs,
                         allowed_tools=allowed_tools,
+                        skill_runtime=skill_runtime,
                     )
 
                     # Follow-up streaming request (keep tools for next round)

--- a/backend/src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py
+++ b/backend/src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py
@@ -58,6 +58,7 @@ from eneo.model_providers.infrastructure.litellm_provider import (
 from eneo.model_providers.infrastructure.tenant_model_credential_resolver import (
     TenantModelCredentialResolver,
 )
+from eneo.tokens.token_utils import measure_provider_input_tokens
 
 logger = get_logger(__name__)
 
@@ -590,6 +591,25 @@ class TenantModelAdapter(CompletionModelAdapter):
             reasoning_tokens=_add(existing.reasoning_tokens, new.reasoning_tokens),
         )
 
+    def _resolve_request_input_tokens(
+        self,
+        *,
+        response: _LiteLLMHasUsage,
+        messages: list[dict[str, Any]],
+        provider_tools: list[dict[str, Any]],
+    ) -> tuple[int, bool]:
+        """Return one provider request's input count and whether it is estimated."""
+
+        usage = self._extract_usage(response)
+        if usage is not None and usage.prompt_tokens is not None:
+            return usage.prompt_tokens, False
+        measurement = measure_provider_input_tokens(
+            messages,
+            provider_tools,
+            self.litellm_model,
+        )
+        return measurement.tokens, True
+
     def _build_tools_from_context(self, context: "Context") -> list[dict[str, Any]]:
         """
         Build tools/functions array from context function definitions.
@@ -638,7 +658,10 @@ class TenantModelAdapter(CompletionModelAdapter):
             for tool in mcp_tools
             if not (
                 isinstance(tool.get("function"), dict)
-                and tool["function"].get("name") in built_in_names
+                and (
+                    tool["function"].get("name") in built_in_names
+                    or tool["function"].get("name") == SKILL_ACTIVATION_TOOL_NAME
+                )
             )
         ]
         if skill_runtime is not None and any(
@@ -839,6 +862,8 @@ class TenantModelAdapter(CompletionModelAdapter):
         )
 
         try:
+            cumulative_input_tokens = 0
+            used_input_estimate = False
             # Call LiteLLM with drop_params=True to handle unsupported params gracefully
             response = cast(
                 _LiteLLMResponse,
@@ -850,6 +875,18 @@ class TenantModelAdapter(CompletionModelAdapter):
                     **litellm_kwargs,
                 ),
             )
+            request_input_tokens, request_was_estimated = (
+                self._resolve_request_input_tokens(
+                    response=response,
+                    messages=messages,
+                    provider_tools=cast(
+                        "list[dict[str, Any]]",
+                        litellm_kwargs.get("tools") or [],
+                    ),
+                )
+            )
+            cumulative_input_tokens += request_input_tokens
+            used_input_estimate = used_input_estimate or request_was_estimated
 
             # Extract token usage from provider response
             usage = self._extract_usage(response)
@@ -982,6 +1019,18 @@ class TenantModelAdapter(CompletionModelAdapter):
                             **litellm_kwargs,
                         ),
                     )
+                    request_input_tokens, request_was_estimated = (
+                        self._resolve_request_input_tokens(
+                            response=response,
+                            messages=messages,
+                            provider_tools=cast(
+                                "list[dict[str, Any]]",
+                                litellm_kwargs.get("tools") or [],
+                            ),
+                        )
+                    )
+                    cumulative_input_tokens += request_input_tokens
+                    used_input_estimate = used_input_estimate or request_was_estimated
                     usage = self._accumulate_usage(usage, response)
                     if not response.choices:
                         break
@@ -994,6 +1043,10 @@ class TenantModelAdapter(CompletionModelAdapter):
                     completion.text = self._strip_thinking_content(msg.content)
                 completion.stop = choice.finish_reason == "stop"
 
+            if used_input_estimate:
+                completion.input_token_estimate = cumulative_input_tokens
+                if usage is not None:
+                    usage = usage.model_copy(update={"prompt_tokens": None})
             completion.usage = usage
             logger.info(
                 f"[TenantModelAdapter] {self.litellm_model}: Completion successful"
@@ -1185,17 +1238,25 @@ class TenantModelAdapter(CompletionModelAdapter):
                     self.tool_calls_acc: dict[int, _AccumulatedToolCall] = {}
                     self.assistant_content: list[str] = []
                     self.usage: TokenUsage | None = None
+                    self.cumulative_input_tokens = 0
+                    self.used_input_estimate = False
 
             result = _StreamResult()
 
             async def _drain_stream(
-                s: AsyncIterator[_LiteLLMStreamChunk], res: _StreamResult
+                s: AsyncIterator[_LiteLLMStreamChunk],
+                res: _StreamResult,
+                *,
+                request_messages: list[dict[str, Any]] | None = None,
+                provider_tools: list[dict[str, Any]] | None = None,
             ) -> AsyncIterator[Completion]:
                 """Drain a stream: yield text Completions, accumulate tool calls into res."""
                 buffer = ""
                 inside_thinking = False
                 thinking_stripped = False
                 pending_emitted: set[int] = set()
+                request_prompt_tokens = 0
+                provider_reported_prompt_tokens = False
                 res.has_tool_calls = False
                 res.tool_calls_acc = {}
                 res.assistant_content = []
@@ -1208,6 +1269,9 @@ class TenantModelAdapter(CompletionModelAdapter):
                     if chunk_usage_obj:
                         chunk_usage = self._extract_usage(chunk)
                         if chunk_usage:
+                            if chunk_usage.prompt_tokens is not None:
+                                request_prompt_tokens += chunk_usage.prompt_tokens
+                                provider_reported_prompt_tokens = True
                             res.usage = (
                                 self._accumulate_usage(res.usage, chunk)
                                 if res.usage
@@ -1329,8 +1393,29 @@ class TenantModelAdapter(CompletionModelAdapter):
                                 yield Completion(text=cleaned)
                         buffer = ""
 
+                if provider_reported_prompt_tokens:
+                    res.cumulative_input_tokens += request_prompt_tokens
+                elif request_messages is not None:
+                    measurement = measure_provider_input_tokens(
+                        request_messages,
+                        provider_tools or [],
+                        self.litellm_model,
+                    )
+                    res.cumulative_input_tokens += measurement.tokens
+                    res.used_input_estimate = True
+
             # --- Drain initial stream ---
-            async for comp in _drain_stream(source_stream, result):
+            async for comp in _drain_stream(
+                source_stream,
+                result,
+                request_messages=list(prepared.messages) if prepared else None,
+                provider_tools=cast(
+                    "list[dict[str, Any]]",
+                    prepared.kwargs.get("tools") or [],
+                )
+                if prepared
+                else None,
+            ):
                 yield comp
 
             # --- Built-in activation and MCP tool call loop ---
@@ -1441,7 +1526,15 @@ class TenantModelAdapter(CompletionModelAdapter):
                                 **litellm_kwargs,
                             ),
                         )
-                        async for comp in _drain_stream(follow_up, result):
+                        async for comp in _drain_stream(
+                            follow_up,
+                            result,
+                            request_messages=list(messages),
+                            provider_tools=cast(
+                                "list[dict[str, Any]]",
+                                litellm_kwargs.get("tools") or [],
+                            ),
+                        ):
                             yield comp
                         continue
 
@@ -1787,7 +1880,15 @@ class TenantModelAdapter(CompletionModelAdapter):
                     )
 
                     # Drain follow-up stream
-                    async for comp in _drain_stream(follow_up, result):
+                    async for comp in _drain_stream(
+                        follow_up,
+                        result,
+                        request_messages=list(messages),
+                        provider_tools=cast(
+                            "list[dict[str, Any]]",
+                            litellm_kwargs.get("tools") or [],
+                        ),
+                    ):
                         yield comp
 
                 if result.has_tool_calls and tool_round >= max_rounds:
@@ -1797,8 +1898,22 @@ class TenantModelAdapter(CompletionModelAdapter):
                         code="tool_round_limit",
                     )
 
-            # Final stop — attach accumulated usage
-            yield Completion(text="", stop=True, usage=result.usage)
+            # Final stop — attach accumulated usage. If any request lacked
+            # provider prompt usage, keep that field unset and expose the
+            # cumulative request-payload estimate separately.
+            final_usage = result.usage
+            if result.used_input_estimate and final_usage is not None:
+                final_usage = final_usage.model_copy(update={"prompt_tokens": None})
+            yield Completion(
+                text="",
+                stop=True,
+                usage=final_usage,
+                input_token_estimate=(
+                    result.cumulative_input_tokens
+                    if result.used_input_estimate
+                    else None
+                ),
+            )
 
             logger.info(
                 f"[TenantModelAdapter] {self.litellm_model}: Stream iteration completed"

--- a/backend/src/eneo/completion_models/infrastructure/completion_service.py
+++ b/backend/src/eneo/completion_models/infrastructure/completion_service.py
@@ -349,6 +349,8 @@ class CompletionService:
                     mcp_proxy=mcp_proxy,
                     skill_runtime=skill_runtime,
                 )
+                adapter_input_estimate = completion.input_token_estimate
+                usage = completion.usage
             finally:
                 # Ensure cleanup for non-streaming
                 if mcp_proxy:
@@ -436,17 +438,23 @@ class CompletionService:
                         await mcp_proxy.close()
 
             completion = self._handle_tool_call(streaming_wrapper())
+            adapter_input_estimate = None
+            usage = None
 
         final_skill_tokens = (
             skill_runtime.snapshot().measurement.tokens
             if skill_runtime is not None
             else 0
         )
-        total_token_count = context.token_count + max(
-            final_skill_tokens - initial_skill_tokens,
-            0,
+        total_token_count = (
+            adapter_input_estimate
+            if adapter_input_estimate is not None
+            else context.token_count
+            + max(
+                final_skill_tokens - initial_skill_tokens,
+                0,
+            )
         )
-        usage = getattr(completion, "usage", None) if not stream else None
         if usage is not None:
             log_token_count_drift(
                 model_name=model_adapter.get_model_route(),

--- a/backend/src/eneo/completion_models/infrastructure/completion_service.py
+++ b/backend/src/eneo/completion_models/infrastructure/completion_service.py
@@ -12,6 +12,7 @@ from eneo.ai_models.completion_models.completion_model import (
     ModelKwargs,
     ResponseType,
 )
+from eneo.completion_models.domain.skill_activation import SkillActivationRuntime
 from eneo.completion_models.infrastructure.context_builder import ContextBuilder
 from eneo.files.file_models import File
 from eneo.info_blobs.info_blob import InfoBlobChunkInDBWithScore
@@ -234,6 +235,7 @@ class CompletionService:
         use_image_generation: bool = False,
         mcp_servers: list["MCPServer"] | None = None,
         require_tool_approval: bool = False,
+        skill_runtime: SkillActivationRuntime | None = None,
     ) -> CompletionModelResponse:
         if files is None:
             files = []
@@ -258,6 +260,11 @@ class CompletionService:
         # (effective_config_service), so re-filtering here is idempotent.
         mcp_servers = [server for server in mcp_servers if server.is_enabled]
         model_adapter = await self._get_adapter(model)
+        initial_skill_tokens = (
+            skill_runtime.snapshot().measurement.tokens
+            if skill_runtime is not None
+            else 0
+        )
 
         # Make sure everything fits in the context of the model
         max_tokens = model_adapter.get_token_limit_of_model()
@@ -306,6 +313,12 @@ class CompletionService:
                 version=version,
                 use_image_generation=use_image_generation,
                 web_search_results=web_search_results,
+                mcp_tools=(
+                    [skill_runtime.tool_definition]
+                    if skill_runtime is not None
+                    and skill_runtime.tool_definition is not None
+                    else None
+                ),
                 vision=model.vision,
                 extra_tool_dicts=(
                     mcp_proxy.get_tools_for_llm()
@@ -334,6 +347,7 @@ class CompletionService:
                     context=context,
                     model_kwargs=model_kwargs,
                     mcp_proxy=mcp_proxy,
+                    skill_runtime=skill_runtime,
                 )
             finally:
                 # Ensure cleanup for non-streaming
@@ -348,6 +362,7 @@ class CompletionService:
                     context=context,
                     model_kwargs=model_kwargs,
                     mcp_proxy=mcp_proxy,
+                    skill_runtime=skill_runtime,
                 )
             except BaseException:
                 # If stream prep fails, close the proxy here — the streaming_wrapper's
@@ -422,11 +437,20 @@ class CompletionService:
 
             completion = self._handle_tool_call(streaming_wrapper())
 
+        final_skill_tokens = (
+            skill_runtime.snapshot().measurement.tokens
+            if skill_runtime is not None
+            else 0
+        )
+        total_token_count = context.token_count + max(
+            final_skill_tokens - initial_skill_tokens,
+            0,
+        )
         usage = getattr(completion, "usage", None) if not stream else None
         if usage is not None:
             log_token_count_drift(
                 model_name=model_adapter.get_model_route(),
-                predicted=context.token_count,
+                predicted=total_token_count,
                 actual=usage.prompt_tokens,
             )
 
@@ -434,7 +458,7 @@ class CompletionService:
             completion=completion,
             model=model_adapter.model,
             extended_logging=logging_details,
-            total_token_count=context.token_count,
+            total_token_count=total_token_count,
             usage=usage,
         )
 

--- a/backend/src/eneo/completion_models/infrastructure/context_builder.py
+++ b/backend/src/eneo/completion_models/infrastructure/context_builder.py
@@ -11,6 +11,7 @@ from eneo.ai_models.completion_models.completion_model import (
     FunctionDefinition,
     Message,
     MessageToolCall,
+    function_definition_to_tool,
 )
 from eneo.completion_models.infrastructure.message_payload import (
     build_turn_messages,
@@ -575,15 +576,7 @@ class ContextBuilder:
         functions.extend(mcp_tools)
 
         tool_dicts: list[dict[str, Any]] = [
-            {
-                "type": "function",
-                "function": {
-                    "name": func_def.name,
-                    "description": func_def.description,
-                    "parameters": func_def.schema,
-                },
-            }
-            for func_def in functions
+            function_definition_to_tool(func_def) for func_def in functions
         ]
         if extra_tool_dicts:
             tool_dicts.extend(extra_tool_dicts)

--- a/backend/src/eneo/help_assistants/application/helper_run_service.py
+++ b/backend/src/eneo/help_assistants/application/helper_run_service.py
@@ -524,8 +524,8 @@ class HelperRunService:
         ``questions_repo`` with ``logging_details=None`` so no row reaches
         the ``logging`` table (PRD §6 + Critical test #3). Token counts
         prefer provider-reported values from the final ``TokenUsage`` chunk
-        and fall back to ``response.total_token_count`` if absent —
-        matching the assistant-service pattern.
+        and fall back to the adapter's cumulative request estimate, then the
+        initial context estimate, if provider usage is absent.
 
         The persistence call wraps a defensive ``session.begin()`` when the
         request-scoped transaction has already committed — same idiom as
@@ -541,10 +541,13 @@ class HelperRunService:
 
         response_string = ""
         stream_usage: TokenUsage | None = None
+        stream_input_token_estimate: int | None = None
 
         async for chunk in completion:
             if chunk.usage is not None:
                 stream_usage = chunk.usage
+            if chunk.input_token_estimate is not None:
+                stream_input_token_estimate = chunk.input_token_estimate
             if chunk.response_type == ResponseType.TEXT and chunk.text is not None:
                 response_string = f"{response_string}{chunk.text}"
             yield chunk
@@ -552,7 +555,11 @@ class HelperRunService:
         if stream_usage is not None and stream_usage.prompt_tokens is not None:
             num_tokens_question = stream_usage.prompt_tokens
         else:
-            num_tokens_question = response.total_token_count
+            num_tokens_question = (
+                stream_input_token_estimate
+                if stream_input_token_estimate is not None
+                else response.total_token_count
+            )
 
         if stream_usage is not None and stream_usage.completion_tokens is not None:
             num_tokens_answer = stream_usage.completion_tokens

--- a/backend/src/eneo/questions/questions_repo.py
+++ b/backend/src/eneo/questions/questions_repo.py
@@ -1,8 +1,10 @@
+from collections.abc import Sequence
 from datetime import datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID
 
 import sqlalchemy as sa
+from pydantic import TypeAdapter
 from sqlalchemy.orm import selectinload, undefer
 
 from eneo.database.database import AsyncSession
@@ -28,12 +30,19 @@ from eneo.files.file_models import File
 from eneo.info_blobs.info_blob import InfoBlobChunkInDBWithScore
 from eneo.questions.question import Question, QuestionAdd
 from eneo.questions.question_file_projection import attach_question_files
+from eneo.skills.domain.skill import (
+    SkillActivationEvidenceV1,
+    SkillExecutionReference,
+)
 
 if TYPE_CHECKING:
     from eneo.ai_models.completion_models.completion_model import McpToolReference
     from eneo.completion_models.infrastructure.web_search import WebSearchResult
     from eneo.logging.logging import LoggingDetails
     from eneo.questions.question import ToolCallInfo
+
+
+_SKILL_PROVENANCE_ADAPTER = TypeAdapter(tuple[SkillExecutionReference, ...])
 
 
 class QuestionRepository:
@@ -217,6 +226,8 @@ class QuestionRepository:
         web_search_results: list["WebSearchResult"] | None = None,
         logging_details: "LoggingDetails | None" = None,
         mcp_tool_references: list["McpToolReference"] | None = None,
+        skill_provenance: Sequence[SkillExecutionReference] | None = None,
+        skill_activation: SkillActivationEvidenceV1 | None = None,
     ) -> None:
         """Update an existing placeholder Question row with the final or partial answer.
 
@@ -250,6 +261,12 @@ class QuestionRepository:
             update_values["reasoning"] = reasoning
         if logging_details_id is not None:
             update_values["logging_details_id"] = logging_details_id
+        update_values.update(
+            self._serialize_skill_runtime_state(
+                skill_provenance=skill_provenance,
+                skill_activation=skill_activation,
+            )
+        )
 
         update_stmt = (
             sa.update(Questions)
@@ -280,6 +297,48 @@ class QuestionRepository:
                 mcp_tool_references=mcp_tool_references,
                 question_id=question_id,
             )
+
+    @staticmethod
+    def _serialize_skill_runtime_state(
+        *,
+        skill_provenance: Sequence[SkillExecutionReference] | None,
+        skill_activation: SkillActivationEvidenceV1 | None,
+    ) -> dict[str, object]:
+        values: dict[str, object] = {}
+        if skill_provenance is not None:
+            values["skill_provenance"] = cast(
+                "list[dict[str, object]]",
+                _SKILL_PROVENANCE_ADAPTER.dump_python(
+                    tuple(skill_provenance),
+                    mode="json",
+                ),
+            )
+        if skill_activation is not None:
+            values["skill_activation_data"] = skill_activation.model_dump(mode="json")
+        return values
+
+    async def update_skill_runtime_state(
+        self,
+        *,
+        question_id: UUID,
+        tenant_id: UUID,
+        skill_provenance: Sequence[SkillExecutionReference],
+        skill_activation: SkillActivationEvidenceV1,
+    ) -> None:
+        """Persist final Skill state when provider work fails before an answer."""
+
+        update_stmt = (
+            sa.update(Questions)
+            .where(Questions.id == question_id)
+            .where(Questions.tenant_id == tenant_id)
+            .values(
+                **self._serialize_skill_runtime_state(
+                    skill_provenance=skill_provenance,
+                    skill_activation=skill_activation,
+                )
+            )
+        )
+        await self.session.execute(update_stmt)
 
     async def add(
         self,

--- a/backend/src/eneo/sessions/session_service.py
+++ b/backend/src/eneo/sessions/session_service.py
@@ -130,6 +130,29 @@ async def persist_partial_question_answer(
         )
 
 
+async def persist_final_skill_runtime_state(
+    *,
+    tenant_id: UUID,
+    question_id: UUID,
+    skill_provenance: Sequence[SkillExecutionReference],
+    skill_activation: SkillActivationEvidenceV1,
+) -> None:
+    """Commit final Skill evidence independently of a failing request transaction."""
+
+    async with sessionmanager.session() as session, session.begin():
+        repo = QuestionRepository(session)
+        await repo.update_skill_runtime_state(
+            question_id=question_id,
+            tenant_id=tenant_id,
+            skill_provenance=skill_provenance,
+            skill_activation=skill_activation,
+        )
+    logger.info(
+        "Persisted final Skill activation evidence after completion failure",
+        extra={"question_id": str(question_id)},
+    )
+
+
 class SessionService:
     def __init__(
         self,
@@ -499,23 +522,6 @@ class SessionService:
                 else None,
                 logging_details=logging_details,
                 mcp_tool_references=mcp_tool_references,
-                skill_provenance=skill_provenance,
-                skill_activation=skill_activation,
-            )
-
-    async def update_question_skill_runtime_state(
-        self,
-        *,
-        question_id: UUID,
-        skill_provenance: Sequence[SkillExecutionReference],
-        skill_activation: SkillActivationEvidenceV1,
-    ) -> None:
-        """Persist final Skill evidence when completion fails before finalization."""
-
-        async with self._write_transaction():
-            await self.question_repo.update_skill_runtime_state(
-                question_id=question_id,
-                tenant_id=self.user.tenant_id,
                 skill_provenance=skill_provenance,
                 skill_activation=skill_activation,
             )

--- a/backend/src/eneo/sessions/session_service.py
+++ b/backend/src/eneo/sessions/session_service.py
@@ -92,6 +92,8 @@ async def persist_partial_question_answer(
     num_tokens_answer: int,
     completion_model_id: UUID | None = None,
     reasoning: str | None = None,
+    skill_provenance: Sequence[SkillExecutionReference] | None = None,
+    skill_activation: SkillActivationEvidenceV1 | None = None,
 ) -> None:
     """Persist the answer text on a previously-created placeholder question using a fresh
     DB session.
@@ -111,6 +113,8 @@ async def persist_partial_question_answer(
                 num_tokens_answer=num_tokens_answer,
                 completion_model_id=completion_model_id,
                 reasoning=reasoning,
+                skill_provenance=skill_provenance,
+                skill_activation=skill_activation,
             )
         logger.info(
             "Persisted partial chat answer on stream abort",
@@ -473,6 +477,8 @@ class SessionService:
         tool_calls: list[ToolCallInfo] | None = None,
         mcp_tool_references: list["McpToolReference"] | None = None,
         reasoning: str | None = None,
+        skill_provenance: Sequence[SkillExecutionReference] | None = None,
+        skill_activation: SkillActivationEvidenceV1 | None = None,
     ) -> None:
         """Update a placeholder Question row with the final assistant answer."""
         completion_model_id = completion_model.id if completion_model else None
@@ -493,6 +499,25 @@ class SessionService:
                 else None,
                 logging_details=logging_details,
                 mcp_tool_references=mcp_tool_references,
+                skill_provenance=skill_provenance,
+                skill_activation=skill_activation,
+            )
+
+    async def update_question_skill_runtime_state(
+        self,
+        *,
+        question_id: UUID,
+        skill_provenance: Sequence[SkillExecutionReference],
+        skill_activation: SkillActivationEvidenceV1,
+    ) -> None:
+        """Persist final Skill evidence when completion fails before finalization."""
+
+        async with self._write_transaction():
+            await self.question_repo.update_skill_runtime_state(
+                question_id=question_id,
+                tenant_id=self.user.tenant_id,
+                skill_provenance=skill_provenance,
+                skill_activation=skill_activation,
             )
 
     async def leave_feedback(

--- a/backend/src/eneo/skills/application/skill_service.py
+++ b/backend/src/eneo/skills/application/skill_service.py
@@ -905,7 +905,7 @@ class SkillService:
         policy = await self.repo.get_or_seed_runtime_policy(
             tenant_id=self.user.tenant_id
         )
-        return SkillTurnPlan.create_eager(
+        return SkillTurnPlan.create(
             base_instructions=base_instructions,
             resolution=resolution,
             policy=policy,

--- a/backend/src/eneo/skills/domain/skill.py
+++ b/backend/src/eneo/skills/domain/skill.py
@@ -720,6 +720,7 @@ class SkillActivationFallbackReason(str, Enum):
 class SkillActivationRejectionReason(str, Enum):
     UNKNOWN_KEY = "unknown_key"
     BLOCKED = "blocked"
+    ACTIVATION_UNAVAILABLE = "activation_unavailable"
     ACTIVATION_LIMIT_EXCEEDED = "activation_limit_exceeded"
     CONTEXT_LIMIT_EXCEEDED = "context_limit_exceeded"
     MODEL_CONTEXT_LIMIT_EXCEEDED = "model_context_limit_exceeded"

--- a/backend/src/eneo/skills/domain/skill.py
+++ b/backend/src/eneo/skills/domain/skill.py
@@ -8,13 +8,19 @@ import re
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from eneo.main.exceptions import BadRequestException
 from eneo.model_providers.domain.model_route import MAX_MODEL_ROUTE_LENGTH
+
+if TYPE_CHECKING:
+    from eneo.completion_models.domain.skill_activation import (
+        SkillActivationRuntime,
+        SkillActivationSnapshot,
+    )
 
 MAX_SKILL_SLUG_LENGTH = 64
 MAX_SKILL_DISPLAY_NAME_LENGTH = 200
@@ -25,6 +31,7 @@ DEFAULT_SKILL_CATALOG_PAGE_LIMIT = 25
 MAX_SKILL_ADOPTION_PAGE_LIMIT = 100
 DEFAULT_SKILL_ADOPTION_PAGE_LIMIT = 25
 MAX_SKILL_EXECUTION_BLOCK_REASON_LENGTH = 1000
+MAX_RETAINED_SKILL_ACTIVATION_REJECTIONS = 50
 
 _SKILL_SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 _SKILL_BOUNDARY = (
@@ -706,15 +713,17 @@ class SkillTurnEffectiveMode(str, Enum):
 class SkillActivationFallbackReason(str, Enum):
     MODEL_LACKS_TOOL_CALLING = "model_lacks_tool_calling"
     CATALOG_BUDGET_EXCEEDED = "catalog_budget_exceeded"
+    TOKEN_MEASUREMENT_UNAVAILABLE = "token_measurement_unavailable"
     SELECTIVE_ACTIVATION_DISABLED = "selective_activation_disabled"
 
 
 class SkillActivationRejectionReason(str, Enum):
     UNKNOWN_KEY = "unknown_key"
     BLOCKED = "blocked"
-    REPEATED = "repeated"
     ACTIVATION_LIMIT_EXCEEDED = "activation_limit_exceeded"
     CONTEXT_LIMIT_EXCEEDED = "context_limit_exceeded"
+    MODEL_CONTEXT_LIMIT_EXCEEDED = "model_context_limit_exceeded"
+    TOKEN_MEASUREMENT_UNAVAILABLE = "token_measurement_unavailable"
     RESERVED_TOOL_COLLISION = "reserved_tool_collision"
 
 
@@ -818,6 +827,13 @@ class SkillActivationEvidenceV1(BaseModel):
                 raise ValueError(
                     f"{field_name} contains an unknown Skill activation key"
                 )
+        rejection_identities = [
+            (rejection.activation_key, rejection.reason) for rejection in self.rejected
+        ]
+        if len(rejection_identities) > MAX_RETAINED_SKILL_ACTIVATION_REJECTIONS:
+            raise ValueError("Too many retained Skill activation rejections")
+        if len(rejection_identities) != len(set(rejection_identities)):
+            raise ValueError("Skill activation rejections must be unique")
         return self
 
 
@@ -834,12 +850,12 @@ class SkillTurnPlan:
     base_instructions: str
     policy: SkillRuntimePolicy
     available: tuple[SkillTurnBinding, ...]
-    blocked: tuple[ResolvedSkillBinding, ...]
+    blocked: tuple[SkillTurnBinding, ...]
     initially_active_keys: tuple[str, ...]
     composition: SkillComposition
 
     @classmethod
-    def create_eager(
+    def create(
         cls,
         *,
         base_instructions: str,
@@ -853,30 +869,86 @@ class SkillTurnPlan:
             SkillTurnBinding(activation_key=f"skill-{index}", binding=binding)
             for index, binding in enumerate(ordered, start=1)
         )
+        blocked = tuple(
+            SkillTurnBinding(
+                activation_key=f"blocked-skill-{index}",
+                binding=binding,
+            )
+            for index, binding in enumerate(
+                sorted(resolution.blocked, key=lambda binding: binding.position),
+                start=1,
+            )
+        )
+        initially_active = tuple(
+            binding
+            for binding in available
+            if binding.binding.activation_mode is SkillActivationMode.ALWAYS
+        )
         return cls(
             base_instructions=base_instructions,
             policy=policy,
             available=available,
-            blocked=tuple(
-                sorted(resolution.blocked, key=lambda binding: binding.position)
-            ),
+            blocked=blocked,
             initially_active_keys=tuple(
-                binding.activation_key for binding in available
+                binding.activation_key for binding in initially_active
             ),
             composition=compose_skill_instructions(
                 base_instructions=base_instructions,
-                bindings=list(ordered),
+                bindings=[binding.binding for binding in initially_active],
             ),
         )
+
+    def to_activation_runtime(
+        self,
+        *,
+        selected_model_route: str,
+        max_input_tokens: int,
+        supports_tool_calling: bool,
+    ) -> "SkillActivationRuntime":
+        from eneo.completion_models.domain.skill_activation import (
+            FrozenSkillInstruction,
+            SkillActivationRuntime,
+        )
+
+        initially_active = set(self.initially_active_keys)
+        return SkillActivationRuntime.create(
+            base_instructions=self.base_instructions,
+            skills=tuple(
+                FrozenSkillInstruction(
+                    activation_key=binding.activation_key,
+                    binding=binding.binding,
+                    initially_active=binding.activation_key in initially_active,
+                )
+                for binding in self.available
+            ),
+            blocked_keys=frozenset(binding.activation_key for binding in self.blocked),
+            selective_activation_enabled=self.policy.selective_activation_enabled,
+            max_activations_per_turn=self.policy.max_activations_per_turn,
+            context_share_percent=self.policy.context_share_percent,
+            model_route=selected_model_route,
+            max_input_tokens=max_input_tokens,
+            supports_tool_calling=supports_tool_calling,
+        )
+
+    def active_provenance(
+        self, snapshot: "SkillActivationSnapshot"
+    ) -> tuple[SkillExecutionReference, ...]:
+        active_keys = set(snapshot.active)
+        return compose_skill_instructions(
+            base_instructions=self.base_instructions,
+            bindings=[
+                binding.binding
+                for binding in self.available
+                if binding.activation_key in active_keys
+            ],
+        ).provenance
 
     def activation_evidence(
         self,
         *,
         selected_model_id: UUID,
         selected_model_route: str,
-        skill_context_tokens: int,
-        skill_context_token_limit: int,
-        token_count_source: Literal["litellm", "fallback_estimate"],
+        snapshot: "SkillActivationSnapshot",
     ) -> SkillActivationEvidenceV1:
         available = tuple(
             SkillActivationReference.from_binding(
@@ -886,16 +958,31 @@ class SkillTurnPlan:
             for binding in self.available
         )
         return SkillActivationEvidenceV1(
-            effective_mode=SkillTurnEffectiveMode.EAGER,
+            effective_mode=snapshot.effective_mode,
+            fallback_reason=snapshot.fallback_reason,
             available=available,
             blocked=tuple(
-                SkillActivationReference.from_binding(binding)
+                SkillActivationReference.from_binding(
+                    binding.binding,
+                    activation_key=binding.activation_key,
+                )
                 for binding in self.blocked
             ),
-            initially_active=self.initially_active_keys,
+            initially_active=snapshot.initially_active,
+            accepted=snapshot.accepted,
+            repeated=snapshot.repeated,
+            rejected=tuple(
+                SkillActivationRejection(
+                    activation_key=rejection.activation_key,
+                    reason=rejection.reason,
+                )
+                for rejection in snapshot.rejected
+            ),
             selected_model_id=selected_model_id,
             selected_model_route=selected_model_route,
-            skill_context_tokens=skill_context_tokens,
-            skill_context_token_limit=skill_context_token_limit,
-            token_count_source=token_count_source,
+            skill_context_tokens=snapshot.measurement.tokens,
+            skill_context_token_limit=snapshot.measurement.limit,
+            token_count_source=snapshot.measurement.source.value,
+            activation_rounds=snapshot.activation_rounds,
+            selection_latency_ms=snapshot.selection_latency_ms,
         )

--- a/backend/src/eneo/tokens/token_utils.py
+++ b/backend/src/eneo/tokens/token_utils.py
@@ -15,6 +15,7 @@ is expensive to build just for counting.
 
 import base64
 import io
+import json
 import logging
 from dataclasses import dataclass
 from enum import StrEnum
@@ -157,6 +158,10 @@ def _fallback_message_tokens(messages: list[dict[str, Any]]) -> int:
     return total
 
 
+def _fallback_tool_tokens(tools: list[dict[str, Any]]) -> int:
+    return len(json.dumps(tools)) // 4
+
+
 def _measure_messages_with_litellm(
     messages: list[dict[str, Any]],
     model_name: str,
@@ -234,10 +239,12 @@ def count_message_tokens(messages: list[dict[str, Any]], model_name: str = "") -
     return measure_message_tokens(messages, model_name).tokens
 
 
-def count_tool_tokens(tools: list[dict[str, Any]], model_name: str = "") -> int:
-    """Count tokens consumed by tool/function definitions sent with a request."""
+def measure_tool_tokens(
+    tools: list[dict[str, Any]], model_name: str = ""
+) -> TokenCount:
+    """Measure tool definitions and identify the counter used."""
     if not tools:
-        return 0
+        return TokenCount(tokens=0, source=TokenCountSource.LITELLM)
 
     try:
         with_tools = litellm.token_counter(  # type: ignore[reportPrivateImportUsage]
@@ -248,16 +255,57 @@ def count_tool_tokens(tools: list[dict[str, Any]], model_name: str = "") -> int:
         without_tools = litellm.token_counter(  # type: ignore[reportPrivateImportUsage]
             model=model_name, messages=[{"role": "user", "content": ""}]
         )
-        return max(with_tools - without_tools, 0)
+        return TokenCount(
+            tokens=max(with_tools - without_tools, 0),
+            source=TokenCountSource.LITELLM,
+        )
     except Exception as e:
-        import json
-
-        serialized = json.dumps(tools)
         logger.error(
             f"Tool token counting failed for model '{model_name}' "
             f"({len(tools)} tools), falling back to len//4: {e}"
         )
-        return len(serialized) // 4
+        return TokenCount(
+            tokens=_fallback_tool_tokens(tools),
+            source=TokenCountSource.FALLBACK_ESTIMATE,
+        )
+
+
+def measure_provider_input_tokens(
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    model_name: str = "",
+) -> TokenCount:
+    """Measure the exact chat messages and tools proposed for one provider call."""
+
+    stripped_messages, image_tokens = _split_image_blocks(messages, model_name)
+    try:
+        payload_tokens = litellm.token_counter(  # type: ignore[reportPrivateImportUsage]
+            model=model_name,
+            messages=stripped_messages,
+            tools=tools,  # pyright: ignore[reportArgumentType]  # litellm accepts plain dicts
+        )
+        return TokenCount(
+            tokens=payload_tokens + image_tokens,
+            source=TokenCountSource.LITELLM,
+        )
+    except Exception as error:
+        logger.error(
+            "Provider input token counting failed for model '%s' "
+            "(%d messages, %d tools), using one fallback estimate: %s",
+            model_name,
+            len(messages),
+            len(tools),
+            error,
+        )
+        return TokenCount(
+            tokens=_fallback_message_tokens(messages) + _fallback_tool_tokens(tools),
+            source=TokenCountSource.FALLBACK_ESTIMATE,
+        )
+
+
+def count_tool_tokens(tools: list[dict[str, Any]], model_name: str = "") -> int:
+    """Count tokens consumed by tool/function definitions sent with a request."""
+    return measure_tool_tokens(tools, model_name).tokens
 
 
 def count_assistant_prompt_tokens(prompt: Optional[str], model_name: str) -> int:

--- a/backend/tests/integration/services/test_conversation_stream_abort.py
+++ b/backend/tests/integration/services/test_conversation_stream_abort.py
@@ -19,13 +19,21 @@ from uuid import UUID, uuid4
 import pytest
 import sqlalchemy as sa
 
+from eneo.completion_models.domain.skill_activation import (
+    SKILL_ACTIVATION_TOOL_NAME,
+    ProviderToolCall,
+)
 from eneo.database.database import sessionmanager
 from eneo.database.tables.questions_table import Questions
 from eneo.database.tables.sessions_table import Sessions
 from eneo.questions.questions_repo import QuestionRepository
-from eneo.sessions.session_service import persist_partial_question_answer
+from eneo.sessions.session_service import (
+    persist_final_skill_runtime_state,
+    persist_partial_question_answer,
+)
 from eneo.skills.domain.skill import (
     ResolvedSkillBinding,
+    SkillActivationMode,
     SkillBindingSource,
     SkillRuntimePolicy,
     SkillRuntimeResolution,
@@ -405,6 +413,116 @@ async def test_frozen_skill_evidence_is_deferred_from_conversation_reads(
     assert after_abort is not None
     assert after_abort.answer == "Partial answer"
     assert after_abort.skill_activation == evidence
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_provider_failure_evidence_survives_request_transaction_rollback(
+    client,
+    db_container,
+    default_user,
+    default_user_token,
+):
+    space_id = await _create_space(client, default_user_token)
+    assistant_id = await _create_assistant(client, default_user_token, space_id)
+    binding = ResolvedSkillBinding(
+        skill_id=uuid4(),
+        skill_revision_id=uuid4(),
+        current_revision_id=uuid4(),
+        skill_space_id=uuid4(),
+        slug="payroll",
+        revision_number=3,
+        current_revision_number=3,
+        display_name="Payroll",
+        instructions="Use the payroll handbook.",
+        content_digest="a" * 64,
+        position=0,
+        source=SkillBindingSource.SPACE,
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    plan = SkillTurnPlan.create(
+        base_instructions="Base",
+        resolution=SkillRuntimeResolution(eligible=(binding,), blocked=()),
+        policy=SkillRuntimePolicy(
+            selective_activation_enabled=True,
+            max_attached_skills=100,
+            context_share_percent=100,
+            max_activations_per_turn=10,
+        ),
+    )
+    runtime = plan.to_activation_runtime(
+        selected_model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+    model_id = uuid4()
+    initial_snapshot = runtime.snapshot()
+
+    async with db_container() as container:
+        session_service = container.session_service()
+        chat_session = await session_service.create_session(
+            name="provider-failure-evidence",
+            assistant_id=UUID(assistant_id),
+        )
+        question_id = await session_service.create_question_placeholder(
+            question="Use the payroll procedure",
+            session=chat_session,
+            files=None,
+            assistant_id=UUID(assistant_id),
+            completion_model=None,
+            skill_provenance=plan.active_provenance(initial_snapshot),
+            skill_activation=plan.activation_evidence(
+                selected_model_id=model_id,
+                selected_model_route="openai/gpt-4o",
+                snapshot=initial_snapshot,
+            ),
+        )
+
+    runtime.apply_provider_tool_calls(
+        calls=(
+            ProviderToolCall(
+                call_id="activation-1",
+                name=SKILL_ACTIVATION_TOOL_NAME,
+                arguments='{"skill_key":"skill-1"}',
+            ),
+        ),
+        messages=[{"role": "system", "content": runtime.prompt}],
+    )
+    final_snapshot = runtime.snapshot()
+
+    # Model the request dependency: a provider error unwinds and rolls back the
+    # request transaction after the failure handler has persisted final evidence.
+    with pytest.raises(RuntimeError, match="provider failed"):
+        async with sessionmanager.session() as request_session:
+            async with request_session.begin():
+                await request_session.execute(
+                    sa.select(Questions.id).where(Questions.id == question_id)
+                )
+                await persist_final_skill_runtime_state(
+                    tenant_id=default_user.tenant_id,
+                    question_id=question_id,
+                    skill_provenance=plan.active_provenance(final_snapshot),
+                    skill_activation=plan.activation_evidence(
+                        selected_model_id=model_id,
+                        selected_model_route="openai/gpt-4o",
+                        snapshot=final_snapshot,
+                    ),
+                )
+                raise RuntimeError("provider failed")
+
+    async with db_container() as container:
+        persisted = await container.question_repo().get_with_skill_activation(
+            id=question_id,
+            tenant_id=default_user.tenant_id,
+        )
+
+    assert persisted is not None
+    assert persisted.skill_activation is not None
+    assert persisted.skill_activation.accepted == ("skill-1",)
+    assert persisted.skill_activation.activation_rounds == 1
+    assert persisted.skill_provenance[0].skill_revision_id == (
+        binding.skill_revision_id
+    )
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/services/test_conversation_stream_abort.py
+++ b/backend/tests/integration/services/test_conversation_stream_abort.py
@@ -31,7 +31,6 @@ from eneo.skills.domain.skill import (
     SkillRuntimeResolution,
     SkillTurnPlan,
 )
-from eneo.tokens.token_utils import TokenCountSource
 
 
 @dataclass
@@ -291,7 +290,7 @@ async def test_frozen_skill_evidence_is_deferred_from_conversation_reads(
         position=0,
         source=SkillBindingSource.SPACE,
     )
-    plan = SkillTurnPlan.create_eager(
+    plan = SkillTurnPlan.create(
         base_instructions="Base",
         resolution=SkillRuntimeResolution(eligible=(binding,), blocked=()),
         policy=SkillRuntimePolicy(
@@ -301,12 +300,15 @@ async def test_frozen_skill_evidence_is_deferred_from_conversation_reads(
             max_activations_per_turn=10,
         ),
     )
+    runtime = plan.to_activation_runtime(
+        selected_model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
     evidence = plan.activation_evidence(
         selected_model_id=uuid4(),
         selected_model_route="openai/gpt-4o",
-        skill_context_tokens=12,
-        skill_context_token_limit=100,
-        token_count_source=TokenCountSource.LITELLM,
+        snapshot=runtime.snapshot(),
     )
 
     async with db_container() as container:

--- a/backend/tests/unit/test_chat_stream_abort_persistence.py
+++ b/backend/tests/unit/test_chat_stream_abort_persistence.py
@@ -67,6 +67,29 @@ def _make_session_in_db() -> SimpleNamespace:
     return SimpleNamespace(id=uuid4(), questions=[])
 
 
+def _skill_runtime_args(
+    *,
+    changed: bool = False,
+    initial_skill_context_tokens: int = 0,
+    final_skill_context_tokens: int = 0,
+) -> dict[str, object]:
+    snapshot = SimpleNamespace(
+        changed=changed,
+        measurement=SimpleNamespace(tokens=final_skill_context_tokens),
+    )
+    return {
+        "skill_plan": SimpleNamespace(
+            active_provenance=MagicMock(return_value=()),
+            activation_evidence=MagicMock(
+                return_value=SimpleNamespace(effective_mode="selective")
+            ),
+        ),
+        "skill_runtime": SimpleNamespace(snapshot=MagicMock(return_value=snapshot)),
+        "selected_model_route": "openai/gpt-4",
+        "initial_skill_context_tokens": initial_skill_context_tokens,
+    }
+
+
 @contextmanager
 def _independent_placeholder_store(service: SessionService) -> Iterator[None]:
     @asynccontextmanager
@@ -387,6 +410,7 @@ async def test_streaming_handle_response_schedules_partial_save_on_abort():
             stream=True,
             assistant_id=uuid4(),
             question_id=question_id,
+            **_skill_runtime_args(),
         )
 
         # Pull 2 chunks then close — simulates the SSE client disconnecting after
@@ -406,6 +430,64 @@ async def test_streaming_handle_response_schedules_partial_save_on_abort():
     assert call["answer"] == "hello wor"  # only what was streamed before close
 
     # The normal-completion path must NOT have run.
+    session_service_mock.complete_question_with_answer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_streaming_abort_persists_changed_skill_evidence_without_text():
+    async def fake_completion_stream():
+        yield SimpleNamespace(
+            reasoning_token_count=0,
+            usage=None,
+            response_type=ResponseType.ENEO_EVENT,
+        )
+
+    response = SimpleNamespace(
+        completion=fake_completion_stream(),
+        total_token_count=5,
+        usage=None,
+        extended_logging=None,
+    )
+    session_service_mock = AsyncMock()
+    session_service_mock.complete_question_with_answer = AsyncMock()
+    svc = _make_assistant_service_for_streaming(session_service_mock)
+    persist_calls: list[dict[str, object]] = []
+
+    async def tracking_persist(**kwargs: object) -> None:
+        persist_calls.append(kwargs)
+
+    with patch.object(
+        session_service_module,
+        "persist_partial_question_answer",
+        tracking_persist,
+    ):
+        from eneo.assistants.assistant_service import AssistantService
+
+        gen = await AssistantService._handle_response(  # pyright: ignore[reportPrivateUsage]
+            svc,  # pyright: ignore[reportArgumentType]
+            response=response,
+            datastore_result=SimpleNamespace(
+                info_blobs=[],
+                no_duplicate_chunks=[],
+            ),
+            question="hello?",
+            files=[],
+            completion_model=SimpleNamespace(id=uuid4(), name="gpt-4"),
+            session=_make_session_in_db(),
+            stream=True,
+            assistant_id=uuid4(),
+            question_id=uuid4(),
+            **_skill_runtime_args(changed=True),
+        )
+
+        await _drain_until(gen, 1)
+        await gen.aclose()
+        await asyncio.sleep(0)
+
+    assert len(persist_calls) == 1
+    assert persist_calls[0]["answer"] == ""
+    assert persist_calls[0]["skill_provenance"] == ()
+    assert persist_calls[0]["skill_activation"] is not None
     session_service_mock.complete_question_with_answer.assert_not_called()
 
 
@@ -461,6 +543,10 @@ async def test_streaming_handle_response_no_partial_save_on_normal_completion():
             stream=True,
             assistant_id=uuid4(),
             question_id=question_id,
+            **_skill_runtime_args(
+                initial_skill_context_tokens=2,
+                final_skill_context_tokens=7,
+            ),
         )
 
         # Drain the generator fully — this is the "normal completion" path.
@@ -474,6 +560,9 @@ async def test_streaming_handle_response_no_partial_save_on_normal_completion():
     update_kwargs = session_service_mock.complete_question_with_answer.call_args.kwargs
     assert update_kwargs["question_id"] == question_id
     assert update_kwargs["answer"] == "ok"
+    assert update_kwargs["num_tokens_question"] == 8
+    assert update_kwargs["skill_provenance"] == ()
+    assert update_kwargs["skill_activation"] is not None
 
     # Crucially: no partial-save task was scheduled on a clean finish.
     assert persist_calls == []
@@ -538,6 +627,7 @@ async def test_streaming_handle_response_keeps_distinct_refs_with_same_uri():
         stream=True,
         assistant_id=uuid4(),
         question_id=uuid4(),
+        **_skill_runtime_args(),
     )
     async for _ in gen:
         pass
@@ -592,6 +682,7 @@ async def test_streaming_handle_response_persists_reasoning_separately_from_answ
         stream=True,
         assistant_id=uuid4(),
         question_id=uuid4(),
+        **_skill_runtime_args(),
     )
 
     async for _ in gen:
@@ -658,6 +749,7 @@ async def test_streaming_handle_response_partial_save_keeps_reasoning_on_abort()
             stream=True,
             assistant_id=uuid4(),
             question_id=uuid4(),
+            **_skill_runtime_args(),
         )
 
         chunks = await _drain_until(gen, 1)
@@ -720,6 +812,7 @@ async def test_streaming_handle_response_skips_partial_save_when_no_content():
             stream=True,
             assistant_id=uuid4(),
             question_id=uuid4(),
+            **_skill_runtime_args(),
         )
 
         with pytest.raises(RuntimeError, match="upstream LLM unreachable"):
@@ -799,6 +892,7 @@ async def test_streaming_handle_response_count_tokens_failure_still_persists_par
             stream=True,
             assistant_id=uuid4(),
             question_id=uuid4(),
+            **_skill_runtime_args(),
         )
 
         first = await _drain_until(gen, 1)

--- a/backend/tests/unit/test_chat_stream_abort_persistence.py
+++ b/backend/tests/unit/test_chat_stream_abort_persistence.py
@@ -361,12 +361,10 @@ async def test_streaming_handle_response_schedules_partial_save_on_abort():
 
     async def fake_completion_stream():
         for text in ["hello ", "wor", "ld"]:
-            yield SimpleNamespace(
+            yield Completion(
                 reasoning_token_count=0,
-                usage=None,
                 response_type=ResponseType.TEXT,
                 text=text,
-                reference_chunks=[],
             )
 
     response = SimpleNamespace(
@@ -436,9 +434,8 @@ async def test_streaming_handle_response_schedules_partial_save_on_abort():
 @pytest.mark.asyncio
 async def test_streaming_abort_persists_changed_skill_evidence_without_text():
     async def fake_completion_stream():
-        yield SimpleNamespace(
+        yield Completion(
             reasoning_token_count=0,
-            usage=None,
             response_type=ResponseType.ENEO_EVENT,
         )
 
@@ -497,12 +494,10 @@ async def test_streaming_handle_response_no_partial_save_on_normal_completion():
     called (once) and no partial-save task should be scheduled."""
 
     async def fake_completion_stream():
-        yield SimpleNamespace(
+        yield Completion(
             reasoning_token_count=0,
-            usage=None,
             response_type=ResponseType.TEXT,
             text="ok",
-            reference_chunks=[],
         )
 
     response = SimpleNamespace(
@@ -566,6 +561,56 @@ async def test_streaming_handle_response_no_partial_save_on_normal_completion():
 
     # Crucially: no partial-save task was scheduled on a clean finish.
     assert persist_calls == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_handle_response_persists_cumulative_input_estimate():
+    async def fake_completion_stream():
+        yield Completion(
+            reasoning_token_count=0,
+            response_type=ResponseType.TEXT,
+            text="ok",
+        )
+        yield Completion(
+            reasoning_token_count=0,
+            stop=True,
+            input_token_estimate=41,
+        )
+
+    response = SimpleNamespace(
+        completion=fake_completion_stream(),
+        total_token_count=3,
+        usage=None,
+        extended_logging=None,
+    )
+    session_service_mock = AsyncMock()
+    session_service_mock.complete_question_with_answer = AsyncMock()
+    svc = _make_assistant_service_for_streaming(session_service_mock)
+
+    from eneo.assistants.assistant_service import AssistantService
+
+    gen = await AssistantService._handle_response(  # pyright: ignore[reportPrivateUsage]
+        svc,  # pyright: ignore[reportArgumentType]
+        response=response,
+        datastore_result=SimpleNamespace(info_blobs=[], no_duplicate_chunks=[]),
+        question="hello?",
+        files=[],
+        completion_model=SimpleNamespace(id=uuid4(), name="gpt-4"),
+        session=_make_session_in_db(),
+        stream=True,
+        assistant_id=uuid4(),
+        question_id=uuid4(),
+        assistant_selector_tokens=2,
+        **_skill_runtime_args(
+            initial_skill_context_tokens=2,
+            final_skill_context_tokens=7,
+        ),
+    )
+    async for _ in gen:
+        pass
+
+    persisted = session_service_mock.complete_question_with_answer.await_args.kwargs
+    assert persisted["num_tokens_question"] == 43
 
 
 @pytest.mark.asyncio
@@ -643,18 +688,15 @@ async def test_streaming_handle_response_persists_reasoning_separately_from_answ
 
     async def fake_completion_stream():
         for reasoning in ["let me ", "think"]:
-            yield SimpleNamespace(
+            yield Completion(
                 reasoning_token_count=0,
-                usage=None,
                 response_type=ResponseType.REASONING,
                 reasoning_content=reasoning,
             )
-        yield SimpleNamespace(
+        yield Completion(
             reasoning_token_count=2,
-            usage=None,
             response_type=ResponseType.TEXT,
             text="ok",
-            reference_chunks=[],
         )
 
     response = SimpleNamespace(
@@ -701,18 +743,15 @@ async def test_streaming_handle_response_partial_save_keeps_reasoning_on_abort()
     transparency record even for interrupted turns."""
 
     async def fake_completion_stream():
-        yield SimpleNamespace(
+        yield Completion(
             reasoning_token_count=0,
-            usage=None,
             response_type=ResponseType.REASONING,
             reasoning_content="thinking hard",
         )
-        yield SimpleNamespace(
+        yield Completion(
             reasoning_token_count=0,
-            usage=None,
             response_type=ResponseType.TEXT,
             text="never reached",
-            reference_chunks=[],
         )
 
     response = SimpleNamespace(
@@ -835,21 +874,17 @@ async def test_streaming_handle_response_count_tokens_failure_still_persists_par
     save through with num_tokens_answer=0."""
 
     async def fake_completion_stream():
-        yield SimpleNamespace(
+        yield Completion(
             reasoning_token_count=0,
-            usage=None,
             response_type=ResponseType.TEXT,
             text="partial",
-            reference_chunks=[],
         )
         # Hang on the next chunk — the consumer will aclose() in between.
         await asyncio.sleep(10)
-        yield SimpleNamespace(
+        yield Completion(
             reasoning_token_count=0,
-            usage=None,
             response_type=ResponseType.TEXT,
             text="lost",
-            reference_chunks=[],
         )
 
     response = SimpleNamespace(

--- a/backend/tests/unit/test_completion_service_streaming.py
+++ b/backend/tests/unit/test_completion_service_streaming.py
@@ -137,3 +137,30 @@ async def test_estimated_context_overflow_is_still_sent_to_provider():
         adapter.prepare_streaming.await_args.kwargs["context"].token_count
         == response.total_token_count
     )
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_uses_adapter_cumulative_input_estimate():
+    completion_model = _make_completion_model()
+    adapter = _DummyAdapter(model=completion_model)
+    adapter.get_response = AsyncMock(
+        return_value=Completion(
+            text="ok",
+            input_token_estimate=321,
+        )
+    )
+
+    service = CompletionService(
+        context_builder=_DummyContextBuilder(),
+        tenant=SimpleNamespace(id=uuid4()),
+        session=AsyncMock(),
+        redis_client=AsyncMock(),
+    )
+    service._get_adapter = AsyncMock(return_value=adapter)
+
+    response = await service.get_response(
+        model=completion_model,
+        text_input="hi",
+    )
+
+    assert response.total_token_count == 321

--- a/backend/tests/unit/test_tenant_model_adapter_skill_activation.py
+++ b/backend/tests/unit/test_tenant_model_adapter_skill_activation.py
@@ -1,0 +1,685 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+from uuid import uuid4
+
+import pytest
+
+from eneo.ai_models.completion_models.completion_model import ResponseType
+from eneo.completion_models.domain.skill_activation import (
+    SKILL_ACTIVATION_TOOL_NAME,
+    FrozenSkillInstruction,
+    SkillActivationRejectionReason,
+    SkillActivationRuntime,
+)
+from eneo.completion_models.infrastructure.adapters.tenant_model_adapter import (
+    PreparedModelStream,
+    TenantModelAdapter,
+)
+from eneo.main.exceptions import OpenAIException
+from eneo.skills.domain.skill import ResolvedSkillBinding, SkillBindingSource
+
+
+class _AsyncChunkStream:
+    def __init__(self, chunks: list[object]) -> None:
+        self._chunks = chunks
+
+    def __aiter__(self):
+        self._iterator = iter(self._chunks)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iterator)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class _FakeMCPProxy:
+    def __init__(self) -> None:
+        self.calls: list[list[tuple[str, dict[str, object]]]] = []
+
+    def get_tools_for_llm(self) -> list[dict[str, object]]:
+        return [
+            {
+                "type": "function",
+                "function": {"name": "server__lookup"},
+            }
+        ]
+
+    def get_allowed_tool_names(self) -> set[str]:
+        return {"server__lookup"}
+
+    def get_tool_info(self, name: str) -> tuple[str, str, str | None] | None:
+        if name == "server__lookup":
+            return ("server", "lookup", "Lookup")
+        return None
+
+    async def refresh_tools(self, *, touched_tool_names: list[str]) -> bool:
+        del touched_tool_names
+        return False
+
+    async def call_tools_parallel(
+        self, calls: list[tuple[str, dict[str, object]]]
+    ) -> list[dict[str, object]]:
+        self.calls.append(calls)
+        return [
+            {
+                "content": [{"type": "text", "text": "lookup result"}],
+                "is_error": False,
+            }
+            for _ in calls
+        ]
+
+
+class _CollisionMCPProxy(_FakeMCPProxy):
+    def get_tools_for_llm(self) -> list[dict[str, object]]:
+        return [
+            {
+                "type": "function",
+                "function": {"name": SKILL_ACTIVATION_TOOL_NAME},
+            }
+        ]
+
+
+def _runtime() -> SkillActivationRuntime:
+    binding = ResolvedSkillBinding(
+        skill_id=uuid4(),
+        skill_revision_id=uuid4(),
+        current_revision_id=uuid4(),
+        skill_space_id=uuid4(),
+        slug="payroll",
+        revision_number=2,
+        current_revision_number=2,
+        display_name="Payroll",
+        description="Use for payroll questions",
+        instructions="Use the exact payroll procedure.",
+        content_digest="a" * 64,
+        position=0,
+        source=SkillBindingSource.SPACE,
+    )
+    return SkillActivationRuntime.create(
+        base_instructions="Base instructions",
+        skills=(
+            FrozenSkillInstruction(
+                activation_key="skill-1",
+                binding=binding,
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset({"blocked-skill-1"}),
+        selective_activation_enabled=True,
+        max_activations_per_turn=2,
+        context_share_percent=100,
+        model_route="openai/test-model",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+
+
+def _always_only_runtime() -> SkillActivationRuntime:
+    return SkillActivationRuntime.create(
+        base_instructions="Base instructions",
+        skills=(),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=2,
+        context_share_percent=100,
+        model_route="openai/test-model",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+
+
+def _adapter() -> TenantModelAdapter:
+    adapter = object.__new__(TenantModelAdapter)
+    adapter.litellm_model = "openai/test-model"
+    adapter.provider_type = "openai"
+    adapter.model = SimpleNamespace(
+        name="test-model",
+        supports_tool_calling=True,
+    )
+    adapter._prepare_kwargs = Mock(return_value={})
+    adapter._create_messages_from_context = Mock(
+        return_value=[
+            {
+                "role": "system",
+                "content": "Base instructions\n\nKNOWLEDGE_SENTINEL",
+            },
+            {"role": "user", "content": "Help with payroll"},
+        ]
+    )
+    adapter._build_tools_from_context = Mock(return_value=[])
+    adapter._merge_mcp_tools = Mock(return_value=[])
+    adapter._get_dropped_params = Mock(return_value=set())
+    adapter._get_effective_params = Mock(return_value={})
+    return adapter
+
+
+def _provider_tool_call(
+    *,
+    call_id: str,
+    name: str,
+    arguments: str,
+) -> object:
+    return SimpleNamespace(
+        id=call_id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _response(
+    *,
+    content: str | None = None,
+    tool_calls: list[object] | None = None,
+    finish_reason: str = "stop",
+) -> object:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=content,
+                    reasoning_content=None,
+                    tool_calls=tool_calls,
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=None,
+    )
+
+
+def _tool_chunk(
+    *,
+    calls: list[tuple[str, str, str]],
+    content: str | None = None,
+) -> object:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(
+                    content=content,
+                    reasoning_content=None,
+                    tool_calls=[
+                        SimpleNamespace(
+                            index=index,
+                            id=call_id,
+                            function=SimpleNamespace(
+                                name=name,
+                                arguments=arguments,
+                            ),
+                        )
+                        for index, (call_id, name, arguments) in enumerate(calls)
+                    ],
+                ),
+                finish_reason="tool_calls",
+            )
+        ],
+        usage=None,
+    )
+
+
+def _text_chunk(text: str) -> object:
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(
+                    content=text,
+                    reasoning_content=None,
+                    tool_calls=None,
+                ),
+                finish_reason="stop",
+            )
+        ],
+        usage=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_activates_skill_before_follow_up() -> None:
+    adapter = _adapter()
+    runtime = _runtime()
+    responses = [
+        _response(
+            tool_calls=[
+                _provider_tool_call(
+                    call_id="activation-1",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"skill-1"}',
+                )
+            ],
+            finish_reason="tool_calls",
+        ),
+        _response(content="Payroll answer"),
+    ]
+
+    with patch(
+        "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(side_effect=responses),
+    ) as completion_call:
+        completion = await adapter.get_response(
+            context=SimpleNamespace(),
+            model_kwargs={},
+            skill_runtime=runtime,
+        )
+
+    assert completion.text == "Payroll answer"
+    assert runtime.snapshot().accepted == ("skill-1",)
+    follow_up_messages = completion_call.await_args_list[1].kwargs["messages"]
+    assert follow_up_messages[0]["role"] == "system"
+    assert "Use the exact payroll procedure." in follow_up_messages[0]["content"]
+    assert "KNOWLEDGE_SENTINEL" in follow_up_messages[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_maps_prompt_ownership_failure_without_mutating_runtime() -> (
+    None
+):
+    adapter = _adapter()
+    adapter._create_messages_from_context = Mock(
+        return_value=[
+            {"role": "system", "content": "DIFFERENT_BASE"},
+            {"role": "user", "content": "Help with payroll"},
+        ]
+    )
+    runtime = _runtime()
+    snapshot_before = runtime.snapshot()
+
+    with (
+        patch(
+            "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+            AsyncMock(
+                return_value=_response(
+                    tool_calls=[
+                        _provider_tool_call(
+                            call_id="activation-1",
+                            name=SKILL_ACTIVATION_TOOL_NAME,
+                            arguments='{"skill_key":"skill-1"}',
+                        )
+                    ],
+                    finish_reason="tool_calls",
+                )
+            ),
+        ),
+        pytest.raises(OpenAIException) as exc_info,
+    ):
+        await adapter.get_response(
+            context=SimpleNamespace(),
+            model_kwargs={},
+            skill_runtime=runtime,
+        )
+
+    assert exc_info.value.code == "skill_prompt_ownership"
+    assert runtime.snapshot() == snapshot_before
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_rejects_duplicate_provider_call_ids() -> None:
+    adapter = _adapter()
+    runtime = _runtime()
+
+    with (
+        patch(
+            "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+            AsyncMock(
+                return_value=_response(
+                    tool_calls=[
+                        _provider_tool_call(
+                            call_id="duplicate",
+                            name=SKILL_ACTIVATION_TOOL_NAME,
+                            arguments='{"skill_key":"skill-1"}',
+                        ),
+                        _provider_tool_call(
+                            call_id="duplicate",
+                            name=SKILL_ACTIVATION_TOOL_NAME,
+                            arguments='{"skill_key":"skill-1"}',
+                        ),
+                    ],
+                    finish_reason="tool_calls",
+                )
+            ),
+        ),
+        pytest.raises(OpenAIException) as exc_info,
+    ):
+        await adapter.get_response(
+            context=SimpleNamespace(),
+            model_kwargs={},
+            skill_runtime=runtime,
+        )
+
+    assert exc_info.value.code == "invalid_tool_call"
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_existing_builtin_is_not_treated_as_unauthorized_without_mcp() -> (
+    None
+):
+    adapter = _adapter()
+    runtime = _runtime()
+
+    with patch(
+        "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(
+            return_value=_response(
+                tool_calls=[
+                    _provider_tool_call(
+                        call_id="image-1",
+                        name="generate_image",
+                        arguments='{"prompt":"A municipal skyline"}',
+                    )
+                ],
+                finish_reason="tool_calls",
+            )
+        ),
+    ) as completion_call:
+        await adapter.get_response(
+            context=SimpleNamespace(),
+            model_kwargs={},
+            skill_runtime=runtime,
+        )
+
+    assert completion_call.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_accepted_activation_defers_external_sibling_call() -> None:
+    adapter = _adapter()
+    runtime = _runtime()
+    proxy = _FakeMCPProxy()
+    responses = [
+        _response(
+            tool_calls=[
+                _provider_tool_call(
+                    call_id="activation-1",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"skill-1"}',
+                ),
+                _provider_tool_call(
+                    call_id="external-1",
+                    name="server__lookup",
+                    arguments='{"query":"payroll"}',
+                ),
+            ],
+            finish_reason="tool_calls",
+        ),
+        _response(content="Updated answer"),
+    ]
+
+    with patch(
+        "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(side_effect=responses),
+    ):
+        await adapter.get_response(
+            context=SimpleNamespace(),
+            model_kwargs={},
+            mcp_proxy=proxy,
+            skill_runtime=runtime,
+        )
+
+    assert proxy.calls == []
+
+
+@pytest.mark.asyncio
+async def test_rejected_activation_keeps_external_sibling_dispatchable() -> None:
+    adapter = _adapter()
+    runtime = _runtime()
+    proxy = _FakeMCPProxy()
+    responses = [
+        _response(
+            tool_calls=[
+                _provider_tool_call(
+                    call_id="activation-1",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"missing"}',
+                ),
+                _provider_tool_call(
+                    call_id="external-1",
+                    name="server__lookup",
+                    arguments='{"query":"payroll"}',
+                ),
+            ],
+            finish_reason="tool_calls",
+        ),
+        _response(content="Lookup answer"),
+    ]
+
+    with patch(
+        "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(side_effect=responses),
+    ):
+        await adapter.get_response(
+            context=SimpleNamespace(),
+            model_kwargs={},
+            mcp_proxy=proxy,
+            skill_runtime=runtime,
+        )
+
+    assert proxy.calls == [[("server__lookup", {"query": "payroll"})]]
+    assert runtime.snapshot().rejected[0].reason is (
+        SkillActivationRejectionReason.UNKNOWN_KEY
+    )
+
+
+@pytest.mark.asyncio
+async def test_streaming_activates_skill_without_mcp_proxy() -> None:
+    adapter = _adapter()
+    runtime = _runtime()
+    prepared = PreparedModelStream(
+        stream=_AsyncChunkStream(
+            [
+                _tool_chunk(
+                    calls=[
+                        (
+                            "activation-1",
+                            SKILL_ACTIVATION_TOOL_NAME,
+                            '{"skill_key":"skill-1"}',
+                        )
+                    ],
+                    content="I will load the payroll procedure.",
+                )
+            ]
+        ),
+        messages=[
+            {"role": "system", "content": "Base instructions"},
+            {"role": "user", "content": "Help with payroll"},
+        ],
+        kwargs={"tools": []},
+        mcp_proxy=None,
+        skill_runtime=runtime,
+        has_tools=True,
+    )
+
+    with patch(
+        "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(return_value=_AsyncChunkStream([_text_chunk("Payroll answer")])),
+    ) as completion_call:
+        output = [
+            completion
+            async for completion in adapter.iterate_stream(
+                stream=prepared,
+                model_kwargs={},
+            )
+        ]
+
+    assert any(completion.text == "Payroll answer" for completion in output)
+    assert runtime.snapshot().accepted == ("skill-1",)
+    follow_up_messages = completion_call.await_args.kwargs["messages"]
+    assert "Use the exact payroll procedure." in follow_up_messages[0]["content"]
+    assert follow_up_messages[-2]["content"] == ("I will load the payroll procedure.")
+
+
+@pytest.mark.asyncio
+async def test_streaming_accepted_activation_defers_external_sibling_call() -> None:
+    adapter = _adapter()
+    runtime = _runtime()
+    proxy = _FakeMCPProxy()
+    prepared = PreparedModelStream(
+        stream=_AsyncChunkStream(
+            [
+                _tool_chunk(
+                    calls=[
+                        (
+                            "activation-1",
+                            SKILL_ACTIVATION_TOOL_NAME,
+                            '{"skill_key":"skill-1"}',
+                        ),
+                        (
+                            "external-1",
+                            "server__lookup",
+                            '{"query":"payroll"}',
+                        ),
+                    ]
+                )
+            ]
+        ),
+        messages=[
+            {"role": "system", "content": "Base instructions"},
+            {"role": "user", "content": "Help with payroll"},
+        ],
+        kwargs={"tools": []},
+        mcp_proxy=proxy,
+        skill_runtime=runtime,
+        has_tools=True,
+    )
+
+    with patch(
+        "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(return_value=_AsyncChunkStream([_text_chunk("Payroll answer")])),
+    ):
+        output = [
+            completion
+            async for completion in adapter.iterate_stream(
+                stream=prepared,
+                model_kwargs={},
+            )
+        ]
+
+    assert any(completion.text == "Payroll answer" for completion in output)
+    assert runtime.snapshot().accepted == ("skill-1",)
+    assert proxy.calls == []
+    deferred = [
+        metadata
+        for completion in output
+        for metadata in completion.tool_calls_metadata or []
+        if metadata.tool_call_id == "external-1"
+    ]
+    assert deferred
+    assert deferred[-1].result_status == "deferred"
+
+
+@pytest.mark.asyncio
+async def test_streaming_existing_builtin_is_not_treated_as_unauthorized_without_mcp() -> (
+    None
+):
+    adapter = _adapter()
+    for runtime in (_always_only_runtime(), _runtime()):
+        prepared = PreparedModelStream(
+            stream=_AsyncChunkStream(
+                [
+                    _tool_chunk(
+                        calls=[
+                            (
+                                "image-1",
+                                "generate_image",
+                                '{"prompt":"A municipal skyline"}',
+                            )
+                        ]
+                    )
+                ]
+            ),
+            messages=[
+                {"role": "system", "content": "Base instructions"},
+                {"role": "user", "content": "Create an image"},
+            ],
+            kwargs={"tools": []},
+            mcp_proxy=None,
+            skill_runtime=runtime,
+            has_tools=True,
+        )
+
+        output = [
+            completion
+            async for completion in adapter.iterate_stream(
+                stream=prepared,
+                model_kwargs={},
+            )
+        ]
+
+        assert all(
+            completion.response_type is not ResponseType.ERROR for completion in output
+        )
+
+
+@pytest.mark.asyncio
+async def test_streaming_rejected_activation_dispatches_external_sibling() -> None:
+    adapter = _adapter()
+    runtime = _runtime()
+    proxy = _FakeMCPProxy()
+    prepared = PreparedModelStream(
+        stream=_AsyncChunkStream(
+            [
+                _tool_chunk(
+                    calls=[
+                        (
+                            "activation-1",
+                            SKILL_ACTIVATION_TOOL_NAME,
+                            '{"skill_key":"missing"}',
+                        ),
+                        (
+                            "external-1",
+                            "server__lookup",
+                            '{"query":"payroll"}',
+                        ),
+                    ]
+                )
+            ]
+        ),
+        messages=[
+            {"role": "system", "content": "Base instructions"},
+            {"role": "user", "content": "Help with payroll"},
+        ],
+        kwargs={"tools": []},
+        mcp_proxy=proxy,
+        skill_runtime=runtime,
+        has_tools=True,
+    )
+
+    with patch(
+        "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(return_value=_AsyncChunkStream([_text_chunk("Lookup answer")])),
+    ):
+        output = [
+            completion
+            async for completion in adapter.iterate_stream(
+                stream=prepared,
+                model_kwargs={},
+            )
+        ]
+
+    assert any(completion.text == "Lookup answer" for completion in output)
+    assert proxy.calls == [[("server__lookup", {"query": "payroll"})]]
+    assert runtime.snapshot().rejected[0].reason is (
+        SkillActivationRejectionReason.UNKNOWN_KEY
+    )
+
+
+def test_reserved_activation_tool_collision_is_dropped_and_recorded() -> None:
+    adapter = object.__new__(TenantModelAdapter)
+    adapter.model = SimpleNamespace(
+        name="test-model",
+        supports_tool_calling=True,
+    )
+    runtime = _runtime()
+    built_in = {
+        "type": "function",
+        "function": {"name": SKILL_ACTIVATION_TOOL_NAME},
+    }
+    proxy = _CollisionMCPProxy()
+
+    tools = adapter._merge_mcp_tools([built_in], proxy, runtime)
+
+    assert tools == [built_in]
+    assert runtime.snapshot().rejected[0].reason is (
+        SkillActivationRejectionReason.RESERVED_TOOL_COLLISION
+    )

--- a/backend/tests/unit/test_tenant_model_adapter_skill_activation.py
+++ b/backend/tests/unit/test_tenant_model_adapter_skill_activation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
@@ -19,6 +20,7 @@ from eneo.completion_models.infrastructure.adapters.tenant_model_adapter import 
 )
 from eneo.main.exceptions import OpenAIException
 from eneo.skills.domain.skill import ResolvedSkillBinding, SkillBindingSource
+from eneo.tokens.token_utils import measure_provider_input_tokens
 
 
 class _AsyncChunkStream:
@@ -83,7 +85,7 @@ class _CollisionMCPProxy(_FakeMCPProxy):
         ]
 
 
-def _runtime() -> SkillActivationRuntime:
+def _runtime(*, selective_activation_enabled: bool = True) -> SkillActivationRuntime:
     binding = ResolvedSkillBinding(
         skill_id=uuid4(),
         skill_revision_id=uuid4(),
@@ -109,7 +111,7 @@ def _runtime() -> SkillActivationRuntime:
             ),
         ),
         blocked_keys=frozenset({"blocked-skill-1"}),
-        selective_activation_enabled=True,
+        selective_activation_enabled=selective_activation_enabled,
         max_activations_per_turn=2,
         context_share_percent=100,
         model_route="openai/test-model",
@@ -270,6 +272,99 @@ async def test_non_streaming_activates_skill_before_follow_up() -> None:
     assert follow_up_messages[0]["role"] == "system"
     assert "Use the exact payroll procedure." in follow_up_messages[0]["content"]
     assert "KNOWLEDGE_SENTINEL" in follow_up_messages[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_rejects_unadvertised_activation_with_mcp_present() -> None:
+    adapter = _adapter()
+    runtime = _runtime(selective_activation_enabled=False)
+    proxy = _CollisionMCPProxy()
+    initial_prompt = runtime.prompt
+    responses = [
+        _response(
+            tool_calls=[
+                _provider_tool_call(
+                    call_id="activation-1",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"skill-1"}',
+                )
+            ],
+            finish_reason="tool_calls",
+        ),
+        _response(content="Answer without the hidden Skill"),
+    ]
+
+    with patch(
+        "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(side_effect=responses),
+    ):
+        completion = await adapter.get_response(
+            context=SimpleNamespace(),
+            model_kwargs={},
+            mcp_proxy=proxy,
+            skill_runtime=runtime,
+        )
+
+    snapshot = runtime.snapshot()
+    assert completion.text == "Answer without the hidden Skill"
+    assert runtime.prompt == initial_prompt
+    assert snapshot.accepted == ()
+    assert snapshot.active == ()
+    assert snapshot.rejected[0].reason is (
+        SkillActivationRejectionReason.ACTIVATION_UNAVAILABLE
+    )
+    assert proxy.calls == []
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_estimates_every_request_when_provider_omits_usage() -> (
+    None
+):
+    adapter = _adapter()
+    runtime = _runtime()
+    responses = [
+        _response(
+            tool_calls=[
+                _provider_tool_call(
+                    call_id="activation-1",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"skill-1"}',
+                )
+            ],
+            finish_reason="tool_calls",
+        ),
+        _response(content="Payroll answer"),
+    ]
+    request_payloads: list[tuple[list[dict[str, object]], list[dict[str, object]]]] = []
+
+    async def complete(**kwargs):
+        request_payloads.append(
+            (
+                deepcopy(kwargs["messages"]),
+                deepcopy(kwargs.get("tools") or []),
+            )
+        )
+        return responses[len(request_payloads) - 1]
+
+    with patch(
+        "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        complete,
+    ):
+        completion = await adapter.get_response(
+            context=SimpleNamespace(),
+            model_kwargs={},
+            skill_runtime=runtime,
+        )
+
+    expected = sum(
+        measure_provider_input_tokens(messages, tools, adapter.litellm_model).tokens
+        for messages, tools in request_payloads
+    )
+    assert len(request_payloads) == 2
+    assert request_payloads[1][0][-2]["role"] == "assistant"
+    assert request_payloads[1][0][-1]["role"] == "tool"
+    assert completion.input_token_estimate == expected
+    assert completion.usage is None or completion.usage.prompt_tokens is None
 
 
 @pytest.mark.asyncio
@@ -510,6 +605,132 @@ async def test_streaming_activates_skill_without_mcp_proxy() -> None:
 
 
 @pytest.mark.asyncio
+async def test_streaming_rejects_unadvertised_activation_with_mcp_present() -> None:
+    adapter = _adapter()
+    runtime = _runtime(selective_activation_enabled=False)
+    proxy = _CollisionMCPProxy()
+    initial_prompt = runtime.prompt
+    prepared = PreparedModelStream(
+        stream=_AsyncChunkStream(
+            [
+                _tool_chunk(
+                    calls=[
+                        (
+                            "activation-1",
+                            SKILL_ACTIVATION_TOOL_NAME,
+                            '{"skill_key":"skill-1"}',
+                        )
+                    ]
+                )
+            ]
+        ),
+        messages=[
+            {"role": "system", "content": initial_prompt},
+            {"role": "user", "content": "Help with payroll"},
+        ],
+        kwargs={"tools": proxy.get_tools_for_llm()},
+        mcp_proxy=proxy,
+        skill_runtime=runtime,
+        has_tools=True,
+    )
+
+    with patch(
+        "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(
+            return_value=_AsyncChunkStream(
+                [_text_chunk("Answer without the hidden Skill")]
+            )
+        ),
+    ):
+        output = [
+            completion
+            async for completion in adapter.iterate_stream(
+                stream=prepared,
+                model_kwargs={},
+            )
+        ]
+
+    snapshot = runtime.snapshot()
+    assert any(
+        completion.text == "Answer without the hidden Skill" for completion in output
+    )
+    assert runtime.prompt == initial_prompt
+    assert snapshot.accepted == ()
+    assert snapshot.active == ()
+    assert snapshot.rejected[0].reason is (
+        SkillActivationRejectionReason.ACTIVATION_UNAVAILABLE
+    )
+    assert proxy.calls == []
+
+
+@pytest.mark.asyncio
+async def test_streaming_estimates_every_request_when_provider_omits_usage() -> None:
+    adapter = _adapter()
+    runtime = _runtime()
+    adapter._merge_mcp_tools = Mock(
+        return_value=[
+            {
+                "type": "function",
+                "function": {"name": SKILL_ACTIVATION_TOOL_NAME},
+            }
+        ]
+    )
+    streams = [
+        _AsyncChunkStream(
+            [
+                _tool_chunk(
+                    calls=[
+                        (
+                            "activation-1",
+                            SKILL_ACTIVATION_TOOL_NAME,
+                            '{"skill_key":"skill-1"}',
+                        )
+                    ]
+                )
+            ]
+        ),
+        _AsyncChunkStream([_text_chunk("Payroll answer")]),
+    ]
+    request_payloads: list[tuple[list[dict[str, object]], list[dict[str, object]]]] = []
+
+    async def complete(**kwargs):
+        request_payloads.append(
+            (
+                deepcopy(kwargs["messages"]),
+                deepcopy(kwargs.get("tools") or []),
+            )
+        )
+        return streams[len(request_payloads) - 1]
+
+    with patch(
+        "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        complete,
+    ):
+        prepared = await adapter.prepare_streaming(
+            context=SimpleNamespace(),
+            model_kwargs={},
+            skill_runtime=runtime,
+        )
+        output = [
+            completion
+            async for completion in adapter.iterate_stream(
+                stream=prepared,
+                model_kwargs={},
+            )
+        ]
+
+    expected = sum(
+        measure_provider_input_tokens(messages, tools, adapter.litellm_model).tokens
+        for messages, tools in request_payloads
+    )
+    assert len(request_payloads) == 2
+    assert request_payloads[1][0][-2]["role"] == "assistant"
+    assert request_payloads[1][0][-1]["role"] == "tool"
+    assert output[-1].input_token_estimate == expected
+    assert output[-1].usage is None
+
+
+@pytest.mark.asyncio
 async def test_streaming_accepted_activation_defers_external_sibling_call() -> None:
     adapter = _adapter()
     runtime = _runtime()
@@ -611,10 +832,27 @@ async def test_streaming_existing_builtin_is_not_treated_as_unauthorized_without
         )
 
 
+@pytest.mark.parametrize(
+    ("selective_activation_enabled", "skill_key", "expected_reason"),
+    [
+        (True, "missing", SkillActivationRejectionReason.UNKNOWN_KEY),
+        (
+            False,
+            "skill-1",
+            SkillActivationRejectionReason.ACTIVATION_UNAVAILABLE,
+        ),
+    ],
+)
 @pytest.mark.asyncio
-async def test_streaming_rejected_activation_dispatches_external_sibling() -> None:
+async def test_streaming_rejected_activation_dispatches_external_sibling(
+    selective_activation_enabled: bool,
+    skill_key: str,
+    expected_reason: SkillActivationRejectionReason,
+) -> None:
     adapter = _adapter()
-    runtime = _runtime()
+    runtime = _runtime(
+        selective_activation_enabled=selective_activation_enabled,
+    )
     proxy = _FakeMCPProxy()
     prepared = PreparedModelStream(
         stream=_AsyncChunkStream(
@@ -624,7 +862,7 @@ async def test_streaming_rejected_activation_dispatches_external_sibling() -> No
                         (
                             "activation-1",
                             SKILL_ACTIVATION_TOOL_NAME,
-                            '{"skill_key":"missing"}',
+                            f'{{"skill_key":"{skill_key}"}}',
                         ),
                         (
                             "external-1",
@@ -659,9 +897,7 @@ async def test_streaming_rejected_activation_dispatches_external_sibling() -> No
 
     assert any(completion.text == "Lookup answer" for completion in output)
     assert proxy.calls == [[("server__lookup", {"query": "payroll"})]]
-    assert runtime.snapshot().rejected[0].reason is (
-        SkillActivationRejectionReason.UNKNOWN_KEY
-    )
+    assert runtime.snapshot().rejected[0].reason is expected_reason
 
 
 def test_reserved_activation_tool_collision_is_dropped_and_recorded() -> None:
@@ -680,6 +916,23 @@ def test_reserved_activation_tool_collision_is_dropped_and_recorded() -> None:
     tools = adapter._merge_mcp_tools([built_in], proxy, runtime)
 
     assert tools == [built_in]
+    assert runtime.snapshot().rejected[0].reason is (
+        SkillActivationRejectionReason.RESERVED_TOOL_COLLISION
+    )
+
+
+def test_reserved_activation_tool_collision_is_dropped_during_fallback() -> None:
+    adapter = object.__new__(TenantModelAdapter)
+    adapter.model = SimpleNamespace(
+        name="test-model",
+        supports_tool_calling=True,
+    )
+    runtime = _runtime(selective_activation_enabled=False)
+    proxy = _CollisionMCPProxy()
+
+    tools = adapter._merge_mcp_tools([], proxy, runtime)
+
+    assert tools == []
     assert runtime.snapshot().rejected[0].reason is (
         SkillActivationRejectionReason.RESERVED_TOOL_COLLISION
     )

--- a/backend/tests/unittests/assistants/test_governance_policy_runtime.py
+++ b/backend/tests/unittests/assistants/test_governance_policy_runtime.py
@@ -842,6 +842,9 @@ async def test_provider_failure_persists_activation_that_happened_before_error()
         personal_default=False,
         skill_service=skill_service,
     )
+    assistant.completion_model = TEST_MODEL_CHATGPT.model_copy(
+        update={"supports_tool_calling": True}
+    )
 
     async def activate_then_fail(**kwargs):
         runtime = kwargs["skill_runtime"]
@@ -859,13 +862,21 @@ async def test_provider_failure_persists_activation_that_happened_before_error()
 
     assistant.ask.side_effect = activate_then_fail
 
-    with pytest.raises(RuntimeError, match="provider failed"):
+    with (
+        patch(
+            "eneo.sessions.session_service.persist_final_skill_runtime_state",
+            AsyncMock(),
+        ) as persist_final_state,
+        pytest.raises(RuntimeError, match="provider failed"),
+    ):
         await service.ask(question="hello", assistant_id=assistant.id)
 
-    state = session_service.update_question_skill_runtime_state.await_args.kwargs
+    state = persist_final_state.await_args.kwargs
+    assert state["tenant_id"] == TEST_USER.tenant_id
     assert state["skill_activation"].accepted == ("skill-1",)
     assert state["skill_activation"].activation_rounds == 1
     assert state["skill_provenance"][0].skill_revision_id == (binding.skill_revision_id)
+    session_service.update_question_skill_runtime_state.assert_not_awaited()
 
 
 async def test_evidence_write_failure_does_not_mask_provider_failure():
@@ -887,6 +898,9 @@ async def test_evidence_write_failure_does_not_mask_provider_failure():
         personal_default=False,
         skill_service=skill_service,
     )
+    assistant.completion_model = TEST_MODEL_CHATGPT.model_copy(
+        update={"supports_tool_calling": True}
+    )
 
     async def activate_then_fail(**kwargs):
         runtime = kwargs["skill_runtime"]
@@ -903,11 +917,14 @@ async def test_evidence_write_failure_does_not_mask_provider_failure():
         raise RuntimeError("provider failed")
 
     assistant.ask.side_effect = activate_then_fail
-    session_service.update_question_skill_runtime_state.side_effect = RuntimeError(
-        "evidence write failed"
-    )
 
-    with pytest.raises(RuntimeError, match="provider failed"):
+    with (
+        patch(
+            "eneo.sessions.session_service.persist_final_skill_runtime_state",
+            AsyncMock(side_effect=RuntimeError("evidence write failed")),
+        ),
+        pytest.raises(RuntimeError, match="provider failed"),
+    ):
         await service.ask(question="hello", assistant_id=assistant.id)
 
 

--- a/backend/tests/unittests/assistants/test_governance_policy_runtime.py
+++ b/backend/tests/unittests/assistants/test_governance_policy_runtime.py
@@ -6,12 +6,17 @@ from uuid import uuid4
 import pytest
 
 from eneo.assistants.assistant_service import AssistantService
+from eneo.completion_models.domain.skill_activation import (
+    SKILL_ACTIVATION_TOOL_NAME,
+    ProviderToolCall,
+)
 from eneo.completion_models.domain.skill_context import SkillContextMeasurement
 from eneo.main.exceptions import BadRequestException
 from eneo.services.service import DatastoreResult
 from eneo.sessions.session import SessionInDB
 from eneo.skills.domain.skill import (
     ResolvedSkillBinding,
+    SkillActivationMode,
     SkillBindingSource,
     SkillRuntimePolicy,
     SkillRuntimeResolution,
@@ -39,7 +44,7 @@ def _empty_skill_service():
         SkillRuntimeResolution(eligible=(), blocked=())
     )
     service.create_turn_plan.side_effect = (
-        lambda *, base_instructions, resolution: SkillTurnPlan.create_eager(
+        lambda *, base_instructions, resolution: SkillTurnPlan.create(
             base_instructions=base_instructions,
             resolution=resolution,
             policy=SkillRuntimePolicy(
@@ -668,7 +673,12 @@ async def test_get_effective_completion_model_allows_personal_default_for_baseli
     assert model is TEST_MODEL_CHATGPT
 
 
-def _resolved_skill(*, position: int = 0, name: str = "Payroll"):
+def _resolved_skill(
+    *,
+    position: int = 0,
+    name: str = "Payroll",
+    activation_mode: SkillActivationMode = SkillActivationMode.ALWAYS,
+):
     return ResolvedSkillBinding(
         skill_id=uuid4(),
         skill_revision_id=uuid4(),
@@ -682,6 +692,7 @@ def _resolved_skill(*, position: int = 0, name: str = "Payroll"):
         content_digest="a" * 64,
         position=position,
         source=SkillBindingSource.SPACE,
+        activation_mode=activation_mode,
     )
 
 
@@ -776,7 +787,7 @@ async def test_ordinary_assistant_uses_composed_prompt_and_persists_provenance()
         binding.skill_revision_id
     )
     activation = placeholder["skill_activation"]
-    assert activation.effective_mode == "eager"
+    assert activation.effective_mode == "always_only"
     assert activation.available[0].skill_revision_id == binding.skill_revision_id
     assert activation.initially_active == ("skill-1",)
     assert activation.selected_model_id == TEST_MODEL_CHATGPT.id
@@ -796,7 +807,7 @@ async def test_skill_measurement_and_evidence_use_the_provider_route():
     expected_route = f"azure/{TEST_MODEL_CHATGPT.name}"
 
     with patch(
-        "eneo.assistants.assistant_service.measure_skill_context",
+        "eneo.completion_models.domain.skill_activation.measure_skill_context",
         return_value=SkillContextMeasurement(
             tokens=12,
             limit=100,
@@ -810,6 +821,94 @@ async def test_skill_measurement_and_evidence_use_the_provider_route():
         session_service.create_session_with_question_placeholder.await_args.kwargs
     )
     assert placeholder["skill_activation"].selected_model_route == expected_route
+
+
+async def test_provider_failure_persists_activation_that_happened_before_error():
+    binding = _resolved_skill(activation_mode=SkillActivationMode.ON_DEMAND)
+    skill_service = _skill_service_with_resolution(eligible=(binding,))
+    skill_service.create_turn_plan.side_effect = (
+        lambda *, base_instructions, resolution: SkillTurnPlan.create(
+            base_instructions=base_instructions,
+            resolution=resolution,
+            policy=SkillRuntimePolicy(
+                selective_activation_enabled=True,
+                max_attached_skills=100,
+                context_share_percent=100,
+                max_activations_per_turn=3,
+            ),
+        )
+    )
+    service, assistant, session_service = _runtime_service(
+        personal_default=False,
+        skill_service=skill_service,
+    )
+
+    async def activate_then_fail(**kwargs):
+        runtime = kwargs["skill_runtime"]
+        runtime.apply_provider_tool_calls(
+            calls=(
+                ProviderToolCall(
+                    call_id="activation-1",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"skill-1"}',
+                ),
+            ),
+            messages=[{"role": "system", "content": runtime.prompt}],
+        )
+        raise RuntimeError("provider failed")
+
+    assistant.ask.side_effect = activate_then_fail
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        await service.ask(question="hello", assistant_id=assistant.id)
+
+    state = session_service.update_question_skill_runtime_state.await_args.kwargs
+    assert state["skill_activation"].accepted == ("skill-1",)
+    assert state["skill_activation"].activation_rounds == 1
+    assert state["skill_provenance"][0].skill_revision_id == (binding.skill_revision_id)
+
+
+async def test_evidence_write_failure_does_not_mask_provider_failure():
+    binding = _resolved_skill(activation_mode=SkillActivationMode.ON_DEMAND)
+    skill_service = _skill_service_with_resolution(eligible=(binding,))
+    skill_service.create_turn_plan.side_effect = (
+        lambda *, base_instructions, resolution: SkillTurnPlan.create(
+            base_instructions=base_instructions,
+            resolution=resolution,
+            policy=SkillRuntimePolicy(
+                selective_activation_enabled=True,
+                max_attached_skills=100,
+                context_share_percent=100,
+                max_activations_per_turn=3,
+            ),
+        )
+    )
+    service, assistant, session_service = _runtime_service(
+        personal_default=False,
+        skill_service=skill_service,
+    )
+
+    async def activate_then_fail(**kwargs):
+        runtime = kwargs["skill_runtime"]
+        runtime.apply_provider_tool_calls(
+            calls=(
+                ProviderToolCall(
+                    call_id="activation-1",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"skill-1"}',
+                ),
+            ),
+            messages=[{"role": "system", "content": runtime.prompt}],
+        )
+        raise RuntimeError("provider failed")
+
+    assistant.ask.side_effect = activate_then_fail
+    session_service.update_question_skill_runtime_state.side_effect = RuntimeError(
+        "evidence write failed"
+    )
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        await service.ask(question="hello", assistant_id=assistant.id)
 
 
 async def test_existing_session_persists_composed_skill_provenance():

--- a/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
+++ b/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
@@ -1,0 +1,1039 @@
+import json
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from eneo.completion_models.domain.skill_activation import (
+    SKILL_ACTIVATION_TOOL_NAME,
+    FrozenSkillInstruction,
+    InvalidSkillToolCallError,
+    ProviderToolCall,
+    SkillActivationFallbackReason,
+    SkillActivationRejectionReason,
+    SkillActivationRejectionSnapshot,
+    SkillActivationRequest,
+    SkillActivationRoundResult,
+    SkillActivationRuntime,
+    SkillPromptOwnershipError,
+    SkillTurnEffectiveMode,
+)
+from eneo.completion_models.domain.skill_context import SkillContextMeasurement
+from eneo.skills.domain.skill import (
+    MAX_SKILL_ACTIVATIONS_PER_TURN,
+    ResolvedSkillBinding,
+    SkillBindingSource,
+)
+from eneo.tokens.token_utils import TokenCount, TokenCountSource
+
+
+def _skill(
+    *,
+    key: str,
+    name: str,
+    description: str,
+    position: int,
+    instructions: str,
+    initially_active: bool,
+) -> FrozenSkillInstruction:
+    return FrozenSkillInstruction(
+        activation_key=key,
+        binding=ResolvedSkillBinding(
+            skill_id=uuid4(),
+            skill_revision_id=uuid4(),
+            current_revision_id=uuid4(),
+            skill_space_id=uuid4(),
+            slug=name.lower().replace(" ", "-"),
+            revision_number=1,
+            current_revision_number=1,
+            display_name=name,
+            description=description,
+            instructions=instructions,
+            content_digest="a" * 64,
+            position=position,
+            source=SkillBindingSource.SPACE,
+        ),
+        initially_active=initially_active,
+    )
+
+
+def _apply_activation_requests(
+    runtime: SkillActivationRuntime,
+    *requests: tuple[str, str | None],
+) -> list[dict[str, bool]]:
+    messages: list[dict[str, object]] = [
+        {"role": "system", "content": runtime.prompt},
+    ]
+    runtime.apply_provider_tool_calls(
+        calls=tuple(
+            ProviderToolCall(
+                call_id=call_id,
+                name=SKILL_ACTIVATION_TOOL_NAME,
+                arguments=json.dumps({"skill_key": activation_key}),
+            )
+            for call_id, activation_key in requests
+        ),
+        messages=messages,
+    )
+    return [
+        json.loads(str(message["content"]))
+        for message in messages
+        if message.get("role") == "tool"
+    ]
+
+
+def test_selective_runtime_advertises_descriptors_without_instruction_bodies():
+    always = _skill(
+        key="skill-1",
+        name="Safety",
+        description="Required safety rules",
+        position=0,
+        instructions="Never reveal the safety body.",
+        initially_active=True,
+    )
+    on_demand = _skill(
+        key="skill-2",
+        name="Payroll",
+        description="Use for payroll and salary questions",
+        position=1,
+        instructions="Secret payroll instructions.",
+        initially_active=False,
+    )
+
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(always, on_demand),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=3,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+
+    tool = runtime.tool_definition
+    snapshot = runtime.snapshot()
+
+    assert snapshot.effective_mode is SkillTurnEffectiveMode.SELECTIVE
+    assert snapshot.fallback_reason is None
+    assert snapshot.initially_active == ("skill-1",)
+    assert runtime.prompt.index("Safety") > runtime.prompt.index("Base")
+    assert "Never reveal the safety body." in runtime.prompt
+    assert "Secret payroll instructions." not in runtime.prompt
+    assert tool is not None
+    assert "__" not in tool.name
+    assert "skill-2" in tool.description
+    assert "Payroll" in tool.description
+    assert "Use for payroll and salary questions" in tool.description
+    assert "Secret payroll instructions." not in tool.description
+    assert tool.schema["properties"]["skill_key"]["enum"] == ["skill-2"]
+
+
+def test_runtime_without_native_tool_calls_keeps_only_required_skills():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(
+            _skill(
+                key="skill-1",
+                name="Safety",
+                description="Required",
+                position=0,
+                instructions="Always body",
+                initially_active=True,
+            ),
+            _skill(
+                key="skill-2",
+                name="Payroll",
+                description="Optional",
+                position=1,
+                instructions="On-demand body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=3,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=False,
+    )
+
+    snapshot = runtime.snapshot()
+
+    assert snapshot.effective_mode is SkillTurnEffectiveMode.ALWAYS_ONLY
+    assert (
+        snapshot.fallback_reason
+        is SkillActivationFallbackReason.MODEL_LACKS_TOOL_CALLING
+    )
+    assert runtime.tool_definition is None
+    assert "Always body" in runtime.prompt
+    assert "On-demand body" not in runtime.prompt
+
+
+def test_descriptor_overflow_falls_back_atomically_instead_of_advertising_a_prefix():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=tuple(
+            _skill(
+                key=f"skill-{index}",
+                name=f"Skill {index}",
+                description="Distinct descriptor " * 20,
+                position=index,
+                instructions=f"Body {index}",
+                initially_active=False,
+            )
+            for index in range(1, 4)
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=3,
+        context_share_percent=1,
+        model_route="openai/gpt-4o",
+        max_input_tokens=1_000,
+        supports_tool_calling=True,
+    )
+
+    snapshot = runtime.snapshot()
+
+    assert snapshot.effective_mode is SkillTurnEffectiveMode.ALWAYS_ONLY
+    assert (
+        snapshot.fallback_reason
+        is SkillActivationFallbackReason.CATALOG_BUDGET_EXCEEDED
+    )
+    assert runtime.tool_definition is None
+    assert not any(f"Body {index}" in runtime.prompt for index in range(1, 4))
+
+
+def test_selective_runtime_falls_back_when_catalogue_fit_cannot_be_measured():
+    with patch(
+        "eneo.completion_models.domain.skill_activation.measure_skill_context",
+        return_value=SkillContextMeasurement(
+            tokens=1,
+            limit=100,
+            source=TokenCountSource.FALLBACK_ESTIMATE,
+        ),
+    ):
+        runtime = SkillActivationRuntime.create(
+            base_instructions="Base",
+            skills=(
+                _skill(
+                    key="skill-1",
+                    name="Payroll",
+                    description="給与と報酬に関する質問",
+                    position=1,
+                    instructions="給与データを確認する",
+                    initially_active=False,
+                ),
+            ),
+            blocked_keys=frozenset(),
+            selective_activation_enabled=True,
+            max_activations_per_turn=1,
+            context_share_percent=10,
+            model_route="custom/unknown",
+            max_input_tokens=1_000,
+            supports_tool_calling=True,
+        )
+
+    snapshot = runtime.snapshot()
+    assert snapshot.effective_mode is SkillTurnEffectiveMode.ALWAYS_ONLY
+    assert (
+        snapshot.fallback_reason
+        is SkillActivationFallbackReason.TOKEN_MEASUREMENT_UNAVAILABLE
+    )
+    assert runtime.tool_definition is None
+
+
+def test_activation_rejects_candidate_when_fit_cannot_be_measured():
+    with patch(
+        "eneo.completion_models.domain.skill_activation.measure_skill_context",
+        side_effect=(
+            SkillContextMeasurement(
+                tokens=1,
+                limit=100,
+                source=TokenCountSource.LITELLM,
+            ),
+            SkillContextMeasurement(
+                tokens=1,
+                limit=100,
+                source=TokenCountSource.FALLBACK_ESTIMATE,
+            ),
+        ),
+    ):
+        runtime = SkillActivationRuntime.create(
+            base_instructions="Base",
+            skills=(
+                _skill(
+                    key="skill-1",
+                    name="Payroll",
+                    description="給与と報酬に関する質問",
+                    position=1,
+                    instructions="給与データを確認する",
+                    initially_active=False,
+                ),
+            ),
+            blocked_keys=frozenset(),
+            selective_activation_enabled=True,
+            max_activations_per_turn=1,
+            context_share_percent=10,
+            model_route="custom/unknown",
+            max_input_tokens=1_000,
+            supports_tool_calling=True,
+        )
+        decisions = _apply_activation_requests(runtime, ("activate", "skill-1"))
+
+    assert decisions[0] == {
+        "activated": False,
+        "unavailable": True,
+    }
+    snapshot = runtime.snapshot()
+    assert snapshot.accepted == ()
+    assert snapshot.active == ()
+    assert snapshot.rejected[0].reason is (
+        SkillActivationRejectionReason.TOKEN_MEASUREMENT_UNAVAILABLE
+    )
+
+
+def test_activation_rejects_when_complete_follow_up_exceeds_model_input_limit():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(
+            _skill(
+                key="skill-1",
+                name="Payroll",
+                description="Payroll questions",
+                position=1,
+                instructions="Payroll body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=1,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=1_000,
+        supports_tool_calling=True,
+    )
+    messages: list[dict[str, object]] = [
+        {"role": "system", "content": "Base"},
+        {"role": "user", "content": "Question"},
+    ]
+    provider_tools = [{"type": "function", "function": {"name": "lookup"}}]
+
+    with patch(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        return_value=TokenCount(tokens=1_001, source=TokenCountSource.LITELLM),
+    ) as measure:
+        runtime.apply_provider_tool_calls(
+            calls=(
+                ProviderToolCall(
+                    call_id="activate",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"skill-1"}',
+                ),
+            ),
+            messages=messages,
+            provider_tools=provider_tools,
+            assistant_content="I will load the payroll procedure.",
+        )
+
+    measured_messages, measured_tools, measured_route = measure.call_args.args
+    assert measured_tools == provider_tools
+    assert measured_route == "openai/gpt-4o"
+    assert measured_messages[-1]["content"] == '{"activated": true}'
+    assert measured_messages[-2]["content"] == "I will load the payroll procedure."
+    snapshot = runtime.snapshot()
+    assert snapshot.accepted == ()
+    assert snapshot.active == ()
+    assert snapshot.rejected[0].reason is (
+        SkillActivationRejectionReason.MODEL_CONTEXT_LIMIT_EXCEEDED
+    )
+    assert "Payroll body" not in str(messages[0]["content"])
+
+
+def test_model_limit_rejects_oversized_earlier_skill_and_keeps_later_fit():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(
+            _skill(
+                key="skill-a",
+                name="Large",
+                description="Large procedure",
+                position=1,
+                instructions="Large body",
+                initially_active=False,
+            ),
+            _skill(
+                key="skill-b",
+                name="Small",
+                description="Small procedure",
+                position=2,
+                instructions="Small body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=2,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=1_000,
+        supports_tool_calling=True,
+    )
+    messages: list[dict[str, object]] = [
+        {"role": "system", "content": "Base"},
+        {"role": "user", "content": "Question"},
+    ]
+
+    def measure_staged_payload(
+        staged_messages: list[dict[str, object]],
+        _provider_tools: list[dict[str, object]],
+        _model_route: str,
+    ) -> TokenCount:
+        rendered_prompt = str(staged_messages[0]["content"])
+        return TokenCount(
+            tokens=1_001 if "Large body" in rendered_prompt else 900,
+            source=TokenCountSource.LITELLM,
+        )
+
+    with patch(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        side_effect=measure_staged_payload,
+    ):
+        runtime.apply_provider_tool_calls(
+            calls=(
+                ProviderToolCall(
+                    call_id="activate-large",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"skill-a"}',
+                ),
+                ProviderToolCall(
+                    call_id="activate-small",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"skill-b"}',
+                ),
+            ),
+            messages=messages,
+        )
+
+    snapshot = runtime.snapshot()
+    assert snapshot.accepted == ("skill-b",)
+    assert snapshot.active == ("skill-b",)
+    assert snapshot.rejected == (
+        SkillActivationRejectionSnapshot(
+            activation_key="skill-a",
+            reason=SkillActivationRejectionReason.MODEL_CONTEXT_LIMIT_EXCEEDED,
+        ),
+    )
+    assert "Large body" not in str(messages[0]["content"])
+    assert "Small body" in str(messages[0]["content"])
+
+
+def test_provider_round_bounds_activation_work_and_closes_every_internal_call():
+    skills = tuple(
+        _skill(
+            key=f"skill-{index}",
+            name=f"Skill {index}",
+            description=f"Procedure {index}",
+            position=index,
+            instructions=f"Body {index}",
+            initially_active=False,
+        )
+        for index in range(30)
+    )
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=skills,
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=MAX_SKILL_ACTIVATIONS_PER_TURN,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=1_000,
+        supports_tool_calling=True,
+    )
+    messages: list[dict[str, object]] = [
+        {"role": "system", "content": "Base"},
+        {"role": "user", "content": "Question"},
+    ]
+    calls = tuple(
+        ProviderToolCall(
+            call_id=f"activate-{index}",
+            name=SKILL_ACTIVATION_TOOL_NAME,
+            arguments=json.dumps({"skill_key": f"skill-{index}"}),
+        )
+        for index in range(30)
+    )
+    apply_round_batch_sizes: list[int] = []
+    original_apply_round = SkillActivationRuntime._apply_round
+
+    def record_apply_round_batch_size(
+        staged: SkillActivationRuntime,
+        requests: tuple[SkillActivationRequest, ...],
+        *,
+        forced_rejections: dict[str, SkillActivationRejectionReason],
+    ) -> SkillActivationRoundResult:
+        apply_round_batch_sizes.append(len(requests))
+        return original_apply_round(
+            staged,
+            requests,
+            forced_rejections=forced_rejections,
+        )
+
+    with (
+        patch.object(
+            SkillActivationRuntime,
+            "_apply_round",
+            new=record_apply_round_batch_size,
+        ),
+        patch(
+            "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+            return_value=TokenCount(tokens=900, source=TokenCountSource.LITELLM),
+        ) as measure_provider_payload,
+    ):
+        runtime.apply_provider_tool_calls(calls=calls, messages=messages)
+
+    tool_messages = [message for message in messages if message.get("role") == "tool"]
+    snapshot = runtime.snapshot()
+    assert apply_round_batch_sizes
+    assert max(apply_round_batch_sizes) <= MAX_SKILL_ACTIVATIONS_PER_TURN
+    assert measure_provider_payload.call_count == 1
+    assert len(tool_messages) == len(calls)
+    assert snapshot.accepted == tuple(
+        f"skill-{index}" for index in range(MAX_SKILL_ACTIVATIONS_PER_TURN)
+    )
+    assert all(
+        json.loads(str(message["content"])) == {"activated": False, "unavailable": True}
+        for message in tool_messages[MAX_SKILL_ACTIVATIONS_PER_TURN:]
+    )
+    assert all(
+        rejection.reason is SkillActivationRejectionReason.ACTIVATION_LIMIT_EXCEEDED
+        for rejection in snapshot.rejected
+    )
+
+
+def test_overflowed_repeat_does_not_record_an_accepted_skill_as_rejected():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(
+            _skill(
+                key="skill-1",
+                name="Payroll",
+                description="Payroll procedure",
+                position=1,
+                instructions="Payroll body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=MAX_SKILL_ACTIVATIONS_PER_TURN,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=1_000,
+        supports_tool_calling=True,
+    )
+
+    with patch(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        return_value=TokenCount(tokens=900, source=TokenCountSource.LITELLM),
+    ):
+        results = _apply_activation_requests(
+            runtime,
+            *((f"activate-{index}", "skill-1") for index in range(15)),
+        )
+
+    snapshot = runtime.snapshot()
+    assert snapshot.accepted == ("skill-1",)
+    assert snapshot.repeated == ("skill-1",)
+    assert snapshot.rejected == ()
+    assert results[0] == {"activated": True}
+    assert all(result.get("already_active") is True for result in results[1:10])
+    assert all(result.get("already_active") is True for result in results[10:])
+
+
+def test_activation_rejects_when_complete_follow_up_cannot_be_measured():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(
+            _skill(
+                key="skill-1",
+                name="Payroll",
+                description="Payroll questions",
+                position=1,
+                instructions="Payroll body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=1,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+    messages: list[dict[str, object]] = [
+        {"role": "system", "content": "Base"},
+        {"role": "user", "content": "Question"},
+    ]
+
+    with patch(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        return_value=TokenCount(
+            tokens=1,
+            source=TokenCountSource.FALLBACK_ESTIMATE,
+        ),
+    ):
+        runtime.apply_provider_tool_calls(
+            calls=(
+                ProviderToolCall(
+                    call_id="activate",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"skill-1"}',
+                ),
+            ),
+            messages=messages,
+        )
+
+    snapshot = runtime.snapshot()
+    assert snapshot.accepted == ()
+    assert snapshot.active == ()
+    assert snapshot.rejected[0].reason is (
+        SkillActivationRejectionReason.TOKEN_MEASUREMENT_UNAVAILABLE
+    )
+    assert "Payroll body" not in str(messages[0]["content"])
+
+
+def test_activation_recomposes_accepted_skills_in_saved_binding_order():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(
+            _skill(
+                key="skill-2",
+                name="Second",
+                description="Second descriptor",
+                position=2,
+                instructions="Second body",
+                initially_active=False,
+            ),
+            _skill(
+                key="skill-1",
+                name="First",
+                description="First descriptor",
+                position=1,
+                instructions="First body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=2,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+
+    decisions = _apply_activation_requests(
+        runtime,
+        ("call-1", "skill-2"),
+        ("call-2", "skill-1"),
+    )
+
+    assert decisions == [
+        {"activated": True},
+        {"activated": True},
+    ]
+    assert runtime.prompt.index("First body") < runtime.prompt.index("Second body")
+    assert runtime.snapshot().accepted == ("skill-2", "skill-1")
+    assert runtime.snapshot().active == ("skill-1", "skill-2")
+
+
+def test_repeated_blocked_unknown_and_limit_decisions_are_closed_per_call():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(
+            _skill(
+                key="skill-1",
+                name="First",
+                description="First descriptor",
+                position=1,
+                instructions="First body",
+                initially_active=False,
+            ),
+            _skill(
+                key="skill-2",
+                name="Second",
+                description="Second descriptor",
+                position=2,
+                instructions="Second body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset({"blocked-skill-1"}),
+        selective_activation_enabled=True,
+        max_activations_per_turn=1,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+
+    decisions = _apply_activation_requests(
+        runtime,
+        ("accepted", "skill-1"),
+        ("repeated", "skill-1"),
+        ("blocked", "blocked-skill-1"),
+        ("unknown", "forged"),
+        ("limited", "skill-2"),
+    )
+
+    assert decisions[1] == {
+        "activated": True,
+        "already_active": True,
+    }
+    assert decisions[2] == {
+        "activated": False,
+        "unavailable": True,
+    }
+    assert decisions[3] == decisions[2]
+    assert decisions[4] == decisions[2]
+    snapshot = runtime.snapshot()
+    assert snapshot.repeated == ("skill-1",)
+    assert [(item.activation_key, item.reason) for item in snapshot.rejected] == [
+        ("blocked-skill-1", SkillActivationRejectionReason.BLOCKED),
+        ("forged", SkillActivationRejectionReason.UNKNOWN_KEY),
+        ("skill-2", SkillActivationRejectionReason.ACTIVATION_LIMIT_EXCEEDED),
+    ]
+
+
+def test_one_context_overflow_does_not_reject_other_calls_in_the_round():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(
+            _skill(
+                key="skill-1",
+                name="Too large",
+                description="Large optional body",
+                position=1,
+                instructions="large " * 20_000,
+                initially_active=False,
+            ),
+            _skill(
+                key="skill-2",
+                name="Fits",
+                description="Small optional body",
+                position=2,
+                instructions="Small body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=2,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=2_000,
+        supports_tool_calling=True,
+    )
+
+    decisions = _apply_activation_requests(
+        runtime,
+        ("large", "skill-1"),
+        ("small", "skill-2"),
+    )
+
+    assert decisions[0] == {
+        "activated": False,
+        "unavailable": True,
+    }
+    assert decisions[1] == {"activated": True}
+    assert runtime.snapshot().active == ("skill-2",)
+    assert runtime.snapshot().rejected[0].reason is (
+        SkillActivationRejectionReason.CONTEXT_LIMIT_EXCEEDED
+    )
+
+
+def test_rejected_evidence_is_deduplicated_and_bounded():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(
+            _skill(
+                key="skill-1",
+                name="Optional",
+                description="Optional descriptor",
+                position=1,
+                instructions="Optional body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=1,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+
+    for index in range(100):
+        _apply_activation_requests(
+            runtime,
+            (f"call-{index}", f"forged-{index}"),
+            (f"duplicate-{index}", "same-forged-key"),
+        )
+
+    rejected = runtime.snapshot().rejected
+    assert len(rejected) == 50
+    assert sum(item.activation_key == "same-forged-key" for item in rejected) == 1
+
+
+def test_accepted_internal_call_preserves_rendered_context_and_defers_external_sibling():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(
+            _skill(
+                key="skill-1",
+                name="Payroll",
+                description="Payroll questions",
+                position=1,
+                instructions="Payroll body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=1,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+    messages: list[dict[str, object]] = [
+        {
+            "role": "system",
+            "content": "Base\n\nKNOWLEDGE_SENTINEL\n\nATTACHMENT_SENTINEL",
+        },
+        {"role": "user", "content": "Question"},
+    ]
+
+    result = runtime.apply_provider_tool_calls(
+        calls=(
+            ProviderToolCall(
+                call_id="activate",
+                name=SKILL_ACTIVATION_TOOL_NAME,
+                arguments='{"skill_key":"skill-1"}',
+            ),
+            ProviderToolCall(
+                call_id="external",
+                name="server__lookup",
+                arguments="{}",
+            ),
+        ),
+        messages=messages,
+    )
+
+    assert result.external_calls == ()
+    assert result.assistant_message_appended is True
+    assert "Payroll body" in str(messages[0]["content"])
+    assert "KNOWLEDGE_SENTINEL" in str(messages[0]["content"])
+    assert "ATTACHMENT_SENTINEL" in str(messages[0]["content"])
+    assert messages[-1] == {
+        "role": "tool",
+        "tool_call_id": "external",
+        "content": (
+            '{"deferred": true, "reason": "skill_context_updated", "retryable": true}'
+        ),
+    }
+
+
+def test_accepted_internal_call_separates_skill_prompt_from_rendered_context():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="",
+        skills=(
+            _skill(
+                key="skill-1",
+                name="Payroll",
+                description="Payroll questions",
+                position=1,
+                instructions="Payroll body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=1,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+    messages: list[dict[str, object]] = [
+        {"role": "system", "content": "KNOWLEDGE_SENTINEL"},
+        {"role": "user", "content": "Question"},
+    ]
+
+    runtime.apply_provider_tool_calls(
+        calls=(
+            ProviderToolCall(
+                call_id="activate",
+                name=SKILL_ACTIVATION_TOOL_NAME,
+                arguments='{"skill_key":"skill-1"}',
+            ),
+        ),
+        messages=messages,
+    )
+
+    assert str(messages[0]["content"]).endswith("Payroll body\n\nKNOWLEDGE_SENTINEL")
+
+
+def test_accepted_internal_call_rejects_unowned_rendered_prompt():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(
+            _skill(
+                key="skill-1",
+                name="Payroll",
+                description="Payroll questions",
+                position=1,
+                instructions="Payroll body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=1,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+    messages: list[dict[str, object]] = [
+        {"role": "system", "content": "DIFFERENT_BASE"},
+        {"role": "user", "content": "Question"},
+    ]
+    snapshot_before = runtime.snapshot()
+    messages_before = [message.copy() for message in messages]
+
+    with pytest.raises(SkillPromptOwnershipError, match="frozen Skill prompt"):
+        runtime.apply_provider_tool_calls(
+            calls=(
+                ProviderToolCall(
+                    call_id="activate",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"skill-1"}',
+                ),
+            ),
+            messages=messages,
+        )
+
+    assert runtime.snapshot() == snapshot_before
+    assert messages == messages_before
+
+
+def test_internal_calls_reject_duplicate_call_ids_before_mutating_runtime():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(
+            _skill(
+                key="skill-1",
+                name="Payroll",
+                description="Payroll questions",
+                position=1,
+                instructions="Payroll body",
+                initially_active=False,
+            ),
+            _skill(
+                key="skill-2",
+                name="Benefits",
+                description="Benefits questions",
+                position=2,
+                instructions="Benefits body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=2,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+    messages: list[dict[str, object]] = [
+        {"role": "system", "content": "Base"},
+        {"role": "user", "content": "Question"},
+    ]
+    snapshot_before = runtime.snapshot()
+
+    with pytest.raises(InvalidSkillToolCallError, match="invalid tool call"):
+        runtime.apply_provider_tool_calls(
+            calls=(
+                ProviderToolCall(
+                    call_id="duplicate",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"skill-1"}',
+                ),
+                ProviderToolCall(
+                    call_id="duplicate",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments='{"skill_key":"skill-2"}',
+                ),
+            ),
+            messages=messages,
+        )
+
+    assert runtime.snapshot() == snapshot_before
+
+
+def test_rejected_internal_call_keeps_external_sibling_dispatchable():
+    runtime = SkillActivationRuntime.create(
+        base_instructions="",
+        skills=(
+            _skill(
+                key="skill-1",
+                name="Payroll",
+                description="Payroll questions",
+                position=1,
+                instructions="Payroll body",
+                initially_active=False,
+            ),
+        ),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=1,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+    external = ProviderToolCall(
+        call_id="external",
+        name="server__lookup",
+        arguments="{}",
+    )
+    messages: list[dict[str, object]] = [{"role": "user", "content": "Question"}]
+
+    result = runtime.apply_provider_tool_calls(
+        calls=(
+            ProviderToolCall(
+                call_id="invalid",
+                name=SKILL_ACTIVATION_TOOL_NAME,
+                arguments="{",
+            ),
+            external,
+        ),
+        messages=messages,
+    )
+
+    assert result.external_calls == (external,)
+    assert result.assistant_message_appended is True
+    assert messages[0]["role"] == "user"
+    assert messages[-1] == {
+        "role": "tool",
+        "tool_call_id": "invalid",
+        "content": '{"activated": false, "unavailable": true}',
+    }

--- a/backend/tests/unittests/help_assistants/application/test_helper_run_service_followup.py
+++ b/backend/tests/unittests/help_assistants/application/test_helper_run_service_followup.py
@@ -28,6 +28,7 @@ import pytest
 from eneo.ai_models.completion_models.completion_model import (
     Completion,
     CompletionModelResponse,
+    ResponseType,
 )
 from eneo.help_assistants.application.helper_run_service import HelperRunService
 from eneo.help_assistants.domain.factory import HelperAssistantsFactory
@@ -294,6 +295,44 @@ async def test_continue_turn_reuses_session_and_persists_question():
     # Status was NOT mutated — continue_turn keeps the run IN_PROGRESS.
     mocks["helper_run_repo"].update_status.assert_not_awaited()
     assert result.answer == "Follow-up answer."
+
+
+@pytest.mark.asyncio
+async def test_streaming_persists_adapter_cumulative_input_estimate():
+    user = _make_user()
+    helper_assistant = _mock_helper_assistant(assistant_id=uuid4())
+    session = _build_session(session_id=uuid4())
+    question_repo = AsyncMock()
+    question_repo.session = MagicMock()
+    question_repo.session.in_transaction.return_value = True
+    service, _ = _build_service(user=user, question_repo=question_repo)
+
+    async def completion_stream():
+        yield Completion(response_type=ResponseType.TEXT, text="Helper answer.")
+        yield Completion(stop=True, input_token_estimate=57)
+
+    response = CompletionModelResponse.model_construct(
+        completion=completion_stream(),
+        model=helper_assistant.completion_model,
+        extended_logging=None,
+        total_token_count=10,
+        usage=None,
+    )
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_and_persist(
+            response=response,
+            session=session,
+            question="Help me",
+            datastore_chunks=[],
+            helper_assistant=helper_assistant,
+        )
+    ]
+
+    assert any(chunk.text == "Helper answer." for chunk in chunks)
+    persisted = question_repo.add.await_args.args[0]
+    assert persisted.num_tokens_question == 57
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unittests/questions/test_questions_repo.py
+++ b/backend/tests/unittests/questions/test_questions_repo.py
@@ -8,6 +8,8 @@ from eneo.questions.question import QuestionAdd
 from eneo.questions.questions_repo import QuestionRepository
 from eneo.skills.domain.skill import (
     SkillActivationEvidenceV1,
+    SkillActivationReference,
+    SkillBindingSource,
     SkillExecutionReference,
     SkillTurnEffectiveMode,
 )
@@ -120,3 +122,93 @@ async def test_answer_finalization_does_not_rewrite_frozen_skill_activation():
     compiled = statement.compile(dialect=postgresql.dialect())
     assert "skill_activation" not in str(compiled)
     assert "skill_activation" not in compiled.params
+
+
+async def test_answer_finalization_replaces_initial_skill_runtime_state():
+    session = AsyncMock()
+    repo = QuestionRepository(session)
+    reference = SkillExecutionReference(
+        skill_id=uuid4(),
+        skill_revision_id=uuid4(),
+        revision_number=4,
+        content_digest="b" * 64,
+        position=1,
+    )
+    evidence = SkillActivationEvidenceV1(
+        effective_mode=SkillTurnEffectiveMode.SELECTIVE,
+        available=(
+            SkillActivationReference(
+                activation_key="skill-1",
+                skill_id=reference.skill_id,
+                skill_revision_id=reference.skill_revision_id,
+                revision_number=reference.revision_number,
+                content_digest=reference.content_digest,
+                position=reference.position,
+                source=SkillBindingSource.SPACE,
+            ),
+        ),
+        blocked=(),
+        initially_active=(),
+        accepted=("skill-1",),
+        selected_model_id=uuid4(),
+        selected_model_route="openai/gpt-4o",
+        skill_context_tokens=24,
+        skill_context_token_limit=12_800,
+        token_count_source="litellm",
+        activation_rounds=1,
+    )
+
+    await repo.update_with_answer(
+        question_id=uuid4(),
+        tenant_id=uuid4(),
+        answer="Completed",
+        skill_provenance=(reference,),
+        skill_activation=evidence,
+    )
+
+    statement = session.execute.await_args.args[0]
+    params = statement.compile(dialect=postgresql.dialect()).params
+    assert params["skill_provenance"] == [
+        {
+            "skill_id": str(reference.skill_id),
+            "skill_revision_id": str(reference.skill_revision_id),
+            "revision_number": 4,
+            "content_digest": "b" * 64,
+            "position": 1,
+        }
+    ]
+    assert params["skill_activation"] == evidence.model_dump(mode="json")
+
+
+async def test_skill_runtime_state_update_is_tenant_scoped():
+    session = AsyncMock()
+    repo = QuestionRepository(session)
+    question_id = uuid4()
+    tenant_id = uuid4()
+    evidence = SkillActivationEvidenceV1(
+        effective_mode=SkillTurnEffectiveMode.ALWAYS_ONLY,
+        available=(),
+        blocked=(),
+        initially_active=(),
+        selected_model_id=uuid4(),
+        selected_model_route="openai/gpt-4o",
+        skill_context_tokens=0,
+        skill_context_token_limit=12_800,
+        token_count_source="litellm",
+    )
+
+    await repo.update_skill_runtime_state(
+        question_id=question_id,
+        tenant_id=tenant_id,
+        skill_provenance=(),
+        skill_activation=evidence,
+    )
+
+    statement = session.execute.await_args.args[0]
+    compiled = statement.compile(dialect=postgresql.dialect())
+    assert "questions.id =" in str(compiled)
+    assert "questions.tenant_id =" in str(compiled)
+    assert question_id in compiled.params.values()
+    assert tenant_id in compiled.params.values()
+    assert compiled.params["skill_provenance"] == []
+    assert compiled.params["skill_activation"] == evidence.model_dump(mode="json")

--- a/backend/tests/unittests/skills/test_skill.py
+++ b/backend/tests/unittests/skills/test_skill.py
@@ -2,11 +2,15 @@ import json
 from dataclasses import FrozenInstanceError, replace
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from pydantic import ValidationError
 
+from eneo.completion_models.domain.skill_activation import (
+    SKILL_ACTIVATION_TOOL_NAME,
+    ProviderToolCall,
+)
 from eneo.main.exceptions import BadRequestException
 from eneo.model_providers.domain.model_route import MAX_MODEL_ROUTE_LENGTH
 from eneo.skills import (
@@ -21,6 +25,7 @@ from eneo.skills.application.skill_service import SkillService
 from eneo.skills.domain.skill import (
     NormalizedSkillContent,
     Skill,
+    SkillActivationEvidenceV1,
     SkillActivationMode,
     SkillBindingReference,
     SkillBindingSource,
@@ -31,9 +36,9 @@ from eneo.skills.domain.skill import (
     SkillRevision,
     SkillRuntimePolicy,
     SkillRuntimeResolution,
+    SkillTurnEffectiveMode,
     SkillTurnPlan,
 )
-from eneo.tokens.token_utils import TokenCountSource
 
 SKILL_ACTIVATION_EVIDENCE_SIZE_BUDGET_BYTES = 400_000
 
@@ -52,6 +57,24 @@ def _binding(*, position: int, name: str = "Payroll") -> ResolvedSkillBinding:
         content_digest="a" * 64,
         position=position,
         source=SkillBindingSource.SPACE,
+    )
+
+
+def _activation_evidence(
+    plan: SkillTurnPlan,
+    *,
+    selected_model_id: UUID | None = None,
+    selected_model_route: str = "openai/gpt-4o",
+) -> SkillActivationEvidenceV1:
+    runtime = plan.to_activation_runtime(
+        selected_model_route=selected_model_route,
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+    return plan.activation_evidence(
+        selected_model_id=selected_model_id or uuid4(),
+        selected_model_route=selected_model_route,
+        snapshot=runtime.snapshot(),
     )
 
 
@@ -260,7 +283,7 @@ def test_activation_mode_is_dormant_in_composition():
     )
 
 
-def test_eager_turn_plan_preserves_composition_and_freezes_exact_bindings():
+def test_turn_plan_freezes_bindings_and_starts_with_required_skills():
     always = _binding(position=0, name="Payroll")
     on_demand = replace(
         _binding(position=1, name="Leave"),
@@ -274,7 +297,7 @@ def test_eager_turn_plan_preserves_composition_and_freezes_exact_bindings():
         max_activations_per_turn=5,
     )
 
-    plan = SkillTurnPlan.create_eager(
+    plan = SkillTurnPlan.create(
         base_instructions="Base instructions",
         resolution=SkillRuntimeResolution(
             eligible=(always, on_demand),
@@ -285,7 +308,7 @@ def test_eager_turn_plan_preserves_composition_and_freezes_exact_bindings():
 
     assert plan.composition == compose_skill_instructions(
         base_instructions="Base instructions",
-        bindings=[always, on_demand],
+        bindings=[always],
     )
     assert [binding.binding for binding in plan.available] == [always, on_demand]
     assert [binding.activation_key for binding in plan.available] == [
@@ -299,20 +322,14 @@ def test_eager_turn_plan_preserves_composition_and_freezes_exact_bindings():
     with pytest.raises(FrozenInstanceError):
         plan.base_instructions = "Changed"  # type: ignore[misc]
 
-    evidence = plan.activation_evidence(
-        selected_model_id=uuid4(),
-        selected_model_route="gpt-4o",
-        skill_context_tokens=321,
-        skill_context_token_limit=19_200,
-        token_count_source=TokenCountSource.LITELLM,
-    )
-    assert evidence.effective_mode == "eager"
+    evidence = _activation_evidence(plan)
+    assert evidence.effective_mode == "selective"
     assert [reference.skill_id for reference in evidence.available] == [
         always.skill_id,
         on_demand.skill_id,
     ]
     assert [reference.skill_id for reference in evidence.blocked] == [blocked.skill_id]
-    assert evidence.initially_active == ("skill-1", "skill-2")
+    assert evidence.initially_active == ("skill-1",)
     assert evidence.accepted == ()
     assert evidence.repeated == ()
     assert evidence.rejected == ()
@@ -321,7 +338,7 @@ def test_eager_turn_plan_preserves_composition_and_freezes_exact_bindings():
 
 
 def test_zero_skill_turn_plan_preserves_base_and_records_empty_evidence():
-    plan = SkillTurnPlan.create_eager(
+    plan = SkillTurnPlan.create(
         base_instructions="  Base instructions\n",
         resolution=SkillRuntimeResolution(eligible=(), blocked=()),
         policy=SkillRuntimePolicy(
@@ -332,24 +349,18 @@ def test_zero_skill_turn_plan_preserves_base_and_records_empty_evidence():
         ),
     )
 
-    evidence = plan.activation_evidence(
-        selected_model_id=uuid4(),
-        selected_model_route="gpt-4o",
-        skill_context_tokens=0,
-        skill_context_token_limit=12_800,
-        token_count_source=TokenCountSource.LITELLM,
-    )
+    evidence = _activation_evidence(plan)
 
     assert plan.composition.prompt == "  Base instructions\n"
     assert plan.composition.provenance == ()
     assert evidence.available == ()
     assert evidence.blocked == ()
     assert evidence.initially_active == ()
-    assert evidence.skill_context_tokens == 0
+    assert evidence.skill_context_tokens >= 0
 
 
 def test_skill_activation_evidence_round_trips_strict_versioned_body_free_json():
-    plan = SkillTurnPlan.create_eager(
+    plan = SkillTurnPlan.create(
         base_instructions="Base",
         resolution=SkillRuntimeResolution(
             eligible=(_binding(position=0),),
@@ -362,13 +373,7 @@ def test_skill_activation_evidence_round_trips_strict_versioned_body_free_json()
             max_activations_per_turn=10,
         ),
     )
-    evidence = plan.activation_evidence(
-        selected_model_id=uuid4(),
-        selected_model_route="gpt-4o",
-        skill_context_tokens=42,
-        skill_context_token_limit=100,
-        token_count_source=TokenCountSource.FALLBACK_ESTIMATE,
-    )
+    evidence = _activation_evidence(plan)
 
     assert type(evidence).model_validate_json(evidence.model_dump_json()) == evidence
 
@@ -404,7 +409,7 @@ def test_skill_activation_evidence_rejects_coerced_numeric_counters(
     field: str,
     value: str,
 ):
-    plan = SkillTurnPlan.create_eager(
+    plan = SkillTurnPlan.create(
         base_instructions="Base",
         resolution=SkillRuntimeResolution(
             eligible=(_binding(position=0),),
@@ -417,13 +422,7 @@ def test_skill_activation_evidence_rejects_coerced_numeric_counters(
             max_activations_per_turn=10,
         ),
     )
-    evidence = plan.activation_evidence(
-        selected_model_id=uuid4(),
-        selected_model_route="openai/gpt-4o",
-        skill_context_tokens=42,
-        skill_context_token_limit=100,
-        token_count_source=TokenCountSource.LITELLM,
-    )
+    evidence = _activation_evidence(plan)
     dumped = evidence.model_dump(mode="json")
 
     with pytest.raises(ValidationError):
@@ -431,7 +430,7 @@ def test_skill_activation_evidence_rejects_coerced_numeric_counters(
 
 
 def test_skill_activation_reference_rejects_coerced_numeric_identity():
-    plan = SkillTurnPlan.create_eager(
+    plan = SkillTurnPlan.create(
         base_instructions="Base",
         resolution=SkillRuntimeResolution(
             eligible=(_binding(position=0),),
@@ -444,13 +443,7 @@ def test_skill_activation_reference_rejects_coerced_numeric_identity():
             max_activations_per_turn=10,
         ),
     )
-    evidence = plan.activation_evidence(
-        selected_model_id=uuid4(),
-        selected_model_route="openai/gpt-4o",
-        skill_context_tokens=42,
-        skill_context_token_limit=100,
-        token_count_source=TokenCountSource.LITELLM,
-    )
+    evidence = _activation_evidence(plan)
     dumped = evidence.model_dump(mode="json")
     dumped["available"][0]["revision_number"] = "1"
 
@@ -460,7 +453,7 @@ def test_skill_activation_reference_rejects_coerced_numeric_identity():
 
 def test_skill_activation_evidence_rejects_duplicate_reference_catalogue_entries():
     binding = _binding(position=0)
-    plan = SkillTurnPlan.create_eager(
+    plan = SkillTurnPlan.create(
         base_instructions="Base",
         resolution=SkillRuntimeResolution(
             eligible=(binding,),
@@ -473,13 +466,7 @@ def test_skill_activation_evidence_rejects_duplicate_reference_catalogue_entries
             max_activations_per_turn=10,
         ),
     )
-    evidence = plan.activation_evidence(
-        selected_model_id=uuid4(),
-        selected_model_route="openai/gpt-4o",
-        skill_context_tokens=42,
-        skill_context_token_limit=100,
-        token_count_source=TokenCountSource.LITELLM,
-    )
+    evidence = _activation_evidence(plan)
     dumped = evidence.model_dump(mode="json")
     dumped["blocked"] = dumped["available"]
 
@@ -492,7 +479,7 @@ def test_skill_activation_evidence_stays_compact_at_attachment_ceiling():
         _binding(position=position, name=f"Skill-{position}")
         for position in range(1000)
     )
-    plan = SkillTurnPlan.create_eager(
+    plan = SkillTurnPlan.create(
         base_instructions="Base",
         resolution=SkillRuntimeResolution(
             eligible=bindings,
@@ -505,12 +492,9 @@ def test_skill_activation_evidence_stays_compact_at_attachment_ceiling():
             max_activations_per_turn=10,
         ),
     )
-    evidence = plan.activation_evidence(
-        selected_model_id=uuid4(),
+    evidence = _activation_evidence(
+        plan,
         selected_model_route="m" * MAX_MODEL_ROUTE_LENGTH,
-        skill_context_tokens=42,
-        skill_context_token_limit=100,
-        token_count_source=TokenCountSource.LITELLM,
     )
 
     serialized = json.dumps(evidence.model_dump(mode="json"), separators=(",", ":"))
@@ -520,7 +504,7 @@ def test_skill_activation_evidence_stays_compact_at_attachment_ceiling():
 
 def test_skill_activation_evidence_rejects_an_oversized_model_route():
     binding = _binding(position=0)
-    plan = SkillTurnPlan.create_eager(
+    plan = SkillTurnPlan.create(
         base_instructions="Base",
         resolution=SkillRuntimeResolution(
             eligible=(binding,),
@@ -538,9 +522,11 @@ def test_skill_activation_evidence_rejects_an_oversized_model_route():
         plan.activation_evidence(
             selected_model_id=uuid4(),
             selected_model_route="m" * (MAX_MODEL_ROUTE_LENGTH + 1),
-            skill_context_tokens=42,
-            skill_context_token_limit=100,
-            token_count_source=TokenCountSource.LITELLM,
+            snapshot=plan.to_activation_runtime(
+                selected_model_route="openai/gpt-4o",
+                max_input_tokens=128_000,
+                supports_tool_calling=True,
+            ).snapshot(),
         )
 
 
@@ -757,11 +743,82 @@ async def test_turn_plan_reads_stored_policy_once_and_preserves_dormant_modes():
     assert plan.available[0].binding is binding
     assert plan.composition == compose_skill_instructions(
         base_instructions="Base",
-        bindings=[binding],
+        bindings=[],
     )
+    runtime = plan.to_activation_runtime(
+        selected_model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+    assert runtime.tool_definition is not None
+    assert binding.instructions not in runtime.prompt
     repo.get_or_seed_runtime_policy.assert_awaited_once_with(
         tenant_id=service.user.tenant_id
     )
+
+
+def test_turn_plan_freezes_hidden_blocked_keys_and_maps_runtime_evidence():
+    always = replace(
+        _binding(position=0, name="Safety"),
+        activation_mode=SkillActivationMode.ALWAYS,
+    )
+    optional = replace(
+        _binding(position=1, name="Payroll"),
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    blocked = replace(
+        _binding(position=2, name="Blocked"),
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    policy = SkillRuntimePolicy(
+        selective_activation_enabled=True,
+        max_attached_skills=100,
+        context_share_percent=20,
+        max_activations_per_turn=2,
+    )
+    plan = SkillTurnPlan.create(
+        base_instructions="Base",
+        resolution=SkillRuntimeResolution(
+            eligible=(always, optional),
+            blocked=(blocked,),
+        ),
+        policy=policy,
+    )
+
+    assert plan.initially_active_keys == ("skill-1",)
+    assert plan.blocked[0].activation_key == "blocked-skill-1"
+    assert plan.blocked[0].activation_key not in {
+        binding.activation_key for binding in plan.available
+    }
+    runtime = plan.to_activation_runtime(
+        selected_model_route="openai/gpt-4o",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+    )
+    runtime.apply_provider_tool_calls(
+        calls=(
+            ProviderToolCall(
+                call_id="activate",
+                name=SKILL_ACTIVATION_TOOL_NAME,
+                arguments='{"skill_key":"skill-2"}',
+            ),
+        ),
+        messages=[{"role": "system", "content": runtime.prompt}],
+    )
+    evidence = plan.activation_evidence(
+        selected_model_id=uuid4(),
+        selected_model_route="openai/gpt-4o",
+        snapshot=runtime.snapshot(),
+    )
+
+    assert evidence.effective_mode is SkillTurnEffectiveMode.SELECTIVE
+    assert evidence.initially_active == ("skill-1",)
+    assert evidence.accepted == ("skill-2",)
+    assert evidence.blocked[0].activation_key == "blocked-skill-1"
+    assert [
+        reference.skill_revision_id
+        for reference in plan.active_provenance(runtime.snapshot())
+    ] == [always.skill_revision_id, optional.skill_revision_id]
 
 
 async def test_execution_snapshot_hides_incident_reason_when_skill_is_blocked():

--- a/backend/tests/unittests/tokens/test_token_utils.py
+++ b/backend/tests/unittests/tokens/test_token_utils.py
@@ -13,6 +13,7 @@ from eneo.tokens.token_utils import (
     log_token_count_drift,
     measure_message_token_delta,
     measure_message_tokens,
+    measure_provider_input_tokens,
 )
 
 
@@ -172,6 +173,43 @@ def test_measure_message_token_delta_short_circuits_identical_messages():
     counter.assert_not_called()
     assert measurement.tokens == 0
     assert measurement.source is TokenCountSource.LITELLM
+
+
+def test_measure_provider_input_tokens_counts_one_combined_provider_payload():
+    messages = [{"role": "user", "content": "Question"}]
+    with patch(
+        "eneo.tokens.token_utils.litellm.token_counter",
+        return_value=47,
+    ) as counter:
+        measurement = measure_provider_input_tokens(
+            messages,
+            _TOOLS,
+            "openai/gpt-4o",
+        )
+
+    assert measurement.tokens == 47
+    assert measurement.source is TokenCountSource.LITELLM
+    counter.assert_called_once_with(
+        model="openai/gpt-4o",
+        messages=messages,
+        tools=_TOOLS,
+    )
+
+
+def test_measure_provider_input_tokens_falls_back_for_the_whole_payload():
+    with patch(
+        "eneo.tokens.token_utils.litellm.token_counter",
+        side_effect=RuntimeError("boom"),
+    ) as counter:
+        measurement = measure_provider_input_tokens(
+            [{"role": "user", "content": "Question"}],
+            _TOOLS,
+            "custom/unknown",
+        )
+
+    assert measurement.tokens > 0
+    assert measurement.source is TokenCountSource.FALLBACK_ESTIMATE
+    assert counter.call_count == 1
 
 
 def test_count_tool_tokens_fallback_when_litellm_fails():

--- a/docs/enterprise-skills-roadmap.md
+++ b/docs/enterprise-skills-roadmap.md
@@ -96,26 +96,29 @@ The foundation merged into `develop` before this roadmap was written:
   squash-merged as `b186f175` on 2026-07-23.
 - PR #580 locked the deletion and retained-provenance recovery contract. It
   squash-merged as `c642da49` on 2026-07-23.
+- PR #593 closed the execution-block configuration and visibility gap while
+  preserving retained exact pins. It squash-merged as `5d54e242` on 2026-07-24.
 
 The delivery graph was last verified on 2026-07-24:
 
-| Work item                                                | Purpose                                         | State and next action                                                                                               |
-| -------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| [#552](https://github.com/eneo-ai/eneo/pull/552)         | S1 first-class local Skills                     | Merged as `a29e9464`; required CI and final review passed.                                                          |
-| [#559](https://github.com/eneo-ai/eneo/pull/559)         | Skill revision restore                          | Merged as `8ef96390`; required CI and final review passed.                                                          |
-| [#560](https://github.com/eneo-ai/eneo/pull/560)         | O1 organisation catalogue                       | Merged as `71de15e5`; required CI, final review, and product review passed.                                         |
-| [#574](https://github.com/eneo-ai/eneo/pull/574)         | O1 adoption and drift evidence                  | Merged as `dfe9dbe7`; required CI and final review passed.                                                          |
-| [#577](https://github.com/eneo-ai/eneo/pull/577)         | O1 emergency execution block                    | Merged as `b186f175`; required CI passed and the final review found no current findings.                            |
-| [#580](https://github.com/eneo-ai/eneo/pull/580)         | O1 deletion and retained-provenance closure     | Merged as `c642da49`; PostgreSQL behavior proof, documentation, required CI, and final full-coverage review passed. |
-| [#581](https://github.com/eneo-ai/eneo/pull/581)         | Selective activation planning blueprint         | Merged as `677c54ca`; required CI passed and the final review found no current findings.                            |
-| [#582](https://github.com/eneo-ai/eneo/pull/582)         | Task #553 slice 1: dormant binding mode         | Merged as `80b5f377`; required CI passed and the final review found no current findings.                            |
-| [#583](https://github.com/eneo-ai/eneo/pull/583)         | Task #553 slice 2: typed runtime policy         | Merged as `e681171f`; required CI passed and the final review found no current findings.                            |
-| [#590](https://github.com/eneo-ai/eneo/pull/590)         | Task #553 slice 3: frozen plan and evidence     | Merged as `d2651dee`; required CI passed and Review 2 found no current findings.                                    |
-| [Issue #551](https://github.com/eneo-ai/eneo/issues/551) | File, InfoBlob, and Icon object-content cutover | Open. This gates the fallback file-reference path, not the preferred internal-MCP core split.                       |
-| [#464](https://github.com/eneo-ai/eneo/pull/464)         | MCP file references                             | Open and conflict-marked. It belongs to the object-content/file track.                                              |
-| [#538](https://github.com/eneo-ai/eneo/pull/538)         | Loopback internal MCP and on-demand knowledge   | Open and coupled to #464. It is useful comparison evidence, not a merge dependency for selective Skills.            |
-| [#541](https://github.com/eneo-ai/eneo/pull/541)         | Web search MCP provider                         | Draft. It does not gate Skills.                                                                                     |
-| `refactor/flows-clean`                                   | Flow package export/import vertical             | Active at `77202b4f`; it must land on `develop` before S2 extracts any shared package mechanics.                    |
+| Work item                                                | Purpose                                          | State and next action                                                                                               |
+| -------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| [#552](https://github.com/eneo-ai/eneo/pull/552)         | S1 first-class local Skills                      | Merged as `a29e9464`; required CI and final review passed.                                                          |
+| [#559](https://github.com/eneo-ai/eneo/pull/559)         | Skill revision restore                           | Merged as `8ef96390`; required CI and final review passed.                                                          |
+| [#560](https://github.com/eneo-ai/eneo/pull/560)         | O1 organisation catalogue                        | Merged as `71de15e5`; required CI, final review, and product review passed.                                         |
+| [#574](https://github.com/eneo-ai/eneo/pull/574)         | O1 adoption and drift evidence                   | Merged as `dfe9dbe7`; required CI and final review passed.                                                          |
+| [#577](https://github.com/eneo-ai/eneo/pull/577)         | O1 emergency execution block                     | Merged as `b186f175`; required CI passed and the final review found no current findings.                            |
+| [#580](https://github.com/eneo-ai/eneo/pull/580)         | O1 deletion and retained-provenance closure      | Merged as `c642da49`; PostgreSQL behavior proof, documentation, required CI, and final full-coverage review passed. |
+| [#581](https://github.com/eneo-ai/eneo/pull/581)         | Selective activation planning blueprint          | Merged as `677c54ca`; required CI passed and the final review found no current findings.                            |
+| [#582](https://github.com/eneo-ai/eneo/pull/582)         | Task #553 slice 1: dormant binding mode          | Merged as `80b5f377`; required CI passed and the final review found no current findings.                            |
+| [#583](https://github.com/eneo-ai/eneo/pull/583)         | Task #553 slice 2: typed runtime policy          | Merged as `e681171f`; required CI passed and the final review found no current findings.                            |
+| [#590](https://github.com/eneo-ai/eneo/pull/590)         | Task #553 slice 3: frozen plan and evidence      | Merged as `d2651dee`; required CI passed and Review 2 found no current findings.                                    |
+| [#593](https://github.com/eneo-ai/eneo/pull/593)         | Execution-block binding integrity and visibility | Merged as `5d54e242`; required CI passed and Review 3 found no current findings.                                    |
+| [Issue #551](https://github.com/eneo-ai/eneo/issues/551) | File, InfoBlob, and Icon object-content cutover  | Open. This gates the fallback file-reference path, not the preferred internal-MCP core split.                       |
+| [#464](https://github.com/eneo-ai/eneo/pull/464)         | MCP file references                              | Open and conflict-marked. It belongs to the object-content/file track.                                              |
+| [#538](https://github.com/eneo-ai/eneo/pull/538)         | Loopback internal MCP and on-demand knowledge    | Open and coupled to #464. It is useful comparison evidence, not a merge dependency for selective Skills.            |
+| [#541](https://github.com/eneo-ai/eneo/pull/541)         | Web search MCP provider                          | Draft. It does not gate Skills.                                                                                     |
+| `refactor/flows-clean`                                   | Flow package export/import vertical              | Active at `77202b4f`; it must land on `develop` before S2 extracts any shared package mechanics.                    |
 
 Passing checks on an old PR head do not remove the need to rebase and rerun the
 full checks against the current `develop` branch.
@@ -721,10 +724,10 @@ on-demand loading ineffective without adding a second event source.
    existing Skill and App-run owners and merged as `c642da49`.
 5. **Completed:** T013 froze one immutable eager plan per turn and added
    body-free activation evidence; PR #590 merged as `d2651dee`.
-6. **Active:** land T014 block integrity and visibility before the trusted runtime:
-   reject new or changed pins while blocked, retain unchanged pins, and expose
-   the derived block state in catalogue and binding projections.
-7. Finish Task #553 through T015 trusted runtime and T016 save contract/UI.
+6. **Completed:** T014/PR #593 rejects new or changed pins while blocked,
+   retains unchanged pins, and exposes the derived block state in catalogue and
+   binding projections.
+7. **Active:** finish Task #553 through T015 trusted runtime and T016 save contract/UI.
    T016 must leave one concrete fit/activatability function shared by save,
    preview, apply, API/UI projections, and tests.
 8. Consolidate T008 typed lifecycle conflicts after the #553 backend core and

--- a/docs/goals/enterprise-skills-rollout/state.yaml
+++ b/docs/goals/enterprise-skills-rollout/state.yaml
@@ -966,6 +966,8 @@ tasks:
       - "Completed T013 frozen SkillTurnPlan and activation evidence"
       - "Current streaming and non-streaming completion loops and external MCP dispatch"
     allowed_files:
+      - "backend/src/eneo/assistants/assistant.py"
+      - "backend/src/eneo/assistants/assistant_service.py"
       - "backend/src/eneo/completion_models/"
       - "backend/src/eneo/questions/"
       - "backend/src/eneo/sessions/"

--- a/docs/goals/enterprise-skills-rollout/state.yaml
+++ b/docs/goals/enterprise-skills-rollout/state.yaml
@@ -30,12 +30,12 @@ continuity:
   current_thread_id: "019f8f85-2ea6-7030-8c48-6d90143da5e0"
   previous_thread_id: "019f84c4-21db-7a00-b2cd-ae3d294d14ba"
   rotation_count: 1
-  completed_write_tasks_in_thread: 5
+  completed_write_tasks_in_thread: 6
   handoff_note: null
   last_handoff_at: null
-  last_verified_revision: "d2651deeeb94d93e367aac41bfab7d477f1cf871"
+  last_verified_revision: "5d54e242a0edd878ef0768c00ea35b63c827e50a"
 
-active_task: T014
+active_task: T015
 
 tasks:
   - id: T001
@@ -880,7 +880,7 @@ tasks:
   - id: T014
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Close the execution-block configuration and visibility gap without deleting bindings or changing established runtime behavior."
     inputs:
@@ -920,12 +920,43 @@ tasks:
     stop_if:
       - "The change requires deleting bindings, stopping an entire Assistant, or changing queued App provenance."
       - "Block state cannot be derived without creating a second source of truth."
-    receipt: null
+    receipt:
+      result: done
+      summary: "Closed the execution-block configuration and visibility gap at the canonical reference-resolution seam, preserved retained exact pins, passed local and GitHub gates, and squash-merged PR #593."
+      tracking_issue: "https://github.com/eneo-ai/eneo/issues/595"
+      merged_pr: 593
+      source_head: "6f228b47ae31e046fa79b8fd9e1efaab26447c65"
+      merge_commit: "5d54e242a0edd878ef0768c00ea35b63c827e50a"
+      merged_at: "2026-07-24T16:58:45Z"
+      github_checks: "All 19 non-skipped checks passed; one scope-dependent check was skipped."
+      final_review: "Review 3 confirmed F2-F3 resolved and found no current in-scope findings: https://github.com/eneo-ai/eneo/pull/593#issuecomment-5072051504"
+      changed_files:
+        - "backend/src/eneo/skills/"
+        - "backend/tests/"
+        - "frontend/apps/docs-site/src/content/guides/skills.mdx"
+        - "frontend/apps/web/messages/"
+        - "frontend/apps/web/src/lib/features/skills/"
+        - "frontend/apps/web/src/routes/(app)/spaces/organization/skills/"
+        - "frontend/packages/eneo-js/"
+        - "docs/adr/marketplace-hub-package-portability-and-skills.md"
+        - "docs/enterprise-skills-roadmap.md"
+        - "docs/goals/enterprise-skills-rollout/"
+      commands:
+        - cmd: "uv run pytest -n 2 -m 'not integration' tests/"
+          result: "pass: 2570 tests"
+        - cmd: "uv run pytest tests/integration/"
+          result: "pass: 1131 passed, 26 skipped, 52 deselected, 1 xfailed"
+        - cmd: "focused block-reference concurrency test repeated three times"
+          result: "pass: 9 behavior cases"
+        - cmd: "backend Ruff check/format, Pyright, frontend unit/check/lint/i18n, and hooks"
+          result: pass
+        - cmd: "required GitHub CI and final /review"
+          result: pass
 
   - id: T015
     type: worker
     assignee: Worker
-    status: queued
+    status: active
     reasoning_hint: high
     objective: "Implement Task #553 slice 4: the trusted internal on-demand activation effect through the existing completion loop."
     tracking_issue: "https://github.com/eneo-ai/eneo/issues/553"
@@ -1155,10 +1186,9 @@ checks:
   dirty_fingerprint: "main worktree contains unrelated user-owned changes; roadmap files are isolated"
   last_verification:
     result: pass
-    task: T006
+    task: T014
     commands:
-      - "GitHub: all 18 reported PR #577 checks reached a terminal non-failing state"
-      - "backend: 53 focused unit tests passed"
-      - "backend: 8 focused PostgreSQL execution-block integration tests passed"
-      - "backend: isolated migration test, Ruff, format, Pyright, and uv lock checks passed"
-      - "frontend: Prettier and docs-site production build passed"
+      - "GitHub: PR #593 merged after 19 successful checks, one scope skip, and Review 3 with no current findings"
+      - "backend: 2570 unit tests and 1131 integration tests passed"
+      - "backend: focused block-reference concurrency proof passed across three repeated runs"
+      - "backend/frontend: Ruff, format, Pyright, component tests, check, lint, i18n, and hooks passed"


### PR DESCRIPTION
## Changes

- add one plan-local activation function to the existing streaming and non-streaming completion loops
- keep exact Skill revisions and bodies server-side while the model sees only frozen keys, names and descriptions
- make `SkillActivationRuntime` the single owner of admission, saved-order composition, token limits, transcript closure and bounded evidence
- defer sibling external MCP calls safely when Skill context changes, without adding a second tool runtime
- persist the same final activation evidence on success, failure, cancellation and stream abort

## Why

Attached Skills currently have to be composed eagerly. This slice adds the trusted internal effect required for honest on-demand loading while preserving eager Apps, `always_only` fallback for models without native tool calls, and the frozen exact-revision boundary.

## Planning

- Task: Fixes #599
- Related delivery plan: #553, slice 4
- Parent epic: #545
- Goal board: T015

## Testing

- `uv run pytest tests/unit tests/unittests -q` — 3,898 passed
- focused T015 unit bundle — 147 passed
- `uv run pytest tests/integration/services/test_conversation_stream_abort.py -q` — 6 passed
- runtime robustness suite — 19 passed, including bounded 30-call fan-out and repeated-key transcript evidence
- Ruff format/check, source Pyright, `uv lock --check`, `git diff --check` and pre-push schema drift — passed
- Codex final gate — green, score 8
- Claude Opus 5/1M same-session final gate — green, score 8
- full local integration suite is running; GitHub CI remains authoritative for the merge gate

## Screenshots

Not applicable; this slice exposes no UI.