### PR TITLE
feat(skills): save Assistant activation modes

### DIFF
--- a/backend/src/eneo/assistants/api/assistant_models.py
+++ b/backend/src/eneo/assistants/api/assistant_models.py
@@ -44,7 +44,7 @@ from eneo.main.models import (
 from eneo.prompts.api.prompt_models import PromptCreate, PromptPublic
 from eneo.questions.question import UseTools
 from eneo.sessions.session import SessionInDB
-from eneo.skills.presentation.skill_models import SkillBindingReferenceInput
+from eneo.skills.presentation.skill_models import AssistantSkillBindingInput
 from eneo.users.user import UserSparse
 from eneo.websites.presentation.website_models import WebsitePublic
 
@@ -238,7 +238,7 @@ class AssistantUpdatePublic(AssistantCreatePublic):
         default=NOT_PROVIDED,
         description="Icon ID referencing an uploaded icon. Set to null to remove.",
     )
-    skill_bindings: Optional[list[SkillBindingReferenceInput]] = None
+    skill_bindings: Optional[list[AssistantSkillBindingInput]] = None
 
 
 class AssistantCreate(AssistantBase):

--- a/backend/src/eneo/assistants/api/assistant_router.py
+++ b/backend/src/eneo/assistants/api/assistant_router.py
@@ -54,8 +54,8 @@ from eneo.sessions.session_protocol import (
     to_sessions_paginated_response,
 )
 from eneo.skills.presentation.skill_assembler import (
+    assistant_skill_binding_intents_from_input,
     skill_binding_audit_entries,
-    skill_binding_references_from_input,
 )
 from eneo.spaces.api.space_models import TransferApplicationRequest
 
@@ -644,9 +644,11 @@ async def update_assistant(
     if assistant.completion_model_kwargs is not None:
         completion_model_kwargs = assistant.completion_model_kwargs
 
-    skill_references = None
+    skill_binding_intents = None
     if assistant.skill_bindings is not None:
-        skill_references = skill_binding_references_from_input(assistant.skill_bindings)
+        skill_binding_intents = assistant_skill_binding_intents_from_input(
+            assistant.skill_bindings
+        )
 
     # get original request dict to check if description was actually provided
     # (@partial_model overrides NOT_PROVIDED with None)
@@ -688,7 +690,7 @@ async def update_assistant(
         data_retention_days=data_retention_days,
         metadata_json=metadata_json,
         icon_id=icon_id,
-        skill_references=skill_references,
+        skill_binding_intents=skill_binding_intents,
     )
 
     changes, change_summary = _build_assistant_update_changes(

--- a/backend/src/eneo/assistants/assistant_service.py
+++ b/backend/src/eneo/assistants/assistant_service.py
@@ -593,11 +593,16 @@ class AssistantService:
             effective_config=effective_config,
             space_is_personal=space.is_personal(),
         )
+        validation_plan = (
+            skill_plan.for_on_demand_save_validation()
+            if validate_all_on_demand_candidates
+            else skill_plan
+        )
         candidate_ids = set(on_demand_skill_ids_requiring_validation)
         if validate_all_on_demand_candidates:
             candidate_ids.update(
                 binding.binding.skill_id
-                for binding in skill_plan.available
+                for binding in validation_plan.available
                 if binding.binding.activation_mode is SkillActivationMode.ON_DEMAND
             )
         candidate_skill_ids = frozenset(candidate_ids)
@@ -609,9 +614,9 @@ class AssistantService:
                 )
             return
 
-        runtime = skill_plan.to_activation_runtime(
+        runtime = validation_plan.to_activation_runtime(
             selected_model_route=model.get_model_route(),
-            max_input_tokens=attachment_token_ceiling(model.max_input_tokens),
+            max_input_tokens=model.max_input_tokens,
             supports_tool_calling=model.supports_tool_calling,
         )
         snapshot = runtime.snapshot()
@@ -685,6 +690,7 @@ class AssistantService:
             candidate_skill_ids,
             messages=provider_input.messages,
             provider_tools=provider_input.tools,
+            provider_input_token_limit=attachment_token_ceiling(model.max_input_tokens),
         )
         rejected_provider_assessment = next(
             (

--- a/backend/src/eneo/assistants/assistant_service.py
+++ b/backend/src/eneo/assistants/assistant_service.py
@@ -571,8 +571,11 @@ class AssistantService:
         Attachments are sent whole (never truncated), so a set that doesn't fit
         can't run — a clear rejection beats silently sending part of a document.
         The prompt counts toward the ceiling on its own, so a prompt that alone
-        overflows is rejected even with no attachments. Skipped only when no
-        model is resolved."""
+        overflows is rejected even with no attachments. Changed on-demand
+        candidates are each checked from the always-active baseline; combinations
+        remain a turn-time decision. Existing candidates are not revalidated for
+        unrelated attachment or policy drift. Skipped only when no model is
+        resolved."""
         # Mirror ask()'s governance resolution so the fit check uses the model
         # and prompt the request will really send, not the assistant's own.
         effective_config = await self._resolve_effective_config(
@@ -634,6 +637,13 @@ class AssistantService:
             assistant=assistant,
             model=model,
             prompt_text=runtime.prompt,
+            alternative_prompts=tuple(
+                (
+                    f'on-demand Skill "{assessment.display_name}"',
+                    assessment.prompt,
+                )
+                for assessment in assessments
+            ),
         )
 
     @staticmethod
@@ -659,6 +669,7 @@ class AssistantService:
         assistant: Assistant,
         model: "CompletionModel",
         prompt_text: str,
+        alternative_prompts: Sequence[tuple[str, str]] = (),
     ) -> None:
         completion_prompt_files = await self._completion_prompt_files_for_model(
             persistent_attachments=assistant.attachments,
@@ -669,6 +680,7 @@ class AssistantService:
             model_name=model.name,
             prompt_text=prompt_text,
             files=completion_prompt_files,
+            alternative_prompts=alternative_prompts,
         )
 
     async def assert_personal_default_governance_context_fit(self) -> None:

--- a/backend/src/eneo/assistants/assistant_service.py
+++ b/backend/src/eneo/assistants/assistant_service.py
@@ -62,11 +62,15 @@ from eneo.roles.permissions import (
 from eneo.services.service import DatastoreResult
 from eneo.services.service_repo import ServiceRepository
 from eneo.skills.domain.skill import (
+    AssistantSkillConfigurationProjection,
+    AssistantSkillRuntimeProjection,
     SkillActivationEvidenceV1,
-    SkillBindingReference,
+    SkillActivationFallbackReason,
+    SkillBindingIntent,
     SkillComposition,
     SkillExecutionReference,
     SkillRuntimeResolution,
+    SkillTurnEffectiveMode,
     SkillTurnPlan,
     compose_skill_instructions,
 )
@@ -80,6 +84,28 @@ from eneo.users.user import UserInDB
 from eneo.workflows.step_repo import StepRepository
 
 logger = get_logger(__name__)
+
+_ON_DEMAND_REJECTION_DEFAULT = (
+    "On-demand Skills cannot be enabled for this configuration"
+)
+_ON_DEMAND_REJECTION_MESSAGES: dict[
+    SkillActivationFallbackReason | None,
+    str,
+] = {
+    None: _ON_DEMAND_REJECTION_DEFAULT,
+    SkillActivationFallbackReason.SELECTIVE_ACTIVATION_DISABLED: (
+        "On-demand Skills are disabled by the organisation runtime policy"
+    ),
+    SkillActivationFallbackReason.MODEL_LACKS_TOOL_CALLING: (
+        "The selected completion model does not support on-demand Skills"
+    ),
+    SkillActivationFallbackReason.CATALOG_BUDGET_EXCEEDED: (
+        "The on-demand Skill catalogue exceeds the configured context allowance"
+    ),
+    SkillActivationFallbackReason.TOKEN_MEASUREMENT_UNAVAILABLE: (
+        "The selected completion model cannot measure the Skill catalogue exactly"
+    ),
+}
 
 if TYPE_CHECKING:
     from eneo.actors import ActorManager
@@ -275,26 +301,6 @@ class AssistantService:
         ):
             return effective_config.enforced_prompt_text
         return assistant.get_prompt_text()
-
-    async def _compose_assistant_prompt(
-        self,
-        *,
-        assistant: Assistant,
-        effective_config: "EffectiveConfig | None",
-        space_is_personal: bool,
-    ) -> SkillComposition:
-        base_instructions = self._governed_base_instructions(
-            assistant, effective_config
-        )
-        resolution = await self._resolve_assistant_skill_runtime(
-            assistant=assistant,
-            effective_config=effective_config,
-            space_is_personal=space_is_personal,
-        )
-        return compose_skill_instructions(
-            base_instructions=base_instructions,
-            bindings=list(resolution.eligible),
-        )
 
     async def _resolve_assistant_skill_runtime(
         self,
@@ -537,7 +543,11 @@ class AssistantService:
         return await self.file_service.with_derived_images(persistent_attachments)
 
     async def _validate_attachments_fit(
-        self, assistant: Assistant, *, space: "Space"
+        self,
+        assistant: Assistant,
+        *,
+        space: "Space",
+        explicit_on_demand_skill_ids: frozenset[UUID] = frozenset(),
     ) -> None:
         """Reject saving when the system prompt + persistent attachments don't
         fit the model's context window with room left to ask a question.
@@ -560,19 +570,47 @@ class AssistantService:
         effective_config = await self._resolve_effective_config(
             space=space, assistant=assistant
         )
-        composition = await self._compose_assistant_prompt(
+        skill_plan = await self._create_skill_turn_plan(
             assistant=assistant,
             effective_config=effective_config,
             space_is_personal=space.is_personal(),
         )
+        available_skill_ids = {
+            binding.binding.skill_id for binding in skill_plan.available
+        }
+        if not explicit_on_demand_skill_ids <= available_skill_ids:
+            raise BadRequestException(
+                "Blocked organisation Skills cannot receive new or changed bindings"
+            )
+
         model = self._context_model(assistant, effective_config=effective_config)
         if model is None:
+            if explicit_on_demand_skill_ids:
+                raise BadRequestException(
+                    "Choose a completion model before enabling on-demand Skills"
+                )
             return
+
+        runtime = skill_plan.to_activation_runtime(
+            selected_model_route=model.get_model_route(),
+            max_input_tokens=model.max_input_tokens,
+            supports_tool_calling=model.supports_tool_calling,
+        )
+        snapshot = runtime.snapshot()
+        if (
+            explicit_on_demand_skill_ids
+            and snapshot.effective_mode is not SkillTurnEffectiveMode.SELECTIVE
+        ):
+            message = _ON_DEMAND_REJECTION_MESSAGES.get(
+                snapshot.fallback_reason,
+                _ON_DEMAND_REJECTION_DEFAULT,
+            )
+            raise BadRequestException(message)
 
         await self._assert_persistent_baseline_fits(
             assistant=assistant,
             model=model,
-            prompt_text=composition.prompt,
+            prompt_text=runtime.prompt,
         )
 
     @staticmethod
@@ -743,7 +781,7 @@ class AssistantService:
         data_retention_days: Union[int, None, NotProvided] = NOT_PROVIDED,
         metadata_json: Union[dict[str, object], None, NotProvided] = NOT_PROVIDED,
         icon_id: Union[UUID, None, NotProvided] = NOT_PROVIDED,
-        skill_references: list[SkillBindingReference] | None = None,
+        skill_binding_intents: list[SkillBindingIntent] | None = None,
     ) -> tuple[Assistant, list[ResourcePermission]]:
         if logging_enabled:
             validate_permission(self.user, Permission.ADMIN)
@@ -796,7 +834,7 @@ class AssistantService:
                 mcp_tools,
                 attachment_ids,
                 insight_enabled,
-                skill_references,
+                skill_binding_intents,
             )
         ) or any(
             is_provided(value)
@@ -1011,12 +1049,14 @@ class AssistantService:
             knowledge_changing=knowledge_changing,
         )
 
-        if skill_references is not None:
-            await self.skill_service.replace_assistant_bindings(
+        changed_to_on_demand_skill_ids: frozenset[UUID] = frozenset()
+        if skill_binding_intents is not None:
+            replacement = await self.skill_service.replace_assistant_bindings(
                 space_id=assistant.space_id,
                 assistant_id=assistant_id,
-                references=skill_references,
+                intents=skill_binding_intents,
             )
+            changed_to_on_demand_skill_ids = replacement.changed_to_on_demand_skill_ids
 
         # Validate before persisting (the in-memory assistant already reflects the
         # final model + prompt + attachments from update() above), so a save that
@@ -1027,9 +1067,13 @@ class AssistantService:
             attachments is not None
             or completion_model is not None
             or prompt_obj is not None
-            or skill_references is not None
+            or skill_binding_intents is not None
         ):
-            await self._validate_attachments_fit(assistant, space=space)
+            await self._validate_attachments_fit(
+                assistant,
+                space=space,
+                explicit_on_demand_skill_ids=changed_to_on_demand_skill_ids,
+            )
 
         refreshed_space = await self.space_repo.update(space)
         assistant = refreshed_space.get_assistant(assistant_id=assistant_id)
@@ -1147,13 +1191,74 @@ class AssistantService:
         effective_config = await self._resolve_effective_config(
             space=space, assistant=assistant
         )
-        composition = await self._compose_assistant_prompt(
+        skill_plan = await self._create_skill_turn_plan(
             assistant=assistant,
             effective_config=effective_config,
             space_is_personal=space.is_personal(),
         )
+        model = self._context_model(assistant, effective_config=effective_config)
+        prompt = skill_plan.composition.prompt
+        if model is not None:
+            prompt = skill_plan.to_activation_runtime(
+                selected_model_route=model.get_model_route(),
+                max_input_tokens=model.max_input_tokens,
+                supports_tool_calling=model.supports_tool_calling,
+            ).prompt
 
-        return composition.prompt, assistant.attachments
+        return prompt, assistant.attachments
+
+    async def get_skill_configuration(
+        self,
+        *,
+        space_id: UUID,
+        assistant_id: UUID,
+    ) -> AssistantSkillConfigurationProjection:
+        """Return saved Assistant bindings and their exact initial runtime state.
+
+        The binding projection intentionally runs first because it owns both
+        Assistant and Skill-read authorization. Runtime resolution then follows
+        the same turn-plan path as ask and save validation.
+        """
+        bindings = await self.skill_service.list_assistant_binding_projections(
+            space_id=space_id,
+            assistant_id=assistant_id,
+        )
+        space = await self.space_repo.get_space_by_assistant(assistant_id=assistant_id)
+        assistant = space.get_assistant(assistant_id=assistant_id)
+        if space.is_personal() and assistant.is_default:
+            return AssistantSkillConfigurationProjection(
+                bindings=tuple(bindings),
+                runtime=None,
+            )
+
+        effective_config = await self._resolve_effective_config(
+            space=space,
+            assistant=assistant,
+        )
+        model = self._context_model(assistant, effective_config=effective_config)
+        if model is None:
+            return AssistantSkillConfigurationProjection(
+                bindings=tuple(bindings),
+                runtime=None,
+            )
+
+        skill_plan = await self._create_skill_turn_plan(
+            assistant=assistant,
+            effective_config=effective_config,
+            space_is_personal=space.is_personal(),
+        )
+        runtime = skill_plan.to_activation_runtime(
+            selected_model_route=model.get_model_route(),
+            max_input_tokens=model.max_input_tokens,
+            supports_tool_calling=model.supports_tool_calling,
+        )
+        return AssistantSkillConfigurationProjection(
+            bindings=tuple(bindings),
+            runtime=AssistantSkillRuntimeProjection(
+                effective_model_id=model.id,
+                snapshot=runtime.snapshot(),
+            ),
+        )
 
     async def is_help_assistant(self, assistant_id: UUID) -> bool:
         """Whether ``assistant_id`` currently fills a Help Assistant role.

--- a/backend/src/eneo/assistants/assistant_service.py
+++ b/backend/src/eneo/assistants/assistant_service.py
@@ -594,7 +594,7 @@ class AssistantService:
             space_is_personal=space.is_personal(),
         )
         validation_plan = (
-            skill_plan.for_on_demand_save_validation()
+            skill_plan.for_full_save_validation()
             if validate_all_on_demand_candidates
             else skill_plan
         )

--- a/backend/src/eneo/assistants/assistant_service.py
+++ b/backend/src/eneo/assistants/assistant_service.py
@@ -66,6 +66,7 @@ from eneo.skills.domain.skill import (
     AssistantSkillRuntimeProjection,
     SkillActivationEvidenceV1,
     SkillActivationFallbackReason,
+    SkillActivationRejectionReason,
     SkillBindingIntent,
     SkillComposition,
     SkillExecutionReference,
@@ -88,11 +89,7 @@ logger = get_logger(__name__)
 _ON_DEMAND_REJECTION_DEFAULT = (
     "On-demand Skills cannot be enabled for this configuration"
 )
-_ON_DEMAND_REJECTION_MESSAGES: dict[
-    SkillActivationFallbackReason | None,
-    str,
-] = {
-    None: _ON_DEMAND_REJECTION_DEFAULT,
+_ON_DEMAND_REJECTION_MESSAGES: dict[SkillActivationFallbackReason, str] = {
     SkillActivationFallbackReason.SELECTIVE_ACTIVATION_DISABLED: (
         "On-demand Skills are disabled by the organisation runtime policy"
     ),
@@ -104,6 +101,17 @@ _ON_DEMAND_REJECTION_MESSAGES: dict[
     ),
     SkillActivationFallbackReason.TOKEN_MEASUREMENT_UNAVAILABLE: (
         "The selected completion model cannot measure the Skill catalogue exactly"
+    ),
+}
+_ON_DEMAND_CANDIDATE_REJECTION_MESSAGES: dict[
+    SkillActivationRejectionReason,
+    str,
+] = {
+    SkillActivationRejectionReason.CONTEXT_LIMIT_EXCEEDED: (
+        "An on-demand Skill exceeds the configured context allowance"
+    ),
+    SkillActivationRejectionReason.TOKEN_MEASUREMENT_UNAVAILABLE: (
+        "The selected completion model cannot measure an on-demand Skill exactly"
     ),
 }
 
@@ -547,7 +555,7 @@ class AssistantService:
         assistant: Assistant,
         *,
         space: "Space",
-        explicit_on_demand_skill_ids: frozenset[UUID] = frozenset(),
+        on_demand_skill_ids_requiring_validation: frozenset[UUID] = frozenset(),
     ) -> None:
         """Reject saving when the system prompt + persistent attachments don't
         fit the model's context window with room left to ask a question.
@@ -575,17 +583,9 @@ class AssistantService:
             effective_config=effective_config,
             space_is_personal=space.is_personal(),
         )
-        available_skill_ids = {
-            binding.binding.skill_id for binding in skill_plan.available
-        }
-        if not explicit_on_demand_skill_ids <= available_skill_ids:
-            raise BadRequestException(
-                "Blocked organisation Skills cannot receive new or changed bindings"
-            )
-
         model = self._context_model(assistant, effective_config=effective_config)
         if model is None:
-            if explicit_on_demand_skill_ids:
+            if on_demand_skill_ids_requiring_validation:
                 raise BadRequestException(
                     "Choose a completion model before enabling on-demand Skills"
                 )
@@ -598,14 +598,37 @@ class AssistantService:
         )
         snapshot = runtime.snapshot()
         if (
-            explicit_on_demand_skill_ids
+            on_demand_skill_ids_requiring_validation
             and snapshot.effective_mode is not SkillTurnEffectiveMode.SELECTIVE
         ):
-            message = _ON_DEMAND_REJECTION_MESSAGES.get(
-                snapshot.fallback_reason,
-                _ON_DEMAND_REJECTION_DEFAULT,
+            message = (
+                _ON_DEMAND_REJECTION_MESSAGES.get(
+                    snapshot.fallback_reason,
+                    _ON_DEMAND_REJECTION_DEFAULT,
+                )
+                if snapshot.fallback_reason is not None
+                else _ON_DEMAND_REJECTION_DEFAULT
             )
             raise BadRequestException(message)
+
+        assessments = runtime.assess_on_demand_candidates(
+            on_demand_skill_ids_requiring_validation
+        )
+        rejection = next(
+            (
+                assessment.rejection_reason
+                for assessment in assessments
+                if assessment.rejection_reason is not None
+            ),
+            None,
+        )
+        if rejection is not None:
+            raise BadRequestException(
+                _ON_DEMAND_CANDIDATE_REJECTION_MESSAGES.get(
+                    rejection,
+                    _ON_DEMAND_REJECTION_DEFAULT,
+                )
+            )
 
         await self._assert_persistent_baseline_fits(
             assistant=assistant,
@@ -1049,14 +1072,16 @@ class AssistantService:
             knowledge_changing=knowledge_changing,
         )
 
-        changed_to_on_demand_skill_ids: frozenset[UUID] = frozenset()
+        on_demand_skill_ids_requiring_validation: frozenset[UUID] = frozenset()
         if skill_binding_intents is not None:
             replacement = await self.skill_service.replace_assistant_bindings(
                 space_id=assistant.space_id,
                 assistant_id=assistant_id,
                 intents=skill_binding_intents,
             )
-            changed_to_on_demand_skill_ids = replacement.changed_to_on_demand_skill_ids
+            on_demand_skill_ids_requiring_validation = (
+                replacement.on_demand_skill_ids_requiring_validation
+            )
 
         # Validate before persisting (the in-memory assistant already reflects the
         # final model + prompt + attachments from update() above), so a save that
@@ -1072,7 +1097,9 @@ class AssistantService:
             await self._validate_attachments_fit(
                 assistant,
                 space=space,
-                explicit_on_demand_skill_ids=changed_to_on_demand_skill_ids,
+                on_demand_skill_ids_requiring_validation=(
+                    on_demand_skill_ids_requiring_validation
+                ),
             )
 
         refreshed_space = await self.space_repo.update(space)

--- a/backend/src/eneo/assistants/assistant_service.py
+++ b/backend/src/eneo/assistants/assistant_service.py
@@ -23,7 +23,10 @@ from eneo.completion_models.infrastructure.context_builder import (
     count_tokens,
 )
 from eneo.completion_models.infrastructure.web_search import WebSearch
-from eneo.files.attachment_budget import assert_prompt_and_files_fit_context
+from eneo.files.attachment_budget import (
+    assert_prompt_and_files_fit_context,
+    attachment_token_ceiling,
+)
 from eneo.files.file_models import File, FileType
 from eneo.files.file_service import FileService
 from eneo.governance_policy.domain.policy_resolver import (
@@ -608,7 +611,7 @@ class AssistantService:
 
         runtime = skill_plan.to_activation_runtime(
             selected_model_route=model.get_model_route(),
-            max_input_tokens=model.max_input_tokens,
+            max_input_tokens=attachment_token_ceiling(model.max_input_tokens),
             supports_tool_calling=model.supports_tool_calling,
         )
         snapshot = runtime.snapshot()

--- a/backend/src/eneo/assistants/assistant_service.py
+++ b/backend/src/eneo/assistants/assistant_service.py
@@ -1202,6 +1202,7 @@ class AssistantService:
                     attachments is not None
                     or completion_model is not None
                     or prompt_obj is not None
+                    or skill_binding_intents is not None
                     or mcp_server_ids is not None
                     or mcp_tools is not None
                 ),
@@ -2543,7 +2544,33 @@ class AssistantService:
         if mcp_server_id in existing_server_ids:
             raise BadRequestException("MCP server already associated with assistant")
 
-        # Add new association
+        available_mcp_servers = (
+            effective_config.available_mcp_servers
+            if effective_config is not None and effective_config.mcp_enforced
+            else space.mcp_servers
+        )
+        new_mcp_server = next(
+            (server for server in available_mcp_servers if server.id == mcp_server_id),
+            None,
+        )
+        if new_mcp_server is None:
+            raise BadRequestException("MCP server is not available to this assistant")
+
+        staged_mcp_servers = list(assistant.mcp_servers)
+        staged_mcp_servers.append(new_mcp_server)
+        projected_mcp_servers = await self.space_repo.project_assistant_mcp_servers(
+            space_id=space.id,
+            assistant_id=assistant_id,
+            mcp_servers=staged_mcp_servers,
+        )
+        await self._validate_attachments_fit(
+            assistant,
+            space=space,
+            validate_all_on_demand_candidates=True,
+            mcp_servers_override=projected_mcp_servers,
+        )
+
+        # Persist only after the complete post-add provider payload is accepted.
         existing_server_ids.append(mcp_server_id)
         # Update via repository
         from eneo.database.tables.assistant_table import Assistants

--- a/backend/src/eneo/assistants/assistant_service.py
+++ b/backend/src/eneo/assistants/assistant_service.py
@@ -66,6 +66,7 @@ from eneo.skills.domain.skill import (
     AssistantSkillRuntimeProjection,
     SkillActivationEvidenceV1,
     SkillActivationFallbackReason,
+    SkillActivationMode,
     SkillActivationRejectionReason,
     SkillBindingIntent,
     SkillComposition,
@@ -108,10 +109,13 @@ _ON_DEMAND_CANDIDATE_REJECTION_MESSAGES: dict[
     str,
 ] = {
     SkillActivationRejectionReason.CONTEXT_LIMIT_EXCEEDED: (
-        "An on-demand Skill exceeds the configured context allowance"
+        "exceeds the configured context allowance"
     ),
     SkillActivationRejectionReason.TOKEN_MEASUREMENT_UNAVAILABLE: (
-        "The selected completion model cannot measure an on-demand Skill exactly"
+        "cannot be measured exactly by the selected completion model"
+    ),
+    SkillActivationRejectionReason.MODEL_CONTEXT_LIMIT_EXCEEDED: (
+        "does not fit the selected completion model context"
     ),
 }
 
@@ -556,6 +560,8 @@ class AssistantService:
         *,
         space: "Space",
         on_demand_skill_ids_requiring_validation: frozenset[UUID] = frozenset(),
+        validate_all_on_demand_candidates: bool = False,
+        mcp_servers_override: list["MCPServer"] | None = None,
     ) -> None:
         """Reject saving when the system prompt + persistent attachments don't
         fit the model's context window with room left to ask a question.
@@ -570,12 +576,10 @@ class AssistantService:
 
         Attachments are sent whole (never truncated), so a set that doesn't fit
         can't run — a clear rejection beats silently sending part of a document.
-        The prompt counts toward the ceiling on its own, so a prompt that alone
-        overflows is rejected even with no attachments. Changed on-demand
-        candidates are each checked from the always-active baseline; combinations
-        remain a turn-time decision. Existing candidates are not revalidated for
-        unrelated attachment or policy drift. Skipped only when no model is
-        resolved."""
+        On-demand candidates are staged one at a time against the provider-visible
+        baseline, including the activation transcript and configured MCP schemas.
+        Combinations and live per-user MCP narrowing remain turn-time decisions.
+        Skipped only when no model is resolved."""
         # Mirror ask()'s governance resolution so the fit check uses the model
         # and prompt the request will really send, not the assistant's own.
         effective_config = await self._resolve_effective_config(
@@ -586,9 +590,17 @@ class AssistantService:
             effective_config=effective_config,
             space_is_personal=space.is_personal(),
         )
+        candidate_ids = set(on_demand_skill_ids_requiring_validation)
+        if validate_all_on_demand_candidates:
+            candidate_ids.update(
+                binding.binding.skill_id
+                for binding in skill_plan.available
+                if binding.binding.activation_mode is SkillActivationMode.ON_DEMAND
+            )
+        candidate_skill_ids = frozenset(candidate_ids)
         model = self._context_model(assistant, effective_config=effective_config)
         if model is None:
-            if on_demand_skill_ids_requiring_validation:
+            if candidate_skill_ids:
                 raise BadRequestException(
                     "Choose a completion model before enabling on-demand Skills"
                 )
@@ -601,7 +613,7 @@ class AssistantService:
         )
         snapshot = runtime.snapshot()
         if (
-            on_demand_skill_ids_requiring_validation
+            candidate_skill_ids
             and snapshot.effective_mode is not SkillTurnEffectiveMode.SELECTIVE
         ):
             message = (
@@ -614,37 +626,82 @@ class AssistantService:
             )
             raise BadRequestException(message)
 
-        assessments = runtime.assess_on_demand_candidates(
-            on_demand_skill_ids_requiring_validation
-        )
-        rejection = next(
+        assessments = runtime.assess_on_demand_candidates(candidate_skill_ids)
+        rejected_assessment = next(
             (
-                assessment.rejection_reason
+                assessment
                 for assessment in assessments
                 if assessment.rejection_reason is not None
             ),
             None,
         )
-        if rejection is not None:
+        if rejected_assessment is not None:
+            rejection_reason = rejected_assessment.rejection_reason
+            assert rejection_reason is not None
             raise BadRequestException(
-                _ON_DEMAND_CANDIDATE_REJECTION_MESSAGES.get(
-                    rejection,
+                f'on-demand Skill "{rejected_assessment.display_name}" '
+                + _ON_DEMAND_CANDIDATE_REJECTION_MESSAGES.get(
+                    rejection_reason,
                     _ON_DEMAND_REJECTION_DEFAULT,
                 )
             )
 
+        completion_prompt_files = await self._completion_prompt_files_for_model(
+            persistent_attachments=assistant.attachments,
+            completion_model=model,
+        )
         await self._assert_persistent_baseline_fits(
             assistant=assistant,
             model=model,
             prompt_text=runtime.prompt,
-            alternative_prompts=tuple(
-                (
-                    f'on-demand Skill "{assessment.display_name}"',
-                    assessment.prompt,
-                )
-                for assessment in assessments
-            ),
+            completion_prompt_files=completion_prompt_files,
         )
+
+        if not candidate_skill_ids:
+            return
+
+        if effective_config is not None and effective_config.mcp_enforced:
+            effective_mcp_servers = effective_config.available_mcp_servers
+        elif mcp_servers_override is not None:
+            effective_mcp_servers = mcp_servers_override
+        else:
+            effective_mcp_servers = assistant.mcp_servers
+        if assistant.has_knowledge():
+            effective_mcp_servers = []
+
+        provider_input = (
+            await self.completion_service.prepare_skill_activation_preflight(
+                model=cast("AICompletionModel", model),
+                prompt=runtime.prompt,
+                prompt_files=completion_prompt_files,
+                mcp_servers=effective_mcp_servers,
+                skill_runtime=runtime,
+            )
+        )
+        provider_assessments = runtime.assess_provider_payload_candidates(
+            candidate_skill_ids,
+            messages=provider_input.messages,
+            provider_tools=provider_input.tools,
+        )
+        rejected_provider_assessment = next(
+            (
+                assessment
+                for assessment in provider_assessments
+                if assessment.rejection_reason is not None
+            ),
+            None,
+        )
+        if rejected_provider_assessment is not None:
+            rejection_reason = rejected_provider_assessment.rejection_reason
+            assert rejection_reason is not None
+            message = _ON_DEMAND_CANDIDATE_REJECTION_MESSAGES.get(
+                rejection_reason,
+                _ON_DEMAND_REJECTION_DEFAULT,
+            )
+            raise BadRequestException(
+                f'on-demand Skill "{rejected_provider_assessment.display_name}" '
+                f"{message}"
+            )
 
     @staticmethod
     def _context_model(
@@ -669,18 +726,18 @@ class AssistantService:
         assistant: Assistant,
         model: "CompletionModel",
         prompt_text: str,
-        alternative_prompts: Sequence[tuple[str, str]] = (),
+        completion_prompt_files: list[File] | None = None,
     ) -> None:
-        completion_prompt_files = await self._completion_prompt_files_for_model(
-            persistent_attachments=assistant.attachments,
-            completion_model=model,
-        )
+        if completion_prompt_files is None:
+            completion_prompt_files = await self._completion_prompt_files_for_model(
+                persistent_attachments=assistant.attachments,
+                completion_model=model,
+            )
         assert_prompt_and_files_fit_context(
             max_input_tokens=model.max_input_tokens,
-            model_name=model.name,
+            model_name=model.get_model_route(),
             prompt_text=prompt_text,
             files=completion_prompt_files,
-            alternative_prompts=alternative_prompts,
         )
 
     async def assert_personal_default_governance_context_fit(self) -> None:
@@ -1036,6 +1093,30 @@ class AssistantService:
             effective_config=mcp_effective_config,
         )
 
+        mcp_servers_for_validation: list["MCPServer"] | None = None
+        if mcp_server_ids is not None or mcp_tools is not None:
+            assert space.id is not None
+            selected_ids = (
+                set(mcp_server_ids)
+                if mcp_server_ids is not None
+                else {server.id for server in assistant.mcp_servers}
+            )
+            source_servers = (
+                space.mcp_servers
+                if mcp_server_ids is not None
+                else assistant.mcp_servers
+            )
+            mcp_servers_for_validation = (
+                await self.space_repo.project_assistant_mcp_servers(
+                    space_id=space.id,
+                    assistant_id=assistant_id,
+                    mcp_servers=[
+                        server for server in source_servers if server.id in selected_ids
+                    ],
+                    tool_settings=mcp_tools,
+                )
+            )
+
         # Store MCP server IDs and tool settings for repository to handle.
         setattr(assistant, "_mcp_server_ids", mcp_server_ids)
         setattr(assistant, "_mcp_tool_settings", mcp_tools)
@@ -1105,6 +1186,8 @@ class AssistantService:
             or completion_model is not None
             or prompt_obj is not None
             or skill_binding_intents is not None
+            or mcp_server_ids is not None
+            or mcp_tools is not None
         ):
             await self._validate_attachments_fit(
                 assistant,
@@ -1112,6 +1195,14 @@ class AssistantService:
                 on_demand_skill_ids_requiring_validation=(
                     on_demand_skill_ids_requiring_validation
                 ),
+                validate_all_on_demand_candidates=(
+                    attachments is not None
+                    or completion_model is not None
+                    or prompt_obj is not None
+                    or mcp_server_ids is not None
+                    or mcp_tools is not None
+                ),
+                mcp_servers_override=mcp_servers_for_validation,
             )
 
         refreshed_space = await self.space_repo.update(space)

--- a/backend/src/eneo/completion_models/domain/skill_activation.py
+++ b/backend/src/eneo/completion_models/domain/skill_activation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from time import perf_counter_ns
 from typing import Any, cast
 from uuid import UUID
@@ -362,18 +362,23 @@ class SkillActivationRuntime:
         Save-time preflight uses the same transcript mutation and token
         measurement as a real activation round. Each probe runs on a fork so
         neither the frozen turn state nor the caller's messages are changed.
+        Each selected on-demand candidate is measured exactly once.
         """
-        assessments = self.assess_on_demand_candidates(skill_ids)
+        if self._effective_mode is not SkillTurnEffectiveMode.SELECTIVE:
+            return ()
+
         provider_assessments: list[SkillActivationCandidateAssessment] = []
-        for assessment in assessments:
+        for skill in self._skills:
+            if skill.initially_active or skill.binding.skill_id not in skill_ids:
+                continue
             staged = self._fork()
             staged_messages = [message.copy() for message in messages]
             staged.apply_provider_tool_calls(
                 calls=(
                     ProviderToolCall(
-                        call_id=f"preflight-{assessment.activation_key}",
+                        call_id=f"preflight-{skill.activation_key}",
                         name=SKILL_ACTIVATION_TOOL_NAME,
-                        arguments=json.dumps({"skill_key": assessment.activation_key}),
+                        arguments=json.dumps({"skill_key": skill.activation_key}),
                     ),
                 ),
                 messages=cast("list[dict[str, object]]", staged_messages),
@@ -387,14 +392,19 @@ class SkillActivationRuntime:
                 (
                     rejection.reason
                     for rejection in snapshot.rejected
-                    if rejection.activation_key == assessment.activation_key
+                    if rejection.activation_key == skill.activation_key
                 ),
                 None,
             )
             provider_assessments.append(
-                replace(
-                    assessment,
-                    prompt=staged.prompt,
+                SkillActivationCandidateAssessment(
+                    skill_id=skill.binding.skill_id,
+                    display_name=skill.display_name,
+                    activation_key=skill.activation_key,
+                    prompt=_compose_prompt(
+                        base_instructions=self._base_instructions,
+                        skills=self._active_skills(skill.activation_key),
+                    ),
                     rejection_reason=rejection_reason,
                     measurement=snapshot.measurement,
                 )

--- a/backend/src/eneo/completion_models/domain/skill_activation.py
+++ b/backend/src/eneo/completion_models/domain/skill_activation.py
@@ -5,6 +5,7 @@ import json
 from dataclasses import dataclass
 from time import perf_counter_ns
 from typing import Any, cast
+from uuid import UUID
 
 from eneo.ai_models.completion_models.completion_model import (
     FunctionDefinition,
@@ -84,6 +85,16 @@ class SkillActivationSnapshot:
 class SkillActivationRejectionSnapshot:
     activation_key: str
     reason: SkillActivationRejectionReason
+
+
+@dataclass(frozen=True)
+class SkillActivationCandidateAssessment:
+    """Non-mutating fit result for one on-demand candidate."""
+
+    skill_id: UUID
+    activation_key: str
+    rejection_reason: SkillActivationRejectionReason | None
+    measurement: SkillContextMeasurement
 
 
 @dataclass(frozen=True)
@@ -315,6 +326,51 @@ class SkillActivationRuntime:
             ),
         )
 
+    def assess_on_demand_candidates(
+        self,
+        skill_ids: frozenset[UUID],
+    ) -> tuple[SkillActivationCandidateAssessment, ...]:
+        """Measure requested candidates against the current selective state.
+
+        The method reuses the exact runtime measurement path without mutating
+        activation state. Callers must handle plan-level fallback before asking
+        for candidate results; an ALWAYS_ONLY runtime has no activatable
+        candidates to assess. Unknown or blocked Skill ids are omitted because
+        binding resolution owns membership and governance validation.
+        """
+        if self._effective_mode is not SkillTurnEffectiveMode.SELECTIVE:
+            return ()
+
+        assessments: list[SkillActivationCandidateAssessment] = []
+        for skill in self._skills:
+            if skill.initially_active or skill.binding.skill_id not in skill_ids:
+                continue
+            _, assessment = self._assess_candidate(skill)
+            assessments.append(assessment)
+        return tuple(assessments)
+
+    def _assess_candidate(
+        self,
+        skill: FrozenSkillInstruction,
+    ) -> tuple[str, SkillActivationCandidateAssessment]:
+        prompt, measurement = self._measure(self._active_skills(skill.activation_key))
+        rejection_reason: SkillActivationRejectionReason | None = None
+        if measurement.source is TokenCountSource.FALLBACK_ESTIMATE:
+            rejection_reason = (
+                SkillActivationRejectionReason.TOKEN_MEASUREMENT_UNAVAILABLE
+            )
+        elif measurement.tokens > measurement.limit:
+            rejection_reason = SkillActivationRejectionReason.CONTEXT_LIMIT_EXCEEDED
+        return (
+            prompt,
+            SkillActivationCandidateAssessment(
+                skill_id=skill.binding.skill_id,
+                activation_key=skill.activation_key,
+                rejection_reason=rejection_reason,
+                measurement=measurement,
+            ),
+        )
+
     @staticmethod
     def _provider_unavailable() -> dict[str, bool]:
         return {"activated": False, "unavailable": True}
@@ -472,27 +528,11 @@ class SkillActivationRuntime:
                 )
                 continue
 
-            candidate_prompt, candidate_measurement = self._measure(
-                self._active_skills(key)
-            )
-            if candidate_measurement.source is TokenCountSource.FALLBACK_ESTIMATE:
+            candidate_prompt, assessment = self._assess_candidate(candidate)
+            if assessment.rejection_reason is not None:
                 self._reject(
                     activation_key=key,
-                    reason=(
-                        SkillActivationRejectionReason.TOKEN_MEASUREMENT_UNAVAILABLE
-                    ),
-                )
-                decisions.append(
-                    SkillActivationDecision(
-                        call_id=request.call_id,
-                        provider_payload=self._provider_unavailable(),
-                    )
-                )
-                continue
-            if candidate_measurement.tokens > candidate_measurement.limit:
-                self._reject(
-                    activation_key=key,
-                    reason=SkillActivationRejectionReason.CONTEXT_LIMIT_EXCEEDED,
+                    reason=assessment.rejection_reason,
                 )
                 decisions.append(
                     SkillActivationDecision(
@@ -505,7 +545,7 @@ class SkillActivationRuntime:
             self._active_keys.add(key)
             self._accepted.append(key)
             self.prompt = candidate_prompt
-            self._measurement = candidate_measurement
+            self._measurement = assessment.measurement
             accepted_any = True
             decisions.append(
                 SkillActivationDecision(

--- a/backend/src/eneo/completion_models/domain/skill_activation.py
+++ b/backend/src/eneo/completion_models/domain/skill_activation.py
@@ -92,7 +92,9 @@ class SkillActivationCandidateAssessment:
     """Non-mutating fit result for one on-demand candidate."""
 
     skill_id: UUID
+    display_name: str
     activation_key: str
+    prompt: str
     rejection_reason: SkillActivationRejectionReason | None
     measurement: SkillContextMeasurement
 
@@ -345,14 +347,13 @@ class SkillActivationRuntime:
         for skill in self._skills:
             if skill.initially_active or skill.binding.skill_id not in skill_ids:
                 continue
-            _, assessment = self._assess_candidate(skill)
-            assessments.append(assessment)
+            assessments.append(self._assess_candidate(skill))
         return tuple(assessments)
 
     def _assess_candidate(
         self,
         skill: FrozenSkillInstruction,
-    ) -> tuple[str, SkillActivationCandidateAssessment]:
+    ) -> SkillActivationCandidateAssessment:
         prompt, measurement = self._measure(self._active_skills(skill.activation_key))
         rejection_reason: SkillActivationRejectionReason | None = None
         if measurement.source is TokenCountSource.FALLBACK_ESTIMATE:
@@ -361,14 +362,13 @@ class SkillActivationRuntime:
             )
         elif measurement.tokens > measurement.limit:
             rejection_reason = SkillActivationRejectionReason.CONTEXT_LIMIT_EXCEEDED
-        return (
-            prompt,
-            SkillActivationCandidateAssessment(
-                skill_id=skill.binding.skill_id,
-                activation_key=skill.activation_key,
-                rejection_reason=rejection_reason,
-                measurement=measurement,
-            ),
+        return SkillActivationCandidateAssessment(
+            skill_id=skill.binding.skill_id,
+            display_name=skill.display_name,
+            activation_key=skill.activation_key,
+            prompt=prompt,
+            rejection_reason=rejection_reason,
+            measurement=measurement,
         )
 
     @staticmethod
@@ -528,7 +528,7 @@ class SkillActivationRuntime:
                 )
                 continue
 
-            candidate_prompt, assessment = self._assess_candidate(candidate)
+            assessment = self._assess_candidate(candidate)
             if assessment.rejection_reason is not None:
                 self._reject(
                     activation_key=key,
@@ -544,7 +544,7 @@ class SkillActivationRuntime:
 
             self._active_keys.add(key)
             self._accepted.append(key)
-            self.prompt = candidate_prompt
+            self.prompt = assessment.prompt
             self._measurement = assessment.measurement
             accepted_any = True
             decisions.append(

--- a/backend/src/eneo/completion_models/domain/skill_activation.py
+++ b/backend/src/eneo/completion_models/domain/skill_activation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from time import perf_counter_ns
 from typing import Any, cast
 from uuid import UUID
@@ -349,6 +349,57 @@ class SkillActivationRuntime:
                 continue
             assessments.append(self._assess_candidate(skill))
         return tuple(assessments)
+
+    def assess_provider_payload_candidates(
+        self,
+        skill_ids: frozenset[UUID],
+        *,
+        messages: list[dict[str, Any]],
+        provider_tools: list[dict[str, Any]],
+    ) -> tuple[SkillActivationCandidateAssessment, ...]:
+        """Stage each candidate against the provider-visible request payload.
+
+        Save-time preflight uses the same transcript mutation and token
+        measurement as a real activation round. Each probe runs on a fork so
+        neither the frozen turn state nor the caller's messages are changed.
+        """
+        assessments = self.assess_on_demand_candidates(skill_ids)
+        provider_assessments: list[SkillActivationCandidateAssessment] = []
+        for assessment in assessments:
+            staged = self._fork()
+            staged_messages = [message.copy() for message in messages]
+            staged.apply_provider_tool_calls(
+                calls=(
+                    ProviderToolCall(
+                        call_id=f"preflight-{assessment.activation_key}",
+                        name=SKILL_ACTIVATION_TOOL_NAME,
+                        arguments=json.dumps({"skill_key": assessment.activation_key}),
+                    ),
+                ),
+                messages=cast("list[dict[str, object]]", staged_messages),
+                provider_tools=cast(
+                    "list[dict[str, object]]",
+                    provider_tools,
+                ),
+            )
+            snapshot = staged.snapshot()
+            rejection_reason = next(
+                (
+                    rejection.reason
+                    for rejection in snapshot.rejected
+                    if rejection.activation_key == assessment.activation_key
+                ),
+                None,
+            )
+            provider_assessments.append(
+                replace(
+                    assessment,
+                    prompt=staged.prompt,
+                    rejection_reason=rejection_reason,
+                    measurement=snapshot.measurement,
+                )
+            )
+        return tuple(provider_assessments)
 
     def _assess_candidate(
         self,

--- a/backend/src/eneo/completion_models/domain/skill_activation.py
+++ b/backend/src/eneo/completion_models/domain/skill_activation.py
@@ -356,13 +356,16 @@ class SkillActivationRuntime:
         *,
         messages: list[dict[str, Any]],
         provider_tools: list[dict[str, Any]],
+        provider_input_token_limit: int | None = None,
     ) -> tuple[SkillActivationCandidateAssessment, ...]:
         """Stage each candidate against the provider-visible request payload.
 
         Save-time preflight uses the same transcript mutation and token
         measurement as a real activation round. Each probe runs on a fork so
         neither the frozen turn state nor the caller's messages are changed.
-        Each selected on-demand candidate is measured exactly once.
+        Each selected on-demand candidate is measured exactly once. Save-time
+        callers may reserve question space with a lower provider-input limit;
+        the runtime's model window still owns Skill-share measurement.
         """
         if self._effective_mode is not SkillTurnEffectiveMode.SELECTIVE:
             return ()
@@ -386,6 +389,7 @@ class SkillActivationRuntime:
                     "list[dict[str, object]]",
                     provider_tools,
                 ),
+                provider_input_token_limit=provider_input_token_limit,
             )
             snapshot = staged.snapshot()
             rejection_reason = next(
@@ -753,8 +757,15 @@ class SkillActivationRuntime:
         messages: list[dict[str, object]],
         provider_tools: list[dict[str, object]] | None = None,
         assistant_content: str | None = None,
+        provider_input_token_limit: int | None = None,
     ) -> SkillToolCallApplication:
         """Close internal calls and return external calls safe to dispatch."""
+
+        provider_limit = (
+            self._max_input_tokens
+            if provider_input_token_limit is None
+            else provider_input_token_limit
+        )
 
         internal = tuple(
             call for call in calls if call.name == SKILL_ACTIVATION_TOOL_NAME
@@ -884,7 +895,7 @@ class SkillActivationRuntime:
                     }
                 )
                 continue
-            if provider_measurement.tokens > self._max_input_tokens:
+            if provider_measurement.tokens > provider_limit:
                 overflow_key = newly_accepted[-1]
                 for index, candidate_key in enumerate(newly_accepted[:-1]):
                     probe_rejections = {
@@ -919,7 +930,7 @@ class SkillActivationRuntime:
                         )
                         overflow_key = None
                         break
-                    if probe_measurement.tokens > self._max_input_tokens:
+                    if probe_measurement.tokens > provider_limit:
                         overflow_key = candidate_key
                         break
 

--- a/backend/src/eneo/completion_models/domain/skill_context.py
+++ b/backend/src/eneo/completion_models/domain/skill_context.py
@@ -14,6 +14,14 @@ class SkillContextMeasurement:
     source: TokenCountSource
 
 
+def skill_context_token_allowance(
+    *,
+    max_input_tokens: int,
+    context_share_percent: int,
+) -> int:
+    return max_input_tokens * context_share_percent // 100
+
+
 def _system_message(instructions: str) -> list[dict[str, str]]:
     if not instructions:
         return []
@@ -45,6 +53,9 @@ def measure_skill_context(
     )
     return SkillContextMeasurement(
         tokens=message_delta.tokens + tool_delta.tokens,
-        limit=max_input_tokens * context_share_percent // 100,
+        limit=skill_context_token_allowance(
+            max_input_tokens=max_input_tokens,
+            context_share_percent=context_share_percent,
+        ),
         source=source,
     )

--- a/backend/src/eneo/completion_models/infrastructure/adapters/base_adapter.py
+++ b/backend/src/eneo/completion_models/infrastructure/adapters/base_adapter.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, AsyncIterator, Optional
 
 if TYPE_CHECKING:
@@ -10,6 +11,15 @@ if TYPE_CHECKING:
     )
     from eneo.completion_models.domain.skill_activation import SkillActivationRuntime
     from eneo.logging.logging import LoggingDetails
+
+
+@dataclass(frozen=True)
+class ProviderInput:
+    """Canonical messages and tools sent to a completion provider."""
+
+    messages: list[dict[str, Any]]
+    tools: list[dict[str, Any]]
+    built_in_tools: list[dict[str, Any]]
 
 
 class CompletionModelAdapter(ABC):
@@ -32,6 +42,17 @@ class CompletionModelAdapter(ABC):
         self, context: "Context", model_kwargs: "ModelKwargs | dict[str, Any] | None"
     ) -> "LoggingDetails":
         raise NotImplementedError()
+
+    @abstractmethod
+    def prepare_provider_input(
+        self,
+        context: "Context",
+        *,
+        mcp_proxy: Any | None = None,
+        skill_runtime: "SkillActivationRuntime | None" = None,
+    ) -> ProviderInput:
+        """Serialize the exact provider-visible messages and tool catalogue."""
+        pass
 
     async def get_response(
         self,

--- a/backend/src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py
+++ b/backend/src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py
@@ -40,6 +40,7 @@ from eneo.completion_models.domain.skill_activation import (
 )
 from eneo.completion_models.infrastructure.adapters.base_adapter import (
     CompletionModelAdapter,
+    ProviderInput,
 )
 from eneo.completion_models.infrastructure.message_payload import (
     build_content,
@@ -747,6 +748,28 @@ class TenantModelAdapter(CompletionModelAdapter):
 
         return messages
 
+    @override
+    def prepare_provider_input(
+        self,
+        context: "Context",
+        *,
+        mcp_proxy: "MCPProxySession | None" = None,
+        skill_runtime: SkillActivationRuntime | None = None,
+    ) -> ProviderInput:
+        """Build the canonical payload shared by preflight and provider calls."""
+        messages = self._create_messages_from_context(context)
+        eneo_tools = self._build_tools_from_context(context)
+        tools = self._merge_mcp_tools(
+            eneo_tools,
+            mcp_proxy,
+            skill_runtime,
+        )
+        return ProviderInput(
+            messages=messages,
+            tools=tools,
+            built_in_tools=eneo_tools,
+        )
+
     def _prepare_kwargs(
         self,
         model_kwargs: ModelKwargs | dict[str, Any] | None = None,
@@ -840,18 +863,14 @@ class TenantModelAdapter(CompletionModelAdapter):
         # Prepare LiteLLM kwargs with credentials and provider-specific handling
         litellm_kwargs = self._prepare_kwargs(model_kwargs=model_kwargs, **kwargs)
 
-        # Convert messages to OpenAI format (with vision support)
-        messages = self._create_messages_from_context(context)
-
-        # Build combined tools (Eneo built-in + MCP)
-        eneo_tools = self._build_tools_from_context(context)
-        all_tools = self._merge_mcp_tools(
-            eneo_tools,
-            mcp_proxy,
-            skill_runtime,
+        provider_input = self.prepare_provider_input(
+            context,
+            mcp_proxy=mcp_proxy,
+            skill_runtime=skill_runtime,
         )
-        if all_tools:
-            litellm_kwargs["tools"] = all_tools
+        messages = provider_input.messages
+        if provider_input.tools:
+            litellm_kwargs["tools"] = provider_input.tools
 
         # Check which params will be dropped and log effective params
         dropped = self._get_dropped_params(litellm_kwargs)
@@ -1100,18 +1119,14 @@ class TenantModelAdapter(CompletionModelAdapter):
         # Prepare LiteLLM kwargs with credentials and provider-specific handling
         litellm_kwargs = self._prepare_kwargs(model_kwargs=model_kwargs, **kwargs)
 
-        # Convert messages to OpenAI format (with vision support)
-        messages = self._create_messages_from_context(context)
-
-        # Build combined tools (Eneo built-in + MCP)
-        eneo_tools = self._build_tools_from_context(context)
-        all_tools = self._merge_mcp_tools(
-            eneo_tools,
-            mcp_proxy,
-            skill_runtime,
+        provider_input = self.prepare_provider_input(
+            context,
+            mcp_proxy=mcp_proxy,
+            skill_runtime=skill_runtime,
         )
-        if all_tools:
-            litellm_kwargs["tools"] = all_tools
+        messages = provider_input.messages
+        if provider_input.tools:
+            litellm_kwargs["tools"] = provider_input.tools
 
         # Check which params will be dropped and log effective params
         dropped = self._get_dropped_params(litellm_kwargs)
@@ -1146,8 +1161,8 @@ class TenantModelAdapter(CompletionModelAdapter):
                 kwargs=litellm_kwargs,
                 mcp_proxy=mcp_proxy,
                 skill_runtime=skill_runtime,
-                has_tools=bool(all_tools),
-                eneo_tools=eneo_tools,
+                has_tools=bool(provider_input.tools),
+                eneo_tools=provider_input.built_in_tools,
             )
 
         except Exception as exc:

--- a/backend/src/eneo/completion_models/infrastructure/completion_service.py
+++ b/backend/src/eneo/completion_models/infrastructure/completion_service.py
@@ -13,6 +13,7 @@ from eneo.ai_models.completion_models.completion_model import (
     ResponseType,
 )
 from eneo.completion_models.domain.skill_activation import SkillActivationRuntime
+from eneo.completion_models.infrastructure.adapters.base_adapter import ProviderInput
 from eneo.completion_models.infrastructure.context_builder import ContextBuilder
 from eneo.files.file_models import File
 from eneo.info_blobs.info_blob import InfoBlobChunkInDBWithScore
@@ -150,6 +151,57 @@ class CompletionService:
             credential_resolver=credential_resolver,
             provider_type=provider.provider_type,
         )
+
+    async def prepare_skill_activation_preflight(
+        self,
+        *,
+        model: CompletionModel,
+        prompt: str,
+        prompt_files: list[File],
+        mcp_servers: list["MCPServer"],
+        skill_runtime: SkillActivationRuntime,
+    ) -> ProviderInput:
+        """Build a deterministic upper bound for save-time activation checks.
+
+        The persisted, permission-filtered MCP catalogue is used without live
+        discovery or a network connection. Runtime still performs the final
+        per-user check after live tool narrowing.
+        """
+        adapter = await self._get_adapter(model)
+        enabled_servers = [server for server in mcp_servers if server.is_enabled]
+        mcp_proxy: MCPProxySession | None = None
+        if enabled_servers and model.supports_tool_calling:
+            mcp_proxy = self._mcp_proxy_factory.create(
+                enabled_servers,
+                identity_headers=build_identity_headers(self.user, self.tenant),
+                mcp_server_tool_repo=self.mcp_server_tool_repo,
+            )
+
+        try:
+            context = self.context_builder.build_context(
+                input_str="",
+                max_tokens=adapter.get_token_limit_of_model(),
+                model_name=adapter.get_model_route(),
+                prompt=prompt,
+                prompt_files=prompt_files,
+                mcp_tools=(
+                    [skill_runtime.tool_definition]
+                    if skill_runtime.tool_definition is not None
+                    else None
+                ),
+                extra_tool_dicts=(
+                    mcp_proxy.get_tools_for_llm() if mcp_proxy is not None else None
+                ),
+                vision=model.vision,
+            )
+            return adapter.prepare_provider_input(
+                context,
+                mcp_proxy=mcp_proxy,
+                skill_runtime=skill_runtime,
+            )
+        finally:
+            if mcp_proxy is not None:
+                await mcp_proxy.close()
 
     @staticmethod
     def is_valid_arguments(arguments: str):

--- a/backend/src/eneo/files/attachment_budget.py
+++ b/backend/src/eneo/files/attachment_budget.py
@@ -24,16 +24,28 @@ def assert_prompt_and_files_fit_context(
     model_name: str,
     prompt_text: str,
     files: Sequence[File],
+    alternative_prompts: Sequence[tuple[str, str]] = (),
 ) -> None:
+    """Check the baseline first, then each named alternative against one ceiling."""
     ceiling = attachment_token_ceiling(max_input_tokens)
-    used = count_tokens(prompt_text, model_name) + count_attachment_tokens(
+    attachment_tokens = count_attachment_tokens(
         text_files=[file for file in files if file.file_type == FileType.TEXT],
         image_files=[file for file in files if file.file_type == FileType.IMAGE],
         model_name=model_name,
     )
-    if used > ceiling:
+    baseline_used = count_tokens(prompt_text, model_name) + attachment_tokens
+    if baseline_used > ceiling:
         raise BadRequestException(
-            f"The prompt and attachments need ~{used} tokens, but only "
+            f"The prompt and attachments need ~{baseline_used} tokens, but only "
             f"{ceiling} fit this model's context window. Remove content or "
             f"choose a model with a larger context."
         )
+
+    for label, prompt_variant in alternative_prompts:
+        used = count_tokens(prompt_variant, model_name) + attachment_tokens
+        if used > ceiling:
+            raise BadRequestException(
+                f"The prompt for {label} and attachments need ~{used} tokens, "
+                f"but only {ceiling} fit this model's context window. Remove "
+                f"content or choose a model with a larger context."
+            )

--- a/backend/src/eneo/settings/setting_service.py
+++ b/backend/src/eneo/settings/setting_service.py
@@ -7,6 +7,7 @@ from eneo.ai_models.embedding_models.embedding_model import EmbeddingModelPublic
 from eneo.audit.application.audit_service import AuditService
 from eneo.audit.domain.action_types import ActionType
 from eneo.audit.domain.entity_types import EntityType
+from eneo.completion_models.domain.skill_context import skill_context_token_allowance
 from eneo.main.config import get_settings as get_app_settings
 from eneo.main.exceptions import (
     BadRequestException,
@@ -301,8 +302,9 @@ class SettingService:
                     nickname=model.nickname,
                     max_input_tokens=model.max_input_tokens,
                     supports_tool_calling=model.supports_tool_calling,
-                    skill_context_token_allowance=(
-                        model.max_input_tokens * policy.context_share_percent // 100
+                    skill_context_token_allowance=skill_context_token_allowance(
+                        max_input_tokens=model.max_input_tokens,
+                        context_share_percent=policy.context_share_percent,
                     ),
                 )
                 for model in models

--- a/backend/src/eneo/settings/settings.py
+++ b/backend/src/eneo/settings/settings.py
@@ -108,11 +108,23 @@ class SkillExecutionBlockState(BaseModel):
         )
 
 
+class SkillRuntimePolicyFieldBounds(BaseModel):
+    minimum: int
+    maximum: int
+
+
+class SkillRuntimePolicyEditableBounds(BaseModel):
+    max_attached_skills: SkillRuntimePolicyFieldBounds
+    context_share_percent: SkillRuntimePolicyFieldBounds
+    max_activations_per_turn: SkillRuntimePolicyFieldBounds
+
+
 class SkillRuntimePolicyPublic(BaseModel):
     selective_activation_enabled: bool
     max_attached_skills: int
     context_share_percent: int
     max_activations_per_turn: int
+    editable_bounds: SkillRuntimePolicyEditableBounds
 
     @classmethod
     def from_domain(cls, policy: SkillRuntimePolicy) -> "SkillRuntimePolicyPublic":
@@ -121,6 +133,20 @@ class SkillRuntimePolicyPublic(BaseModel):
             max_attached_skills=policy.max_attached_skills,
             context_share_percent=policy.context_share_percent,
             max_activations_per_turn=policy.max_activations_per_turn,
+            editable_bounds=SkillRuntimePolicyEditableBounds(
+                max_attached_skills=SkillRuntimePolicyFieldBounds(
+                    minimum=MIN_SKILL_ATTACHMENT_LIMIT,
+                    maximum=MAX_SKILL_ATTACHMENT_LIMIT,
+                ),
+                context_share_percent=SkillRuntimePolicyFieldBounds(
+                    minimum=MIN_SKILL_CONTEXT_SHARE_PERCENT,
+                    maximum=MAX_SKILL_CONTEXT_SHARE_PERCENT,
+                ),
+                max_activations_per_turn=SkillRuntimePolicyFieldBounds(
+                    minimum=MIN_SKILL_ACTIVATIONS_PER_TURN,
+                    maximum=MAX_SKILL_ACTIVATIONS_PER_TURN,
+                ),
+            ),
         )
 
 

--- a/backend/src/eneo/skills/application/skill_service.py
+++ b/backend/src/eneo/skills/application/skill_service.py
@@ -13,11 +13,14 @@ from eneo.roles.permissions import Permission, validate_permission
 from eneo.skills.domain.skill import (
     MAX_SKILL_CATALOG_PAGE_LIMIT,
     MAX_SKILL_CATALOG_QUERY_LENGTH,
+    AssistantSkillBindingReplacement,
     NormalizedSkillContent,
     PublishedSkillDeactivationError,
     PublishedSkillDeletionError,
     ResolvedSkillBinding,
     Skill,
+    SkillActivationMode,
+    SkillBindingIntent,
     SkillBindingProjection,
     SkillBindingReference,
     SkillCatalogPage,
@@ -483,6 +486,7 @@ class SkillService:
         references: list[SkillBindingReference],
         resolved_groups: tuple[list[ResolvedSkillBinding], ...],
         existing: list[ResolvedSkillBinding],
+        requested_modes: dict[UUID, SkillActivationMode] | None = None,
         missing_error: Exception,
     ) -> list[ResolvedSkillBinding]:
         resolved_by_reference = {
@@ -492,21 +496,21 @@ class SkillService:
         }
         if any(reference not in resolved_by_reference for reference in references):
             raise missing_error
-        # Re-resolution rebuilds bindings from catalogue state, which would
-        # silently reset a stored activation mode. A parent carries at most one
-        # binding per Skill, so a Skill already bound to the parent keeps its
-        # saved mode even when the request pins a different revision; only a
-        # genuinely new Skill takes the resolver default.
+        # Explicit mode intent wins; otherwise a retained Skill keeps its mode.
         existing_mode_by_skill_id = {
             binding.skill_id: binding.activation_mode for binding in existing
         }
+        requested_modes = requested_modes or {}
         return [
             replace(
                 resolved_by_reference[reference],
                 position=position,
-                activation_mode=existing_mode_by_skill_id.get(
+                activation_mode=requested_modes.get(
                     reference.skill_id,
-                    resolved_by_reference[reference].activation_mode,
+                    existing_mode_by_skill_id.get(
+                        reference.skill_id,
+                        resolved_by_reference[reference].activation_mode,
+                    ),
                 ),
             )
             for position, reference in enumerate(references)
@@ -520,6 +524,7 @@ class SkillService:
         organization_space: bool,
         references: list[SkillBindingReference],
         existing: list[ResolvedSkillBinding],
+        requested_modes: dict[UUID, SkillActivationMode] | None = None,
     ) -> list[ResolvedSkillBinding]:
         await self._validate_reference_count(tenant_id=tenant_id, references=references)
         retained_by_reference, new_references = await self._resolve_retained_references(
@@ -566,6 +571,7 @@ class SkillService:
                 published,
             ),
             existing=existing,
+            requested_modes=requested_modes,
             missing_error=NotFoundException(
                 "One or more Skill revisions are unavailable for this resource"
             ),
@@ -653,8 +659,8 @@ class SkillService:
         *,
         space_id: UUID,
         assistant_id: UUID,
-        references: list[SkillBindingReference],
-    ) -> list[ResolvedSkillBinding]:
+        intents: list[SkillBindingIntent],
+    ) -> AssistantSkillBindingReplacement:
         if self.user.active_api_key is not None:
             raise UnauthorizedException("Skill binding changes require a session token")
         space = await self._space(space_id)
@@ -678,6 +684,20 @@ class SkillService:
         if locked_space_id != space_id:
             raise NotFoundException()
         existing = await self.repo.list_assistant_bindings(assistant_id=assistant_id)
+        references = [intent.reference for intent in intents]
+        requested_modes = {
+            intent.reference.skill_id: intent.activation_mode
+            for intent in intents
+            if intent.activation_mode is not None
+        }
+        explicitly_requested_on_demand_skill_ids = {
+            intent.reference.skill_id
+            for intent in intents
+            if intent.activation_mode is SkillActivationMode.ON_DEMAND
+        }
+        existing_modes = {
+            binding.skill_id: binding.activation_mode for binding in existing
+        }
         tenant_id = self._tenant_id(space)
         resolved = await self._resolve_resource_references(
             space_id=space_id,
@@ -685,6 +705,15 @@ class SkillService:
             organization_space=space.is_organization(),
             references=references,
             existing=existing,
+            requested_modes=requested_modes,
+        )
+        changed_to_on_demand_skill_ids = frozenset(
+            binding.skill_id
+            for binding in resolved
+            if binding.skill_id in explicitly_requested_on_demand_skill_ids
+            and binding.activation_mode is SkillActivationMode.ON_DEMAND
+            and existing_modes.get(binding.skill_id)
+            is not SkillActivationMode.ON_DEMAND
         )
         await self.repo.replace_assistant_bindings(
             assistant_id=assistant_id,
@@ -692,7 +721,10 @@ class SkillService:
             space_id=space_id,
             bindings=resolved,
         )
-        return resolved
+        return AssistantSkillBindingReplacement(
+            bindings=tuple(resolved),
+            changed_to_on_demand_skill_ids=changed_to_on_demand_skill_ids,
+        )
 
     async def list_app_bindings(
         self, *, space_id: UUID, app_id: UUID

--- a/backend/src/eneo/skills/application/skill_service.py
+++ b/backend/src/eneo/skills/application/skill_service.py
@@ -559,9 +559,20 @@ class SkillService:
         )
         # Resolution holds the Skill rows FOR SHARE, so this read observes a
         # concurrent execution block that acquired FOR UPDATE first.
+        existing_by_reference = {
+            self._binding_reference(binding): binding for binding in existing
+        }
+        requested_modes = requested_modes or {}
+        mode_changed_retained_references = [
+            reference
+            for reference in retained_by_reference
+            if reference.skill_id in requested_modes
+            and requested_modes[reference.skill_id]
+            is not existing_by_reference[reference].activation_mode
+        ]
         await self._reject_blocked_references(
             tenant_id=tenant_id,
-            references=new_references,
+            references=[*new_references, *mode_changed_retained_references],
         )
         return self._order_resolved_bindings(
             references=references,
@@ -690,14 +701,7 @@ class SkillService:
             for intent in intents
             if intent.activation_mode is not None
         }
-        explicitly_requested_on_demand_skill_ids = {
-            intent.reference.skill_id
-            for intent in intents
-            if intent.activation_mode is SkillActivationMode.ON_DEMAND
-        }
-        existing_modes = {
-            binding.skill_id: binding.activation_mode for binding in existing
-        }
+        existing_by_skill_id = {binding.skill_id: binding for binding in existing}
         tenant_id = self._tenant_id(space)
         resolved = await self._resolve_resource_references(
             space_id=space_id,
@@ -707,13 +711,15 @@ class SkillService:
             existing=existing,
             requested_modes=requested_modes,
         )
-        changed_to_on_demand_skill_ids = frozenset(
+        on_demand_skill_ids_requiring_validation = frozenset(
             binding.skill_id
             for binding in resolved
-            if binding.skill_id in explicitly_requested_on_demand_skill_ids
-            and binding.activation_mode is SkillActivationMode.ON_DEMAND
-            and existing_modes.get(binding.skill_id)
-            is not SkillActivationMode.ON_DEMAND
+            if binding.activation_mode is SkillActivationMode.ON_DEMAND
+            and (
+                (stored := existing_by_skill_id.get(binding.skill_id)) is None
+                or stored.skill_revision_id != binding.skill_revision_id
+                or stored.activation_mode is not SkillActivationMode.ON_DEMAND
+            )
         )
         await self.repo.replace_assistant_bindings(
             assistant_id=assistant_id,
@@ -723,7 +729,9 @@ class SkillService:
         )
         return AssistantSkillBindingReplacement(
             bindings=tuple(resolved),
-            changed_to_on_demand_skill_ids=changed_to_on_demand_skill_ids,
+            on_demand_skill_ids_requiring_validation=(
+                on_demand_skill_ids_requiring_validation
+            ),
         )
 
     async def list_app_bindings(

--- a/backend/src/eneo/skills/domain/skill.py
+++ b/backend/src/eneo/skills/domain/skill.py
@@ -638,9 +638,35 @@ class ResolvedSkillBinding:
 
 
 @dataclass(frozen=True)
+class SkillBindingIntent:
+    """Assistant binding identity plus an optional requested mode change."""
+
+    reference: SkillBindingReference
+    activation_mode: SkillActivationMode | None = None
+
+
+@dataclass(frozen=True)
+class AssistantSkillBindingReplacement:
+    bindings: tuple[ResolvedSkillBinding, ...]
+    changed_to_on_demand_skill_ids: frozenset[UUID]
+
+
+@dataclass(frozen=True)
 class SkillBindingProjection:
     binding: ResolvedSkillBinding
     execution_blocked: bool
+
+
+@dataclass(frozen=True)
+class AssistantSkillRuntimeProjection:
+    effective_model_id: UUID
+    snapshot: SkillActivationSnapshot
+
+
+@dataclass(frozen=True)
+class AssistantSkillConfigurationProjection:
+    bindings: tuple[SkillBindingProjection, ...]
+    runtime: AssistantSkillRuntimeProjection | None
 
 
 @dataclass(frozen=True)

--- a/backend/src/eneo/skills/domain/skill.py
+++ b/backend/src/eneo/skills/domain/skill.py
@@ -648,7 +648,7 @@ class SkillBindingIntent:
 @dataclass(frozen=True)
 class AssistantSkillBindingReplacement:
     bindings: tuple[ResolvedSkillBinding, ...]
-    changed_to_on_demand_skill_ids: frozenset[UUID]
+    on_demand_skill_ids_requiring_validation: frozenset[UUID]
 
 
 @dataclass(frozen=True)

--- a/backend/src/eneo/skills/domain/skill.py
+++ b/backend/src/eneo/skills/domain/skill.py
@@ -925,35 +925,26 @@ class SkillTurnPlan:
             ),
         )
 
-    def for_on_demand_save_validation(self) -> "SkillTurnPlan":
-        """Stage retained blocked candidates as they would appear after unblock.
+    def for_full_save_validation(self) -> "SkillTurnPlan":
+        """Stage retained blocked bindings as they would appear after unblock.
 
         Execution blocks must keep the live plan fail-closed. Save validation,
-        however, must prove that a retained on-demand pin remains activatable
-        when its block is later released. Rebuild through the canonical plan
-        constructor so ordering, activation keys, catalogue composition, and
-        required instructions match the first real post-unblock turn.
+        however, must prove that retained always-on instructions and on-demand
+        candidates still fit together when their blocks are later released.
+        Rebuild through the canonical plan constructor so ordering, activation
+        keys, catalogue composition, and required instructions match the first
+        real post-unblock turn.
         """
-        blocked_on_demand = tuple(
-            binding.binding
-            for binding in self.blocked
-            if binding.binding.activation_mode is SkillActivationMode.ON_DEMAND
-        )
-        if not blocked_on_demand:
+        if not self.blocked:
             return self
         return SkillTurnPlan.create(
             base_instructions=self.base_instructions,
             resolution=SkillRuntimeResolution(
                 eligible=(
                     *(binding.binding for binding in self.available),
-                    *blocked_on_demand,
+                    *(binding.binding for binding in self.blocked),
                 ),
-                blocked=tuple(
-                    binding.binding
-                    for binding in self.blocked
-                    if binding.binding.activation_mode
-                    is not SkillActivationMode.ON_DEMAND
-                ),
+                blocked=(),
             ),
             policy=self.policy,
         )

--- a/backend/src/eneo/skills/domain/skill.py
+++ b/backend/src/eneo/skills/domain/skill.py
@@ -925,6 +925,39 @@ class SkillTurnPlan:
             ),
         )
 
+    def for_on_demand_save_validation(self) -> "SkillTurnPlan":
+        """Stage retained blocked candidates as they would appear after unblock.
+
+        Execution blocks must keep the live plan fail-closed. Save validation,
+        however, must prove that a retained on-demand pin remains activatable
+        when its block is later released. Rebuild through the canonical plan
+        constructor so ordering, activation keys, catalogue composition, and
+        required instructions match the first real post-unblock turn.
+        """
+        blocked_on_demand = tuple(
+            binding.binding
+            for binding in self.blocked
+            if binding.binding.activation_mode is SkillActivationMode.ON_DEMAND
+        )
+        if not blocked_on_demand:
+            return self
+        return SkillTurnPlan.create(
+            base_instructions=self.base_instructions,
+            resolution=SkillRuntimeResolution(
+                eligible=(
+                    *(binding.binding for binding in self.available),
+                    *blocked_on_demand,
+                ),
+                blocked=tuple(
+                    binding.binding
+                    for binding in self.blocked
+                    if binding.binding.activation_mode
+                    is not SkillActivationMode.ON_DEMAND
+                ),
+            ),
+            policy=self.policy,
+        )
+
     def to_activation_runtime(
         self,
         *,

--- a/backend/src/eneo/skills/presentation/skill_assembler.py
+++ b/backend/src/eneo/skills/presentation/skill_assembler.py
@@ -1,3 +1,4 @@
+from eneo.main.models import is_provided
 from eneo.skills.domain.skill import (
     AssistantSkillConfigurationProjection,
     OrganizationSkillProjection,
@@ -65,7 +66,7 @@ def assistant_skill_binding_intents_from_input(
             ),
             activation_mode=(
                 binding.activation_mode
-                if "activation_mode" in binding.model_fields_set
+                if is_provided(binding.activation_mode)
                 else None
             ),
         )

--- a/backend/src/eneo/skills/presentation/skill_assembler.py
+++ b/backend/src/eneo/skills/presentation/skill_assembler.py
@@ -1,4 +1,5 @@
 from eneo.skills.domain.skill import (
+    AssistantSkillConfigurationProjection,
     OrganizationSkillProjection,
     OrganizationSkillSummaryProjection,
     PublishedSkillProjection,
@@ -10,6 +11,7 @@ from eneo.skills.domain.skill import (
     SkillAdoptionResource,
     SkillAdoptionRevisionCount,
     SkillAdoptionSummary,
+    SkillBindingIntent,
     SkillBindingProjection,
     SkillBindingReference,
     SkillCatalogEntry,
@@ -17,6 +19,10 @@ from eneo.skills.domain.skill import (
     SkillRevisionSummary,
 )
 from eneo.skills.presentation.skill_models import (
+    AssistantSkillBindingInput,
+    AssistantSkillBindingSummary,
+    AssistantSkillConfigurationPublic,
+    AssistantSkillRuntimeSummary,
     OrganizationSkillPublic,
     OrganizationSkillSummaryPublic,
     PublishedSkillPublic,
@@ -48,6 +54,25 @@ def skill_binding_references_from_input(
     ]
 
 
+def assistant_skill_binding_intents_from_input(
+    bindings: list[AssistantSkillBindingInput],
+) -> list[SkillBindingIntent]:
+    return [
+        SkillBindingIntent(
+            reference=SkillBindingReference(
+                skill_id=binding.skill_id,
+                skill_revision_id=binding.skill_revision_id,
+            ),
+            activation_mode=(
+                binding.activation_mode
+                if "activation_mode" in binding.model_fields_set
+                else None
+            ),
+        )
+        for binding in bindings
+    ]
+
+
 def skill_binding_audit_entries(
     bindings: list[ResolvedSkillBinding],
 ) -> list[dict[str, object]]:
@@ -58,6 +83,7 @@ def skill_binding_audit_entries(
             "revision_number": binding.revision_number,
             "content_digest": binding.content_digest,
             "position": binding.position,
+            "activation_mode": binding.activation_mode.value,
         }
         for binding in bindings
     ]
@@ -307,4 +333,37 @@ class SkillAssembler:
             is_active=binding.is_active,
             source=binding.source,
             execution_blocked=projection.execution_blocked,
+        )
+
+    @classmethod
+    def assistant_binding_to_summary(
+        cls, projection: SkillBindingProjection
+    ) -> AssistantSkillBindingSummary:
+        return AssistantSkillBindingSummary(
+            **cls.binding_to_summary(projection).model_dump(),
+            activation_mode=projection.binding.activation_mode,
+        )
+
+    @classmethod
+    def assistant_configuration_to_public(
+        cls, projection: AssistantSkillConfigurationProjection
+    ) -> AssistantSkillConfigurationPublic:
+        runtime = projection.runtime
+        return AssistantSkillConfigurationPublic(
+            bindings=[
+                cls.assistant_binding_to_summary(binding)
+                for binding in projection.bindings
+            ],
+            runtime=(
+                AssistantSkillRuntimeSummary(
+                    effective_model_id=runtime.effective_model_id,
+                    effective_mode=runtime.snapshot.effective_mode,
+                    fallback_reason=runtime.snapshot.fallback_reason,
+                    skill_context_tokens=runtime.snapshot.measurement.tokens,
+                    skill_context_token_limit=runtime.snapshot.measurement.limit,
+                    token_count_source=runtime.snapshot.measurement.source,
+                )
+                if runtime is not None
+                else None
+            ),
         )

--- a/backend/src/eneo/skills/presentation/skill_models.py
+++ b/backend/src/eneo/skills/presentation/skill_models.py
@@ -1,18 +1,22 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from eneo.main.models import PaginatedResponse
 from eneo.skills.domain.skill import (
     MAX_SKILL_DESCRIPTION_LENGTH,
     MAX_SKILL_DISPLAY_NAME_LENGTH,
     MAX_SKILL_SLUG_LENGTH,
+    SkillActivationFallbackReason,
+    SkillActivationMode,
     SkillAdoptionDrift,
     SkillAdoptionResourceKind,
     SkillBindingSource,
     SkillPublicationState,
+    SkillTurnEffectiveMode,
 )
+from eneo.tokens.token_utils import TokenCountSource
 
 
 class SkillContentInput(BaseModel):
@@ -179,8 +183,20 @@ class PublishedSkillSummaryPagePublic(PaginatedResponse[PublishedSkillSummaryPub
 
 
 class SkillBindingReferenceInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     skill_id: UUID
     skill_revision_id: UUID
+
+
+class AssistantSkillBindingInput(SkillBindingReferenceInput):
+    activation_mode: SkillActivationMode | None = None
+
+    @model_validator(mode="after")
+    def reject_explicit_null_mode(self) -> "AssistantSkillBindingInput":
+        if "activation_mode" in self.model_fields_set and self.activation_mode is None:
+            raise ValueError("activation_mode cannot be null")
+        return self
 
 
 class SkillBindingSummary(BaseModel):
@@ -197,3 +213,21 @@ class SkillBindingSummary(BaseModel):
     is_active: bool
     source: SkillBindingSource
     execution_blocked: bool
+
+
+class AssistantSkillBindingSummary(SkillBindingSummary):
+    activation_mode: SkillActivationMode
+
+
+class AssistantSkillRuntimeSummary(BaseModel):
+    effective_model_id: UUID
+    effective_mode: SkillTurnEffectiveMode
+    fallback_reason: SkillActivationFallbackReason | None
+    skill_context_tokens: int
+    skill_context_token_limit: int
+    token_count_source: TokenCountSource
+
+
+class AssistantSkillConfigurationPublic(BaseModel):
+    bindings: list[AssistantSkillBindingSummary]
+    runtime: AssistantSkillRuntimeSummary | None

--- a/backend/src/eneo/skills/presentation/skill_models.py
+++ b/backend/src/eneo/skills/presentation/skill_models.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field
 
-from eneo.main.models import PaginatedResponse
+from eneo.main.models import NotProvided, PaginatedResponse
 from eneo.skills.domain.skill import (
     MAX_SKILL_DESCRIPTION_LENGTH,
     MAX_SKILL_DISPLAY_NAME_LENGTH,
@@ -190,13 +190,9 @@ class SkillBindingReferenceInput(BaseModel):
 
 
 class AssistantSkillBindingInput(SkillBindingReferenceInput):
-    activation_mode: SkillActivationMode | None = None
-
-    @model_validator(mode="after")
-    def reject_explicit_null_mode(self) -> "AssistantSkillBindingInput":
-        if "activation_mode" in self.model_fields_set and self.activation_mode is None:
-            raise ValueError("activation_mode cannot be null")
-        return self
+    activation_mode: SkillActivationMode | NotProvided = Field(
+        default_factory=NotProvided
+    )
 
 
 class SkillBindingSummary(BaseModel):

--- a/backend/src/eneo/skills/presentation/skill_router.py
+++ b/backend/src/eneo/skills/presentation/skill_router.py
@@ -20,6 +20,7 @@ from eneo.skills.domain.skill import (
 )
 from eneo.skills.presentation.skill_audit import audit_skill_created, skill_audit_extra
 from eneo.skills.presentation.skill_models import (
+    AssistantSkillConfigurationPublic,
     SkillActiveUpdateRequest,
     SkillBindingSummary,
     SkillCreateRequest,
@@ -395,6 +396,23 @@ async def list_assistant_skill_bindings(
     )
     assembler = container.skill_assembler()
     return [assembler.binding_to_summary(binding) for binding in bindings]
+
+
+@router.get(
+    "/{space_id}/assistants/{assistant_id}/skills/configuration/",
+    response_model=AssistantSkillConfigurationPublic,
+    responses=responses.get_responses([403, 404]),
+)
+async def get_assistant_skill_configuration(
+    space_id: UUID,
+    assistant_id: UUID,
+    container: _ContainerWithUser,
+) -> AssistantSkillConfigurationPublic:
+    configuration = await container.assistant_service().get_skill_configuration(
+        space_id=space_id,
+        assistant_id=assistant_id,
+    )
+    return container.skill_assembler().assistant_configuration_to_public(configuration)
 
 
 @router.get(

--- a/backend/src/eneo/spaces/space_repo.py
+++ b/backend/src/eneo/spaces/space_repo.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Optional, Protocol
 from uuid import UUID
 
@@ -826,6 +827,7 @@ class SpaceRepository:
         space_id: UUID,
         assistant_id: UUID,
         mcp_servers: list["MCPServer"],
+        assistant_tool_overrides: dict[UUID, bool] | None = None,
     ) -> list["MCPServer"]:
         """Load tools for assistant's MCP servers and apply space + assistant-level overrides.
 
@@ -884,20 +886,18 @@ class SpaceRepository:
             for override in space_overrides_db
         }
 
-        # Load assistant-level tool overrides
-        assistant_overrides_query = sa.select(AssistantMCPServerTools).where(
-            AssistantMCPServerTools.assistant_id == assistant_id
-        )
-        assistant_overrides_result = await self.session.execute(
-            assistant_overrides_query
-        )
-        assistant_overrides_db = assistant_overrides_result.scalars().all()
-
-        # Create map: tool_id -> is_enabled (assistant level)
-        assistant_tool_overrides = {
-            override.mcp_server_tool_id: override.is_enabled
-            for override in assistant_overrides_db
-        }
+        if assistant_tool_overrides is None:
+            assistant_overrides_query = sa.select(AssistantMCPServerTools).where(
+                AssistantMCPServerTools.assistant_id == assistant_id
+            )
+            assistant_overrides_result = await self.session.execute(
+                assistant_overrides_query
+            )
+            assistant_overrides_db = assistant_overrides_result.scalars().all()
+            assistant_tool_overrides = {
+                override.mcp_server_tool_id: override.is_enabled
+                for override in assistant_overrides_db
+            }
 
         # Group tools by server
         from collections import defaultdict
@@ -954,6 +954,28 @@ class SpaceRepository:
             server.tools = tools_by_server.get(server.id, [])
 
         return mcp_servers
+
+    async def project_assistant_mcp_servers(
+        self,
+        *,
+        space_id: UUID,
+        assistant_id: UUID,
+        mcp_servers: list["MCPServer"],
+        tool_settings: list[tuple[UUID, bool]] | None = None,
+    ) -> list["MCPServer"]:
+        """Project staged assistant tool settings through the canonical policy.
+
+        Copies the read-model entities because tool projection is intentionally
+        mutable and save-time validation must not alter the loaded Space.
+        """
+        return await self._load_assistant_mcp_server_tools_with_overrides(
+            space_id=space_id,
+            assistant_id=assistant_id,
+            mcp_servers=deepcopy(mcp_servers),
+            assistant_tool_overrides=(
+                dict(tool_settings) if tool_settings is not None else None
+            ),
+        )
 
     async def _get_assistants(self, space_id: UUID) -> Sequence[Assistants]:
         stmt = (

--- a/backend/tests/integration/skills/test_assistant_skill_save_contract.py
+++ b/backend/tests/integration/skills/test_assistant_skill_save_contract.py
@@ -1,10 +1,20 @@
 from types import SimpleNamespace
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 import sqlalchemy as sa
 
-from eneo.database.tables.assistant_table import Assistants
+from eneo.database.tables.assistant_table import (
+    AssistantMCPServers,
+    AssistantMCPServerTools,
+    Assistants,
+    AssistantsFiles,
+)
+from eneo.database.tables.mcp_server_table import (
+    MCPServers,
+    MCPServerTools,
+    SpacesMCPServers,
+)
 from eneo.database.tables.roles_table import Roles
 from eneo.database.tables.skill_table import AssistantSkillBindings
 from eneo.database.tables.spaces_table import SpacesUsers
@@ -16,6 +26,7 @@ from eneo.skills.domain.skill import (
     SkillBindingReference,
     SkillRuntimePolicy,
 )
+from eneo.tokens.token_utils import TokenCount, TokenCountSource
 
 
 @pytest.fixture
@@ -50,6 +61,19 @@ async def _persisted_assistant_state(db_container, *, assistant_id):
             .all()
         )
     return name, tuple(bindings)
+
+
+async def _persisted_attachment_ids(db_container, *, assistant_id):
+    async with db_container() as container:
+        return tuple(
+            (
+                await container.session().scalars(
+                    sa.select(AssistantsFiles.file_id)
+                    .where(AssistantsFiles.assistant_id == assistant_id)
+                    .order_by(AssistantsFiles.file_id)
+                )
+            ).all()
+        )
 
 
 @pytest.mark.integration
@@ -279,6 +303,11 @@ async def test_on_demand_revision_upgrade_rejection_rolls_back_parent_and_bindin
     assert persisted_bindings == original_bindings
 
 
+@pytest.mark.parametrize(
+    ("activated_tokens", "expected_status"),
+    [(8_000, 200), (8_001, 400)],
+    ids=("fits", "overflow"),
+)
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_on_demand_candidate_and_persistent_attachment_overflow_rolls_back(
@@ -290,6 +319,8 @@ async def test_on_demand_candidate_and_persistent_attachment_overflow_rolls_back
     space_factory,
     assistant_factory,
     monkeypatch,
+    activated_tokens,
+    expected_status,
 ):
     monkeypatch.setattr(
         "eneo.files.attachment_budget.get_settings",
@@ -304,6 +335,20 @@ async def test_on_demand_candidate_and_persistent_attachment_overflow_rolls_back
     monkeypatch.setattr(
         "eneo.files.attachment_budget.count_attachment_tokens",
         lambda *, text_files, image_files, model_name: (2_000 if text_files else 0),
+    )
+
+    def measure_provider_payload(messages, _tools, _model_route):
+        activated = any(message.get("role") == "tool" for message in messages)
+        if activated:
+            assert "persistent attachment" in str(messages)
+        return TokenCount(
+            tokens=activated_tokens if activated else 100,
+            source=TokenCountSource.LITELLM,
+        )
+
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        measure_provider_payload,
     )
 
     async with db_container() as container:
@@ -352,8 +397,19 @@ async def test_on_demand_candidate_and_persistent_attachment_overflow_rolls_back
             created_by_user_id=admin_user.id,
         )
         assistant_id = assistant.id
-        skill_id = skill.id
-        revision_id = skill.current_revision.id
+        await container.skill_service().replace_assistant_bindings(
+            space_id=space.id,
+            assistant_id=assistant.id,
+            intents=[
+                SkillBindingIntent(
+                    reference=SkillBindingReference(
+                        skill_id=skill.id,
+                        skill_revision_id=skill.current_revision.id,
+                    ),
+                    activation_mode=SkillActivationMode.ON_DEMAND,
+                )
+            ],
+        )
 
     headers = {"Authorization": f"Bearer {admin_token}"}
     upload = await client.post(
@@ -369,12 +425,202 @@ async def test_on_demand_candidate_and_persistent_attachment_overflow_rolls_back
     )
     assert upload.status_code == 200, upload.text
     attachment_id = upload.json()["id"]
-    attach_response = await client.post(
+    original_name, original_bindings = await _persisted_assistant_state(
+        db_container,
+        assistant_id=assistant_id,
+    )
+    assert (
+        await _persisted_attachment_ids(
+            db_container,
+            assistant_id=assistant_id,
+        )
+        == ()
+    )
+    response = await client.post(
         f"/api/v1/assistants/{assistant_id}/",
-        json={"attachments": [{"id": attachment_id}]},
+        json={
+            "name": "Rejected attachment-fit Assistant",
+            "attachments": [{"id": attachment_id}],
+        },
         headers=headers,
     )
-    assert attach_response.status_code == 200, attach_response.text
+
+    assert response.status_code == expected_status, response.text
+    if expected_status == 400:
+        assert (
+            'on-demand Skill "Candidate attachment Skill"' in response.json()["message"]
+        )
+    persisted_name, persisted_bindings = await _persisted_assistant_state(
+        db_container,
+        assistant_id=assistant_id,
+    )
+    assert persisted_name == (
+        "Rejected attachment-fit Assistant" if expected_status == 200 else original_name
+    )
+    assert persisted_bindings == original_bindings
+    assert await _persisted_attachment_ids(
+        db_container,
+        assistant_id=assistant_id,
+    ) == ((UUID(attachment_id),) if expected_status == 200 else ())
+
+
+@pytest.mark.parametrize(
+    ("activated_tokens", "expected_status"),
+    [(8_000, 200), (8_001, 400)],
+    ids=("fits", "overflow"),
+)
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_mcp_schema_activation_preflight_is_atomic(
+    client,
+    admin_token,
+    admin_user,
+    db_container,
+    completion_model_factory,
+    space_factory,
+    assistant_factory,
+    monkeypatch,
+    activated_tokens,
+    expected_status,
+):
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.get_settings",
+        lambda: SimpleNamespace(attachment_context_reserve_tokens=0),
+    )
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.count_tokens",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.count_attachment_tokens",
+        lambda **_kwargs: 0,
+    )
+    measured_tool_names: list[set[str]] = []
+
+    def measure_provider_payload(messages, tools, _model_route):
+        measured_tool_names.append(
+            {
+                tool["function"]["name"]
+                for tool in tools
+                if isinstance(tool.get("function"), dict)
+            }
+        )
+        activated = any(message.get("role") == "tool" for message in messages)
+        return TokenCount(
+            tokens=activated_tokens if activated else 100,
+            source=TokenCountSource.LITELLM,
+        )
+
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        measure_provider_payload,
+    )
+
+    async with db_container() as container:
+        session = container.session()
+        model = await completion_model_factory(
+            session,
+            "gpt-4o",
+            max_input_tokens=8_000,
+        )
+        model.supports_tool_calling = True
+        space = await space_factory(
+            session,
+            "Assistant activation tool contract",
+            [model.id],
+        )
+        session.add(
+            SpacesUsers(
+                space_id=space.id,
+                user_id=admin_user.id,
+                role="admin",
+            )
+        )
+        assistant = await assistant_factory(
+            session,
+            "Original activation-tool Assistant",
+            model.id,
+            space_id=space.id,
+        )
+        mcp_server = MCPServers(
+            tenant_id=admin_user.tenant_id,
+            name="Save contract MCP",
+            description="Approved warehouse contract",
+            http_url="http://localhost:9000/mcp",
+            http_auth_type="none",
+            is_enabled=True,
+            forward_identity=False,
+        )
+        session.add(mcp_server)
+        await session.flush()
+        mcp_tool = MCPServerTools(
+            mcp_server_id=mcp_server.id,
+            name="warehouse_query",
+            title="Warehouse query",
+            description="Query the approved warehouse",
+            input_schema={
+                "type": "object",
+                "properties": {"query": {"type": "string", "description": "SQL query"}},
+                "required": ["query"],
+            },
+            is_enabled_by_default=True,
+            requires_approval=False,
+            removed_from_remote=False,
+        )
+        session.add(mcp_tool)
+        await session.flush()
+        session.add_all(
+            [
+                SpacesMCPServers(
+                    space_id=space.id,
+                    mcp_server_id=mcp_server.id,
+                ),
+                AssistantMCPServers(
+                    assistant_id=assistant.id,
+                    mcp_server_id=mcp_server.id,
+                ),
+                AssistantMCPServerTools(
+                    assistant_id=assistant.id,
+                    mcp_server_tool_id=mcp_tool.id,
+                    is_enabled=True,
+                ),
+            ]
+        )
+        repo = container.skill_repo()
+        await repo.update_runtime_policy(
+            tenant_id=admin_user.tenant_id,
+            policy=SkillRuntimePolicy(
+                selective_activation_enabled=True,
+                max_attached_skills=100,
+                context_share_percent=100,
+                max_activations_per_turn=10,
+            ),
+        )
+        skill = await repo.create(
+            space_id=space.id,
+            slug=f"activation-tool-{uuid4().hex[:8]}",
+            display_name="Activation tool Skill",
+            description="Use for activation-tool questions",
+            instructions="This candidate body fits.",
+            content_digest="f" * 64,
+            created_by_user_id=admin_user.id,
+        )
+        assistant_id = assistant.id
+        mcp_server_id = mcp_server.id
+        mcp_tool_id = mcp_tool.id
+        await container.skill_service().replace_assistant_bindings(
+            space_id=space.id,
+            assistant_id=assistant.id,
+            intents=[
+                SkillBindingIntent(
+                    reference=SkillBindingReference(
+                        skill_id=skill.id,
+                        skill_revision_id=skill.current_revision.id,
+                    ),
+                    activation_mode=SkillActivationMode.ON_DEMAND,
+                )
+            ],
+        )
 
     original_name, original_bindings = await _persisted_assistant_state(
         db_container,
@@ -383,25 +629,30 @@ async def test_on_demand_candidate_and_persistent_attachment_overflow_rolls_back
     response = await client.post(
         f"/api/v1/assistants/{assistant_id}/",
         json={
-            "name": "Rejected attachment-fit Assistant",
-            "skill_bindings": [
+            "name": "Staged MCP Assistant",
+            "mcp_servers": [{"id": str(mcp_server_id)}],
+            "mcp_tools": [
                 {
-                    "skill_id": str(skill_id),
-                    "skill_revision_id": str(revision_id),
-                    "activation_mode": "on_demand",
+                    "tool_id": str(mcp_tool_id),
+                    "is_enabled": True,
                 }
             ],
         },
-        headers=headers,
+        headers={"Authorization": f"Bearer {admin_token}"},
     )
 
-    assert response.status_code == 400, response.text
-    assert 'on-demand Skill "Candidate attachment Skill"' in response.json()["message"]
+    assert response.status_code == expected_status, response.text
+    assert any(
+        "save_contract_mcp__warehouse_query" in tool_names
+        for tool_names in measured_tool_names
+    )
     persisted_name, persisted_bindings = await _persisted_assistant_state(
         db_container,
         assistant_id=assistant_id,
     )
-    assert persisted_name == original_name
+    assert persisted_name == (
+        "Staged MCP Assistant" if expected_status == 200 else original_name
+    )
     assert persisted_bindings == original_bindings
 
 

--- a/backend/tests/integration/skills/test_assistant_skill_save_contract.py
+++ b/backend/tests/integration/skills/test_assistant_skill_save_contract.py
@@ -4,6 +4,10 @@ from uuid import UUID, uuid4
 import pytest
 import sqlalchemy as sa
 
+from eneo.completion_models.domain.skill_activation import (
+    SKILL_ACTIVATION_TOOL_NAME,
+    ProviderToolCall,
+)
 from eneo.database.tables.assistant_table import (
     AssistantMCPServers,
     AssistantMCPServerTools,
@@ -17,7 +21,7 @@ from eneo.database.tables.mcp_server_table import (
 )
 from eneo.database.tables.roles_table import Roles
 from eneo.database.tables.skill_table import AssistantSkillBindings
-from eneo.database.tables.spaces_table import SpacesUsers
+from eneo.database.tables.spaces_table import Spaces, SpacesUsers
 from eneo.database.tables.users_table import users_roles_table
 from eneo.roles.permissions import Permission
 from eneo.skills.domain.skill import (
@@ -25,6 +29,7 @@ from eneo.skills.domain.skill import (
     SkillBindingIntent,
     SkillBindingReference,
     SkillRuntimePolicy,
+    SkillTurnEffectiveMode,
 )
 from eneo.tokens.token_utils import TokenCount, TokenCountSource
 
@@ -89,6 +94,16 @@ async def _persisted_mcp_server_ids(db_container, *, assistant_id):
         )
 
 
+async def _organization_space(session, *, tenant_id):
+    return await session.scalar(
+        sa.select(Spaces).where(
+            Spaces.tenant_id == tenant_id,
+            Spaces.user_id.is_(None),
+            Spaces.tenant_space_id.is_(None),
+        )
+    )
+
+
 async def _create_on_demand_save_contract(
     container,
     *,
@@ -103,6 +118,7 @@ async def _create_on_demand_save_contract(
     skill_name,
     skill_description,
     skill_instructions,
+    organization_skill=False,
 ):
     session = container.session()
     model = await completion_model_factory(
@@ -135,8 +151,15 @@ async def _create_on_demand_save_contract(
             max_activations_per_turn=10,
         ),
     )
+    skill_space = space
+    if organization_skill:
+        skill_space = await _organization_space(
+            session,
+            tenant_id=admin_user.tenant_id,
+        )
+        assert skill_space is not None
     skill = await repo.create(
-        space_id=space.id,
+        space_id=skill_space.id,
         slug=f"{skill_slug}-{uuid4().hex[:8]}",
         display_name=skill_name,
         description=skill_description,
@@ -144,6 +167,12 @@ async def _create_on_demand_save_contract(
         content_digest=uuid4().hex * 2,
         created_by_user_id=admin_user.id,
     )
+    if organization_skill:
+        await repo.publish_organization(
+            tenant_id=admin_user.tenant_id,
+            skill_id=skill.id,
+            expected_revision_id=skill.current_revision.id,
+        )
     await container.skill_service().replace_assistant_bindings(
         space_id=space.id,
         assistant_id=assistant.id,
@@ -508,6 +537,183 @@ async def test_retained_on_demand_candidate_rejection_rolls_back_new_always_bind
     else:
         assert persisted_name == original_name
         assert persisted_bindings == original_bindings
+
+
+@pytest.mark.parametrize(
+    ("activated_tokens", "expected_status"),
+    [(7_000, 200), (7_001, 400)],
+    ids=("fits-after-unblock", "blocked-candidate-overflows"),
+)
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_blocked_on_demand_candidate_is_staged_before_binding_save(
+    client,
+    admin_token,
+    admin_user,
+    db_container,
+    completion_model_factory,
+    space_factory,
+    assistant_factory,
+    monkeypatch,
+    activated_tokens,
+    expected_status,
+):
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.get_settings",
+        lambda: SimpleNamespace(attachment_context_reserve_tokens=1_000),
+    )
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.count_tokens",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.count_attachment_tokens",
+        lambda **_kwargs: 0,
+    )
+
+    def measure_provider_payload(messages, _tools, _model_route):
+        activated = any(message.get("role") == "tool" for message in messages)
+        return TokenCount(
+            tokens=activated_tokens if activated else 100,
+            source=TokenCountSource.LITELLM,
+        )
+
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        measure_provider_payload,
+    )
+
+    async with db_container() as container:
+        (
+            session,
+            target_space,
+            assistant,
+            candidate,
+        ) = await _create_on_demand_save_contract(
+            container,
+            admin_user=admin_user,
+            completion_model_factory=completion_model_factory,
+            space_factory=space_factory,
+            assistant_factory=assistant_factory,
+            model_name="gpt-4o",
+            space_name="Blocked candidate save contract",
+            assistant_name="Original blocked-candidate Assistant",
+            skill_slug="blocked-candidate",
+            skill_name="Blocked candidate Skill",
+            skill_description="Use for blocked-candidate questions",
+            skill_instructions=("This exact reviewed body must remain activatable."),
+            organization_skill=True,
+        )
+        repo = container.skill_repo()
+        always = await repo.create(
+            space_id=target_space.id,
+            slug=f"blocked-always-{uuid4().hex[:8]}",
+            display_name="New always Skill",
+            description="Required context added while the candidate is blocked",
+            instructions="This body expands the required prompt.",
+            content_digest="4" * 64,
+            created_by_user_id=admin_user.id,
+        )
+        blocked = await repo.block_organization_skill(
+            tenant_id=admin_user.tenant_id,
+            skill_id=candidate.id,
+            blocked_by_user_id=admin_user.id,
+            reason="Confirmed unsafe instructions",
+        )
+        assert blocked is not None
+        assistant_id = assistant.id
+        candidate_id = candidate.id
+        candidate_revision_id = candidate.current_revision.id
+        always_id = always.id
+        always_revision_id = always.current_revision.id
+        block_id = blocked.block.id
+        model_route = "openai/gpt-4o"
+
+    original_name, original_bindings = await _persisted_assistant_state(
+        db_container,
+        assistant_id=assistant_id,
+    )
+    response = await client.post(
+        f"/api/v1/assistants/{assistant_id}/",
+        json={
+            "name": "Staged blocked-candidate Assistant",
+            "skill_bindings": [
+                {
+                    "skill_id": str(candidate_id),
+                    "skill_revision_id": str(candidate_revision_id),
+                    "activation_mode": "on_demand",
+                },
+                {
+                    "skill_id": str(always_id),
+                    "skill_revision_id": str(always_revision_id),
+                    "activation_mode": "always",
+                },
+            ],
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == expected_status, response.text
+    persisted_name, persisted_bindings = await _persisted_assistant_state(
+        db_container,
+        assistant_id=assistant_id,
+    )
+    if expected_status == 400:
+        assert 'on-demand Skill "Blocked candidate Skill"' in response.json()["message"]
+        assert persisted_name == original_name
+        assert persisted_bindings == original_bindings
+        return
+
+    assert persisted_name == "Staged blocked-candidate Assistant"
+    assert [binding.skill_id for binding in persisted_bindings] == [
+        candidate_id,
+        always_id,
+    ]
+    async with db_container() as container:
+        repo = container.skill_repo()
+        released = await repo.unblock_organization_skill(
+            tenant_id=admin_user.tenant_id,
+            skill_id=candidate_id,
+            expected_block_id=block_id,
+            unblocked_by_user_id=admin_user.id,
+            reason="The reviewed instructions are safe again",
+        )
+        assert released is not None
+        skill_service = container.skill_service()
+        resolution = await skill_service.resolve_assistant_bindings_for_runtime(
+            assistant_id=assistant_id
+        )
+        plan = await skill_service.create_turn_plan(
+            base_instructions="",
+            resolution=resolution,
+        )
+        runtime = plan.to_activation_runtime(
+            selected_model_route=model_route,
+            max_input_tokens=8_000,
+            supports_tool_calling=True,
+        )
+        candidate_key = next(
+            binding.activation_key
+            for binding in plan.available
+            if binding.binding.skill_id == candidate_id
+        )
+        messages: list[dict[str, object]] = [
+            {"role": "system", "content": runtime.prompt},
+            {"role": "user", "content": "Use the restored Skill"},
+        ]
+        runtime.apply_provider_tool_calls(
+            calls=(
+                ProviderToolCall(
+                    call_id="activate-restored",
+                    name=SKILL_ACTIVATION_TOOL_NAME,
+                    arguments=f'{{"skill_key":"{candidate_key}"}}',
+                ),
+            ),
+            messages=messages,
+        )
+
+    assert runtime.snapshot().effective_mode is SkillTurnEffectiveMode.SELECTIVE
+    assert runtime.snapshot().accepted == (candidate_key,)
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/integration/skills/test_assistant_skill_save_contract.py
+++ b/backend/tests/integration/skills/test_assistant_skill_save_contract.py
@@ -9,7 +9,12 @@ from eneo.database.tables.skill_table import AssistantSkillBindings
 from eneo.database.tables.spaces_table import SpacesUsers
 from eneo.database.tables.users_table import users_roles_table
 from eneo.roles.permissions import Permission
-from eneo.skills.domain.skill import SkillBindingIntent, SkillBindingReference
+from eneo.skills.domain.skill import (
+    SkillActivationMode,
+    SkillBindingIntent,
+    SkillBindingReference,
+    SkillRuntimePolicy,
+)
 
 
 @pytest.fixture
@@ -150,6 +155,121 @@ async def test_assistant_mode_rejection_rolls_back_parent_and_bindings(
 
     assert response.status_code == 400, response.text
 
+    persisted_name, persisted_bindings = await _persisted_assistant_state(
+        db_container,
+        assistant_id=assistant_id,
+    )
+    assert persisted_name == original_name
+    assert persisted_bindings == original_bindings
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_on_demand_revision_upgrade_rejection_rolls_back_parent_and_binding(
+    client,
+    admin_token,
+    admin_user,
+    db_container,
+    completion_model_factory,
+    space_factory,
+    assistant_factory,
+):
+    async with db_container() as container:
+        session = container.session()
+        model = await completion_model_factory(
+            session,
+            "gpt-4o",
+            max_input_tokens=2_000,
+        )
+        model.supports_tool_calling = True
+        space = await space_factory(
+            session,
+            "Assistant Skill revision fit contract",
+            [model.id],
+        )
+        session.add(
+            SpacesUsers(
+                space_id=space.id,
+                user_id=admin_user.id,
+                role="admin",
+            )
+        )
+        assistant = await assistant_factory(
+            session,
+            "Original revision-fit Assistant",
+            model.id,
+            space_id=space.id,
+        )
+        repo = container.skill_repo()
+        await repo.update_runtime_policy(
+            tenant_id=admin_user.tenant_id,
+            policy=SkillRuntimePolicy(
+                selective_activation_enabled=True,
+                max_attached_skills=100,
+                context_share_percent=10,
+                max_activations_per_turn=10,
+            ),
+        )
+        skill = await repo.create(
+            space_id=space.id,
+            slug=f"revision-fit-{uuid4().hex[:8]}",
+            display_name="Revision fit Skill",
+            description="Use for revision-fit questions",
+            instructions="The initial body fits.",
+            content_digest="c" * 64,
+            created_by_user_id=admin_user.id,
+        )
+        original_revision_id = skill.current_revision.id
+        await container.skill_service().replace_assistant_bindings(
+            space_id=space.id,
+            assistant_id=assistant.id,
+            intents=[
+                SkillBindingIntent(
+                    reference=SkillBindingReference(
+                        skill_id=skill.id,
+                        skill_revision_id=original_revision_id,
+                    ),
+                    activation_mode=SkillActivationMode.ON_DEMAND,
+                )
+            ],
+        )
+        revision_change = await repo.create_revision(
+            skill_id=skill.id,
+            display_name="Revision fit Skill",
+            description="Use for revision-fit questions",
+            instructions="oversized " * 20_000,
+            content_digest="d" * 64,
+            created_by_user_id=admin_user.id,
+        )
+        assert revision_change is not None
+        oversized_revision_id = revision_change.revision.id
+        assistant_id = assistant.id
+        skill_id = skill.id
+
+    original_name, original_bindings = await _persisted_assistant_state(
+        db_container,
+        assistant_id=assistant_id,
+    )
+    assert original_name == "Original revision-fit Assistant"
+    assert len(original_bindings) == 1
+    assert original_bindings[0].skill_revision_id == original_revision_id
+    assert original_bindings[0].activation_mode == SkillActivationMode.ON_DEMAND.value
+
+    response = await client.post(
+        f"/api/v1/assistants/{assistant_id}/",
+        json={
+            "name": "Rejected revision-fit Assistant",
+            "skill_bindings": [
+                {
+                    "skill_id": str(skill_id),
+                    "skill_revision_id": str(oversized_revision_id),
+                }
+            ],
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == 400, response.text
     persisted_name, persisted_bindings = await _persisted_assistant_state(
         db_container,
         assistant_id=assistant_id,

--- a/backend/tests/integration/skills/test_assistant_skill_save_contract.py
+++ b/backend/tests/integration/skills/test_assistant_skill_save_contract.py
@@ -76,6 +76,90 @@ async def _persisted_attachment_ids(db_container, *, assistant_id):
         )
 
 
+async def _persisted_mcp_server_ids(db_container, *, assistant_id):
+    async with db_container() as container:
+        return tuple(
+            (
+                await container.session().scalars(
+                    sa.select(AssistantMCPServers.mcp_server_id)
+                    .where(AssistantMCPServers.assistant_id == assistant_id)
+                    .order_by(AssistantMCPServers.mcp_server_id)
+                )
+            ).all()
+        )
+
+
+async def _create_on_demand_save_contract(
+    container,
+    *,
+    admin_user,
+    completion_model_factory,
+    space_factory,
+    assistant_factory,
+    model_name,
+    space_name,
+    assistant_name,
+    skill_slug,
+    skill_name,
+    skill_description,
+    skill_instructions,
+):
+    session = container.session()
+    model = await completion_model_factory(
+        session,
+        model_name,
+        max_input_tokens=8_000,
+    )
+    model.supports_tool_calling = True
+    space = await space_factory(session, space_name, [model.id])
+    session.add(
+        SpacesUsers(
+            space_id=space.id,
+            user_id=admin_user.id,
+            role="admin",
+        )
+    )
+    assistant = await assistant_factory(
+        session,
+        assistant_name,
+        model.id,
+        space_id=space.id,
+    )
+    repo = container.skill_repo()
+    await repo.update_runtime_policy(
+        tenant_id=admin_user.tenant_id,
+        policy=SkillRuntimePolicy(
+            selective_activation_enabled=True,
+            max_attached_skills=100,
+            context_share_percent=100,
+            max_activations_per_turn=10,
+        ),
+    )
+    skill = await repo.create(
+        space_id=space.id,
+        slug=f"{skill_slug}-{uuid4().hex[:8]}",
+        display_name=skill_name,
+        description=skill_description,
+        instructions=skill_instructions,
+        content_digest=uuid4().hex * 2,
+        created_by_user_id=admin_user.id,
+    )
+    await container.skill_service().replace_assistant_bindings(
+        space_id=space.id,
+        assistant_id=assistant.id,
+        intents=[
+            SkillBindingIntent(
+                reference=SkillBindingReference(
+                    skill_id=skill.id,
+                    skill_revision_id=skill.current_revision.id,
+                ),
+                activation_mode=SkillActivationMode.ON_DEMAND,
+            )
+        ],
+    )
+    return session, space, assistant, skill
+
+
 @pytest.mark.integration
 @pytest.mark.asyncio
 async def test_assistant_mode_rejection_rolls_back_parent_and_bindings(
@@ -301,6 +385,129 @@ async def test_on_demand_revision_upgrade_rejection_rolls_back_parent_and_bindin
     )
     assert persisted_name == original_name
     assert persisted_bindings == original_bindings
+
+
+@pytest.mark.parametrize(
+    ("activated_tokens", "expected_status"),
+    [(7_000, 200), (7_001, 400)],
+    ids=("fits-reserved-ceiling", "exceeds-reserved-ceiling"),
+)
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_retained_on_demand_candidate_rejection_rolls_back_new_always_binding(
+    client,
+    admin_token,
+    admin_user,
+    db_container,
+    completion_model_factory,
+    space_factory,
+    assistant_factory,
+    monkeypatch,
+    activated_tokens,
+    expected_status,
+):
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.get_settings",
+        lambda: SimpleNamespace(attachment_context_reserve_tokens=1_000),
+    )
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.count_tokens",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.count_attachment_tokens",
+        lambda **_kwargs: 0,
+    )
+
+    def measure_provider_payload(messages, _tools, _model_route):
+        activated = any(message.get("role") == "tool" for message in messages)
+        return TokenCount(
+            tokens=activated_tokens if activated else 100,
+            source=TokenCountSource.LITELLM,
+        )
+
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        measure_provider_payload,
+    )
+
+    async with db_container() as container:
+        session, space, assistant, candidate = await _create_on_demand_save_contract(
+            container,
+            admin_user=admin_user,
+            completion_model_factory=completion_model_factory,
+            space_factory=space_factory,
+            assistant_factory=assistant_factory,
+            model_name="gpt-4o",
+            space_name="Retained candidate save contract",
+            assistant_name="Original retained-candidate Assistant",
+            skill_slug="retained-candidate",
+            skill_name="Retained candidate Skill",
+            skill_description="Use for retained-candidate questions",
+            skill_instructions="This candidate must remain activatable.",
+        )
+        repo = container.skill_repo()
+        always = await repo.create(
+            space_id=space.id,
+            slug=f"new-always-{uuid4().hex[:8]}",
+            display_name="New always Skill",
+            description="Always-on context added by the save",
+            instructions="This body expands the required prompt.",
+            content_digest="2" * 64,
+            created_by_user_id=admin_user.id,
+        )
+        assistant_id = assistant.id
+        candidate_id = candidate.id
+        candidate_revision_id = candidate.current_revision.id
+        always_id = always.id
+        always_revision_id = always.current_revision.id
+
+    original_name, original_bindings = await _persisted_assistant_state(
+        db_container,
+        assistant_id=assistant_id,
+    )
+    response = await client.post(
+        f"/api/v1/assistants/{assistant_id}/",
+        json={
+            "name": "Rejected retained-candidate Assistant",
+            "skill_bindings": [
+                {
+                    "skill_id": str(candidate_id),
+                    "skill_revision_id": str(candidate_revision_id),
+                    "activation_mode": "on_demand",
+                },
+                {
+                    "skill_id": str(always_id),
+                    "skill_revision_id": str(always_revision_id),
+                    "activation_mode": "always",
+                },
+            ],
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == expected_status, response.text
+    if expected_status == 400:
+        assert (
+            'on-demand Skill "Retained candidate Skill"' in response.json()["message"]
+        )
+    persisted_name, persisted_bindings = await _persisted_assistant_state(
+        db_container,
+        assistant_id=assistant_id,
+    )
+    if expected_status == 200:
+        assert persisted_name == "Rejected retained-candidate Assistant"
+        assert [binding.skill_id for binding in persisted_bindings] == [
+            candidate_id,
+            always_id,
+        ]
+        assert [binding.activation_mode for binding in persisted_bindings] == [
+            SkillActivationMode.ON_DEMAND.value,
+            SkillActivationMode.ALWAYS.value,
+        ]
+    else:
+        assert persisted_name == original_name
+        assert persisted_bindings == original_bindings
 
 
 @pytest.mark.parametrize(
@@ -654,6 +861,149 @@ async def test_mcp_schema_activation_preflight_is_atomic(
         "Staged MCP Assistant" if expected_status == 200 else original_name
     )
     assert persisted_bindings == original_bindings
+
+
+@pytest.mark.parametrize(
+    ("activated_tokens", "expected_status"),
+    [(7_000, 200), (7_001, 400)],
+    ids=("fits-reserved-ceiling", "exceeds-reserved-ceiling"),
+)
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_add_mcp_route_rejects_overflow_without_persisting_association(
+    client,
+    admin_token,
+    admin_user,
+    db_container,
+    completion_model_factory,
+    space_factory,
+    assistant_factory,
+    monkeypatch,
+    activated_tokens,
+    expected_status,
+):
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.get_settings",
+        lambda: SimpleNamespace(attachment_context_reserve_tokens=1_000),
+    )
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.count_tokens",
+        lambda *_args, **_kwargs: 100,
+    )
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.count_attachment_tokens",
+        lambda **_kwargs: 0,
+    )
+    measured_tool_names: list[set[str]] = []
+
+    def measure_provider_payload(messages, tools, _model_route):
+        measured_tool_names.append(
+            {
+                tool["function"]["name"]
+                for tool in tools
+                if isinstance(tool.get("function"), dict)
+            }
+        )
+        activated = any(message.get("role") == "tool" for message in messages)
+        return TokenCount(
+            tokens=activated_tokens if activated else 100,
+            source=TokenCountSource.LITELLM,
+        )
+
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        measure_provider_payload,
+    )
+
+    async with db_container() as container:
+        session, space, assistant, _skill = await _create_on_demand_save_contract(
+            container,
+            admin_user=admin_user,
+            completion_model_factory=completion_model_factory,
+            space_factory=space_factory,
+            assistant_factory=assistant_factory,
+            model_name="gpt-4o",
+            space_name="Dedicated MCP add save contract",
+            assistant_name="Original dedicated-MCP Assistant",
+            skill_slug="dedicated-mcp",
+            skill_name="Dedicated MCP candidate Skill",
+            skill_description="Use for warehouse export questions",
+            skill_instructions="Use the approved warehouse export tool.",
+        )
+        mcp_server = MCPServers(
+            tenant_id=admin_user.tenant_id,
+            name="Dedicated add MCP",
+            description="Approved warehouse contract",
+            http_url="http://localhost:9001/mcp",
+            http_auth_type="none",
+            is_enabled=True,
+            forward_identity=False,
+        )
+        session.add(mcp_server)
+        await session.flush()
+        mcp_tool = MCPServerTools(
+            mcp_server_id=mcp_server.id,
+            name="warehouse_export",
+            title="Warehouse export",
+            description="Export approved warehouse data",
+            input_schema={
+                "type": "object",
+                "properties": {"query": {"type": "string", "description": "SQL query"}},
+                "required": ["query"],
+            },
+            is_enabled_by_default=True,
+            requires_approval=False,
+            removed_from_remote=False,
+        )
+        session.add(mcp_tool)
+        await session.flush()
+        session.add_all(
+            [
+                SpacesMCPServers(
+                    space_id=space.id,
+                    mcp_server_id=mcp_server.id,
+                ),
+                # A previous association can leave this explicit override behind.
+                # Re-adding the server must stage the tool exactly as runtime will.
+                AssistantMCPServerTools(
+                    assistant_id=assistant.id,
+                    mcp_server_tool_id=mcp_tool.id,
+                    is_enabled=True,
+                ),
+            ]
+        )
+        assistant_id = assistant.id
+        mcp_server_id = mcp_server.id
+
+    assert (
+        await _persisted_mcp_server_ids(
+            db_container,
+            assistant_id=assistant_id,
+        )
+        == ()
+    )
+    response = await client.post(
+        f"/api/v1/assistants/{assistant_id}/mcp-servers/{mcp_server_id}/",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == expected_status, response.text
+    if expected_status == 400:
+        assert (
+            'on-demand Skill "Dedicated MCP candidate Skill"'
+            in response.json()["message"]
+        )
+    assert any(
+        "dedicated_add_mcp__warehouse_export" in tool_names
+        for tool_names in measured_tool_names
+    )
+    persisted_mcp_server_ids = await _persisted_mcp_server_ids(
+        db_container,
+        assistant_id=assistant_id,
+    )
+    assert persisted_mcp_server_ids == (
+        (mcp_server_id,) if expected_status == 200 else ()
+    )
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/skills/test_assistant_skill_save_contract.py
+++ b/backend/tests/integration/skills/test_assistant_skill_save_contract.py
@@ -1,0 +1,227 @@
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+
+from eneo.database.tables.assistant_table import Assistants
+from eneo.database.tables.roles_table import Roles
+from eneo.database.tables.skill_table import AssistantSkillBindings
+from eneo.database.tables.spaces_table import SpacesUsers
+from eneo.database.tables.users_table import users_roles_table
+from eneo.roles.permissions import Permission
+from eneo.skills.domain.skill import SkillBindingIntent, SkillBindingReference
+
+
+@pytest.fixture
+async def admin_token(db_container, patch_auth_service_jwt, admin_user):
+    async with db_container() as container:
+        return container.auth_service().create_access_token_for_user(admin_user)
+
+
+async def _persisted_assistant_state(db_container, *, assistant_id):
+    async with db_container() as container:
+        session = container.session()
+        name = await session.scalar(
+            sa.select(Assistants.name).where(Assistants.id == assistant_id)
+        )
+        bindings = (
+            (
+                await session.execute(
+                    sa.select(
+                        AssistantSkillBindings.skill_id,
+                        AssistantSkillBindings.skill_revision_id,
+                        AssistantSkillBindings.position,
+                        AssistantSkillBindings.activation_mode,
+                        AssistantSkillBindings.tenant_id,
+                        AssistantSkillBindings.space_id,
+                        AssistantSkillBindings.skill_space_id,
+                    )
+                    .where(AssistantSkillBindings.assistant_id == assistant_id)
+                    .order_by(AssistantSkillBindings.position)
+                )
+            )
+            .tuples()
+            .all()
+        )
+    return name, tuple(bindings)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_assistant_mode_rejection_rolls_back_parent_and_bindings(
+    client,
+    admin_token,
+    admin_user,
+    db_container,
+    completion_model_factory,
+    space_factory,
+    assistant_factory,
+):
+    async with db_container() as container:
+        session = container.session()
+        model = await completion_model_factory(
+            session,
+            f"assistant-save-contract-{uuid4().hex[:8]}",
+        )
+        space = await space_factory(
+            session,
+            "Assistant Skill save contract",
+            [model.id],
+        )
+        session.add(
+            SpacesUsers(
+                space_id=space.id,
+                user_id=admin_user.id,
+                role="admin",
+            )
+        )
+        assistant = await assistant_factory(
+            session,
+            "Original Assistant name",
+            model.id,
+            space_id=space.id,
+        )
+
+        repo = container.skill_repo()
+        first_skill = await repo.create(
+            space_id=space.id,
+            slug=f"first-{uuid4().hex[:8]}",
+            display_name="First Skill",
+            description="First on-demand candidate",
+            instructions="Use the first Skill when it is relevant.",
+            content_digest="a" * 64,
+            created_by_user_id=admin_user.id,
+        )
+        second_skill = await repo.create(
+            space_id=space.id,
+            slug=f"second-{uuid4().hex[:8]}",
+            display_name="Second Skill",
+            description="Second on-demand candidate",
+            instructions="Use the second Skill when it is relevant.",
+            content_digest="b" * 64,
+            created_by_user_id=admin_user.id,
+        )
+        references = [
+            SkillBindingReference(
+                skill_id=first_skill.id,
+                skill_revision_id=first_skill.current_revision.id,
+            ),
+            SkillBindingReference(
+                skill_id=second_skill.id,
+                skill_revision_id=second_skill.current_revision.id,
+            ),
+        ]
+        await container.skill_service().replace_assistant_bindings(
+            space_id=space.id,
+            assistant_id=assistant.id,
+            intents=[SkillBindingIntent(reference=value) for value in references],
+        )
+        assistant_id = assistant.id
+        first_skill_id = first_skill.id
+        first_revision_id = first_skill.current_revision.id
+        second_skill_id = second_skill.id
+        second_revision_id = second_skill.current_revision.id
+
+    original_name, original_bindings = await _persisted_assistant_state(
+        db_container,
+        assistant_id=assistant_id,
+    )
+    assert original_name == "Original Assistant name"
+    assert len(original_bindings) == 2
+
+    response = await client.post(
+        f"/api/v1/assistants/{assistant_id}/",
+        json={
+            "name": "Rejected Assistant name",
+            "skill_bindings": [
+                {
+                    "skill_id": str(second_skill_id),
+                    "skill_revision_id": str(second_revision_id),
+                },
+                {
+                    "skill_id": str(first_skill_id),
+                    "skill_revision_id": str(first_revision_id),
+                    "activation_mode": "on_demand",
+                },
+            ],
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    assert response.status_code == 400, response.text
+
+    persisted_name, persisted_bindings = await _persisted_assistant_state(
+        db_container,
+        assistant_id=assistant_id,
+    )
+    assert persisted_name == original_name
+    assert persisted_bindings == original_bindings
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_assistant_skill_configuration_requires_skill_read_access(
+    client,
+    db_container,
+    patch_auth_service_jwt,
+    admin_user,
+    user_factory,
+    completion_model_factory,
+    space_factory,
+    assistant_factory,
+):
+    async with db_container() as container:
+        session = container.session()
+        user = await user_factory(session, tenant_id=admin_user.tenant_id)
+        assistant_reader_role = Roles(
+            name=f"Assistant reader {uuid4().hex[:8]}",
+            permissions=[Permission.ASSISTANTS.value],
+            tenant_id=admin_user.tenant_id,
+        )
+        session.add(assistant_reader_role)
+        await session.flush()
+        await session.execute(
+            users_roles_table.insert().values(
+                user_id=user.id,
+                role_id=assistant_reader_role.id,
+            )
+        )
+        model = await completion_model_factory(
+            session,
+            f"assistant-skill-read-{uuid4().hex[:8]}",
+        )
+        space = await space_factory(
+            session,
+            "Assistant Skill read contract",
+            [model.id],
+        )
+        session.add(
+            SpacesUsers(
+                space_id=space.id,
+                user_id=user.id,
+                role="viewer",
+            )
+        )
+        assistant = await assistant_factory(
+            session,
+            "Readable Assistant",
+            model.id,
+            space_id=space.id,
+        )
+        token = container.auth_service().create_access_token_for_user(user)
+        space_id = space.id
+        assistant_id = assistant.id
+
+    headers = {"Authorization": f"Bearer {token}"}
+    assistant_response = await client.get(
+        f"/api/v1/assistants/{assistant_id}/",
+        headers=headers,
+    )
+    assert assistant_response.status_code == 200, assistant_response.text
+
+    configuration_response = await client.get(
+        f"/api/v1/spaces/{space_id}/assistants/{assistant_id}/skills/configuration/",
+        headers=headers,
+    )
+
+    assert configuration_response.status_code == 403, configuration_response.text

--- a/backend/tests/integration/skills/test_assistant_skill_save_contract.py
+++ b/backend/tests/integration/skills/test_assistant_skill_save_contract.py
@@ -8,6 +8,7 @@ from eneo.completion_models.domain.skill_activation import (
     SKILL_ACTIVATION_TOOL_NAME,
     ProviderToolCall,
 )
+from eneo.completion_models.domain.skill_context import SkillContextMeasurement
 from eneo.database.tables.assistant_table import (
     AssistantMCPServers,
     AssistantMCPServerTools,
@@ -540,13 +541,23 @@ async def test_retained_on_demand_candidate_rejection_rolls_back_new_always_bind
 
 
 @pytest.mark.parametrize(
-    ("activated_tokens", "expected_status"),
-    [(7_000, 200), (7_001, 400)],
-    ids=("fits-after-unblock", "blocked-candidate-overflows"),
+    ("blocked_mode", "boundary_tokens", "expected_status"),
+    [
+        (SkillActivationMode.ON_DEMAND, 7_000, 200),
+        (SkillActivationMode.ON_DEMAND, 7_001, 400),
+        (SkillActivationMode.ALWAYS, 100, 200),
+        (SkillActivationMode.ALWAYS, 101, 400),
+    ],
+    ids=(
+        "blocked-on-demand-fits",
+        "blocked-on-demand-overflows",
+        "blocked-always-fits",
+        "blocked-always-overflows",
+    ),
 )
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_blocked_on_demand_candidate_is_staged_before_binding_save(
+async def test_blocked_binding_is_staged_before_binding_save(
     client,
     admin_token,
     admin_user,
@@ -555,9 +566,11 @@ async def test_blocked_on_demand_candidate_is_staged_before_binding_save(
     space_factory,
     assistant_factory,
     monkeypatch,
-    activated_tokens,
+    blocked_mode,
+    boundary_tokens,
     expected_status,
 ):
+    always_instructions = "Required context restored after unblock."
     monkeypatch.setattr(
         "eneo.files.attachment_budget.get_settings",
         lambda: SimpleNamespace(attachment_context_reserve_tokens=1_000),
@@ -574,7 +587,11 @@ async def test_blocked_on_demand_candidate_is_staged_before_binding_save(
     def measure_provider_payload(messages, _tools, _model_route):
         activated = any(message.get("role") == "tool" for message in messages)
         return TokenCount(
-            tokens=activated_tokens if activated else 100,
+            tokens=(
+                boundary_tokens
+                if activated and blocked_mode is SkillActivationMode.ON_DEMAND
+                else 100
+            ),
             source=TokenCountSource.LITELLM,
         )
 
@@ -582,6 +599,22 @@ async def test_blocked_on_demand_candidate_is_staged_before_binding_save(
         "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
         measure_provider_payload,
     )
+    if blocked_mode is SkillActivationMode.ALWAYS:
+
+        def measure_skill_context(*, composed_instructions, tools=None, **_kwargs):
+            includes_post_unblock_plan = (
+                always_instructions in composed_instructions and bool(tools)
+            )
+            return SkillContextMeasurement(
+                tokens=boundary_tokens if includes_post_unblock_plan else 50,
+                limit=100,
+                source=TokenCountSource.LITELLM,
+            )
+
+        monkeypatch.setattr(
+            "eneo.completion_models.domain.skill_activation.measure_skill_context",
+            measure_skill_context,
+        )
 
     async with db_container() as container:
         (
@@ -604,19 +637,53 @@ async def test_blocked_on_demand_candidate_is_staged_before_binding_save(
             skill_instructions=("This exact reviewed body must remain activatable."),
             organization_skill=True,
         )
+        organization_space = await _organization_space(
+            session,
+            tenant_id=admin_user.tenant_id,
+        )
+        assert organization_space is not None
         repo = container.skill_repo()
         always = await repo.create(
-            space_id=target_space.id,
+            space_id=organization_space.id,
             slug=f"blocked-always-{uuid4().hex[:8]}",
-            display_name="New always Skill",
-            description="Required context added while the candidate is blocked",
-            instructions="This body expands the required prompt.",
+            display_name="Retained always Skill",
+            description="Required context retained during an incident",
+            instructions=always_instructions,
             content_digest="4" * 64,
             created_by_user_id=admin_user.id,
         )
+        await repo.publish_organization(
+            tenant_id=admin_user.tenant_id,
+            skill_id=always.id,
+            expected_revision_id=always.current_revision.id,
+        )
+        if blocked_mode is SkillActivationMode.ALWAYS:
+            await container.skill_service().replace_assistant_bindings(
+                space_id=target_space.id,
+                assistant_id=assistant.id,
+                intents=[
+                    SkillBindingIntent(
+                        reference=SkillBindingReference(
+                            skill_id=candidate.id,
+                            skill_revision_id=candidate.current_revision.id,
+                        ),
+                        activation_mode=SkillActivationMode.ON_DEMAND,
+                    ),
+                    SkillBindingIntent(
+                        reference=SkillBindingReference(
+                            skill_id=always.id,
+                            skill_revision_id=always.current_revision.id,
+                        ),
+                        activation_mode=SkillActivationMode.ALWAYS,
+                    ),
+                ],
+            )
+        blocked_skill = (
+            candidate if blocked_mode is SkillActivationMode.ON_DEMAND else always
+        )
         blocked = await repo.block_organization_skill(
             tenant_id=admin_user.tenant_id,
-            skill_id=candidate.id,
+            skill_id=blocked_skill.id,
             blocked_by_user_id=admin_user.id,
             reason="Confirmed unsafe instructions",
         )
@@ -627,6 +694,7 @@ async def test_blocked_on_demand_candidate_is_staged_before_binding_save(
         always_id = always.id
         always_revision_id = always.current_revision.id
         block_id = blocked.block.id
+        blocked_skill_id = blocked_skill.id
         model_route = "openai/gpt-4o"
 
     original_name, original_bindings = await _persisted_assistant_state(
@@ -659,7 +727,11 @@ async def test_blocked_on_demand_candidate_is_staged_before_binding_save(
         assistant_id=assistant_id,
     )
     if expected_status == 400:
-        assert 'on-demand Skill "Blocked candidate Skill"' in response.json()["message"]
+        if blocked_mode is SkillActivationMode.ON_DEMAND:
+            assert (
+                'on-demand Skill "Blocked candidate Skill"'
+                in response.json()["message"]
+            )
         assert persisted_name == original_name
         assert persisted_bindings == original_bindings
         return
@@ -669,16 +741,16 @@ async def test_blocked_on_demand_candidate_is_staged_before_binding_save(
         candidate_id,
         always_id,
     ]
+    unblock_response = await client.post(
+        f"/api/v1/settings/skills/{blocked_skill_id}/execution-block/unblock",
+        json={
+            "expected_block_id": str(block_id),
+            "reason": "The reviewed instructions are safe again",
+        },
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert unblock_response.status_code == 200, unblock_response.text
     async with db_container() as container:
-        repo = container.skill_repo()
-        released = await repo.unblock_organization_skill(
-            tenant_id=admin_user.tenant_id,
-            skill_id=candidate_id,
-            expected_block_id=block_id,
-            unblocked_by_user_id=admin_user.id,
-            reason="The reviewed instructions are safe again",
-        )
-        assert released is not None
         skill_service = container.skill_service()
         resolution = await skill_service.resolve_assistant_bindings_for_runtime(
             assistant_id=assistant_id

--- a/backend/tests/integration/skills/test_assistant_skill_save_contract.py
+++ b/backend/tests/integration/skills/test_assistant_skill_save_contract.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
@@ -270,6 +271,132 @@ async def test_on_demand_revision_upgrade_rejection_rolls_back_parent_and_bindin
     )
 
     assert response.status_code == 400, response.text
+    persisted_name, persisted_bindings = await _persisted_assistant_state(
+        db_container,
+        assistant_id=assistant_id,
+    )
+    assert persisted_name == original_name
+    assert persisted_bindings == original_bindings
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_on_demand_candidate_and_persistent_attachment_overflow_rolls_back(
+    client,
+    admin_token,
+    admin_user,
+    db_container,
+    completion_model_factory,
+    space_factory,
+    assistant_factory,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.get_settings",
+        lambda: SimpleNamespace(attachment_context_reserve_tokens=0),
+    )
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.count_tokens",
+        lambda text, *_args, **_kwargs: (
+            6_500 if "candidate-persistent-overflow" in text else 100
+        ),
+    )
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.count_attachment_tokens",
+        lambda *, text_files, image_files, model_name: (2_000 if text_files else 0),
+    )
+
+    async with db_container() as container:
+        session = container.session()
+        model = await completion_model_factory(
+            session,
+            "gpt-4o",
+            max_input_tokens=8_000,
+        )
+        model.supports_tool_calling = True
+        space = await space_factory(
+            session,
+            "Assistant candidate attachment contract",
+            [model.id],
+        )
+        session.add(
+            SpacesUsers(
+                space_id=space.id,
+                user_id=admin_user.id,
+                role="admin",
+            )
+        )
+        assistant = await assistant_factory(
+            session,
+            "Original attachment-fit Assistant",
+            model.id,
+            space_id=space.id,
+        )
+        repo = container.skill_repo()
+        await repo.update_runtime_policy(
+            tenant_id=admin_user.tenant_id,
+            policy=SkillRuntimePolicy(
+                selective_activation_enabled=True,
+                max_attached_skills=100,
+                context_share_percent=100,
+                max_activations_per_turn=10,
+            ),
+        )
+        skill = await repo.create(
+            space_id=space.id,
+            slug=f"candidate-attachment-{uuid4().hex[:8]}",
+            display_name="Candidate attachment Skill",
+            description="Use for candidate attachment questions",
+            instructions="candidate-persistent-overflow",
+            content_digest="e" * 64,
+            created_by_user_id=admin_user.id,
+        )
+        assistant_id = assistant.id
+        skill_id = skill.id
+        revision_id = skill.current_revision.id
+
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    upload = await client.post(
+        "/api/v1/files/",
+        files={
+            "upload_file": (
+                "persistent.txt",
+                b"persistent attachment",
+                "text/plain",
+            )
+        },
+        headers=headers,
+    )
+    assert upload.status_code == 200, upload.text
+    attachment_id = upload.json()["id"]
+    attach_response = await client.post(
+        f"/api/v1/assistants/{assistant_id}/",
+        json={"attachments": [{"id": attachment_id}]},
+        headers=headers,
+    )
+    assert attach_response.status_code == 200, attach_response.text
+
+    original_name, original_bindings = await _persisted_assistant_state(
+        db_container,
+        assistant_id=assistant_id,
+    )
+    response = await client.post(
+        f"/api/v1/assistants/{assistant_id}/",
+        json={
+            "name": "Rejected attachment-fit Assistant",
+            "skill_bindings": [
+                {
+                    "skill_id": str(skill_id),
+                    "skill_revision_id": str(revision_id),
+                    "activation_mode": "on_demand",
+                }
+            ],
+        },
+        headers=headers,
+    )
+
+    assert response.status_code == 400, response.text
+    assert 'on-demand Skill "Candidate attachment Skill"' in response.json()["message"]
     persisted_name, persisted_bindings = await _persisted_assistant_state(
         db_container,
         assistant_id=assistant_id,

--- a/backend/tests/integration/skills/test_assistant_skill_save_contract.py
+++ b/backend/tests/integration/skills/test_assistant_skill_save_contract.py
@@ -305,8 +305,8 @@ async def test_on_demand_revision_upgrade_rejection_rolls_back_parent_and_bindin
 
 @pytest.mark.parametrize(
     ("activated_tokens", "expected_status"),
-    [(8_000, 200), (8_001, 400)],
-    ids=("fits", "overflow"),
+    [(7_000, 200), (7_001, 400)],
+    ids=("fits-reserved-ceiling", "exceeds-reserved-ceiling"),
 )
 @pytest.mark.integration
 @pytest.mark.asyncio
@@ -324,7 +324,7 @@ async def test_on_demand_candidate_and_persistent_attachment_overflow_rolls_back
 ):
     monkeypatch.setattr(
         "eneo.files.attachment_budget.get_settings",
-        lambda: SimpleNamespace(attachment_context_reserve_tokens=0),
+        lambda: SimpleNamespace(attachment_context_reserve_tokens=1_000),
     )
     monkeypatch.setattr(
         "eneo.files.attachment_budget.count_tokens",
@@ -466,8 +466,8 @@ async def test_on_demand_candidate_and_persistent_attachment_overflow_rolls_back
 
 @pytest.mark.parametrize(
     ("activated_tokens", "expected_status"),
-    [(8_000, 200), (8_001, 400)],
-    ids=("fits", "overflow"),
+    [(7_000, 200), (7_001, 400)],
+    ids=("fits-reserved-ceiling", "exceeds-reserved-ceiling"),
 )
 @pytest.mark.integration
 @pytest.mark.asyncio
@@ -485,7 +485,7 @@ async def test_mcp_schema_activation_preflight_is_atomic(
 ):
     monkeypatch.setattr(
         "eneo.files.attachment_budget.get_settings",
-        lambda: SimpleNamespace(attachment_context_reserve_tokens=0),
+        lambda: SimpleNamespace(attachment_context_reserve_tokens=1_000),
     )
     monkeypatch.setattr(
         "eneo.files.attachment_budget.count_tokens",

--- a/backend/tests/integration/skills/test_skill_adoption_projection.py
+++ b/backend/tests/integration/skills/test_skill_adoption_projection.py
@@ -17,6 +17,7 @@ from eneo.skills.domain.skill import (
     SkillAdoptionCursor,
     SkillAdoptionDrift,
     SkillAdoptionResourceKind,
+    SkillBindingIntent,
     SkillBindingReference,
 )
 
@@ -174,7 +175,7 @@ async def test_adoption_projection_counts_exact_revisions_and_distinct_spaces(
         await skill_service.replace_assistant_bindings(
             space_id=shared_space.id,
             assistant_id=assistant_behind.id,
-            references=[revision_one_reference],
+            intents=[SkillBindingIntent(reference=revision_one_reference)],
         )
         await skill_service.replace_app_bindings(
             space_id=shared_space.id,
@@ -218,10 +219,12 @@ async def test_adoption_projection_counts_exact_revisions_and_distinct_spaces(
         await skill_service.replace_assistant_bindings(
             space_id=second_space.id,
             assistant_id=assistant_current.id,
-            references=[
-                SkillBindingReference(
-                    skill_id=skill.id,
-                    skill_revision_id=revision_two.id,
+            intents=[
+                SkillBindingIntent(
+                    reference=SkillBindingReference(
+                        skill_id=skill.id,
+                        skill_revision_id=revision_two.id,
+                    )
                 )
             ],
         )
@@ -682,10 +685,12 @@ async def test_adoption_projection_uses_one_consistent_statement_snapshot(
         await setup_container.skill_service().replace_assistant_bindings(
             space_id=shared_space.id,
             assistant_id=assistant.id,
-            references=[
-                SkillBindingReference(
-                    skill_id=skill.id,
-                    skill_revision_id=revision.id,
+            intents=[
+                SkillBindingIntent(
+                    reference=SkillBindingReference(
+                        skill_id=skill.id,
+                        skill_revision_id=revision.id,
+                    )
                 )
             ],
         )

--- a/backend/tests/integration/skills/test_skill_catalogue_repo.py
+++ b/backend/tests/integration/skills/test_skill_catalogue_repo.py
@@ -16,6 +16,7 @@ from eneo.skills import compose_skill_instructions
 from eneo.skills.domain.skill import (
     PublishedSkillDeletionError,
     SkillActivationMode,
+    SkillBindingIntent,
     SkillBindingReference,
     SkillBindingSource,
     SkillExecutionReference,
@@ -294,7 +295,7 @@ async def test_published_catalogue_skill_binds_and_executes_across_tenant_spaces
         assistant_bindings = await service.replace_assistant_bindings(
             space_id=target_space.id,
             assistant_id=assistant.id,
-            references=[approved_reference],
+            intents=[SkillBindingIntent(reference=approved_reference)],
         )
         app_bindings = await service.replace_app_bindings(
             space_id=target_space.id,
@@ -302,16 +303,16 @@ async def test_published_catalogue_skill_binds_and_executes_across_tenant_spaces
             references=[approved_reference],
         )
 
-        assert assistant_bindings[0].skill_space_id == organization.id
+        assert assistant_bindings.bindings[0].skill_space_id == organization.id
         assert app_bindings[0].skill_space_id == organization.id
-        assert assistant_bindings[0].source is SkillBindingSource.ORGANIZATION
+        assert assistant_bindings.bindings[0].source is SkillBindingSource.ORGANIZATION
         assert app_bindings[0].source is SkillBindingSource.ORGANIZATION
-        assert assistant_bindings[0].current_revision_id == draft.revision.id
+        assert assistant_bindings.bindings[0].current_revision_id == draft.revision.id
         assert (
-            assistant_bindings[0].attachable_revision_id
+            assistant_bindings.bindings[0].attachable_revision_id
             == published.current_revision.id
         )
-        assert assistant_bindings[0].attachable_revision_number == 1
+        assert assistant_bindings.bindings[0].attachable_revision_number == 1
         assistant_resolution = await service.resolve_assistant_bindings_for_runtime(
             assistant_id=assistant.id
         )
@@ -368,7 +369,7 @@ async def test_published_catalogue_skill_binds_and_executes_across_tenant_spaces
                 await service.replace_assistant_bindings(
                     space_id=target_space.id,
                     assistant_id=assistant.id,
-                    references=[reference],
+                    intents=[SkillBindingIntent(reference=reference)],
                 )
             with pytest.raises(NotFoundException, match="unavailable"):
                 await service.replace_app_bindings(
@@ -404,7 +405,7 @@ async def test_published_catalogue_skill_binds_and_executes_across_tenant_spaces
         await service.replace_assistant_bindings(
             space_id=target_space.id,
             assistant_id=assistant.id,
-            references=[approved_reference],
+            intents=[SkillBindingIntent(reference=approved_reference)],
         )
         await service.replace_app_bindings(
             space_id=target_space.id,
@@ -423,7 +424,7 @@ async def test_published_catalogue_skill_binds_and_executes_across_tenant_spaces
         await service.replace_assistant_bindings(
             space_id=target_space.id,
             assistant_id=assistant.id,
-            references=[],
+            intents=[],
         )
         await service.replace_app_bindings(
             space_id=target_space.id,

--- a/backend/tests/integration/skills/test_skill_concurrency.py
+++ b/backend/tests/integration/skills/test_skill_concurrency.py
@@ -20,7 +20,11 @@ from eneo.main.exceptions import (
 )
 from eneo.main.models import Status
 from eneo.roles.permissions import Permission
-from eneo.skills.domain.skill import SkillBindingReference, SkillRuntimePolicy
+from eneo.skills.domain.skill import (
+    SkillBindingIntent,
+    SkillBindingReference,
+    SkillRuntimePolicy,
+)
 
 
 @dataclass(frozen=True)
@@ -197,7 +201,7 @@ async def test_binding_projection_keeps_pinned_and_current_revision_identity(
         await container.skill_service().replace_assistant_bindings(
             space_id=resources.space_id,
             assistant_id=resources.assistant_id,
-            references=[resources.first_reference],
+            intents=[SkillBindingIntent(reference=resources.first_reference)],
         )
         change = await container.skill_service().create_revision(
             skill_id=resources.first_skill_id,
@@ -239,7 +243,9 @@ async def test_parent_binding_replacements_are_serialized(
             return await service.replace_assistant_bindings(
                 space_id=resources.space_id,
                 assistant_id=resources.assistant_id,
-                references=references,
+                intents=[
+                    SkillBindingIntent(reference=reference) for reference in references
+                ],
             )
         return await service.replace_app_bindings(
             space_id=resources.space_id,
@@ -306,7 +312,7 @@ async def test_assistant_move_and_skill_binding_update_are_serialized(
         return await container.skill_service().replace_assistant_bindings(
             space_id=resources.space_id,
             assistant_id=resources.assistant_id,
-            references=[resources.first_reference],
+            intents=[SkillBindingIntent(reference=resources.first_reference)],
         )
 
     first_action = move if first_operation == "move" else bind
@@ -582,7 +588,7 @@ async def test_block_winning_skill_lock_rejects_concurrent_binding_change(
             await service.replace_assistant_bindings(
                 space_id=resources.space_id,
                 assistant_id=resources.assistant_id,
-                references=[existing_reference],
+                intents=[SkillBindingIntent(reference=existing_reference)],
             )
         elif parent_kind == "app":
             await service.replace_app_bindings(
@@ -619,7 +625,10 @@ async def test_block_winning_skill_lock_rejects_concurrent_binding_change(
                 return await service.replace_assistant_bindings(
                     space_id=resources.space_id,
                     assistant_id=resources.assistant_id,
-                    references=references,
+                    intents=[
+                        SkillBindingIntent(reference=reference)
+                        for reference in references
+                    ],
                 )
             if parent_kind == "app":
                 return await service.replace_app_bindings(
@@ -1039,7 +1048,10 @@ async def test_binding_write_waits_for_concurrent_policy_lowering(
             return await container.skill_service().replace_assistant_bindings(
                 space_id=resources.space_id,
                 assistant_id=resources.assistant_id,
-                references=[resources.first_reference, resources.second_reference],
+                intents=[
+                    SkillBindingIntent(reference=resources.first_reference),
+                    SkillBindingIntent(reference=resources.second_reference),
+                ],
             )
 
     admin_task = asyncio.create_task(holding_admin_lowerer())

--- a/backend/tests/integration/skills/test_skill_execution_blocks.py
+++ b/backend/tests/integration/skills/test_skill_execution_blocks.py
@@ -17,6 +17,7 @@ from eneo.database.tables.users_table import users_roles_table
 from eneo.main.exceptions import BadRequestException
 from eneo.roles.permissions import Permission
 from eneo.skills.domain.skill import (
+    SkillActivationMode,
     SkillBindingIntent,
     SkillBindingReference,
     SkillExecutionBlockConflictError,
@@ -561,6 +562,136 @@ async def test_blocked_skill_rejects_new_and_changed_bindings_but_retains_exact_
             ],
         )
         assert updated.bindings[1].skill_revision_id == revision_two.id
+
+
+@pytest.mark.parametrize(
+    ("initial_mode", "requested_mode"),
+    [
+        (SkillActivationMode.ALWAYS, SkillActivationMode.ON_DEMAND),
+        (SkillActivationMode.ON_DEMAND, SkillActivationMode.ALWAYS),
+    ],
+)
+async def test_blocked_skill_rejects_retained_assistant_mode_change_until_unblocked(
+    initial_mode: SkillActivationMode,
+    requested_mode: SkillActivationMode,
+    db_container,
+    admin_user,
+    completion_model_factory,
+    space_factory,
+    assistant_factory,
+):
+    async with db_container() as container:
+        session = container.session()
+        organization = await _organization_space(
+            session,
+            tenant_id=admin_user.tenant_id,
+        )
+        assert organization is not None
+        model = await completion_model_factory(
+            session,
+            f"blocked-mode-change-{initial_mode.value}",
+        )
+        target_space = await space_factory(
+            session,
+            f"Blocked {initial_mode.value} mode target",
+            [model.id],
+        )
+        session.add(
+            SpacesUsers(
+                space_id=target_space.id,
+                user_id=admin_user.id,
+                role="admin",
+            )
+        )
+        assistant = await assistant_factory(
+            session,
+            f"Blocked {initial_mode.value} mode Assistant",
+            model.id,
+            space_id=target_space.id,
+        )
+        repo = container.skill_repo()
+        skill = await repo.create(
+            space_id=organization.id,
+            slug=f"blocked-mode-{initial_mode.value}-{uuid4().hex[:8]}",
+            display_name="Blocked mode guidance",
+            description="Approved guidance with a retained binding",
+            instructions="Use the approved guidance.",
+            content_digest="9" * 64,
+            created_by_user_id=admin_user.id,
+        )
+        await repo.publish_organization(
+            tenant_id=admin_user.tenant_id,
+            skill_id=skill.id,
+            expected_revision_id=skill.current_revision.id,
+        )
+        reference = SkillBindingReference(
+            skill_id=skill.id,
+            skill_revision_id=skill.current_revision.id,
+        )
+        service = container.skill_service()
+        await service.replace_assistant_bindings(
+            space_id=target_space.id,
+            assistant_id=assistant.id,
+            intents=[
+                SkillBindingIntent(
+                    reference=reference,
+                    activation_mode=initial_mode,
+                )
+            ],
+        )
+        blocked = await repo.block_organization_skill(
+            tenant_id=admin_user.tenant_id,
+            skill_id=skill.id,
+            blocked_by_user_id=admin_user.id,
+            reason="Confirmed mode-change incident",
+        )
+        assert blocked is not None
+
+        unchanged = await service.replace_assistant_bindings(
+            space_id=target_space.id,
+            assistant_id=assistant.id,
+            intents=[
+                SkillBindingIntent(
+                    reference=reference,
+                    activation_mode=initial_mode,
+                )
+            ],
+        )
+        assert unchanged.bindings[0].activation_mode is initial_mode
+
+        with pytest.raises(BadRequestException, match="Blocked organisation Skills"):
+            await service.replace_assistant_bindings(
+                space_id=target_space.id,
+                assistant_id=assistant.id,
+                intents=[
+                    SkillBindingIntent(
+                        reference=reference,
+                        activation_mode=requested_mode,
+                    )
+                ],
+            )
+        persisted = await repo.list_assistant_bindings(assistant_id=assistant.id)
+        assert persisted[0].activation_mode is initial_mode
+
+        released = await repo.unblock_organization_skill(
+            tenant_id=admin_user.tenant_id,
+            skill_id=skill.id,
+            expected_block_id=blocked.block.id,
+            unblocked_by_user_id=admin_user.id,
+            reason="Mode change reviewed and approved",
+        )
+        assert released is not None
+        changed = await service.replace_assistant_bindings(
+            space_id=target_space.id,
+            assistant_id=assistant.id,
+            intents=[
+                SkillBindingIntent(
+                    reference=reference,
+                    activation_mode=requested_mode,
+                )
+            ],
+        )
+        assert changed.bindings[0].activation_mode is requested_mode
 
 
 async def test_blocked_app_run_hides_incident_reason_from_non_admin_runner(

--- a/backend/tests/integration/skills/test_skill_execution_blocks.py
+++ b/backend/tests/integration/skills/test_skill_execution_blocks.py
@@ -17,6 +17,7 @@ from eneo.database.tables.users_table import users_roles_table
 from eneo.main.exceptions import BadRequestException
 from eneo.roles.permissions import Permission
 from eneo.skills.domain.skill import (
+    SkillBindingIntent,
     SkillBindingReference,
     SkillExecutionBlockConflictError,
     SkillExecutionBlockedException,
@@ -466,7 +467,10 @@ async def test_blocked_skill_rejects_new_and_changed_bindings_but_retains_exact_
         await service.replace_assistant_bindings(
             space_id=target_space.id,
             assistant_id=existing_assistant.id,
-            references=[blocked_reference, companion_reference],
+            intents=[
+                SkillBindingIntent(reference=blocked_reference),
+                SkillBindingIntent(reference=companion_reference),
+            ],
         )
         revision_two_change = await repo.create_revision(
             skill_id=blocked_skill.id,
@@ -494,9 +498,12 @@ async def test_blocked_skill_rejects_new_and_changed_bindings_but_retains_exact_
         retained = await service.replace_assistant_bindings(
             space_id=target_space.id,
             assistant_id=existing_assistant.id,
-            references=[companion_reference, blocked_reference],
+            intents=[
+                SkillBindingIntent(reference=companion_reference),
+                SkillBindingIntent(reference=blocked_reference),
+            ],
         )
-        assert [binding.skill_id for binding in retained] == [
+        assert [binding.skill_id for binding in retained.bindings] == [
             companion_skill.id,
             blocked_skill.id,
         ]
@@ -505,10 +512,12 @@ async def test_blocked_skill_rejects_new_and_changed_bindings_but_retains_exact_
             await service.replace_assistant_bindings(
                 space_id=target_space.id,
                 assistant_id=new_assistant.id,
-                references=[
-                    SkillBindingReference(
-                        skill_id=blocked_skill.id,
-                        skill_revision_id=revision_two.id,
+                intents=[
+                    SkillBindingIntent(
+                        reference=SkillBindingReference(
+                            skill_id=blocked_skill.id,
+                            skill_revision_id=revision_two.id,
+                        )
                     )
                 ],
             )
@@ -516,11 +525,13 @@ async def test_blocked_skill_rejects_new_and_changed_bindings_but_retains_exact_
             await service.replace_assistant_bindings(
                 space_id=target_space.id,
                 assistant_id=existing_assistant.id,
-                references=[
-                    companion_reference,
-                    SkillBindingReference(
-                        skill_id=blocked_skill.id,
-                        skill_revision_id=revision_two.id,
+                intents=[
+                    SkillBindingIntent(reference=companion_reference),
+                    SkillBindingIntent(
+                        reference=SkillBindingReference(
+                            skill_id=blocked_skill.id,
+                            skill_revision_id=revision_two.id,
+                        )
                     ),
                 ],
             )
@@ -539,15 +550,17 @@ async def test_blocked_skill_rejects_new_and_changed_bindings_but_retains_exact_
         updated = await service.replace_assistant_bindings(
             space_id=target_space.id,
             assistant_id=existing_assistant.id,
-            references=[
-                companion_reference,
-                SkillBindingReference(
-                    skill_id=blocked_skill.id,
-                    skill_revision_id=revision_two.id,
+            intents=[
+                SkillBindingIntent(reference=companion_reference),
+                SkillBindingIntent(
+                    reference=SkillBindingReference(
+                        skill_id=blocked_skill.id,
+                        skill_revision_id=revision_two.id,
+                    )
                 ),
             ],
         )
-        assert updated[1].skill_revision_id == revision_two.id
+        assert updated.bindings[1].skill_revision_id == revision_two.id
 
 
 async def test_blocked_app_run_hides_incident_reason_from_non_admin_runner(

--- a/backend/tests/unit/test_assistant_mcp_validation.py
+++ b/backend/tests/unit/test_assistant_mcp_validation.py
@@ -20,6 +20,7 @@ def _build_assistant_service_with_mocks(*, is_personal=True, server_in_space=Fal
         get_assistant=lambda **_: assistant,
         is_personal=lambda: is_personal,
         is_mcp_server_in_space=lambda _server_id: server_in_space,
+        mcp_servers=[],
     )
     actor = SimpleNamespace(
         can_edit_assistants=lambda: True,
@@ -30,7 +31,10 @@ def _build_assistant_service_with_mocks(*, is_personal=True, server_in_space=Fal
         execute=AsyncMock(),
     )
     service.space_repo = SimpleNamespace(
-        get_space_by_assistant=AsyncMock(return_value=space)
+        get_space_by_assistant=AsyncMock(return_value=space),
+        project_assistant_mcp_servers=AsyncMock(
+            side_effect=lambda **kwargs: kwargs["mcp_servers"]
+        ),
     )
     service.actor_manager = SimpleNamespace(
         get_space_actor_from_space=MagicMock(return_value=actor)
@@ -42,6 +46,7 @@ def _build_assistant_service_with_mocks(*, is_personal=True, server_in_space=Fal
     )
     service.user = SimpleNamespace(tenant_id=uuid4())
     service.effective_config_service = None
+    service._validate_attachments_fit = AsyncMock()
     return service, assistant_id, session
 
 
@@ -90,13 +95,21 @@ async def test_add_mcp_to_assistant_allows_personal_space_server_enabled_after_c
         is_personal=True, server_in_space=True
     )
     mcp_server_id = uuid4()
+    mcp_server = SimpleNamespace(id=mcp_server_id)
+    existing_mcp_server = SimpleNamespace(id=uuid4())
+    service.space_repo.get_space_by_assistant.return_value.get_assistant(
+        assistant_id=assistant_id
+    ).mcp_servers = [existing_mcp_server]
+    service.space_repo.get_space_by_assistant.return_value.mcp_servers = [mcp_server]
     assistant_in_db = SimpleNamespace(id=assistant_id)
     session.scalar.side_effect = [
         SimpleNamespace(id=mcp_server_id),  # server exists and is enabled
         assistant_in_db,  # assistant row for set_mcp_servers
     ]
     result = MagicMock()
-    result.scalars.return_value = []
+    result.scalars.return_value = [
+        SimpleNamespace(mcp_server_id=existing_mcp_server.id)
+    ]
     session.execute.return_value = result
 
     await service.add_mcp_to_assistant(
@@ -106,20 +119,27 @@ async def test_add_mcp_to_assistant_allows_personal_space_server_enabled_after_c
 
     assert session.scalar.await_count == 2
     service.repo.set_mcp_servers.assert_awaited_once_with(
-        assistant_in_db, [mcp_server_id]
+        assistant_in_db, [existing_mcp_server.id, mcp_server_id]
     )
+    service.space_repo.project_assistant_mcp_servers.assert_awaited_once_with(
+        space_id=service.space_repo.get_space_by_assistant.return_value.id,
+        assistant_id=assistant_id,
+        mcp_servers=[existing_mcp_server, mcp_server],
+    )
+    service._validate_attachments_fit.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_add_mcp_to_assistant_skips_space_mapping_when_governed():
     service, assistant_id, session = _build_assistant_service_with_mocks()
     mcp_server_id = uuid4()
+    mcp_server = SimpleNamespace(id=mcp_server_id)
     assistant_in_db = SimpleNamespace(id=assistant_id)
     service.effective_config_service = AsyncMock(
         resolve_for=AsyncMock(
             return_value=SimpleNamespace(
                 mcp_enforced=True,
-                available_mcp_servers=[SimpleNamespace(id=mcp_server_id)],
+                available_mcp_servers=[mcp_server],
             )
         )
     )

--- a/backend/tests/unittests/assistants/test_assistant_models.py
+++ b/backend/tests/unittests/assistants/test_assistant_models.py
@@ -14,7 +14,7 @@ from pydantic import ValidationError
 
 from eneo.ai_models.completion_models.completion_model import ModelKwargs
 from eneo.assistants.api.assistant_models import AssistantBase, AssistantUpdatePublic
-from eneo.skills.presentation.skill_models import SkillBindingReferenceInput
+from eneo.skills.presentation.skill_models import AssistantSkillBindingInput
 
 
 def test_assistant_base_coerces_db_null_to_default_kwargs():
@@ -47,7 +47,7 @@ def test_assistant_base_rejects_falsy_non_none_values(bad_value):
 def test_assistant_update_skill_bindings_preserve_patch_semantics():
     omitted = AssistantUpdatePublic()
     explicit_null = AssistantUpdatePublic(skill_bindings=None)
-    reference = SkillBindingReferenceInput(
+    reference = AssistantSkillBindingInput(
         skill_id=uuid4(),
         skill_revision_id=uuid4(),
     )

--- a/backend/tests/unittests/assistants/test_assistant_router.py
+++ b/backend/tests/unittests/assistants/test_assistant_router.py
@@ -11,6 +11,7 @@ pattern to prevent regressions from commit 58b73e9e.
 """
 
 import uuid
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -37,10 +38,12 @@ from eneo.main.exceptions import UnauthorizedException
 from eneo.sessions.session import SessionFeedback, SessionInDB
 from eneo.skills.domain.skill import (
     ResolvedSkillBinding,
+    SkillActivationMode,
+    SkillBindingIntent,
     SkillBindingReference,
     SkillBindingSource,
 )
-from eneo.skills.presentation.skill_models import SkillBindingReferenceInput
+from eneo.skills.presentation.skill_models import AssistantSkillBindingInput
 
 
 def _request(*, api_key=None) -> Request:
@@ -490,7 +493,7 @@ def _skill_binding(*, position: int) -> ResolvedSkillBinding:
     )
 
 
-async def test_update_assistant_folds_ordered_body_free_skills_into_single_parent_audit(
+async def test_update_assistant_audits_mode_only_skill_change_without_bodies(
     monkeypatch,
 ):
     assistant_id = uuid.uuid4()
@@ -513,12 +516,19 @@ async def test_update_assistant_folds_ordered_body_free_skills_into_single_paren
         space_id=space_id,
         type=None,
     )
-    before = [_skill_binding(position=0)]
-    after = [_skill_binding(position=0), _skill_binding(position=1)]
+    before_binding = _skill_binding(position=0)
+    before = [before_binding]
+    after = [
+        replace(
+            before_binding,
+            activation_mode=SkillActivationMode.ON_DEMAND,
+        )
+    ]
     references = [
-        SkillBindingReferenceInput(
+        AssistantSkillBindingInput(
             skill_id=binding.skill_id,
             skill_revision_id=binding.skill_revision_id,
+            activation_mode=SkillActivationMode.ON_DEMAND,
         )
         for binding in after
     ]
@@ -560,10 +570,13 @@ async def test_update_assistant_folds_ordered_body_free_skills_into_single_paren
 
     assert result is response
     service.update_assistant.assert_awaited_once()
-    assert service.update_assistant.await_args.kwargs["skill_references"] == [
-        SkillBindingReference(
-            skill_id=reference.skill_id,
-            skill_revision_id=reference.skill_revision_id,
+    assert service.update_assistant.await_args.kwargs["skill_binding_intents"] == [
+        SkillBindingIntent(
+            reference=SkillBindingReference(
+                skill_id=reference.skill_id,
+                skill_revision_id=reference.skill_revision_id,
+            ),
+            activation_mode=SkillActivationMode.ON_DEMAND,
         )
         for reference in references
     ]
@@ -571,6 +584,7 @@ async def test_update_assistant_folds_ordered_body_free_skills_into_single_paren
     audit_call = audit_service.log_async.await_args.kwargs
     assert audit_call["action"] == ActionType.ASSISTANT_UPDATED
     skills_change = audit_call["metadata"]["changes"]["skills"]
-    assert [entry["position"] for entry in skills_change["new"]] == [0, 1]
+    assert skills_change["old"][0]["activation_mode"] == "always"
+    assert skills_change["new"][0]["activation_mode"] == "on_demand"
     assert "instructions" not in str(skills_change)
     assert "description" not in str(skills_change)

--- a/backend/tests/unittests/assistants/test_assistants_service.py
+++ b/backend/tests/unittests/assistants/test_assistants_service.py
@@ -69,6 +69,8 @@ def setup_fixture():
     mock_assistant.has_knowledge.return_value = False
     mock_assistant.has_mcp.return_value = False
     mock_space = MagicMock()
+    mock_space.id = TEST_UUID
+    mock_space.mcp_servers = []
     mock_space.get_assistant.return_value = mock_assistant
     space_repo.get_space_by_assistant.return_value = mock_space
 
@@ -274,6 +276,34 @@ async def test_update_runs_fit_check_for_prompt_only_change(setup: Setup):
     )
 
     setup.service._validate_attachments_fit.assert_awaited_once()
+    assert (
+        setup.service._validate_attachments_fit.await_args.kwargs[
+            "validate_all_on_demand_candidates"
+        ]
+        is True
+    )
+
+
+async def test_update_runs_full_candidate_fit_for_model_change(setup: Setup):
+    model_id = uuid4()
+    model = MagicMock(id=model_id)
+    space = setup.service.space_repo.get_space_by_assistant.return_value
+    space.is_completion_model_available.return_value = True
+    space.is_completion_model_in_space.return_value = True
+    space.get_completion_model.return_value = model
+
+    await setup.service.update_assistant(
+        assistant_id=TEST_UUID,
+        completion_model_id=model_id,
+    )
+
+    setup.service._validate_attachments_fit.assert_awaited_once()
+    assert (
+        setup.service._validate_attachments_fit.await_args.kwargs[
+            "validate_all_on_demand_candidates"
+        ]
+        is True
+    )
 
 
 async def test_update_skips_fit_check_for_unrelated_change(setup: Setup):
@@ -284,6 +314,29 @@ async def test_update_skips_fit_check_for_unrelated_change(setup: Setup):
 
     setup.service._validate_attachments_fit.assert_not_awaited()
     setup.service.skill_service.replace_assistant_bindings.assert_not_awaited()
+
+
+async def test_update_runs_full_candidate_fit_for_mcp_tool_change(setup: Setup):
+    projected_servers = [MagicMock()]
+    setup.service.space_repo.project_assistant_mcp_servers.return_value = (
+        projected_servers
+    )
+
+    await setup.service.update_assistant(
+        assistant_id=TEST_UUID,
+        mcp_tools=[],
+    )
+
+    setup.service.space_repo.project_assistant_mcp_servers.assert_awaited_once_with(
+        space_id=TEST_UUID,
+        assistant_id=TEST_UUID,
+        mcp_servers=[],
+        tool_settings=[],
+    )
+    setup.service._validate_attachments_fit.assert_awaited_once()
+    fit_kwargs = setup.service._validate_attachments_fit.await_args.kwargs
+    assert fit_kwargs["validate_all_on_demand_candidates"] is True
+    assert fit_kwargs["mcp_servers_override"] == projected_servers
 
 
 async def test_update_replaces_assistant_skills_before_fit_and_parent_persist(
@@ -336,6 +389,12 @@ async def test_update_replaces_assistant_skills_before_fit_and_parent_persist(
         intents=intents,
     )
     assert events == ["parent_update", "binding_replace", "fit", "persist"]
+    assert (
+        setup.service._validate_attachments_fit.await_args.kwargs[
+            "validate_all_on_demand_candidates"
+        ]
+        is False
+    )
 
 
 async def test_update_assistant_binding_fit_failure_skips_parent_persist(

--- a/backend/tests/unittests/assistants/test_assistants_service.py
+++ b/backend/tests/unittests/assistants/test_assistants_service.py
@@ -393,7 +393,7 @@ async def test_update_replaces_assistant_skills_before_fit_and_parent_persist(
         setup.service._validate_attachments_fit.await_args.kwargs[
             "validate_all_on_demand_candidates"
         ]
-        is False
+        is True
     )
 
 

--- a/backend/tests/unittests/assistants/test_assistants_service.py
+++ b/backend/tests/unittests/assistants/test_assistants_service.py
@@ -111,7 +111,7 @@ def setup_fixture():
     service.skill_service.replace_assistant_bindings.return_value = (
         AssistantSkillBindingReplacement(
             bindings=(),
-            changed_to_on_demand_skill_ids=frozenset(),
+            on_demand_skill_ids_requiring_validation=frozenset(),
         )
     )
 
@@ -309,7 +309,7 @@ async def test_update_replaces_assistant_skills_before_fit_and_parent_persist(
         events.append("binding_replace")
         return AssistantSkillBindingReplacement(
             bindings=(),
-            changed_to_on_demand_skill_ids=frozenset(),
+            on_demand_skill_ids_requiring_validation=frozenset(),
         )
 
     async def validate_fit(*_, **__):

--- a/backend/tests/unittests/assistants/test_assistants_service.py
+++ b/backend/tests/unittests/assistants/test_assistants_service.py
@@ -22,7 +22,11 @@ from eneo.main.exceptions import (
 )
 from eneo.main.models import ModelId
 from eneo.prompts.api.prompt_models import PromptCreate
-from eneo.skills.domain.skill import SkillBindingReference
+from eneo.skills.domain.skill import (
+    AssistantSkillBindingReplacement,
+    SkillBindingIntent,
+    SkillBindingReference,
+)
 from tests.fixtures import (
     TEST_ASSISTANT,
     TEST_COLLECTION,
@@ -104,6 +108,12 @@ def setup_fixture():
     # orchestration tests (update flow, model selection, permissions) aren't
     # coupled to the token-counting subsystem.
     service._validate_attachments_fit = AsyncMock()
+    service.skill_service.replace_assistant_bindings.return_value = (
+        AssistantSkillBindingReplacement(
+            bindings=(),
+            changed_to_on_demand_skill_ids=frozenset(),
+        )
+    )
 
     setup = Setup(assistant=assistant, service=service, group_service=AsyncMock())
 
@@ -283,9 +293,13 @@ async def test_update_replaces_assistant_skills_before_fit_and_parent_persist(
     assistant.space_id = TEST_UUID
     space = setup.service.space_repo.get_space_by_assistant.return_value
     setup.service.space_repo.update.return_value = space
-    references = [
-        SkillBindingReference(skill_id=uuid4(), skill_revision_id=uuid4()),
-        SkillBindingReference(skill_id=uuid4(), skill_revision_id=uuid4()),
+    intents = [
+        SkillBindingIntent(
+            reference=SkillBindingReference(skill_id=uuid4(), skill_revision_id=uuid4())
+        ),
+        SkillBindingIntent(
+            reference=SkillBindingReference(skill_id=uuid4(), skill_revision_id=uuid4())
+        ),
     ]
     events: list[str] = []
 
@@ -293,6 +307,10 @@ async def test_update_replaces_assistant_skills_before_fit_and_parent_persist(
 
     async def replace_bindings(**_):
         events.append("binding_replace")
+        return AssistantSkillBindingReplacement(
+            bindings=(),
+            changed_to_on_demand_skill_ids=frozenset(),
+        )
 
     async def validate_fit(*_, **__):
         events.append("fit")
@@ -309,13 +327,13 @@ async def test_update_replaces_assistant_skills_before_fit_and_parent_persist(
 
     await setup.service.update_assistant(
         assistant_id=TEST_UUID,
-        skill_references=references,
+        skill_binding_intents=intents,
     )
 
     setup.service.skill_service.replace_assistant_bindings.assert_awaited_once_with(
         space_id=TEST_UUID,
         assistant_id=TEST_UUID,
-        references=references,
+        intents=intents,
     )
     assert events == ["parent_update", "binding_replace", "fit", "persist"]
 
@@ -332,13 +350,13 @@ async def test_update_assistant_binding_fit_failure_skips_parent_persist(
     with pytest.raises(BadRequestException, match="too large"):
         await setup.service.update_assistant(
             assistant_id=TEST_UUID,
-            skill_references=[],
+            skill_binding_intents=[],
         )
 
     setup.service.skill_service.replace_assistant_bindings.assert_awaited_once_with(
         space_id=TEST_UUID,
         assistant_id=TEST_UUID,
-        references=[],
+        intents=[],
     )
     setup.service.space_repo.update.assert_not_awaited()
 
@@ -403,7 +421,7 @@ async def test_personal_chat_can_change_personal_default_completion_model(setup:
         {"data_retention_days": None},
         {"metadata_json": {}},
         {"icon_id": uuid4()},
-        {"skill_references": []},
+        {"skill_binding_intents": []},
     ],
 )
 async def test_personal_chat_cannot_change_extended_default_assistant_fields(

--- a/backend/tests/unittests/assistants/test_attachment_budget.py
+++ b/backend/tests/unittests/assistants/test_attachment_budget.py
@@ -288,6 +288,81 @@ async def test_fit_passes_at_exact_ceiling(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_changed_on_demand_candidates_share_the_attachment_ceiling(
+    monkeypatch,
+):
+    _patch_reserve(monkeypatch, 10)
+    attachment_count_calls = 0
+
+    def fake_count_tokens(text, *args, **kwargs):
+        if "Instructions for Candidate two" in text:
+            return 60
+        if "Instructions for Candidate one" in text:
+            return 30
+        return 5
+
+    def fake_count_attachment_tokens(**kwargs):
+        nonlocal attachment_count_calls
+        attachment_count_calls += 1
+        return 40
+
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.count_tokens",
+        fake_count_tokens,
+    )
+    monkeypatch.setattr(
+        "eneo.files.attachment_budget.count_attachment_tokens",
+        fake_count_attachment_tokens,
+    )
+    measurement = SimpleNamespace(
+        tokens=10,
+        limit=1_000,
+        source=TokenCountSource.LITELLM,
+    )
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_skill_context",
+        lambda **_: measurement,
+    )
+    bindings = (
+        _resolved_skill(
+            name="Candidate one",
+            position=0,
+            activation_mode=SkillActivationMode.ON_DEMAND,
+        ),
+        _resolved_skill(
+            name="Candidate two",
+            position=1,
+            activation_mode=SkillActivationMode.ON_DEMAND,
+        ),
+    )
+    assistant = _assistant_with_runtime_model()
+    assistant.completion_model.max_input_tokens = 100
+    assistant.completion_model.vision = True
+    assistant.attachments = [_text_attachment()]
+    space = MagicMock()
+    space.is_personal.return_value = False
+    file_service = AsyncMock()
+    file_service.with_derived_images.return_value = assistant.attachments
+    service = _service(file_service)
+    service._resolve_effective_config = AsyncMock(return_value=None)
+    service.skill_service.resolve_assistant_bindings_for_runtime.return_value = (
+        SkillRuntimeResolution(eligible=bindings, blocked=())
+    )
+
+    with pytest.raises(BadRequestException, match="Candidate two"):
+        await service._validate_attachments_fit(
+            assistant,
+            space=space,
+            on_demand_skill_ids_requiring_validation=frozenset(
+                binding.skill_id for binding in bindings
+            ),
+        )
+
+    file_service.with_derived_images.assert_awaited_once_with(assistant.attachments)
+    assert attachment_count_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_fit_skipped_when_no_model(monkeypatch):
     _patch_reserve(monkeypatch, 10)
     monkeypatch.setattr(

--- a/backend/tests/unittests/assistants/test_attachment_budget.py
+++ b/backend/tests/unittests/assistants/test_attachment_budget.py
@@ -657,7 +657,69 @@ async def test_explicit_on_demand_change_rejects_runtime_fallbacks(
         await service._validate_attachments_fit(
             assistant,
             space=space,
-            explicit_on_demand_skill_ids=frozenset({binding.skill_id}),
+            on_demand_skill_ids_requiring_validation=frozenset({binding.skill_id}),
+        )
+
+    service._assert_persistent_baseline_fits.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("candidate_measurement", "message"),
+    [
+        (
+            SimpleNamespace(
+                tokens=1_001,
+                limit=1_000,
+                source=TokenCountSource.LITELLM,
+            ),
+            "An on-demand Skill exceeds the configured context allowance",
+        ),
+        (
+            SimpleNamespace(
+                tokens=10,
+                limit=1_000,
+                source=TokenCountSource.FALLBACK_ESTIMATE,
+            ),
+            "The selected completion model cannot measure an on-demand Skill exactly",
+        ),
+    ],
+    ids=("context-limit", "measurement-unavailable"),
+)
+async def test_explicit_on_demand_change_rejects_unloadable_candidate(
+    candidate_measurement,
+    message,
+    monkeypatch,
+):
+    initial_measurement = SimpleNamespace(
+        tokens=10,
+        limit=1_000,
+        source=TokenCountSource.LITELLM,
+    )
+    measurements = iter((initial_measurement, candidate_measurement))
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_skill_context",
+        lambda **_: next(measurements),
+    )
+    binding = _resolved_skill(
+        name="On demand",
+        position=0,
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    assistant = _assistant_with_runtime_model()
+    space = MagicMock()
+    space.is_personal.return_value = False
+    service = _service()
+    service._resolve_effective_config = AsyncMock(return_value=None)
+    service.skill_service.resolve_assistant_bindings_for_runtime.return_value = (
+        SkillRuntimeResolution(eligible=(binding,), blocked=())
+    )
+    service._assert_persistent_baseline_fits = AsyncMock()
+
+    with pytest.raises(BadRequestException, match=message):
+        await service._validate_attachments_fit(
+            assistant,
+            space=space,
+            on_demand_skill_ids_requiring_validation=frozenset({binding.skill_id}),
         )
 
     service._assert_persistent_baseline_fits.assert_not_awaited()
@@ -707,7 +769,7 @@ async def test_existing_on_demand_binding_remains_saveable_during_policy_drift(
     await service._validate_attachments_fit(
         assistant,
         space=space,
-        explicit_on_demand_skill_ids=frozenset(),
+        on_demand_skill_ids_requiring_validation=frozenset(),
     )
 
     service._assert_persistent_baseline_fits.assert_awaited_once()
@@ -737,34 +799,7 @@ async def test_explicit_on_demand_change_requires_an_effective_model():
         await service._validate_attachments_fit(
             assistant,
             space=space,
-            explicit_on_demand_skill_ids=frozenset({binding.skill_id}),
-        )
-
-
-@pytest.mark.asyncio
-async def test_explicit_on_demand_change_rejects_an_execution_blocked_skill():
-    binding = _resolved_skill(
-        name="Blocked",
-        position=0,
-        activation_mode=SkillActivationMode.ON_DEMAND,
-    )
-    assistant = _assistant_with_runtime_model()
-    space = MagicMock()
-    space.is_personal.return_value = False
-    service = _service()
-    service._resolve_effective_config = AsyncMock(return_value=None)
-    service.skill_service.resolve_assistant_bindings_for_runtime.return_value = (
-        SkillRuntimeResolution(eligible=(), blocked=(binding,))
-    )
-
-    with pytest.raises(
-        BadRequestException,
-        match="Blocked organisation Skills cannot receive new or changed bindings",
-    ):
-        await service._validate_attachments_fit(
-            assistant,
-            space=space,
-            explicit_on_demand_skill_ids=frozenset({binding.skill_id}),
+            on_demand_skill_ids_requiring_validation=frozenset({binding.skill_id}),
         )
 
 

--- a/backend/tests/unittests/assistants/test_attachment_budget.py
+++ b/backend/tests/unittests/assistants/test_attachment_budget.py
@@ -7,6 +7,7 @@ import pytest
 from eneo.ai_models.completion_models.completion_model import ModelKwargs
 from eneo.assistants.assistant import Assistant
 from eneo.assistants.assistant_service import AssistantService
+from eneo.completion_models.infrastructure.adapters.base_adapter import ProviderInput
 from eneo.files.attachment_budget import attachment_token_ceiling
 from eneo.files.file_models import FileType
 from eneo.main.exceptions import BadRequestException, UnauthorizedException
@@ -65,6 +66,36 @@ def _service(file_service=None):
             ),
         )
     )
+    completion_service = AsyncMock()
+
+    async def prepare_activation_preflight(**kwargs):
+        runtime = kwargs["skill_runtime"]
+        built_in_tools = (
+            [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": runtime.tool_definition.name,
+                        "description": runtime.tool_definition.description,
+                        "parameters": runtime.tool_definition.schema,
+                    },
+                }
+            ]
+            if runtime.tool_definition is not None
+            else []
+        )
+        return ProviderInput(
+            messages=[
+                {"role": "system", "content": kwargs["prompt"]},
+                {"role": "user", "content": ""},
+            ],
+            tools=built_in_tools,
+            built_in_tools=built_in_tools,
+        )
+
+    completion_service.prepare_skill_activation_preflight.side_effect = (
+        prepare_activation_preflight
+    )
     service = AssistantService(
         repo=AsyncMock(),
         space_repo=AsyncMock(),
@@ -80,7 +111,7 @@ def _service(file_service=None):
         session_service=AsyncMock(),
         actor_manager=MagicMock(),
         integration_knowledge_repo=AsyncMock(),
-        completion_service=AsyncMock(),
+        completion_service=completion_service,
         references_service=AsyncMock(),
         icon_repo=AsyncMock(),
         org_space_assistant_role_repo=AsyncMock(),
@@ -165,8 +196,10 @@ def _assistant_with_runtime_model(*, prompt_text: str = "Base instructions"):
         is_default=False,
         completion_model=model,
         attachments=[],
+        mcp_servers=[],
         prompt=SimpleNamespace(text=prompt_text),
         get_prompt_text=lambda: prompt_text,
+        has_knowledge=lambda: False,
     )
 
 
@@ -322,6 +355,18 @@ async def test_changed_on_demand_candidates_share_the_attachment_ceiling(
     monkeypatch.setattr(
         "eneo.completion_models.domain.skill_activation.measure_skill_context",
         lambda **_: measurement,
+    )
+
+    def measure_provider_input(messages, _tools, _model_name):
+        system_prompt = str(messages[0]["content"])
+        return SimpleNamespace(
+            tokens=(101 if "Instructions for Candidate two" in system_prompt else 80),
+            source=TokenCountSource.LITELLM,
+        )
+
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        measure_provider_input,
     )
     bindings = (
         _resolved_skill(
@@ -747,7 +792,7 @@ async def test_explicit_on_demand_change_rejects_runtime_fallbacks(
                 limit=1_000,
                 source=TokenCountSource.LITELLM,
             ),
-            "An on-demand Skill exceeds the configured context allowance",
+            'on-demand Skill "On demand" exceeds the configured context allowance',
         ),
         (
             SimpleNamespace(
@@ -755,7 +800,7 @@ async def test_explicit_on_demand_change_rejects_runtime_fallbacks(
                 limit=1_000,
                 source=TokenCountSource.FALLBACK_ESTIMATE,
             ),
-            "The selected completion model cannot measure an on-demand Skill exactly",
+            'on-demand Skill "On demand" cannot be measured exactly by the selected completion model',
         ),
     ],
     ids=("context-limit", "measurement-unavailable"),

--- a/backend/tests/unittests/assistants/test_attachment_budget.py
+++ b/backend/tests/unittests/assistants/test_attachment_budget.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
 import pytest
 
@@ -8,8 +9,18 @@ from eneo.assistants.assistant import Assistant
 from eneo.assistants.assistant_service import AssistantService
 from eneo.files.attachment_budget import attachment_token_ceiling
 from eneo.files.file_models import FileType
-from eneo.main.exceptions import BadRequestException
-from eneo.skills.domain.skill import SkillRuntimeResolution
+from eneo.main.exceptions import BadRequestException, UnauthorizedException
+from eneo.skills.domain.skill import (
+    ResolvedSkillBinding,
+    SkillActivationMode,
+    SkillBindingProjection,
+    SkillBindingSource,
+    SkillRuntimePolicy,
+    SkillRuntimeResolution,
+    SkillTurnEffectiveMode,
+    SkillTurnPlan,
+)
+from eneo.tokens.token_utils import TokenCountSource
 
 
 def _settings(**overrides):
@@ -38,6 +49,22 @@ def _image_attachment():
 
 
 def _service(file_service=None):
+    skill_service = AsyncMock()
+    skill_service.resolve_assistant_bindings_for_runtime.return_value = (
+        SkillRuntimeResolution(eligible=(), blocked=())
+    )
+    skill_service.create_turn_plan.side_effect = (
+        lambda *, base_instructions, resolution: SkillTurnPlan.create(
+            base_instructions=base_instructions,
+            resolution=resolution,
+            policy=SkillRuntimePolicy(
+                selective_activation_enabled=True,
+                max_attached_skills=100,
+                context_share_percent=10,
+                max_activations_per_turn=3,
+            ),
+        )
+    )
     service = AssistantService(
         repo=AsyncMock(),
         space_repo=AsyncMock(),
@@ -58,7 +85,7 @@ def _service(file_service=None):
         icon_repo=AsyncMock(),
         org_space_assistant_role_repo=AsyncMock(),
         help_assistant_assignment_history_repo=AsyncMock(),
-        skill_service=AsyncMock(),
+        skill_service=skill_service,
     )
     return service
 
@@ -82,7 +109,11 @@ def _domain_assistant():
 
 def _assistant_with(max_input_tokens, n_attachments=1, prompt_text=None, vision=False):
     model = SimpleNamespace(
-        max_input_tokens=max_input_tokens, name="gpt-4o", vision=vision
+        max_input_tokens=max_input_tokens,
+        name="gpt-4o",
+        vision=vision,
+        supports_tool_calling=True,
+        get_model_route=lambda: "openai/gpt-4o",
     )
     prompt = SimpleNamespace(text=prompt_text) if prompt_text is not None else None
     return SimpleNamespace(
@@ -92,6 +123,50 @@ def _assistant_with(max_input_tokens, n_attachments=1, prompt_text=None, vision=
         attachments=[_text_attachment() for _ in range(n_attachments)],
         prompt=prompt,
         get_prompt_text=lambda: prompt_text or "",
+    )
+
+
+def _resolved_skill(
+    *,
+    name: str,
+    position: int,
+    activation_mode: SkillActivationMode,
+) -> ResolvedSkillBinding:
+    return ResolvedSkillBinding(
+        skill_id=uuid4(),
+        skill_revision_id=uuid4(),
+        current_revision_id=uuid4(),
+        skill_space_id=uuid4(),
+        slug=name.lower(),
+        revision_number=1,
+        current_revision_number=1,
+        display_name=name,
+        description=f"Use {name} when relevant",
+        instructions=f"Instructions for {name}",
+        content_digest="a" * 64,
+        position=position,
+        source=SkillBindingSource.SPACE,
+        activation_mode=activation_mode,
+    )
+
+
+def _assistant_with_runtime_model(*, prompt_text: str = "Base instructions"):
+    model = SimpleNamespace(
+        id=uuid4(),
+        max_input_tokens=16_000,
+        name="gpt-4o",
+        vision=False,
+        supports_tool_calling=True,
+        get_model_route=lambda: "openai/gpt-4o",
+    )
+    return SimpleNamespace(
+        id=uuid4(),
+        space_id=uuid4(),
+        is_default=False,
+        completion_model=model,
+        attachments=[],
+        prompt=SimpleNamespace(text=prompt_text),
+        get_prompt_text=lambda: prompt_text,
     )
 
 
@@ -313,6 +388,471 @@ async def test_fit_passes_prompt_only_within_ceiling(monkeypatch):
     await _service()._validate_attachments_fit(assistant, space=MagicMock())
 
 
+@pytest.mark.parametrize(
+    ("bindings", "selective_activation_enabled"),
+    [
+        ((), True),
+        (
+            (
+                _resolved_skill(
+                    name="Always",
+                    position=0,
+                    activation_mode=SkillActivationMode.ALWAYS,
+                ),
+            ),
+            True,
+        ),
+        (
+            (
+                _resolved_skill(
+                    name="Always",
+                    position=0,
+                    activation_mode=SkillActivationMode.ALWAYS,
+                ),
+                _resolved_skill(
+                    name="On demand",
+                    position=1,
+                    activation_mode=SkillActivationMode.ON_DEMAND,
+                ),
+            ),
+            True,
+        ),
+        (
+            (
+                _resolved_skill(
+                    name="Always",
+                    position=0,
+                    activation_mode=SkillActivationMode.ALWAYS,
+                ),
+                _resolved_skill(
+                    name="On demand",
+                    position=1,
+                    activation_mode=SkillActivationMode.ON_DEMAND,
+                ),
+            ),
+            False,
+        ),
+    ],
+    ids=("none", "all-always", "mixed-selective", "mixed-disabled"),
+)
+async def test_save_fit_uses_the_exact_initial_turn_runtime_prompt(
+    bindings: tuple[ResolvedSkillBinding, ...],
+    selective_activation_enabled: bool,
+    monkeypatch,
+):
+    """Save must validate the exact prompt ask() creates, not eagerly compose
+    every attached Skill through a parallel calculation."""
+
+    measurement = SimpleNamespace(
+        tokens=10,
+        limit=1_000,
+        source=TokenCountSource.LITELLM,
+    )
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_skill_context",
+        lambda **_: measurement,
+    )
+    policy = SkillRuntimePolicy(
+        selective_activation_enabled=selective_activation_enabled,
+        max_attached_skills=100,
+        context_share_percent=10,
+        max_activations_per_turn=3,
+    )
+    resolution = SkillRuntimeResolution(eligible=bindings, blocked=())
+    assistant = _assistant_with_runtime_model()
+    space = MagicMock()
+    space.is_personal.return_value = False
+    service = _service()
+    service._resolve_effective_config = AsyncMock(return_value=None)
+    service.skill_service.resolve_assistant_bindings_for_runtime.return_value = (
+        resolution
+    )
+    service.skill_service.create_turn_plan.side_effect = (
+        lambda *, base_instructions, resolution: SkillTurnPlan.create(
+            base_instructions=base_instructions,
+            resolution=resolution,
+            policy=policy,
+        )
+    )
+    service._assert_persistent_baseline_fits = AsyncMock()
+
+    expected_plan = SkillTurnPlan.create(
+        base_instructions=assistant.get_prompt_text(),
+        resolution=resolution,
+        policy=policy,
+    )
+    expected_runtime = expected_plan.to_activation_runtime(
+        selected_model_route=assistant.completion_model.get_model_route(),
+        max_input_tokens=assistant.completion_model.max_input_tokens,
+        supports_tool_calling=assistant.completion_model.supports_tool_calling,
+    )
+
+    await service._validate_attachments_fit(assistant, space=space)
+
+    assert (
+        service._assert_persistent_baseline_fits.await_args.kwargs["prompt_text"]
+        == expected_runtime.prompt
+    )
+    service.skill_service.create_turn_plan.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_preflight_baseline_uses_the_exact_initial_turn_runtime_prompt(
+    monkeypatch,
+):
+    bindings = (
+        _resolved_skill(
+            name="Always",
+            position=0,
+            activation_mode=SkillActivationMode.ALWAYS,
+        ),
+        _resolved_skill(
+            name="On demand",
+            position=1,
+            activation_mode=SkillActivationMode.ON_DEMAND,
+        ),
+    )
+    measurement = SimpleNamespace(
+        tokens=10,
+        limit=1_000,
+        source=TokenCountSource.LITELLM,
+    )
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_skill_context",
+        lambda **_: measurement,
+    )
+    policy = SkillRuntimePolicy(
+        selective_activation_enabled=True,
+        max_attached_skills=100,
+        context_share_percent=10,
+        max_activations_per_turn=3,
+    )
+    resolution = SkillRuntimeResolution(eligible=bindings, blocked=())
+    assistant = _assistant_with_runtime_model()
+    space = MagicMock()
+    space.get_assistant.return_value = assistant
+    space.is_personal.return_value = False
+    service = _service()
+    service.space_repo.get_space_by_assistant.return_value = space
+    service._resolve_effective_config = AsyncMock(return_value=None)
+    service.skill_service.resolve_assistant_bindings_for_runtime.return_value = (
+        resolution
+    )
+    service.skill_service.create_turn_plan.side_effect = (
+        lambda *, base_instructions, resolution: SkillTurnPlan.create(
+            base_instructions=base_instructions,
+            resolution=resolution,
+            policy=policy,
+        )
+    )
+
+    expected_runtime = SkillTurnPlan.create(
+        base_instructions=assistant.get_prompt_text(),
+        resolution=resolution,
+        policy=policy,
+    ).to_activation_runtime(
+        selected_model_route=assistant.completion_model.get_model_route(),
+        max_input_tokens=assistant.completion_model.max_input_tokens,
+        supports_tool_calling=assistant.completion_model.supports_tool_calling,
+    )
+
+    prompt, attachments = await service.get_preflight_baseline(assistant.id)
+
+    assert prompt == expected_runtime.prompt
+    assert attachments == assistant.attachments
+
+
+@pytest.mark.parametrize(
+    (
+        "selective_activation_enabled",
+        "supports_tool_calling",
+        "measurement",
+        "message",
+    ),
+    [
+        (
+            False,
+            True,
+            SimpleNamespace(
+                tokens=10,
+                limit=1_000,
+                source=TokenCountSource.LITELLM,
+            ),
+            "disabled by the organisation runtime policy",
+        ),
+        (
+            True,
+            False,
+            SimpleNamespace(
+                tokens=10,
+                limit=1_000,
+                source=TokenCountSource.LITELLM,
+            ),
+            "does not support on-demand Skills",
+        ),
+        (
+            True,
+            True,
+            SimpleNamespace(
+                tokens=1_001,
+                limit=1_000,
+                source=TokenCountSource.LITELLM,
+            ),
+            "exceeds the configured context allowance",
+        ),
+        (
+            True,
+            True,
+            SimpleNamespace(
+                tokens=10,
+                limit=1_000,
+                source=TokenCountSource.FALLBACK_ESTIMATE,
+            ),
+            "cannot measure the Skill catalogue exactly",
+        ),
+    ],
+    ids=("disabled", "no-tool-support", "catalogue-too-large", "estimated"),
+)
+async def test_explicit_on_demand_change_rejects_runtime_fallbacks(
+    selective_activation_enabled,
+    supports_tool_calling,
+    measurement,
+    message,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_skill_context",
+        lambda **_: measurement,
+    )
+    binding = _resolved_skill(
+        name="On demand",
+        position=0,
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    resolution = SkillRuntimeResolution(eligible=(binding,), blocked=())
+    assistant = _assistant_with_runtime_model()
+    assistant.completion_model.supports_tool_calling = supports_tool_calling
+    space = MagicMock()
+    space.is_personal.return_value = False
+    service = _service()
+    service._resolve_effective_config = AsyncMock(return_value=None)
+    service.skill_service.resolve_assistant_bindings_for_runtime.return_value = (
+        resolution
+    )
+    service.skill_service.create_turn_plan.side_effect = (
+        lambda *, base_instructions, resolution: SkillTurnPlan.create(
+            base_instructions=base_instructions,
+            resolution=resolution,
+            policy=SkillRuntimePolicy(
+                selective_activation_enabled=selective_activation_enabled,
+                max_attached_skills=100,
+                context_share_percent=10,
+                max_activations_per_turn=3,
+            ),
+        )
+    )
+    service._assert_persistent_baseline_fits = AsyncMock()
+
+    with pytest.raises(BadRequestException, match=message):
+        await service._validate_attachments_fit(
+            assistant,
+            space=space,
+            explicit_on_demand_skill_ids=frozenset({binding.skill_id}),
+        )
+
+    service._assert_persistent_baseline_fits.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_existing_on_demand_binding_remains_saveable_during_policy_drift(
+    monkeypatch,
+):
+    measurement = SimpleNamespace(
+        tokens=10,
+        limit=1_000,
+        source=TokenCountSource.LITELLM,
+    )
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_skill_context",
+        lambda **_: measurement,
+    )
+    binding = _resolved_skill(
+        name="On demand",
+        position=0,
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    resolution = SkillRuntimeResolution(eligible=(binding,), blocked=())
+    assistant = _assistant_with_runtime_model()
+    space = MagicMock()
+    space.is_personal.return_value = False
+    service = _service()
+    service._resolve_effective_config = AsyncMock(return_value=None)
+    service.skill_service.resolve_assistant_bindings_for_runtime.return_value = (
+        resolution
+    )
+    service.skill_service.create_turn_plan.side_effect = (
+        lambda *, base_instructions, resolution: SkillTurnPlan.create(
+            base_instructions=base_instructions,
+            resolution=resolution,
+            policy=SkillRuntimePolicy(
+                selective_activation_enabled=False,
+                max_attached_skills=100,
+                context_share_percent=10,
+                max_activations_per_turn=3,
+            ),
+        )
+    )
+    service._assert_persistent_baseline_fits = AsyncMock()
+
+    await service._validate_attachments_fit(
+        assistant,
+        space=space,
+        explicit_on_demand_skill_ids=frozenset(),
+    )
+
+    service._assert_persistent_baseline_fits.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_explicit_on_demand_change_requires_an_effective_model():
+    binding = _resolved_skill(
+        name="On demand",
+        position=0,
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    assistant = _assistant_with_runtime_model()
+    assistant.completion_model = None
+    space = MagicMock()
+    space.is_personal.return_value = False
+    service = _service()
+    service._resolve_effective_config = AsyncMock(return_value=None)
+    service.skill_service.resolve_assistant_bindings_for_runtime.return_value = (
+        SkillRuntimeResolution(eligible=(binding,), blocked=())
+    )
+
+    with pytest.raises(
+        BadRequestException,
+        match="Choose a completion model before enabling on-demand Skills",
+    ):
+        await service._validate_attachments_fit(
+            assistant,
+            space=space,
+            explicit_on_demand_skill_ids=frozenset({binding.skill_id}),
+        )
+
+
+@pytest.mark.asyncio
+async def test_explicit_on_demand_change_rejects_an_execution_blocked_skill():
+    binding = _resolved_skill(
+        name="Blocked",
+        position=0,
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    assistant = _assistant_with_runtime_model()
+    space = MagicMock()
+    space.is_personal.return_value = False
+    service = _service()
+    service._resolve_effective_config = AsyncMock(return_value=None)
+    service.skill_service.resolve_assistant_bindings_for_runtime.return_value = (
+        SkillRuntimeResolution(eligible=(), blocked=(binding,))
+    )
+
+    with pytest.raises(
+        BadRequestException,
+        match="Blocked organisation Skills cannot receive new or changed bindings",
+    ):
+        await service._validate_attachments_fit(
+            assistant,
+            space=space,
+            explicit_on_demand_skill_ids=frozenset({binding.skill_id}),
+        )
+
+
+@pytest.mark.asyncio
+async def test_skill_configuration_projects_saved_modes_and_exact_runtime(
+    monkeypatch,
+):
+    measurement = SimpleNamespace(
+        tokens=10,
+        limit=1_000,
+        source=TokenCountSource.LITELLM,
+    )
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_skill_context",
+        lambda **_: measurement,
+    )
+    binding = _resolved_skill(
+        name="On demand",
+        position=0,
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    projection = SkillBindingProjection(binding=binding, execution_blocked=False)
+    resolution = SkillRuntimeResolution(eligible=(binding,), blocked=())
+    assistant = _assistant_with_runtime_model()
+    space = MagicMock()
+    space.is_personal.return_value = False
+    space.get_assistant.return_value = assistant
+    service = _service()
+    service.space_repo.get_space_by_assistant.return_value = space
+    service.skill_service.list_assistant_binding_projections.return_value = [projection]
+    service.skill_service.resolve_assistant_bindings_for_runtime.return_value = (
+        resolution
+    )
+
+    configuration = await service.get_skill_configuration(
+        space_id=assistant.space_id,
+        assistant_id=assistant.id,
+    )
+
+    assert configuration.bindings == (projection,)
+    assert configuration.runtime is not None
+    assert configuration.runtime.effective_model_id == assistant.completion_model.id
+    assert (
+        configuration.runtime.snapshot.effective_mode
+        is SkillTurnEffectiveMode.SELECTIVE
+    )
+    assert configuration.runtime.snapshot.measurement is measurement
+
+
+@pytest.mark.asyncio
+async def test_personal_default_skill_configuration_has_no_direct_runtime():
+    assistant = _assistant_with_runtime_model()
+    assistant.is_default = True
+    space = MagicMock()
+    space.is_personal.return_value = True
+    space.get_assistant.return_value = assistant
+    service = _service()
+    service.space_repo.get_space_by_assistant.return_value = space
+    service.skill_service.list_assistant_binding_projections.return_value = []
+    service._resolve_effective_config = AsyncMock()
+
+    configuration = await service.get_skill_configuration(
+        space_id=assistant.space_id,
+        assistant_id=assistant.id,
+    )
+
+    assert configuration.bindings == ()
+    assert configuration.runtime is None
+    service._resolve_effective_config.assert_not_awaited()
+    service.skill_service.create_turn_plan.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_skill_configuration_authorizes_skill_read_before_runtime_resolution():
+    service = _service()
+    service.skill_service.list_assistant_binding_projections.side_effect = (
+        UnauthorizedException("No Skill access")
+    )
+
+    with pytest.raises(UnauthorizedException, match="No Skill access"):
+        await service.get_skill_configuration(
+            space_id=uuid4(),
+            assistant_id=uuid4(),
+        )
+
+    service.space_repo.get_space_by_assistant.assert_not_awaited()
+
+
 # --- context fit: governance validates the model + prompt ask() will send ---
 
 
@@ -325,7 +865,13 @@ async def test_fit_uses_governance_effective_model(monkeypatch):
     monkeypatch.setattr(
         "eneo.files.attachment_budget.count_attachment_tokens", lambda **k: 15
     )
-    small_model = SimpleNamespace(max_input_tokens=20, name="small", vision=False)
+    small_model = SimpleNamespace(
+        max_input_tokens=20,
+        name="small",
+        vision=False,
+        supports_tool_calling=True,
+        get_model_route=lambda: "openai/small",
+    )
     monkeypatch.setattr(
         "eneo.assistants.assistant_service.select_effective_completion_model",
         lambda **k: small_model,
@@ -387,18 +933,24 @@ async def test_governance_preflight_uses_each_assistants_effective_model():
         max_input_tokens=100,
         name="allowed-current",
         vision=False,
+        supports_tool_calling=True,
+        get_model_route=lambda: "openai/allowed-current",
     )
     policy_default = SimpleNamespace(
         id=MagicMock(),
         max_input_tokens=200,
         name="policy-default",
         vision=False,
+        supports_tool_calling=True,
+        get_model_route=lambda: "openai/policy-default",
     )
     stale_model = SimpleNamespace(
         id=MagicMock(),
         max_input_tokens=300,
         name="stale",
         vision=False,
+        supports_tool_calling=True,
+        get_model_route=lambda: "openai/stale",
     )
     assistants = [
         SimpleNamespace(

--- a/backend/tests/unittests/assistants/test_attachment_budget.py
+++ b/backend/tests/unittests/assistants/test_attachment_budget.py
@@ -408,6 +408,114 @@ async def test_changed_on_demand_candidates_share_the_attachment_ceiling(
 
 
 @pytest.mark.asyncio
+async def test_save_skill_share_uses_raw_model_window(monkeypatch):
+    _patch_reserve(monkeypatch, 1_000)
+    measured_windows: list[int] = []
+
+    def measure_skill_share(**kwargs):
+        max_input_tokens = kwargs["max_input_tokens"]
+        measured_windows.append(max_input_tokens)
+        candidate_is_active = (
+            "Instructions for Candidate" in kwargs["composed_instructions"]
+        )
+        return SimpleNamespace(
+            tokens=800 if candidate_is_active else 100,
+            limit=max_input_tokens // 10,
+            source=TokenCountSource.LITELLM,
+        )
+
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_skill_context",
+        measure_skill_share,
+    )
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            tokens=7_000,
+            source=TokenCountSource.LITELLM,
+        ),
+    )
+    candidate = _resolved_skill(
+        name="Candidate",
+        position=0,
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    assistant = _assistant_with_runtime_model()
+    assistant.completion_model.max_input_tokens = 8_000
+    space = MagicMock()
+    space.is_personal.return_value = False
+    service = _service()
+    service._resolve_effective_config = AsyncMock(return_value=None)
+    service.skill_service.resolve_assistant_bindings_for_runtime.return_value = (
+        SkillRuntimeResolution(eligible=(candidate,), blocked=())
+    )
+    service.skill_service.create_turn_plan.side_effect = (
+        lambda *, base_instructions, resolution: SkillTurnPlan.create(
+            base_instructions=base_instructions,
+            resolution=resolution,
+            policy=SkillRuntimePolicy(
+                selective_activation_enabled=True,
+                max_attached_skills=100,
+                context_share_percent=10,
+                max_activations_per_turn=3,
+            ),
+        )
+    )
+    service._assert_persistent_baseline_fits = AsyncMock()
+
+    await service._validate_attachments_fit(
+        assistant,
+        space=space,
+        on_demand_skill_ids_requiring_validation=frozenset({candidate.skill_id}),
+    )
+
+    assert measured_windows
+    assert set(measured_windows) == {8_000}
+
+
+@pytest.mark.asyncio
+async def test_full_save_stages_blocked_on_demand_candidate(monkeypatch):
+    _patch_reserve(monkeypatch, 10)
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_skill_context",
+        lambda **_kwargs: SimpleNamespace(
+            tokens=10,
+            limit=100,
+            source=TokenCountSource.LITELLM,
+        ),
+    )
+    monkeypatch.setattr(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            tokens=91,
+            source=TokenCountSource.LITELLM,
+        ),
+    )
+    blocked_candidate = _resolved_skill(
+        name="Blocked candidate",
+        position=0,
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    assistant = _assistant_with_runtime_model()
+    assistant.completion_model.max_input_tokens = 100
+    space = MagicMock()
+    space.is_personal.return_value = False
+    service = _service()
+    service._resolve_effective_config = AsyncMock(return_value=None)
+    service.skill_service.resolve_assistant_bindings_for_runtime.return_value = (
+        SkillRuntimeResolution(eligible=(), blocked=(blocked_candidate,))
+    )
+    service._assert_persistent_baseline_fits = AsyncMock()
+
+    with pytest.raises(BadRequestException, match="Blocked candidate"):
+        await service._validate_attachments_fit(
+            assistant,
+            space=space,
+            validate_all_on_demand_candidates=True,
+        )
+
+
+@pytest.mark.asyncio
 async def test_fit_skipped_when_no_model(monkeypatch):
     _patch_reserve(monkeypatch, 10)
     monkeypatch.setattr(

--- a/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
+++ b/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
@@ -472,7 +472,7 @@ def test_provider_candidate_assessment_is_exact_and_non_mutating(
     )
     messages = [
         {"role": "system", "content": "Base"},
-        {"role": "user", "content": "Question"},
+        {"role": "user", "content": "Minimal non-empty question"},
     ]
     provider_tools = [
         {
@@ -509,6 +509,7 @@ def test_provider_candidate_assessment_is_exact_and_non_mutating(
     assert len(assessments) == 1
     assert measure_share.call_count == 1
     assert assessments[0].rejection_reason is expected_rejection
+    assert measure.call_args.args[0][1]["content"] == "Minimal non-empty question"
     assert measure.call_args.args[1] == provider_tools
     assert runtime.snapshot() == snapshot_before
     assert messages == messages_before

--- a/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
+++ b/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
@@ -295,6 +295,85 @@ def test_activation_rejects_candidate_when_fit_cannot_be_measured():
     )
 
 
+def test_fresh_candidate_assessment_matches_accepted_first_activation():
+    candidate = _skill(
+        key="skill-1",
+        name="Payroll",
+        description="Payroll questions",
+        position=1,
+        instructions="Use the approved payroll procedure.",
+        initially_active=False,
+    )
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(candidate,),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=1,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=8_000,
+        supports_tool_calling=True,
+    )
+
+    assessments = runtime.assess_on_demand_candidates(
+        frozenset({candidate.binding.skill_id})
+    )
+
+    assert len(assessments) == 1
+    assessment = assessments[0]
+    assert assessment.skill_id == candidate.binding.skill_id
+    assert assessment.activation_key == candidate.activation_key
+    assert assessment.rejection_reason is None
+    assert runtime.snapshot().active == ()
+
+    decisions = _apply_activation_requests(runtime, ("activate", "skill-1"))
+
+    assert decisions == [{"activated": True}]
+    assert runtime.snapshot().measurement == assessment.measurement
+
+
+def test_fresh_candidate_assessment_matches_oversized_first_activation_rejection():
+    candidate = _skill(
+        key="skill-1",
+        name="Oversized",
+        description="A compact descriptor",
+        position=1,
+        instructions="large " * 20_000,
+        initially_active=False,
+    )
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(candidate,),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=1,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=2_000,
+        supports_tool_calling=True,
+    )
+
+    assessments = runtime.assess_on_demand_candidates(
+        frozenset({candidate.binding.skill_id})
+    )
+
+    assert len(assessments) == 1
+    assessment = assessments[0]
+    assert assessment.skill_id == candidate.binding.skill_id
+    assert assessment.activation_key == candidate.activation_key
+    assert assessment.rejection_reason is (
+        SkillActivationRejectionReason.CONTEXT_LIMIT_EXCEEDED
+    )
+    assert assessment.measurement.tokens > assessment.measurement.limit
+    assert runtime.snapshot().active == ()
+
+    decisions = _apply_activation_requests(runtime, ("activate", "skill-1"))
+
+    assert decisions == [{"activated": False, "unavailable": True}]
+    assert runtime.snapshot().rejected[0].reason is assessment.rejection_reason
+
+
 def test_activation_rejects_when_complete_follow_up_exceeds_model_input_limit():
     runtime = SkillActivationRuntime.create(
         base_instructions="Base",

--- a/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
+++ b/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
@@ -18,7 +18,10 @@ from eneo.completion_models.domain.skill_activation import (
     SkillPromptOwnershipError,
     SkillTurnEffectiveMode,
 )
-from eneo.completion_models.domain.skill_context import SkillContextMeasurement
+from eneo.completion_models.domain.skill_context import (
+    SkillContextMeasurement,
+    measure_skill_context,
+)
 from eneo.skills.domain.skill import (
     MAX_SKILL_ACTIVATIONS_PER_TURN,
     ResolvedSkillBinding,
@@ -483,13 +486,20 @@ def test_provider_candidate_assessment_is_exact_and_non_mutating(
     snapshot_before = runtime.snapshot()
     messages_before = [message.copy() for message in messages]
 
-    with patch(
-        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
-        return_value=TokenCount(
-            tokens=provider_tokens,
-            source=TokenCountSource.LITELLM,
-        ),
-    ) as measure:
+    with (
+        patch(
+            "eneo.completion_models.domain.skill_activation.measure_skill_context",
+            wraps=measure_skill_context,
+        ) as measure_share,
+        patch(
+            "eneo.completion_models.domain.skill_activation."
+            "measure_provider_input_tokens",
+            return_value=TokenCount(
+                tokens=provider_tokens,
+                source=TokenCountSource.LITELLM,
+            ),
+        ) as measure,
+    ):
         assessments = runtime.assess_provider_payload_candidates(
             frozenset({candidate.binding.skill_id}),
             messages=messages,
@@ -497,6 +507,7 @@ def test_provider_candidate_assessment_is_exact_and_non_mutating(
         )
 
     assert len(assessments) == 1
+    assert measure_share.call_count == 1
     assert assessments[0].rejection_reason is expected_rejection
     assert measure.call_args.args[1] == provider_tools
     assert runtime.snapshot() == snapshot_before

--- a/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
+++ b/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
@@ -515,6 +515,63 @@ def test_provider_candidate_assessment_is_exact_and_non_mutating(
     assert messages == messages_before
 
 
+@pytest.mark.parametrize(
+    ("provider_tokens", "expected_rejection"),
+    [
+        (900, None),
+        (
+            901,
+            SkillActivationRejectionReason.MODEL_CONTEXT_LIMIT_EXCEEDED,
+        ),
+    ],
+    ids=("reserved-limit", "reserved-overflow"),
+)
+def test_provider_candidate_assessment_uses_explicit_payload_limit(
+    provider_tokens,
+    expected_rejection,
+):
+    candidate = _skill(
+        key="skill-1",
+        name="Payroll",
+        description="Payroll questions",
+        position=1,
+        instructions="Payroll body",
+        initially_active=False,
+    )
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(candidate,),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=1,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=1_000,
+        supports_tool_calling=True,
+    )
+
+    with patch(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        return_value=TokenCount(
+            tokens=provider_tokens,
+            source=TokenCountSource.LITELLM,
+        ),
+    ):
+        assessments = runtime.assess_provider_payload_candidates(
+            frozenset({candidate.binding.skill_id}),
+            messages=[
+                {"role": "system", "content": "Base"},
+                {"role": "user", "content": "Reserved question space"},
+            ],
+            provider_tools=[],
+            provider_input_token_limit=900,
+        )
+
+    assert len(assessments) == 1
+    assert assessments[0].rejection_reason is expected_rejection
+    assert assessments[0].measurement.limit == 1_000
+
+
 def test_model_limit_rejects_oversized_earlier_skill_and_keeps_later_fit():
     runtime = SkillActivationRuntime.create(
         base_instructions="Base",

--- a/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
+++ b/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
@@ -330,6 +330,7 @@ def test_fresh_candidate_assessment_matches_accepted_first_activation():
     decisions = _apply_activation_requests(runtime, ("activate", "skill-1"))
 
     assert decisions == [{"activated": True}]
+    assert runtime.prompt == assessment.prompt
     assert runtime.snapshot().measurement == assessment.measurement
 
 

--- a/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
+++ b/backend/tests/unittests/completion_models/test_skill_activation_runtime.py
@@ -433,6 +433,76 @@ def test_activation_rejects_when_complete_follow_up_exceeds_model_input_limit():
     assert "Payroll body" not in str(messages[0]["content"])
 
 
+@pytest.mark.parametrize(
+    ("provider_tokens", "expected_rejection"),
+    [
+        (1_000, None),
+        (
+            1_001,
+            SkillActivationRejectionReason.MODEL_CONTEXT_LIMIT_EXCEEDED,
+        ),
+    ],
+    ids=("exact-limit", "overflow"),
+)
+def test_provider_candidate_assessment_is_exact_and_non_mutating(
+    provider_tokens,
+    expected_rejection,
+):
+    candidate = _skill(
+        key="skill-1",
+        name="Payroll",
+        description="Payroll questions",
+        position=1,
+        instructions="Payroll body",
+        initially_active=False,
+    )
+    runtime = SkillActivationRuntime.create(
+        base_instructions="Base",
+        skills=(candidate,),
+        blocked_keys=frozenset(),
+        selective_activation_enabled=True,
+        max_activations_per_turn=1,
+        context_share_percent=100,
+        model_route="openai/gpt-4o",
+        max_input_tokens=1_000,
+        supports_tool_calling=True,
+    )
+    messages = [
+        {"role": "system", "content": "Base"},
+        {"role": "user", "content": "Question"},
+    ]
+    provider_tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "large_mcp_schema",
+                "parameters": {"description": "x" * 2_000},
+            },
+        }
+    ]
+    snapshot_before = runtime.snapshot()
+    messages_before = [message.copy() for message in messages]
+
+    with patch(
+        "eneo.completion_models.domain.skill_activation.measure_provider_input_tokens",
+        return_value=TokenCount(
+            tokens=provider_tokens,
+            source=TokenCountSource.LITELLM,
+        ),
+    ) as measure:
+        assessments = runtime.assess_provider_payload_candidates(
+            frozenset({candidate.binding.skill_id}),
+            messages=messages,
+            provider_tools=provider_tools,
+        )
+
+    assert len(assessments) == 1
+    assert assessments[0].rejection_reason is expected_rejection
+    assert measure.call_args.args[1] == provider_tools
+    assert runtime.snapshot() == snapshot_before
+    assert messages == messages_before
+
+
 def test_model_limit_rejects_oversized_earlier_skill_and_keeps_later_fit():
     runtime = SkillActivationRuntime.create(
         base_instructions="Base",

--- a/backend/tests/unittests/completion_models/test_skill_context.py
+++ b/backend/tests/unittests/completion_models/test_skill_context.py
@@ -1,6 +1,9 @@
 from unittest.mock import patch
 
-from eneo.completion_models.domain.skill_context import measure_skill_context
+from eneo.completion_models.domain.skill_context import (
+    measure_skill_context,
+    skill_context_token_allowance,
+)
 from eneo.tokens.token_utils import TokenCount, TokenCountSource
 
 
@@ -25,6 +28,16 @@ def test_measure_skill_context_uses_system_message_delta_and_policy_share():
     assert measurement.tokens == 125
     assert measurement.limit == 19_200
     assert measurement.source is TokenCountSource.LITELLM
+
+
+def test_skill_context_token_allowance_applies_policy_share_with_integer_floor():
+    assert (
+        skill_context_token_allowance(
+            max_input_tokens=8_192,
+            context_share_percent=10,
+        )
+        == 819
+    )
 
 
 def test_measure_skill_context_preserves_the_atomic_counters_source():

--- a/backend/tests/unittests/settings/test_skill_runtime_policy_contract.py
+++ b/backend/tests/unittests/settings/test_skill_runtime_policy_contract.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from eneo.roles.permissions import Permission
+from eneo.settings.setting_service import SettingService
+from eneo.settings.settings import (
+    SkillRuntimePolicyPublic,
+    SkillRuntimePolicyUpdate,
+)
+from eneo.skills.domain.skill import SkillRuntimePolicy
+
+
+def _runtime_policy() -> SkillRuntimePolicy:
+    return SkillRuntimePolicy(
+        selective_activation_enabled=True,
+        max_attached_skills=100,
+        context_share_percent=10,
+        max_activations_per_turn=5,
+    )
+
+
+def test_public_editable_bounds_match_update_validation_bounds():
+    public = SkillRuntimePolicyPublic.from_domain(_runtime_policy())
+    update_schema = SkillRuntimePolicyUpdate.model_json_schema()["properties"]
+
+    assert public.editable_bounds.model_dump() == {
+        "max_attached_skills": {
+            "minimum": update_schema["max_attached_skills"]["minimum"],
+            "maximum": update_schema["max_attached_skills"]["maximum"],
+        },
+        "context_share_percent": {
+            "minimum": update_schema["context_share_percent"]["minimum"],
+            "maximum": update_schema["context_share_percent"]["maximum"],
+        },
+        "max_activations_per_turn": {
+            "minimum": update_schema["max_activations_per_turn"]["minimum"],
+            "maximum": update_schema["max_activations_per_turn"]["maximum"],
+        },
+    }
+
+
+def _setting_service() -> SettingService:
+    user = SimpleNamespace(
+        id=uuid4(),
+        tenant_id=uuid4(),
+        permissions=[Permission.ADMIN],
+    )
+    return SettingService(
+        repo=MagicMock(),
+        user=user,
+        ai_models_service=MagicMock(),
+        feature_flag_service=MagicMock(),
+        tenant_repo=MagicMock(),
+        audit_service=MagicMock(),
+        skill_repo=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_projection_uses_canonical_skill_context_allowance():
+    service = _setting_service()
+    service.skill_repo.get_or_seed_runtime_policy = AsyncMock(
+        return_value=_runtime_policy()
+    )
+    model = SimpleNamespace(
+        id=uuid4(),
+        name="test-model",
+        nickname="Test model",
+        max_input_tokens=128_000,
+        supports_tool_calling=True,
+        can_access=True,
+    )
+    service.ai_models_service.get_completion_models = AsyncMock(return_value=[model])
+
+    with patch(
+        "eneo.settings.setting_service.skill_context_token_allowance",
+        return_value=12_345,
+    ) as allowance:
+        projections = await service.get_skill_runtime_model_projections()
+
+    allowance.assert_called_once_with(
+        max_input_tokens=model.max_input_tokens,
+        context_share_percent=10,
+    )
+    assert projections.models[0].skill_context_token_allowance == 12_345

--- a/backend/tests/unittests/skills/test_skill.py
+++ b/backend/tests/unittests/skills/test_skill.py
@@ -337,7 +337,7 @@ def test_turn_plan_freezes_bindings_and_starts_with_required_skills():
     assert "Confirmed unsafe instructions" not in evidence.model_dump_json()
 
 
-def test_turn_plan_stages_blocked_on_demand_bindings_for_save_validation():
+def test_turn_plan_stages_all_blocked_bindings_for_full_save_validation():
     blocked_always = replace(
         _binding(position=0, name="Blocked required"),
         activation_mode=SkillActivationMode.ALWAYS,
@@ -369,9 +369,10 @@ def test_turn_plan_stages_blocked_on_demand_bindings_for_save_validation():
         policy=policy,
     )
 
-    validation_plan = plan.for_on_demand_save_validation()
+    validation_plan = plan.for_full_save_validation()
 
     assert [binding.binding for binding in validation_plan.available] == [
+        blocked_always,
         blocked_on_demand,
         available_always,
         available_on_demand,
@@ -380,9 +381,10 @@ def test_turn_plan_stages_blocked_on_demand_bindings_for_save_validation():
         "skill-1",
         "skill-2",
         "skill-3",
+        "skill-4",
     ]
-    assert validation_plan.initially_active_keys == ("skill-2",)
-    assert [binding.binding for binding in validation_plan.blocked] == [blocked_always]
+    assert validation_plan.initially_active_keys == ("skill-1", "skill-3")
+    assert validation_plan.blocked == ()
     assert [binding.binding for binding in plan.available] == [
         available_always,
         available_on_demand,

--- a/backend/tests/unittests/skills/test_skill.py
+++ b/backend/tests/unittests/skills/test_skill.py
@@ -337,6 +337,62 @@ def test_turn_plan_freezes_bindings_and_starts_with_required_skills():
     assert "Confirmed unsafe instructions" not in evidence.model_dump_json()
 
 
+def test_turn_plan_stages_blocked_on_demand_bindings_for_save_validation():
+    blocked_always = replace(
+        _binding(position=0, name="Blocked required"),
+        activation_mode=SkillActivationMode.ALWAYS,
+    )
+    blocked_on_demand = replace(
+        _binding(position=1, name="Blocked optional"),
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    available_always = replace(
+        _binding(position=2, name="Available required"),
+        activation_mode=SkillActivationMode.ALWAYS,
+    )
+    available_on_demand = replace(
+        _binding(position=3, name="Available optional"),
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    policy = SkillRuntimePolicy(
+        selective_activation_enabled=True,
+        max_attached_skills=100,
+        context_share_percent=15,
+        max_activations_per_turn=5,
+    )
+    plan = SkillTurnPlan.create(
+        base_instructions="Base instructions",
+        resolution=SkillRuntimeResolution(
+            eligible=(available_always, available_on_demand),
+            blocked=(blocked_always, blocked_on_demand),
+        ),
+        policy=policy,
+    )
+
+    validation_plan = plan.for_on_demand_save_validation()
+
+    assert [binding.binding for binding in validation_plan.available] == [
+        blocked_on_demand,
+        available_always,
+        available_on_demand,
+    ]
+    assert [binding.activation_key for binding in validation_plan.available] == [
+        "skill-1",
+        "skill-2",
+        "skill-3",
+    ]
+    assert validation_plan.initially_active_keys == ("skill-2",)
+    assert [binding.binding for binding in validation_plan.blocked] == [blocked_always]
+    assert [binding.binding for binding in plan.available] == [
+        available_always,
+        available_on_demand,
+    ]
+    assert [binding.binding for binding in plan.blocked] == [
+        blocked_always,
+        blocked_on_demand,
+    ]
+
+
 def test_zero_skill_turn_plan_preserves_base_and_records_empty_evidence():
     plan = SkillTurnPlan.create(
         base_instructions="  Base instructions\n",

--- a/backend/tests/unittests/skills/test_skill_presentation_contract.py
+++ b/backend/tests/unittests/skills/test_skill_presentation_contract.py
@@ -5,12 +5,14 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
-from fastapi import Response
+from fastapi import FastAPI, Response
 from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
 from eneo.audit.domain.action_types import ActionType
 from eneo.main.exceptions import NotFoundException
+from eneo.main.models import NotProvided
 from eneo.skills.application.skill_service import SkillService
 from eneo.skills.domain.skill import (
     ResolvedSkillBinding,
@@ -31,6 +33,7 @@ from eneo.skills.domain.skill import (
 from eneo.skills.presentation import skill_models, skill_router
 from eneo.skills.presentation.skill_assembler import (
     SkillAssembler,
+    assistant_skill_binding_intents_from_input,
     skill_binding_audit_entries,
     skill_binding_references_from_input,
 )
@@ -616,8 +619,11 @@ def test_assistant_binding_input_distinguishes_omitted_and_explicit_modes():
         {**identity, "activation_mode": "on_demand"}
     )
 
-    assert omitted.activation_mode is None
+    assert isinstance(omitted.activation_mode, NotProvided)
     assert "activation_mode" not in omitted.model_fields_set
+    assert (
+        assistant_skill_binding_intents_from_input([omitted])[0].activation_mode is None
+    )
     assert explicit_always.activation_mode is SkillActivationMode.ALWAYS
     assert "activation_mode" in explicit_always.model_fields_set
     assert explicit_on_demand.activation_mode is SkillActivationMode.ON_DEMAND
@@ -634,7 +640,51 @@ def test_assistant_binding_input_rejects_explicit_null_mode():
             }
         )
 
-    assert exc_info.value.errors()[0]["loc"] == ()
+    assert all(
+        error["loc"] and error["loc"][0] == "activation_mode"
+        for error in exc_info.value.errors()
+    )
+
+
+def _assistant_binding_contract_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.post("/binding")
+    def update_binding(
+        binding: skill_models.AssistantSkillBindingInput,
+    ) -> dict[str, bool]:
+        return {"accepted": True}
+
+    return app
+
+
+def test_assistant_binding_input_openapi_is_optional_and_non_nullable():
+    schema = _assistant_binding_contract_app().openapi()["components"]["schemas"][
+        "AssistantSkillBindingInput"
+    ]
+    activation_mode = schema["properties"]["activation_mode"]
+
+    assert "activation_mode" not in schema.get("required", [])
+    assert activation_mode["$ref"] == "#/components/schemas/SkillActivationMode"
+    assert "anyOf" not in activation_mode
+    assert "default" not in activation_mode
+
+
+def test_assistant_binding_input_http_rejects_null_at_field():
+    response = TestClient(_assistant_binding_contract_app()).post(
+        "/binding",
+        json={
+            "skill_id": str(uuid4()),
+            "skill_revision_id": str(uuid4()),
+            "activation_mode": None,
+        },
+    )
+
+    assert response.status_code == 422
+    assert all(
+        error["loc"][:2] == ["body", "activation_mode"]
+        for error in response.json()["detail"]
+    )
 
 
 def test_shared_binding_input_rejects_assistant_activation_mode():

--- a/backend/tests/unittests/skills/test_skill_presentation_contract.py
+++ b/backend/tests/unittests/skills/test_skill_presentation_contract.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 from fastapi import Response
 from fastapi.routing import APIRoute
+from pydantic import ValidationError
 
 from eneo.audit.domain.action_types import ActionType
 from eneo.main.exceptions import NotFoundException
@@ -14,8 +15,8 @@ from eneo.skills.application.skill_service import SkillService
 from eneo.skills.domain.skill import (
     ResolvedSkillBinding,
     Skill,
+    SkillActivationMode,
     SkillBindingProjection,
-    SkillBindingReference,
     SkillBindingSource,
     SkillCatalogEntry,
     SkillCatalogPage,
@@ -25,6 +26,7 @@ from eneo.skills.domain.skill import (
     SkillRevisionRestore,
     SkillRevisionSummary,
     SkillStatusChange,
+    SkillTurnEffectiveMode,
 )
 from eneo.skills.presentation import skill_models, skill_router
 from eneo.skills.presentation.skill_assembler import (
@@ -34,6 +36,7 @@ from eneo.skills.presentation.skill_assembler import (
 )
 from eneo.skills.presentation.skill_models import SkillBindingReferenceInput
 from eneo.skills.presentation.skill_router import router
+from eneo.tokens.token_utils import TokenCountSource
 
 
 def _binding(*, position: int) -> ResolvedSkillBinding:
@@ -131,7 +134,13 @@ def _router_container(*, service, assembler):
 
 
 def test_skill_binding_audit_entries_preserve_order_without_bodies():
-    bindings = [_binding(position=0), _binding(position=1)]
+    bindings = [
+        _binding(position=0),
+        replace(
+            _binding(position=1),
+            activation_mode=SkillActivationMode.ON_DEMAND,
+        ),
+    ]
 
     entries = skill_binding_audit_entries(bindings)
 
@@ -139,6 +148,10 @@ def test_skill_binding_audit_entries_preserve_order_without_bodies():
         str(binding.skill_id) for binding in bindings
     ]
     assert [entry["position"] for entry in entries] == [0, 1]
+    assert [entry["activation_mode"] for entry in entries] == [
+        "always",
+        "on_demand",
+    ]
     assert "instructions" not in str(entries)
     assert "description" not in str(entries)
 
@@ -589,25 +602,148 @@ async def test_lost_delete_race_does_not_emit_a_second_delete_audit():
     audit_service.log_async.assert_not_awaited()
 
 
-def test_public_binding_contracts_cannot_express_activation_mode():
-    """Slice 1 keeps the mode dormant: a client-supplied activation_mode is
-    dropped by the closed input model and no read model advertises one, so
-    the generated OpenAPI/SDK contracts stay unchanged."""
-    payload = {
+def test_assistant_binding_input_distinguishes_omitted_and_explicit_modes():
+    identity = {
         "skill_id": str(uuid4()),
         "skill_revision_id": str(uuid4()),
-        "activation_mode": "on_demand",
     }
-    parsed = SkillBindingReferenceInput.model_validate(payload)
-    references = skill_binding_references_from_input([parsed])
 
-    assert not hasattr(parsed, "activation_mode")
-    assert references[0] == SkillBindingReference(
-        skill_id=parsed.skill_id,
-        skill_revision_id=parsed.skill_revision_id,
+    omitted = skill_models.AssistantSkillBindingInput.model_validate(identity)
+    explicit_always = skill_models.AssistantSkillBindingInput.model_validate(
+        {**identity, "activation_mode": "always"}
     )
-    for public_model in (
-        skill_models.SkillBindingReferenceInput,
-        skill_models.SkillBindingSummary,
-    ):
-        assert "activation_mode" not in public_model.model_json_schema()["properties"]
+    explicit_on_demand = skill_models.AssistantSkillBindingInput.model_validate(
+        {**identity, "activation_mode": "on_demand"}
+    )
+
+    assert omitted.activation_mode is None
+    assert "activation_mode" not in omitted.model_fields_set
+    assert explicit_always.activation_mode is SkillActivationMode.ALWAYS
+    assert "activation_mode" in explicit_always.model_fields_set
+    assert explicit_on_demand.activation_mode is SkillActivationMode.ON_DEMAND
+    assert "activation_mode" in explicit_on_demand.model_fields_set
+
+
+def test_assistant_binding_input_rejects_explicit_null_mode():
+    with pytest.raises(ValidationError) as exc_info:
+        skill_models.AssistantSkillBindingInput.model_validate(
+            {
+                "skill_id": str(uuid4()),
+                "skill_revision_id": str(uuid4()),
+                "activation_mode": None,
+            }
+        )
+
+    assert exc_info.value.errors()[0]["loc"] == ()
+
+
+def test_shared_binding_input_rejects_assistant_activation_mode():
+    with pytest.raises(ValidationError) as exc_info:
+        SkillBindingReferenceInput.model_validate(
+            {
+                "skill_id": str(uuid4()),
+                "skill_revision_id": str(uuid4()),
+                "activation_mode": "on_demand",
+            }
+        )
+
+    assert exc_info.value.errors()[0]["type"] == "extra_forbidden"
+
+
+def test_assistant_binding_summary_exposes_mode_without_broadening_shared_summary():
+    binding = replace(
+        _binding(position=0),
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    projection = SkillBindingProjection(binding=binding, execution_blocked=False)
+
+    assistant_summary = SkillAssembler.assistant_binding_to_summary(projection)
+    shared_summary = SkillAssembler.binding_to_summary(projection)
+
+    assert isinstance(assistant_summary, skill_models.AssistantSkillBindingSummary)
+    assert assistant_summary.activation_mode is SkillActivationMode.ON_DEMAND
+    assert "activation_mode" in assistant_summary.model_json_schema()["properties"]
+    assert not hasattr(shared_summary, "activation_mode")
+    assert (
+        "activation_mode"
+        not in skill_models.SkillBindingSummary.model_json_schema()["properties"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_assistant_skill_configuration_returns_modes_and_exact_runtime():
+    binding = replace(
+        _binding(position=0),
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    projection = SkillBindingProjection(binding=binding, execution_blocked=False)
+    model_id = uuid4()
+    assistant_service = SimpleNamespace(
+        get_skill_configuration=AsyncMock(
+            return_value=SimpleNamespace(
+                bindings=(projection,),
+                runtime=SimpleNamespace(
+                    effective_model_id=model_id,
+                    snapshot=SimpleNamespace(
+                        effective_mode=SkillTurnEffectiveMode.SELECTIVE,
+                        fallback_reason=None,
+                        measurement=SimpleNamespace(
+                            tokens=42,
+                            limit=800,
+                            source=TokenCountSource.LITELLM,
+                        ),
+                    ),
+                ),
+            )
+        )
+    )
+    container = SimpleNamespace(
+        assistant_service=lambda: assistant_service,
+        skill_assembler=lambda: SkillAssembler(),
+    )
+    space_id = uuid4()
+    assistant_id = uuid4()
+
+    response = await skill_router.get_assistant_skill_configuration(
+        space_id=space_id,
+        assistant_id=assistant_id,
+        container=container,
+    )
+
+    assistant_service.get_skill_configuration.assert_awaited_once_with(
+        space_id=space_id,
+        assistant_id=assistant_id,
+    )
+    assert response.bindings[0].activation_mode is SkillActivationMode.ON_DEMAND
+    assert response.runtime is not None
+    assert response.runtime.effective_model_id == model_id
+    assert response.runtime.effective_mode is SkillTurnEffectiveMode.SELECTIVE
+    assert response.runtime.fallback_reason is None
+    assert response.runtime.skill_context_tokens == 42
+    assert response.runtime.skill_context_token_limit == 800
+    assert response.runtime.token_count_source is TokenCountSource.LITELLM
+
+
+def test_assistant_skill_configuration_schema_has_no_runtime_bodies():
+    runtime_properties = skill_models.AssistantSkillRuntimeSummary.model_json_schema()[
+        "properties"
+    ]
+
+    assert "instructions" not in runtime_properties
+    assert "description" not in runtime_properties
+    assert "available" not in runtime_properties
+    assert "active" not in runtime_properties
+    assert "accepted" not in runtime_properties
+
+
+def test_assistant_skill_configuration_route_is_get_only():
+    methods = {
+        method
+        for route in router.routes
+        if isinstance(route, APIRoute)
+        and route.path
+        == "/spaces/{space_id}/assistants/{assistant_id}/skills/configuration/"
+        for method in route.methods
+    }
+
+    assert methods == {"GET"}

--- a/backend/tests/unittests/skills/test_skill_service.py
+++ b/backend/tests/unittests/skills/test_skill_service.py
@@ -16,8 +16,10 @@ from eneo.roles.permissions import Permission
 from eneo.skills.application.skill_service import SkillService
 from eneo.skills.domain.skill import (
     SKILL_RUNTIME_POLICY_DEFAULTS,
+    AssistantSkillBindingReplacement,
     ResolvedSkillBinding,
     SkillActivationMode,
+    SkillBindingIntent,
     SkillBindingReference,
     SkillBindingSource,
     SkillCatalogEntry,
@@ -60,6 +62,17 @@ def _binding_reference(binding: ResolvedSkillBinding) -> SkillBindingReference:
     return SkillBindingReference(
         skill_id=binding.skill_id,
         skill_revision_id=binding.skill_revision_id,
+    )
+
+
+def _binding_intent(
+    binding: ResolvedSkillBinding,
+    *,
+    activation_mode: SkillActivationMode | None = None,
+) -> SkillBindingIntent:
+    return SkillBindingIntent(
+        reference=_binding_reference(binding),
+        activation_mode=activation_mode,
     )
 
 
@@ -603,16 +616,20 @@ async def test_same_space_skill_can_be_reused_by_multiple_parents():
     first = await service.replace_assistant_bindings(
         space_id=space.id,
         assistant_id=uuid4(),
-        references=[_binding_reference(binding)],
+        intents=[_binding_intent(binding)],
     )
     second = await service.replace_assistant_bindings(
         space_id=space.id,
         assistant_id=uuid4(),
-        references=[_binding_reference(binding)],
+        intents=[_binding_intent(binding)],
     )
 
-    assert first == [binding]
-    assert second == [binding]
+    assert first == AssistantSkillBindingReplacement(
+        bindings=(binding,), changed_to_on_demand_skill_ids=frozenset()
+    )
+    assert second == AssistantSkillBindingReplacement(
+        bindings=(binding,), changed_to_on_demand_skill_ids=frozenset()
+    )
     assert repo.replace_assistant_bindings.await_count == 2
 
 
@@ -643,11 +660,20 @@ async def test_resource_binding_resolves_local_and_published_catalogue_skills(
     repo.resolve_published_references_for_binding_update.return_value = [published]
     service = _service(space=space, repo=repo)
 
-    result = await getattr(service, replace_method)(
-        space_id=space.id,
-        **{parent_id_name: getattr(space, parent_attribute).id},
-        references=[_binding_reference(local), _binding_reference(published)],
-    )
+    references = [_binding_reference(local), _binding_reference(published)]
+    if replace_method == "replace_assistant_bindings":
+        replacement = await service.replace_assistant_bindings(
+            space_id=space.id,
+            assistant_id=getattr(space, parent_attribute).id,
+            intents=[SkillBindingIntent(reference=value) for value in references],
+        )
+        result = list(replacement.bindings)
+    else:
+        result = await getattr(service, replace_method)(
+            space_id=space.id,
+            **{parent_id_name: getattr(space, parent_attribute).id},
+            references=references,
+        )
 
     assert result == [local, replace(published, position=1)]
     repo.resolve_local_references_for_binding_update.assert_awaited_once_with(
@@ -680,7 +706,7 @@ async def test_blocked_organization_skill_cannot_receive_new_binding(owner: str)
             await service.replace_assistant_bindings(
                 space_id=space.id,
                 assistant_id=space.assistant.id,
-                references=[_binding_reference(blocked)],
+                intents=[_binding_intent(blocked)],
             )
         elif owner == "app":
             await service.replace_app_bindings(
@@ -723,7 +749,7 @@ async def test_blocked_organization_skill_cannot_change_revision(owner: str):
             await service.replace_assistant_bindings(
                 space_id=space.id,
                 assistant_id=space.assistant.id,
-                references=[_binding_reference(changed)],
+                intents=[_binding_intent(changed)],
             )
         elif owner == "app":
             await service.replace_app_bindings(
@@ -763,7 +789,10 @@ async def test_blocked_retained_bindings_can_be_reordered(owner: str):
         result = await service.replace_assistant_bindings(
             space_id=space.id,
             assistant_id=space.assistant.id,
-            references=reversed_references,
+            intents=[
+                SkillBindingIntent(reference=reference)
+                for reference in reversed_references
+            ],
         )
     elif owner == "app":
         result = await service.replace_app_bindings(
@@ -778,8 +807,12 @@ async def test_blocked_retained_bindings_can_be_reordered(owner: str):
             references=reversed_references,
         )
 
-    assert [binding.skill_id for binding in result] == [second.skill_id, first.skill_id]
-    assert [binding.position for binding in result] == [0, 1]
+    bindings = result.bindings if owner == "assistant" else result
+    assert [binding.skill_id for binding in bindings] == [
+        second.skill_id,
+        first.skill_id,
+    ]
+    assert [binding.position for binding in bindings] == [0, 1]
     repo.list_active_execution_blocks.assert_not_awaited()
 
 
@@ -839,11 +872,18 @@ async def test_organization_space_resource_rejects_unpublished_skill_revision(
     service = _service(space=space, repo=repo)
 
     with pytest.raises(NotFoundException, match="unavailable"):
-        await getattr(service, replace_method)(
-            space_id=space.id,
-            **{parent_id_name: getattr(space, parent_attribute).id},
-            references=[_binding_reference(draft)],
-        )
+        if replace_method == "replace_assistant_bindings":
+            await service.replace_assistant_bindings(
+                space_id=space.id,
+                assistant_id=getattr(space, parent_attribute).id,
+                intents=[_binding_intent(draft)],
+            )
+        else:
+            await getattr(service, replace_method)(
+                space_id=space.id,
+                **{parent_id_name: getattr(space, parent_attribute).id},
+                references=[_binding_reference(draft)],
+            )
 
     repo.resolve_local_references_for_binding_update.assert_not_awaited()
 
@@ -859,10 +899,11 @@ async def test_existing_unpublished_catalogue_binding_can_remain_on_resource():
     result = await service.replace_assistant_bindings(
         space_id=space.id,
         assistant_id=space.assistant.id,
-        references=[_binding_reference(existing)],
+        intents=[_binding_intent(existing)],
     )
 
-    assert result == [existing]
+    assert result.bindings == (existing,)
+    assert result.changed_to_on_demand_skill_ids == frozenset()
     repo.resolve_bound_references_for_binding_update.assert_awaited_once_with(
         tenant_id=space.tenant_id,
         parent_space_id=space.id,
@@ -882,7 +923,7 @@ async def test_assistant_binding_update_rejects_a_concurrent_space_move():
         await service.replace_assistant_bindings(
             space_id=space.id,
             assistant_id=space.assistant.id,
-            references=[],
+            intents=[],
         )
 
     repo.list_assistant_bindings.assert_not_awaited()
@@ -924,7 +965,7 @@ async def test_inactive_skill_cannot_receive_a_new_binding():
         await service.replace_assistant_bindings(
             space_id=space.id,
             assistant_id=space.assistant.id,
-            references=[_binding_reference(inactive)],
+            intents=[_binding_intent(inactive)],
         )
 
 
@@ -939,10 +980,11 @@ async def test_existing_inactive_exact_revision_binding_can_be_reordered():
     result = await service.replace_assistant_bindings(
         space_id=space.id,
         assistant_id=space.assistant.id,
-        references=[_binding_reference(inactive)],
+        intents=[_binding_intent(inactive)],
     )
 
-    assert result == [inactive]
+    assert result.bindings == (inactive,)
+    assert result.changed_to_on_demand_skill_ids == frozenset()
     repo.replace_assistant_bindings.assert_awaited_once()
 
 
@@ -1111,11 +1153,18 @@ async def test_parent_reader_cannot_replace_skill_bindings(
     service = _service(space=space, actor=actor, repo=repo)
 
     with pytest.raises(UnauthorizedException, match="permission to edit"):
-        await getattr(service, replace_method)(
-            space_id=space.id,
-            **{parent_id_name: parent.id},
-            references=[],
-        )
+        if replace_method == "replace_assistant_bindings":
+            await service.replace_assistant_bindings(
+                space_id=space.id,
+                assistant_id=parent.id,
+                intents=[],
+            )
+        else:
+            await getattr(service, replace_method)(
+                space_id=space.id,
+                **{parent_id_name: parent.id},
+                references=[],
+            )
 
     repo.replace_assistant_bindings.assert_not_awaited()
     repo.replace_app_bindings.assert_not_awaited()
@@ -1138,11 +1187,18 @@ async def test_api_key_cannot_replace_parent_skill_bindings(
     service = _service(space=space, repo=repo, active_api_key=MagicMock())
 
     with pytest.raises(UnauthorizedException, match="session token"):
-        await getattr(service, replace_method)(
-            space_id=space.id,
-            **{parent_id_name: parent_id},
-            references=[],
-        )
+        if replace_method == "replace_assistant_bindings":
+            await service.replace_assistant_bindings(
+                space_id=space.id,
+                assistant_id=parent_id,
+                intents=[],
+            )
+        else:
+            await getattr(service, replace_method)(
+                space_id=space.id,
+                **{parent_id_name: parent_id},
+                references=[],
+            )
 
     repo.list_assistant_bindings.assert_not_awaited()
     repo.list_app_bindings.assert_not_awaited()
@@ -1348,10 +1404,11 @@ async def test_retained_assistant_binding_keeps_activation_mode_on_resave():
     result = await service.replace_assistant_bindings(
         space_id=space.id,
         assistant_id=space.assistant.id,
-        references=[_binding_reference(existing)],
+        intents=[_binding_intent(existing)],
     )
 
-    assert result[0].activation_mode is SkillActivationMode.ON_DEMAND
+    assert result.bindings[0].activation_mode is SkillActivationMode.ON_DEMAND
+    assert result.changed_to_on_demand_skill_ids == frozenset()
     persisted = repo.replace_assistant_bindings.await_args.kwargs["bindings"]
     assert [binding.activation_mode for binding in persisted] == [
         SkillActivationMode.ON_DEMAND
@@ -1395,12 +1452,77 @@ async def test_new_binding_defaults_to_always_activation_mode():
     result = await service.replace_assistant_bindings(
         space_id=space.id,
         assistant_id=space.assistant.id,
-        references=[_binding_reference(added)],
+        intents=[_binding_intent(added)],
     )
 
-    assert [binding.activation_mode for binding in result] == [
+    assert [binding.activation_mode for binding in result.bindings] == [
         SkillActivationMode.ALWAYS
     ]
+    assert result.changed_to_on_demand_skill_ids == frozenset()
+
+
+async def test_explicit_assistant_mode_only_change_is_persisted_and_reported():
+    space = _space()
+    existing = replace(_binding(), activation_mode=SkillActivationMode.ALWAYS)
+    repo = AsyncMock()
+    repo.list_assistant_bindings.return_value = [existing]
+    repo.resolve_bound_references_for_binding_update.return_value = [existing]
+    service = _service(space=space, repo=repo)
+
+    result = await service.replace_assistant_bindings(
+        space_id=space.id,
+        assistant_id=space.assistant.id,
+        intents=[
+            _binding_intent(
+                existing,
+                activation_mode=SkillActivationMode.ON_DEMAND,
+            )
+        ],
+    )
+
+    assert result.changed_to_on_demand_skill_ids == frozenset({existing.skill_id})
+    assert result.bindings[0].activation_mode is SkillActivationMode.ON_DEMAND
+    persisted = repo.replace_assistant_bindings.await_args.kwargs["bindings"]
+    assert persisted[0].activation_mode is SkillActivationMode.ON_DEMAND
+
+
+async def test_assistant_reorder_preserves_omitted_mode_and_applies_explicit_mode():
+    space = _space()
+    first = replace(
+        _binding(position=0),
+        activation_mode=SkillActivationMode.ON_DEMAND,
+    )
+    second = replace(
+        _binding(position=1),
+        activation_mode=SkillActivationMode.ALWAYS,
+    )
+    repo = AsyncMock()
+    repo.list_assistant_bindings.return_value = [first, second]
+    repo.resolve_bound_references_for_binding_update.return_value = [second, first]
+    service = _service(space=space, repo=repo)
+
+    result = await service.replace_assistant_bindings(
+        space_id=space.id,
+        assistant_id=space.assistant.id,
+        intents=[
+            _binding_intent(
+                second,
+                activation_mode=SkillActivationMode.ON_DEMAND,
+            ),
+            _binding_intent(first),
+        ],
+    )
+
+    assert [binding.skill_id for binding in result.bindings] == [
+        second.skill_id,
+        first.skill_id,
+    ]
+    assert [binding.position for binding in result.bindings] == [0, 1]
+    assert [binding.activation_mode for binding in result.bindings] == [
+        SkillActivationMode.ON_DEMAND,
+        SkillActivationMode.ON_DEMAND,
+    ]
+    assert result.changed_to_on_demand_skill_ids == frozenset({second.skill_id})
 
 
 async def test_assistant_revision_upgrade_keeps_activation_mode():
@@ -1418,16 +1540,91 @@ async def test_assistant_revision_upgrade_keeps_activation_mode():
     result = await service.replace_assistant_bindings(
         space_id=space.id,
         assistant_id=space.assistant.id,
-        references=[_binding_reference(upgraded)],
+        intents=[_binding_intent(upgraded)],
     )
 
-    assert [binding.activation_mode for binding in result] == [
+    assert [binding.activation_mode for binding in result.bindings] == [
         SkillActivationMode.ON_DEMAND
     ]
+    assert result.changed_to_on_demand_skill_ids == frozenset()
     persisted = repo.replace_assistant_bindings.await_args.kwargs["bindings"]
     assert [binding.activation_mode for binding in persisted] == [
         SkillActivationMode.ON_DEMAND
     ]
+
+
+async def test_assistant_revision_upgrade_applies_explicit_mode_change():
+    space = _space()
+    existing = replace(_binding(), activation_mode=SkillActivationMode.ON_DEMAND)
+    upgraded = replace(
+        _binding(skill_id=existing.skill_id),
+        activation_mode=SkillActivationMode.ALWAYS,
+    )
+    repo = AsyncMock()
+    repo.list_assistant_bindings.return_value = [existing]
+    repo.resolve_local_references_for_binding_update.return_value = [upgraded]
+    service = _service(space=space, repo=repo)
+
+    result = await service.replace_assistant_bindings(
+        space_id=space.id,
+        assistant_id=space.assistant.id,
+        intents=[
+            _binding_intent(
+                upgraded,
+                activation_mode=SkillActivationMode.ALWAYS,
+            )
+        ],
+    )
+
+    assert result.bindings[0].skill_revision_id == upgraded.skill_revision_id
+    assert result.bindings[0].activation_mode is SkillActivationMode.ALWAYS
+    assert result.changed_to_on_demand_skill_ids == frozenset()
+
+
+async def test_echoing_existing_on_demand_mode_is_not_reported_as_a_change():
+    space = _space()
+    existing = replace(_binding(), activation_mode=SkillActivationMode.ON_DEMAND)
+    repo = AsyncMock()
+    repo.list_assistant_bindings.return_value = [existing]
+    repo.resolve_bound_references_for_binding_update.return_value = [existing]
+    service = _service(space=space, repo=repo)
+
+    result = await service.replace_assistant_bindings(
+        space_id=space.id,
+        assistant_id=space.assistant.id,
+        intents=[
+            _binding_intent(
+                existing,
+                activation_mode=SkillActivationMode.ON_DEMAND,
+            )
+        ],
+    )
+
+    assert result.bindings[0].activation_mode is SkillActivationMode.ON_DEMAND
+    assert result.changed_to_on_demand_skill_ids == frozenset()
+
+
+async def test_new_on_demand_binding_is_reported_as_a_change():
+    space = _space()
+    added = _binding()
+    repo = AsyncMock()
+    repo.list_assistant_bindings.return_value = []
+    repo.resolve_local_references_for_binding_update.return_value = [added]
+    service = _service(space=space, repo=repo)
+
+    result = await service.replace_assistant_bindings(
+        space_id=space.id,
+        assistant_id=space.assistant.id,
+        intents=[
+            _binding_intent(
+                added,
+                activation_mode=SkillActivationMode.ON_DEMAND,
+            )
+        ],
+    )
+
+    assert result.bindings[0].activation_mode is SkillActivationMode.ON_DEMAND
+    assert result.changed_to_on_demand_skill_ids == frozenset({added.skill_id})
 
 
 async def test_governance_revision_upgrade_keeps_activation_mode():

--- a/backend/tests/unittests/skills/test_skill_service.py
+++ b/backend/tests/unittests/skills/test_skill_service.py
@@ -625,10 +625,10 @@ async def test_same_space_skill_can_be_reused_by_multiple_parents():
     )
 
     assert first == AssistantSkillBindingReplacement(
-        bindings=(binding,), changed_to_on_demand_skill_ids=frozenset()
+        bindings=(binding,), on_demand_skill_ids_requiring_validation=frozenset()
     )
     assert second == AssistantSkillBindingReplacement(
-        bindings=(binding,), changed_to_on_demand_skill_ids=frozenset()
+        bindings=(binding,), on_demand_skill_ids_requiring_validation=frozenset()
     )
     assert repo.replace_assistant_bindings.await_count == 2
 
@@ -763,6 +763,76 @@ async def test_blocked_organization_skill_cannot_change_revision(owner: str):
                 organization_space_id=space.id,
                 references=[_binding_reference(changed)],
             )
+
+
+@pytest.mark.parametrize(
+    ("existing_mode", "requested_mode"),
+    [
+        (SkillActivationMode.ALWAYS, SkillActivationMode.ON_DEMAND),
+        (SkillActivationMode.ON_DEMAND, SkillActivationMode.ALWAYS),
+    ],
+)
+async def test_blocked_retained_assistant_binding_cannot_change_activation_mode(
+    existing_mode: SkillActivationMode,
+    requested_mode: SkillActivationMode,
+):
+    space = _space()
+    blocked = replace(
+        _binding(),
+        source=SkillBindingSource.ORGANIZATION,
+        activation_mode=existing_mode,
+    )
+    repo = AsyncMock()
+    repo.list_assistant_bindings.return_value = [blocked]
+    repo.resolve_bound_references_for_binding_update.return_value = [blocked]
+    repo.list_active_execution_blocks.return_value = {blocked.skill_id: MagicMock()}
+    service = _service(space=space, repo=repo)
+
+    with pytest.raises(
+        BadRequestException,
+        match="Blocked organisation Skills cannot receive new or changed bindings",
+    ):
+        await service.replace_assistant_bindings(
+            space_id=space.id,
+            assistant_id=space.assistant.id,
+            intents=[_binding_intent(blocked, activation_mode=requested_mode)],
+        )
+
+    repo.replace_assistant_bindings.assert_not_awaited()
+
+
+@pytest.mark.parametrize("existing_mode", list(SkillActivationMode))
+@pytest.mark.parametrize("explicit_mode", [False, True])
+async def test_blocked_retained_assistant_binding_accepts_unchanged_mode(
+    existing_mode: SkillActivationMode,
+    explicit_mode: bool,
+):
+    space = _space()
+    blocked = replace(
+        _binding(),
+        source=SkillBindingSource.ORGANIZATION,
+        activation_mode=existing_mode,
+    )
+    repo = AsyncMock()
+    repo.list_assistant_bindings.return_value = [blocked]
+    repo.resolve_bound_references_for_binding_update.return_value = [blocked]
+    repo.list_active_execution_blocks.return_value = {blocked.skill_id: MagicMock()}
+    service = _service(space=space, repo=repo)
+
+    replacement = await service.replace_assistant_bindings(
+        space_id=space.id,
+        assistant_id=space.assistant.id,
+        intents=[
+            _binding_intent(
+                blocked,
+                activation_mode=existing_mode if explicit_mode else None,
+            )
+        ],
+    )
+
+    assert replacement.bindings[0].activation_mode is existing_mode
+    persisted = repo.replace_assistant_bindings.await_args.kwargs["bindings"]
+    assert persisted[0].activation_mode is existing_mode
 
 
 @pytest.mark.parametrize("owner", ["assistant", "app", "governance"])
@@ -903,7 +973,7 @@ async def test_existing_unpublished_catalogue_binding_can_remain_on_resource():
     )
 
     assert result.bindings == (existing,)
-    assert result.changed_to_on_demand_skill_ids == frozenset()
+    assert result.on_demand_skill_ids_requiring_validation == frozenset()
     repo.resolve_bound_references_for_binding_update.assert_awaited_once_with(
         tenant_id=space.tenant_id,
         parent_space_id=space.id,
@@ -984,7 +1054,7 @@ async def test_existing_inactive_exact_revision_binding_can_be_reordered():
     )
 
     assert result.bindings == (inactive,)
-    assert result.changed_to_on_demand_skill_ids == frozenset()
+    assert result.on_demand_skill_ids_requiring_validation == frozenset()
     repo.replace_assistant_bindings.assert_awaited_once()
 
 
@@ -1408,7 +1478,7 @@ async def test_retained_assistant_binding_keeps_activation_mode_on_resave():
     )
 
     assert result.bindings[0].activation_mode is SkillActivationMode.ON_DEMAND
-    assert result.changed_to_on_demand_skill_ids == frozenset()
+    assert result.on_demand_skill_ids_requiring_validation == frozenset()
     persisted = repo.replace_assistant_bindings.await_args.kwargs["bindings"]
     assert [binding.activation_mode for binding in persisted] == [
         SkillActivationMode.ON_DEMAND
@@ -1458,7 +1528,7 @@ async def test_new_binding_defaults_to_always_activation_mode():
     assert [binding.activation_mode for binding in result.bindings] == [
         SkillActivationMode.ALWAYS
     ]
-    assert result.changed_to_on_demand_skill_ids == frozenset()
+    assert result.on_demand_skill_ids_requiring_validation == frozenset()
 
 
 async def test_explicit_assistant_mode_only_change_is_persisted_and_reported():
@@ -1480,7 +1550,9 @@ async def test_explicit_assistant_mode_only_change_is_persisted_and_reported():
         ],
     )
 
-    assert result.changed_to_on_demand_skill_ids == frozenset({existing.skill_id})
+    assert result.on_demand_skill_ids_requiring_validation == frozenset(
+        {existing.skill_id}
+    )
     assert result.bindings[0].activation_mode is SkillActivationMode.ON_DEMAND
     persisted = repo.replace_assistant_bindings.await_args.kwargs["bindings"]
     assert persisted[0].activation_mode is SkillActivationMode.ON_DEMAND
@@ -1522,7 +1594,9 @@ async def test_assistant_reorder_preserves_omitted_mode_and_applies_explicit_mod
         SkillActivationMode.ON_DEMAND,
         SkillActivationMode.ON_DEMAND,
     ]
-    assert result.changed_to_on_demand_skill_ids == frozenset({second.skill_id})
+    assert result.on_demand_skill_ids_requiring_validation == frozenset(
+        {second.skill_id}
+    )
 
 
 async def test_assistant_revision_upgrade_keeps_activation_mode():
@@ -1546,7 +1620,9 @@ async def test_assistant_revision_upgrade_keeps_activation_mode():
     assert [binding.activation_mode for binding in result.bindings] == [
         SkillActivationMode.ON_DEMAND
     ]
-    assert result.changed_to_on_demand_skill_ids == frozenset()
+    assert result.on_demand_skill_ids_requiring_validation == frozenset(
+        {existing.skill_id}
+    )
     persisted = repo.replace_assistant_bindings.await_args.kwargs["bindings"]
     assert [binding.activation_mode for binding in persisted] == [
         SkillActivationMode.ON_DEMAND
@@ -1578,7 +1654,7 @@ async def test_assistant_revision_upgrade_applies_explicit_mode_change():
 
     assert result.bindings[0].skill_revision_id == upgraded.skill_revision_id
     assert result.bindings[0].activation_mode is SkillActivationMode.ALWAYS
-    assert result.changed_to_on_demand_skill_ids == frozenset()
+    assert result.on_demand_skill_ids_requiring_validation == frozenset()
 
 
 async def test_echoing_existing_on_demand_mode_is_not_reported_as_a_change():
@@ -1601,7 +1677,7 @@ async def test_echoing_existing_on_demand_mode_is_not_reported_as_a_change():
     )
 
     assert result.bindings[0].activation_mode is SkillActivationMode.ON_DEMAND
-    assert result.changed_to_on_demand_skill_ids == frozenset()
+    assert result.on_demand_skill_ids_requiring_validation == frozenset()
 
 
 async def test_new_on_demand_binding_is_reported_as_a_change():
@@ -1624,7 +1700,9 @@ async def test_new_on_demand_binding_is_reported_as_a_change():
     )
 
     assert result.bindings[0].activation_mode is SkillActivationMode.ON_DEMAND
-    assert result.changed_to_on_demand_skill_ids == frozenset({added.skill_id})
+    assert result.on_demand_skill_ids_requiring_validation == frozenset(
+        {added.skill_id}
+    )
 
 
 async def test_governance_revision_upgrade_keeps_activation_mode():

--- a/docs/goals/enterprise-skills-rollout/state.yaml
+++ b/docs/goals/enterprise-skills-rollout/state.yaml
@@ -1001,7 +1001,7 @@ tasks:
       merge_commit: "2746098cc008f7e9b95eae775ae4501a11cdb5c3"
       merged_at: "2026-07-24T22:56:51Z"
       github_checks: "All required CI passed, including backend tests, frontend E2E, schema drift, route metadata, and coverage diff"
-      review: "Review 2 confirmed F1-F3 resolved and reported no current findings with complete changed-file coverage"
+      final_review: "Review 2 confirmed F1-F3 resolved and reported no current findings with complete changed-file coverage"
       review_url: "https://github.com/eneo-ai/eneo/pull/600#issuecomment-5075095090"
       verification:
         - "backend: 3898 unit tests passed"

--- a/docs/goals/enterprise-skills-rollout/state.yaml
+++ b/docs/goals/enterprise-skills-rollout/state.yaml
@@ -35,7 +35,7 @@ continuity:
   last_handoff_at: null
   last_verified_revision: "5d54e242a0edd878ef0768c00ea35b63c827e50a"
 
-active_task: T015
+active_task: T016
 
 tasks:
   - id: T001
@@ -956,10 +956,10 @@ tasks:
   - id: T015
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Task #553 slice 4: the trusted internal on-demand activation effect through the existing completion loop."
-    tracking_issue: "https://github.com/eneo-ai/eneo/issues/553"
+    tracking_issue: "https://github.com/eneo-ai/eneo/issues/599"
     inputs:
       - "Completed T014 receipt"
       - "docs/enterprise-skills-roadmap.md slice 4 contract"
@@ -992,24 +992,69 @@ tasks:
     stop_if:
       - "The implementation requires PR #538's loopback transport, knowledge stack, or a generic plugin framework."
       - "The provider adapter must import the Skills module or a mutable binding lookup occurs after plan construction."
-    receipt: null
+    receipt:
+      result: done
+      summary: "Added the trusted internal on-demand activation effect to the existing streaming and non-streaming completion loops, kept exact Skill content server-side, closed failure and forged-call evidence gaps from Review 1, and squash-merged PR #600."
+      tracking_issue: "https://github.com/eneo-ai/eneo/issues/599"
+      merged_pr: 600
+      source_head: "bba9bbfd1cedca4030601f7a0418b18f2f05b796"
+      merge_commit: "2746098cc008f7e9b95eae775ae4501a11cdb5c3"
+      merged_at: "2026-07-24T22:56:51Z"
+      github_checks: "All required CI passed, including backend tests, frontend E2E, schema drift, route metadata, and coverage diff"
+      review: "Review 2 confirmed F1-F3 resolved and reported no current findings with complete changed-file coverage"
+      review_url: "https://github.com/eneo-ai/eneo/pull/600#issuecomment-5075095090"
+      verification:
+        - "backend: 3898 unit tests passed"
+        - "backend: focused T015 bundle passed 147 tests"
+        - "backend: stream-abort integration passed 6 tests"
+        - "backend: runtime robustness passed 19 cases"
+        - "backend: Ruff, format, Pyright, uv lock, and schema drift passed"
+        - "Claude and Codex final gates passed; GitHub CI completed successfully"
+      changed_files:
+        - "backend/src/eneo/ai_models/completion_models/completion_model.py"
+        - "backend/src/eneo/assistants/"
+        - "backend/src/eneo/completion_models/"
+        - "backend/src/eneo/help_assistants/"
+        - "backend/src/eneo/questions/"
+        - "backend/src/eneo/sessions/"
+        - "backend/src/eneo/skills/"
+        - "backend/src/eneo/tokens/"
+        - "backend/tests/"
+        - "docs/enterprise-skills-roadmap.md"
+        - "docs/goals/enterprise-skills-rollout/"
+      commands:
+        - cmd: "uv run pytest tests/unit tests/unittests -q"
+          result: "pass: 3898 tests"
+        - cmd: "focused T015 unit bundle"
+          result: "pass: 147 tests"
+        - cmd: "uv run pytest tests/integration/services/test_conversation_stream_abort.py -q"
+          result: "pass: 6 tests"
+        - cmd: "runtime robustness suite"
+          result: "pass: 19 cases"
+        - cmd: "Ruff format/check, source Pyright, uv lock --check, git diff --check, and pre-push schema drift"
+          result: pass
+        - cmd: "required GitHub CI and final /review"
+          result: pass
+      review:
+        claude: ".codex/artifacts/claude-peer-loop-t015-selective-skill-activation-pre-commit-gate-20260724T212107Z.md; green, score 8"
+        codex: ".codex/artifacts/codex-peer-loop-t015-trusted-on-demand-skill-activation-final-gate-20260724T202555Z.md; green, score 8"
+        github: "Review 1 findings F1-F3 were fixed; Review 2 found no current findings with complete changed-file coverage"
 
   - id: T016
     type: worker
     assignee: Worker
-    status: queued
+    status: active
     reasoning_hint: high
-    objective: "Implement Task #553 slice 5: public binding-mode save contracts, admin runtime-policy UI, honest activation controls, and one shared fit/activatability owner."
+    objective: "Implement Task #553 slice 5A: Assistant binding-mode save contracts, admin runtime-policy UI, honest activation controls, and the shared fit/activatability owner."
     tracking_issue: "https://github.com/eneo-ai/eneo/issues/553"
     inputs:
       - "Completed T015 receipt"
       - "docs/enterprise-skills-roadmap.md slice 5 contract"
       - "Current typed Skill runtime policy and generated per-model projections"
-      - "Current Assistant and Governance Policy parent-save owners and shared SkillBindingsEditor"
+      - "Current Assistant parent-save owner and shared SkillBindingsEditor"
     allowed_files:
       - "backend/src/eneo/assistants/"
       - "backend/src/eneo/completion_models/"
-      - "backend/src/eneo/governance_policy/"
       - "backend/src/eneo/settings/"
       - "backend/src/eneo/skills/"
       - "backend/tests/"
@@ -1029,14 +1074,57 @@ tasks:
       - "Reuse stored admin policy; platform model-window and safety ceilings remain fixed invariants while tenant values remain admin-configurable."
       - "Use existing admin and binding-editor surfaces with installed shadcn-svelte components; no new dashboard or form store."
     verify:
-      - "Assistant and Governance mode saves, omitted/explicit distinction, model changes, policy precedence, and rollback"
-      - "Small and large context windows, LiteLLM estimate, provider-selected Governance models, and unsupported model fallback"
+      - "Assistant mode saves, omitted/explicit distinction, model changes, policy precedence, and rollback"
+      - "Small and large context windows, canonical LiteLLM measurement, and unsupported model fallback"
       - "Admin bounds/reset/audit and natural Swedish/English UI copy"
       - "Keyboard, invalid-focus, loading/stale/estimated/error/narrow-screen states"
       - "Generated contracts, backend/frontend suites, docs build, CI, and fresh /review"
     stop_if:
       - "Fit or activatability would be calculated in more than one owner."
       - "The UI needs a second design system or Apps would gain on-demand behavior."
+    receipt: null
+
+  - id: T019
+    type: worker
+    assignee: Worker
+    status: queued
+    reasoning_hint: high
+    objective: "Complete Task #553 slice 5 for Personal Chat with Governance Policy mode saves and model-set fit validation through T016A's shared owner."
+    tracking_issue: "https://github.com/eneo-ai/eneo/issues/553"
+    inputs:
+      - "Completed T016 receipt"
+      - "docs/enterprise-skills-roadmap.md slice 5 contract"
+      - "Current Governance Policy parent-save owner and shared SkillBindingsEditor"
+      - "T016A shared fit/activatability owner"
+    allowed_files:
+      - "backend/src/eneo/assistants/"
+      - "backend/src/eneo/completion_models/"
+      - "backend/src/eneo/governance_policy/"
+      - "backend/src/eneo/settings/"
+      - "backend/src/eneo/skills/"
+      - "backend/tests/"
+      - "frontend/apps/web/messages/"
+      - "frontend/apps/web/src/lib/features/skills/"
+      - "frontend/apps/web/src/routes/(app)/admin/personal-assistant/"
+      - "frontend/apps/docs-site/src/content/guides/skills.mdx"
+      - "frontend/packages/eneo-js/"
+      - "docs/adr/marketplace-hub-package-portability-and-skills.md"
+      - "docs/enterprise-skills-roadmap.md"
+      - "docs/goals/enterprise-skills-rollout/"
+    constraints:
+      - "Reuse T016's fit/activatability owner and canonical token counter; do not add a second calculator or tokenizer."
+      - "Evaluate the explicitly applicable Governance model set without scanning every tenant-available model by default."
+      - "Distinguish an omitted mode from an explicit mode change and preserve retained modes."
+      - "Apps expose no mode and remain eager."
+      - "Use the existing Personal Chat policy draft and shared editor; add no new form store."
+    verify:
+      - "Governance mode saves, omitted/explicit distinction, model-set changes, policy precedence, and rollback"
+      - "Provider-selected or unbounded model policies fail closed until their applicable set is explicit"
+      - "Natural Swedish/English UI copy, keyboard, invalid-focus, loading, error, and narrow-screen states"
+      - "Generated contracts, backend/frontend suites, docs build, CI, and fresh /review"
+    stop_if:
+      - "The implementation requires a second fit calculation, a tenant-wide model scan, or speculative caching/job infrastructure."
+      - "Apps would gain on-demand behavior."
     receipt: null
 
   - id: T008
@@ -1046,7 +1134,7 @@ tasks:
     reasoning_hint: medium
     objective: "Consolidate Skill lifecycle and revision conflicts into the existing typed API conflict contract after Task #553 owners are stable."
     inputs:
-      - "Completed T016 receipt"
+      - "Completed T016 and T019 receipts"
       - "Current publish, revision, restore, delete, and binding-mode conflict outcomes"
     constraints:
       - "Do not broaden this into a generic error framework."
@@ -1067,7 +1155,7 @@ tasks:
     reasoning_hint: high
     objective: "Add tenant-admin controlled rollout of one published organisation Skill revision to existing Assistant and Personal Chat pins."
     inputs:
-      - "Completed T008 and T016 receipts"
+      - "Completed T008, T016, and T019 receipts"
       - "docs/enterprise-skills-roadmap.md controlled rollout contract"
       - "docs/adr/marketplace-hub-package-portability-and-skills.md R1 contract"
       - "docs/goals/enterprise-skills-rollout/notes/T014-mcp-rollout-blocking-plan.md"

--- a/docs/goals/enterprise-skills-rollout/state.yaml
+++ b/docs/goals/enterprise-skills-rollout/state.yaml
@@ -1046,12 +1046,13 @@ tasks:
     status: active
     reasoning_hint: high
     objective: "Implement Task #553 slice 5A: Assistant binding-mode save contracts, admin runtime-policy UI, honest activation controls, and the shared fit/activatability owner."
-    tracking_issue: "https://github.com/eneo-ai/eneo/issues/553"
+    tracking_issue: "https://github.com/eneo-ai/eneo/issues/602"
     inputs:
       - "Completed T015 receipt"
       - "docs/enterprise-skills-roadmap.md slice 5 contract"
       - "Current typed Skill runtime policy and generated per-model projections"
       - "Current Assistant parent-save owner and shared SkillBindingsEditor"
+      - ".codex/artifacts/claude-peer-loop-t016-assistant-selective-activation-implementation-ready-gate-20260726T105040Z.md"
     allowed_files:
       - "backend/src/eneo/assistants/"
       - "backend/src/eneo/completion_models/"
@@ -1070,7 +1071,7 @@ tasks:
       - "Expose mode writes only after T015 runtime semantics are merged."
       - "Distinguish an omitted mode from an explicit mode change; preserve retained modes."
       - "Apps expose no mode and remain eager."
-      - "One concrete typed fit/activatability function must own ordinary save, API/UI projection, future rollout preview/apply, and tests."
+      - "SkillTurnPlan.to_activation_runtime() remains the single selective-fit owner for save, read projection, ask, and tests; do not add a second evaluator."
       - "Reuse stored admin policy; platform model-window and safety ceilings remain fixed invariants while tenant values remain admin-configurable."
       - "Use existing admin and binding-editor surfaces with installed shadcn-svelte components; no new dashboard or form store."
     verify:

--- a/frontend/apps/docs-site/src/content/guides/skills.mdx
+++ b/frontend/apps/docs-site/src/content/guides/skills.mdx
@@ -94,8 +94,10 @@ Before attaching that Skill:
 An Assistant cannot currently use knowledge and MCP at the same time. Eneo
 includes every stored, enabled and approved MCP tool schema available to the
 Assistant—not a user-specific subset—when it validates whether a saved on-demand
-Skill can fit. Live discovery, user permissions, approvals, and tool availability
-can still change later, so runtime remains the source of truth and fails closed.
+Skill can fit. The check reserves the same question headroom used for attachments
+instead of letting saved Skill context fill the model window. Live discovery,
+user permissions, approvals, and tool availability can still change later, so
+runtime remains the source of truth and fails closed.
 
 ## Create and attach a Skill
 

--- a/frontend/apps/docs-site/src/content/guides/skills.mdx
+++ b/frontend/apps/docs-site/src/content/guides/skills.mdx
@@ -91,10 +91,11 @@ Before attaching that Skill:
 4. Test an allowed request, a denied request, an approval-required call, an
    unavailable server, and a request outside the Skill's scope.
 
-An Assistant cannot currently use knowledge and MCP at the same time. Tool
-availability can also change after a Skill is saved. Eneo therefore does not
-treat Skill text as a dependency declaration or perform a save-time MCP health
-check: the existing MCP runtime remains the source of truth and fails closed.
+An Assistant cannot currently use knowledge and MCP at the same time. Eneo
+includes the stored, enabled MCP tool schemas when it validates whether a saved
+on-demand Skill can fit. Live discovery, user permissions, approvals, and tool
+availability can still change later, so runtime remains the source of truth and
+fails closed.
 
 ## Create and attach a Skill
 
@@ -292,10 +293,10 @@ and audit guarantees.
 
 The tenant settings API owns the seeded total Skill-context share; its admin
 form arrives in the next UI slice. The selected model window and fixed platform
-safety bounds still apply. Eneo rejects an Assistant configuration when a
-changed on-demand binding cannot fit its configured share, instead of saving a
-Skill that can never load. Models without tool calling keep only **always**
-Skills and report that limitation in runtime evidence.
+safety bounds still apply. Eneo rejects an Assistant configuration when any
+affected on-demand Skill cannot fit after a binding, prompt, model, attachment,
+or MCP-tool change. Models without tool calling keep only **always** Skills and
+report that limitation in runtime evidence.
 
 Editable Space copies with explicit source updates come later. External
 Marketplace distribution remains a separate final phase.

--- a/frontend/apps/docs-site/src/content/guides/skills.mdx
+++ b/frontend/apps/docs-site/src/content/guides/skills.mdx
@@ -92,10 +92,10 @@ Before attaching that Skill:
    unavailable server, and a request outside the Skill's scope.
 
 An Assistant cannot currently use knowledge and MCP at the same time. Eneo
-includes the stored, enabled MCP tool schemas when it validates whether a saved
-on-demand Skill can fit. Live discovery, user permissions, approvals, and tool
-availability can still change later, so runtime remains the source of truth and
-fails closed.
+includes every stored, enabled and approved MCP tool schema available to the
+Assistant—not a user-specific subset—when it validates whether a saved on-demand
+Skill can fit. Live discovery, user permissions, approvals, and tool availability
+can still change later, so runtime remains the source of truth and fails closed.
 
 ## Create and attach a Skill
 

--- a/frontend/apps/docs-site/src/content/guides/skills.mdx
+++ b/frontend/apps/docs-site/src/content/guides/skills.mdx
@@ -99,6 +99,11 @@ instead of letting saved Skill context fill the model window. Live discovery,
 user permissions, approvals, and tool availability can still change later, so
 runtime remains the source of truth and fails closed.
 
+Eneo repeats that validation when a save changes Skill bindings, the selected
+model, prompt, attachments, or the stored MCP catalogue. If an existing
+on-demand Skill would no longer be activatable, the complete save is rejected
+and the previous configuration is kept.
+
 ## Create and attach a Skill
 
 1. Open **Skills** in the relevant Space. Tenant admins use

--- a/frontend/apps/docs-site/src/content/guides/skills.mdx
+++ b/frontend/apps/docs-site/src/content/guides/skills.mdx
@@ -42,7 +42,8 @@ flowchart LR
     Published --> Policy["Personal Chat policy"]
     Builder --> Resource["Assistant or App"]
     Policy --> Chat["Personal Chat"]
-    Resource --> Request["Instructions enter each request"]
+    Resource --> Mode["Always or on demand"]
+    Mode --> Request["Resolved instructions enter the request"]
     Chat --> Request
 ```
 
@@ -143,8 +144,16 @@ These are structural configuration facts:
 | Used       | The model relied on those instructions in its reasoning or output |
 
 The adoption view proves **configured**, not model use or outcome attribution.
-In the current release, all attached Skills enter each request in their listed
-order. Selective per-question activation is not implemented.
+The Assistant API accepts **always** or **on demand** for each binding:
+
+- **Always** includes the exact pinned instructions in every request.
+- **On demand** advertises a compact descriptor and loads the exact pinned
+  instructions only when a tool-capable model requests them.
+
+The web builder control arrives in the next UI slice. Apps and Personal Chat
+remain eager: their attached Skills enter every request in the configured order.
+Runtime evidence, rather than the adoption view, shows which Assistant Skills
+were eligible, requested, blocked, or included.
 
 ## Scopes and permissions
 
@@ -153,7 +162,7 @@ order. Selective per-question activation is not implemented.
 | Surface       | Selection owner                                              | Runtime effect                                      |
 | ------------- | ------------------------------------------------------------ | --------------------------------------------------- |
 | Personal Chat | Tenant admin in Personal Chat settings                       | Ordered versions apply to every user's new requests |
-| Assistant     | Builder with **Use Skills** and edit access to the Assistant | Exact versions apply when that Assistant runs       |
+| Assistant     | Builder with **Use Skills** and edit access to the Assistant | Exact versions run always or load on demand         |
 | App           | Builder with **Use Skills** and edit access to the App       | Exact versions apply when that App runs             |
 
 A Space controls where local Skills can be authored and attached. It does not
@@ -267,25 +276,26 @@ Review the adoption view and update or remove unsafe versions before unblocking.
 - Skills contain instructions and metadata. They do not execute scripts or
   import bundled files.
 - Skills do not grant models, tools, knowledge, or permissions.
-- Every attached Skill currently enters every request in its listed order.
+- Assistant bindings can be **always** or **on demand**. Apps and Personal Chat
+  remain eager.
 - Organisation approval and exact pins do not update existing resources
   automatically.
 - This release has no external Skill marketplace or package installation flow.
 
 ## Planned next steps
 
-The next runtime change will let Assistant builders and tenant admins choose
-between **always** and **on demand** for each approved binding. On-demand Skills
-will advertise a compact description and load the exact pinned instructions only
-when a tool-capable model requests them. Apps will remain eager.
+The next runtime work will make the existing activation evidence easier to
+inspect in the opt-in chat debug panel, including whether each Skill was always
+included or requested on demand and why a candidate was not loaded. Apps will
+remain eager until their execution contracts can preserve the same frozen-plan
+and audit guarantees.
 
-Eneo will show the selected model, measured Skill budget, and whether every
-attached Skill is discoverable. Tenant admins will be able to change the seeded
-10% total Skill-context share in **Admin > Overview** without a code change or
-deployment; the model window and platform safety bounds still apply. Eneo will
-reject a new configuration in which an advertised Skill could never be loaded,
-instead of hiding a subset. Models without tool calling will keep only
-**always** Skills and show that limitation.
+The tenant settings API owns the seeded total Skill-context share; its admin
+form arrives in the next UI slice. The selected model window and fixed platform
+safety bounds still apply. Eneo rejects an Assistant configuration when a
+changed on-demand binding cannot fit its configured share, instead of saving a
+Skill that can never load. Models without tool calling keep only **always**
+Skills and report that limitation in runtime evidence.
 
 Editable Space copies with explicit source updates come later. External
 Marketplace distribution remains a separate final phase.

--- a/frontend/packages/eneo-js/src/types/schema.d.ts
+++ b/frontend/packages/eneo-js/src/types/schema.d.ts
@@ -9251,7 +9251,8 @@ export interface components {
        * Format: uuid
        */
       skill_revision_id: string;
-      activation_mode?: components["schemas"]["SkillActivationMode"] | null;
+      /** Activation Mode */
+      activation_mode?: components["schemas"]["SkillActivationMode"];
     };
     /** AssistantSkillBindingSummary */
     AssistantSkillBindingSummary: {

--- a/frontend/packages/eneo-js/src/types/schema.d.ts
+++ b/frontend/packages/eneo-js/src/types/schema.d.ts
@@ -6002,6 +6002,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/v1/spaces/{space_id}/assistants/{assistant_id}/skills/configuration/": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get Assistant Skill Configuration */
+    get: operations["get_assistant_skill_configuration_api_v1_spaces__space_id__assistants__assistant_id__skills_configuration__get"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/v1/spaces/{space_id}/apps/{app_id}/skills/": {
     parameters: {
       query?: never;
@@ -9221,6 +9238,76 @@ export interface components {
        * @default false
        */
       is_help_assistant?: boolean;
+    };
+    /** AssistantSkillBindingInput */
+    AssistantSkillBindingInput: {
+      /**
+       * Skill Id
+       * Format: uuid
+       */
+      skill_id: string;
+      /**
+       * Skill Revision Id
+       * Format: uuid
+       */
+      skill_revision_id: string;
+      activation_mode?: components["schemas"]["SkillActivationMode"] | null;
+    };
+    /** AssistantSkillBindingSummary */
+    AssistantSkillBindingSummary: {
+      /**
+       * Skill Id
+       * Format: uuid
+       */
+      skill_id: string;
+      /**
+       * Skill Revision Id
+       * Format: uuid
+       */
+      skill_revision_id: string;
+      /** Attachable Revision Id */
+      attachable_revision_id: string | null;
+      /** Slug */
+      slug: string;
+      /** Revision Number */
+      revision_number: number;
+      /** Attachable Revision Number */
+      attachable_revision_number: number | null;
+      /** Display Name */
+      display_name: string;
+      /** Description */
+      description: string;
+      /** Content Digest */
+      content_digest: string;
+      /** Position */
+      position: number;
+      /** Is Active */
+      is_active: boolean;
+      source: components["schemas"]["SkillBindingSource"];
+      /** Execution Blocked */
+      execution_blocked: boolean;
+      activation_mode: components["schemas"]["SkillActivationMode"];
+    };
+    /** AssistantSkillConfigurationPublic */
+    AssistantSkillConfigurationPublic: {
+      /** Bindings */
+      bindings: components["schemas"]["AssistantSkillBindingSummary"][];
+      runtime: components["schemas"]["AssistantSkillRuntimeSummary"] | null;
+    };
+    /** AssistantSkillRuntimeSummary */
+    AssistantSkillRuntimeSummary: {
+      /**
+       * Effective Model Id
+       * Format: uuid
+       */
+      effective_model_id: string;
+      effective_mode: components["schemas"]["SkillTurnEffectiveMode"];
+      fallback_reason: components["schemas"]["SkillActivationFallbackReason"] | null;
+      /** Skill Context Tokens */
+      skill_context_tokens: number;
+      /** Skill Context Token Limit */
+      skill_context_token_limit: number;
+      token_count_source: components["schemas"]["TokenCountSource"];
     };
     /** AssistantSparse */
     AssistantSparse: {
@@ -14613,7 +14700,7 @@ export interface components {
        */
       icon_id?: string | null;
       /** Skill Bindings */
-      skill_bindings?: components["schemas"]["SkillBindingReferenceInput"][] | null;
+      skill_bindings?: components["schemas"]["AssistantSkillBindingInput"][] | null;
     };
     /** PartialCompletionModelUpdate */
     PartialCompletionModelUpdate: {
@@ -16176,6 +16263,22 @@ export interface components {
       /** Expires At */
       expires_at: number;
     };
+    /**
+     * SkillActivationFallbackReason
+     * @enum {string}
+     */
+    SkillActivationFallbackReason:
+      | "model_lacks_tool_calling"
+      | "catalog_budget_exceeded"
+      | "token_measurement_unavailable"
+      | "selective_activation_disabled";
+    /**
+     * SkillActivationMode
+     * @description Closed Assistant/Governance Policy binding mode; Apps compose eagerly
+     *     and carry the fixed ALWAYS value without a persisted column.
+     * @enum {string}
+     */
+    SkillActivationMode: "always" | "on_demand";
     /** SkillActiveUpdateRequest */
     SkillActiveUpdateRequest: {
       /** Is Active */
@@ -16573,6 +16676,19 @@ export interface components {
       /** Models */
       models: components["schemas"]["SkillRuntimeModelProjection"][];
     };
+    /** SkillRuntimePolicyEditableBounds */
+    SkillRuntimePolicyEditableBounds: {
+      max_attached_skills: components["schemas"]["SkillRuntimePolicyFieldBounds"];
+      context_share_percent: components["schemas"]["SkillRuntimePolicyFieldBounds"];
+      max_activations_per_turn: components["schemas"]["SkillRuntimePolicyFieldBounds"];
+    };
+    /** SkillRuntimePolicyFieldBounds */
+    SkillRuntimePolicyFieldBounds: {
+      /** Minimum */
+      minimum: number;
+      /** Maximum */
+      maximum: number;
+    };
     /** SkillRuntimePolicyPublic */
     SkillRuntimePolicyPublic: {
       /** Selective Activation Enabled */
@@ -16583,6 +16699,7 @@ export interface components {
       context_share_percent: number;
       /** Max Activations Per Turn */
       max_activations_per_turn: number;
+      editable_bounds: components["schemas"]["SkillRuntimePolicyEditableBounds"];
     };
     /**
      * SkillRuntimePolicyUpdate
@@ -16643,6 +16760,11 @@ export interface components {
        */
       updated_at: string;
     };
+    /**
+     * SkillTurnEffectiveMode
+     * @enum {string}
+     */
+    SkillTurnEffectiveMode: "eager" | "always_only" | "selective";
     /** SkillsPolicyInput */
     SkillsPolicyInput: {
       /** Bindings */
@@ -17873,6 +17995,11 @@ export interface components {
       /** Enabled */
       enabled: boolean;
     };
+    /**
+     * TokenCountSource
+     * @enum {string}
+     */
+    TokenCountSource: "litellm" | "fallback_estimate";
     /** TokenUsageSummary */
     TokenUsageSummary: {
       /**
@@ -39945,6 +40072,56 @@ export interface operations {
         };
         content: {
           "application/json": components["schemas"]["SkillBindingSummary"][];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  get_assistant_skill_configuration_api_v1_spaces__space_id__assistants__assistant_id__skills_configuration__get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        space_id: string;
+        assistant_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AssistantSkillConfigurationPublic"];
         };
       };
       /** @description Forbidden */


### PR DESCRIPTION
## Summary

- Let Assistant writes explicitly choose `always` or `on_demand` while preserving the stored mode when the field is omitted.
- Validate new on-demand transitions with the exact `SkillTurnPlan` runtime prompt and selected LiteLLM model route.
- Expose a body-free Assistant Skill configuration projection and backend-owned editable policy bounds.
- Keep Apps and Personal Chat eager-only and reject mode fields on those contracts.

## Why

The trusted runtime already supports selective Skill activation, but Assistant saves could neither express the mode nor validate the prompt that would actually run. `SkillTurnPlan.to_activation_runtime()` remains the single source of truth for token fit, fallback, and activation availability.

Fixes #602

## What changed

- Added typed Assistant-only binding intent, replacement result, runtime projection, and API models.
- Deepened `SkillService` as the existing binding resolution and omitted-mode retention owner.
- Reused the shared runtime plan for Assistant save and preflight validation before parent persistence.
- Added the sibling Assistant Skill configuration endpoint without changing the existing bare binding list.
- Returned tenant-editable policy bounds from the same domain constants used by validation.
- Regenerated the OpenAPI TypeScript contract.

## What was deliberately not changed

- No App or Personal Chat on-demand activation.
- No admin or Assistant frontend controls; those are a separate follow-up task.
- No Marketplace, import/export, editable Space copies, Group Chat changes, jobs, cache, feature flag, or second token evaluator.

## Deletion / consolidation

- Removed the parallel eager Assistant prompt composer.
- Consolidated Skill context allowance calculation so settings and runtime use the same owner.
- Preserved the existing binding route for compatibility while adding one typed configuration route for the new UI.

## Risk and rollback

- Runtime/API risk is bounded to Assistant Skill save validation and the new sibling read endpoint; Apps and Personal Chat retain their existing schemas and behavior.
- Reverting the three implementation commits restores the previous eager-only Assistant write contract. There is no migration or persisted-data rewrite.
- A rejected validation is proven to roll back both staged bindings and parent changes in PostgreSQL.

## Validation

- `uv run pytest -v -n 2 -m "not integration" --cov=src/eneo --cov-report=term:skip-covered tests/` — 3952 passed.
- `uv run pytest -q tests/integration/skills/test_assistant_skill_save_contract.py tests/integration/skills/test_skill_adoption_projection.py tests/integration/skills/test_skill_catalogue_repo.py tests/integration/skills/test_skill_concurrency.py tests/integration/skills/test_skill_execution_blocks.py` — 42 passed.
- `uv run pyright` — passed with 0 errors.
- `uv run ruff check src/eneo --output-format concise` — passed.
- `uv run ruff format --check src/eneo` — passed for 833 files.
- `uv lock --check` — passed.
- `python3 scripts/check_route_metadata.py --repo-root . --all` — passed.
- OpenAPI regeneration and byte-for-byte schema drift check — passed.
- `bun run lint` and `bun run test` in `frontend/packages/eneo-js` — passed; 13 tests passed.
- Goal state validation — passed with no errors or warnings.

## Screenshots

Not applicable; this PR has no user-interface changes.
