### PR TITLE
fix(knowledge): preserve active knowledge after ingestion failure

### DIFF
--- a/backend/src/eneo/files/text.py
+++ b/backend/src/eneo/files/text.py
@@ -28,6 +28,15 @@ class ExtractionError(Exception):
         super().__init__(self.message)
 
 
+class NoExtractableTextError(ExtractionError):
+    """Raised when extraction or transcription produces no usable text."""
+
+    def __init__(self, filename: str):
+        super().__init__(
+            f"File '{filename}' contains no extractable text", "NO_EXTRACTABLE_TEXT"
+        )
+
+
 class EncryptedFileError(ExtractionError):
     """Raised for password-protected files."""
 

--- a/backend/src/eneo/worker/upload_tasks.py
+++ b/backend/src/eneo/worker/upload_tasks.py
@@ -1,8 +1,12 @@
 import contextlib
 import os
 from pathlib import Path
+from typing import cast
 from uuid import UUID
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from eneo.files.text import NoExtractableTextError
 from eneo.jobs.task_models import Transcription, UploadInfoBlob
 from eneo.main.container.container import Container
 from eneo.main.exceptions import BadRequestException
@@ -46,12 +50,18 @@ async def transcription_task(
         text = await transcriber.transcribe_from_filepath(
             filepath=filepath, transcription_model=transcription_model
         )
-        info_blob = await uploader.process_text(
-            text=text,
-            embedding_model=embedding_model,
-            title=params.filename,
-            group_id=params.group_id,
-        )
+        if not text.strip():
+            raise NoExtractableTextError(params.filename)
+
+        # Keep knowledge publication atomic while job status uses the ambient transaction.
+        session = cast(AsyncSession, container.session())
+        async with session.begin_nested():
+            info_blob = await uploader.process_text(
+                text=text,
+                embedding_model=embedding_model,
+                title=params.filename,
+                group_id=params.group_id,
+            )
         assert info_blob is not None
 
         task_manager.result_location = f"/api/v1/info-blobs/{info_blob.id}/"
@@ -77,13 +87,20 @@ async def upload_info_blob_task(
         group = await group_service.get_group(params.group_id)
         embedding_model = group.embedding_model
 
-        info_blob = await uploader.process_file(
-            filepath=filepath,
-            filename=params.filename,
-            mimetype=params.mimetype,
-            group_id=params.group_id,
-            embedding_model=embedding_model,
+        text = container.text_extractor().extract(
+            filepath, params.mimetype, params.filename
         )
+        if not text.strip():
+            raise NoExtractableTextError(params.filename)
+
+        session = cast(AsyncSession, container.session())
+        async with session.begin_nested():
+            info_blob = await uploader.process_text(
+                text=text,
+                embedding_model=embedding_model,
+                title=params.filename,
+                group_id=params.group_id,
+            )
         assert info_blob is not None
 
         task_manager.result_location = f"/api/v1/info-blobs/{info_blob.id}/"

--- a/backend/tests/integration/test_ingestion_failure_safety.py
+++ b/backend/tests/integration/test_ingestion_failure_safety.py
@@ -1,0 +1,329 @@
+import struct
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from dependency_injector import providers
+
+from eneo.database.database import sessionmanager
+from eneo.database.tables.ai_models_table import EmbeddingModels
+from eneo.database.tables.collections_table import CollectionsTable
+from eneo.database.tables.info_blob_chunk_table import InfoBlobChunks
+from eneo.database.tables.info_blobs_table import InfoBlobs
+from eneo.database.tables.job_table import Jobs
+from eneo.database.tables.spaces_table import Spaces, SpacesTranscriptionModels
+from eneo.embedding_models.infrastructure.datastore import Datastore
+from eneo.files.chunk_embedding_list import ChunkEmbeddingList
+from eneo.jobs.job_models import Task
+from eneo.jobs.task_models import Transcription, UploadInfoBlob
+from eneo.main.models import Status
+from eneo.worker.upload_tasks import transcription_task, upload_info_blob_task
+
+TITLE = "stable-knowledge.txt"
+OLD_TEXT = "Previously published knowledge that must remain searchable."
+OLD_CHUNKS = (
+    (0, "Previously published knowledge", [0.1, 0.2, 0.3]),
+    (1, "that must remain searchable.", [0.4, 0.5, 0.6]),
+)
+
+
+def _pgvector_values(values: list[float]) -> list[float]:
+    return [struct.unpack("f", struct.pack("f", value))[0] for value in values]
+
+
+class StubExtractor:
+    def __init__(self, result: str | Exception):
+        self.result = result
+
+    def extract(
+        self, filepath: Path, mimetype: str, filename: str | None = None
+    ) -> str:
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+async def _seed_attempt(container, *, with_existing: bool = True):
+    session = container.session()
+    user = container.user()
+    embedding_model = (await session.scalars(sa.select(EmbeddingModels).limit(1))).one()
+    space = Spaces(
+        name="Ingestion safety space",
+        tenant_id=user.tenant_id,
+        user_id=user.id,
+    )
+    session.add(space)
+    await session.flush()
+    group = CollectionsTable(
+        name="Ingestion safety group",
+        size=0,
+        user_id=user.id,
+        tenant_id=user.tenant_id,
+        embedding_model_id=embedding_model.id,
+        space_id=space.id,
+    )
+    job = Jobs(
+        id=uuid4(),
+        user_id=user.id,
+        task=Task.UPLOAD_FILE.value,
+        status=Status.QUEUED.value,
+    )
+    session.add_all((group, job))
+    await session.flush()
+
+    prior = None
+    if with_existing:
+        blob = InfoBlobs(
+            title=TITLE,
+            text=OLD_TEXT,
+            size=777,
+            user_id=user.id,
+            tenant_id=user.tenant_id,
+            group_id=group.id,
+            embedding_model_id=embedding_model.id,
+        )
+        session.add(blob)
+        await session.flush()
+        chunks = [
+            InfoBlobChunks(
+                info_blob_id=blob.id,
+                tenant_id=user.tenant_id,
+                chunk_no=chunk_no,
+                text=text,
+                size=len(text),
+                embedding=embedding,
+            )
+            for chunk_no, text, embedding in OLD_CHUNKS
+        ]
+        session.add_all(chunks)
+        await session.flush()
+        prior = (
+            blob.id,
+            [
+                (chunk.id, chunk_no, text, _pgvector_values(embedding))
+                for chunk, (chunk_no, text, embedding) in zip(
+                    chunks, OLD_CHUNKS, strict=True
+                )
+            ],
+        )
+    return user, space, group, job, prior
+
+
+async def _committed_state(job_id: UUID):
+    async with sessionmanager.session() as session, session.begin():
+        job_state = (
+            await session.execute(
+                sa.select(Jobs.status, Jobs.result_location).where(Jobs.id == job_id)
+            )
+        ).one()
+        blobs = (
+            await session.scalars(sa.select(InfoBlobs).where(InfoBlobs.title == TITLE))
+        ).all()
+        chunks = (
+            await session.scalars(
+                sa.select(InfoBlobChunks).order_by(InfoBlobChunks.chunk_no)
+            )
+        ).all()
+        return (
+            job_state,
+            [(blob.id, blob.text, blob.size) for blob in blobs],
+            [
+                (chunk.id, chunk.chunk_no, chunk.text, list(chunk.embedding))
+                for chunk in chunks
+            ],
+        )
+
+
+def _assert_prior_knowledge(prior, blobs, chunks):
+    blob_id, expected_chunks = prior
+    assert blobs == [(blob_id, OLD_TEXT, 777)]
+    assert chunks == expected_chunks
+
+
+@pytest.mark.parametrize("failure", ["extraction", "chunking", "embedding", "blank"])
+async def test_upload_failure_preserves_committed_prior_knowledge(
+    db_container, tmp_path, monkeypatch, failure
+):
+    filepath = tmp_path / TITLE
+    filepath.write_text("replacement")
+    async with db_container() as container:
+        user, space, group, job, prior = await _seed_attempt(container)
+        job_id = job.id
+        extracted: str | Exception = "replacement knowledge"
+        if failure == "extraction":
+            extracted = RuntimeError("extraction failed")
+        elif failure == "blank":
+            extracted = " \n\t "
+        container.text_extractor.override(providers.Object(StubExtractor(extracted)))
+        if failure in {"embedding", "blank"}:
+            embeddings = AsyncMock()
+            embeddings.get_embeddings.side_effect = RuntimeError("embedding failed")
+            container.create_embeddings_service.override(providers.Object(embeddings))
+        if failure == "chunking":
+            monkeypatch.setattr(
+                Datastore,
+                "_chunk_text",
+                lambda self, info_blob: (_ for _ in ()).throw(
+                    RuntimeError("chunking failed")
+                ),
+            )
+        result = await upload_info_blob_task(
+            job_id=job.id,
+            params=UploadInfoBlob(
+                user_id=user.id,
+                group_id=group.id,
+                space_id=space.id,
+                filepath=str(filepath),
+                filename=TITLE,
+                mimetype="text/plain",
+            ),
+            container=container,
+        )
+        assert result is False
+
+    (status, error), blobs, chunks = await _committed_state(job_id)
+    assert status == Status.FAILED.value
+    if failure == "blank":
+        assert error == f"File '{TITLE}' contains no extractable text"
+        embeddings.get_embeddings.assert_not_awaited()
+    _assert_prior_knowledge(prior, blobs, chunks)
+
+
+@pytest.mark.parametrize("failure", ["embedding", "blank"])
+async def test_first_upload_failure_publishes_no_knowledge(
+    db_container, tmp_path, failure
+):
+    filepath = tmp_path / TITLE
+    filepath.write_text("replacement")
+    async with db_container() as container:
+        user, space, group, job, _ = await _seed_attempt(container, with_existing=False)
+        job_id = job.id
+        container.text_extractor.override(
+            providers.Object(
+                StubExtractor(" \n " if failure == "blank" else "replacement knowledge")
+            )
+        )
+        embeddings = AsyncMock()
+        embeddings.get_embeddings.side_effect = RuntimeError("embedding failed")
+        container.create_embeddings_service.override(providers.Object(embeddings))
+        result = await upload_info_blob_task(
+            job_id=job.id,
+            params=UploadInfoBlob(
+                user_id=user.id,
+                group_id=group.id,
+                space_id=space.id,
+                filepath=str(filepath),
+                filename=TITLE,
+                mimetype="text/plain",
+            ),
+            container=container,
+        )
+        assert result is False
+
+    (status, error), blobs, chunks = await _committed_state(job_id)
+    assert status == Status.FAILED.value
+    if failure == "blank":
+        assert error == f"File '{TITLE}' contains no extractable text"
+        embeddings.get_embeddings.assert_not_awaited()
+    assert blobs == []
+    assert chunks == []
+
+
+async def test_successful_upload_commits_replacement_knowledge(db_container, tmp_path):
+    filepath = tmp_path / TITLE
+    filepath.write_text("replacement")
+    replacement_text = "Committed replacement knowledge"
+    async with db_container() as container:
+        user, space, group, job, prior = await _seed_attempt(container)
+        job_id = job.id
+        container.text_extractor.override(
+            providers.Object(StubExtractor(replacement_text))
+        )
+        embeddings = AsyncMock()
+
+        def embed(*, model, chunks):
+            result = ChunkEmbeddingList()
+            result.add(chunks, [[0.7, 0.8, 0.9] for _ in chunks])
+            return result
+
+        embeddings.get_embeddings.side_effect = embed
+        container.create_embeddings_service.override(providers.Object(embeddings))
+
+        result = await upload_info_blob_task(
+            job_id=job.id,
+            params=UploadInfoBlob(
+                user_id=user.id,
+                group_id=group.id,
+                space_id=space.id,
+                filepath=str(filepath),
+                filename=TITLE,
+                mimetype="text/plain",
+            ),
+            container=container,
+        )
+        assert result is True
+
+    (status, result_location), blobs, chunks = await _committed_state(job_id)
+    old_blob_id, _ = prior
+    assert status == Status.COMPLETE.value
+    assert len(blobs) == 1
+    blob_id, text, size = blobs[0]
+    assert blob_id != old_blob_id
+    assert text == replacement_text
+    assert size > 0
+    assert result_location == f"/api/v1/info-blobs/{blob_id}/"
+    assert [(chunk_no, text) for _, chunk_no, text, _ in chunks] == [
+        (0, replacement_text)
+    ]
+    assert chunks[0][3] == _pgvector_values([0.7, 0.8, 0.9])
+
+
+@pytest.mark.parametrize("failure", ["embedding", "blank"])
+async def test_transcription_failure_preserves_committed_prior_knowledge(
+    db_container, tmp_path, transcription_model_factory, failure
+):
+    filepath = tmp_path / "audio.wav"
+    filepath.write_bytes(b"not used")
+    async with db_container() as container:
+        user, space, group, job, prior = await _seed_attempt(container)
+        job_id = job.id
+        transcription_model = await transcription_model_factory(
+            container.session(), "ingestion-safety-transcription"
+        )
+        container.session().add(
+            SpacesTranscriptionModels(
+                space_id=space.id, transcription_model_id=transcription_model.id
+            )
+        )
+        await container.session().flush()
+        transcriber = AsyncMock()
+        transcriber.transcribe_from_filepath.return_value = (
+            " \n " if failure == "blank" else "replacement transcript"
+        )
+        container.transcriber.override(providers.Object(transcriber))
+        embeddings = AsyncMock()
+        embeddings.get_embeddings.side_effect = RuntimeError("embedding failed")
+        container.create_embeddings_service.override(providers.Object(embeddings))
+
+        result = await transcription_task(
+            job_id=job.id,
+            params=Transcription(
+                user_id=user.id,
+                group_id=group.id,
+                space_id=space.id,
+                filepath=str(filepath),
+                filename=TITLE,
+                mimetype="audio/wav",
+            ),
+            container=container,
+        )
+        assert result is False
+
+    (status, error), blobs, chunks = await _committed_state(job_id)
+    assert status == Status.FAILED.value
+    if failure == "blank":
+        assert error == f"File '{TITLE}' contains no extractable text"
+        embeddings.get_embeddings.assert_not_awaited()
+    _assert_prior_knowledge(prior, blobs, chunks)

--- a/docs/goals/knowledge-ingestion-failure-safety/goal.md
+++ b/docs/goals/knowledge-ingestion-failure-safety/goal.md
@@ -1,0 +1,82 @@
+# Preserve Knowledge On Ingestion Failure
+
+## Objective
+
+Ensure a failed upload or transcription processing attempt records failure without destroying, partially replacing, or publishing knowledge that was previously usable.
+
+## Goal Kind
+
+`specific`
+
+## Current Tranche
+
+Verify the current ingestion and transaction owners; freeze the smallest owner-level design with a skeptical Claude plan pass; prove the unsafe behavior red; implement the bounded restoration/savepoint fix; validate it against real PostgreSQL and whole-backend gates; then publish, review, and merge one PR linked to the correct development task under epic #549.
+
+## Problem And Why It Matters
+
+Current processing may mutate an existing `InfoBlob` and its chunks before extraction, chunking, or embedding has safely succeeded. A refresh failure can therefore remove previously queryable knowledge or expose a partial first version. This is a data-integrity and runtime-reliability defect.
+
+## Ownership Direction To Verify
+
+- Current owner: the upload/transcription worker orchestration and embedding datastore transaction path in current source.
+- Proposed canonical owner: deepen that existing ingestion owner and transaction model with the smallest savepoint or transactional restoration at the mutation seam.
+- Reuse: current `InfoBlob`, chunk, job/attempt, session, and domain-failure owners.
+- Move or merge: only transaction/error handling that current source proves is misplaced or duplicated at this seam.
+- Delete: no path unless source and behavior tests prove it is weaker, dead, or duplicated.
+- Create: only the minimum typed zero-extractable-text failure if no equivalent exists.
+
+## Non-Negotiable Constraints
+
+- Branch from live `origin/develop` base `0c8741c2da1ad3eec210fed55160131f7842d78c` in the isolated worktree.
+- Do not newly move extraction, transcription, chunking, or model I/O into a long PostgreSQL transaction. The current worker already holds one ambient transaction; this temporary savepoint must not extend that scope, and task #571's later ingestion slice owns separating preparation, publication, and status transactions.
+- Preserve a prior active `InfoBlob` and chunks byte-for-byte and query-equivalently when extraction, chunking, embedding, or zero-text processing fails, while recording the attempt as failed.
+- Publish no partial knowledge when a new document's first processing attempt fails.
+- Add no generation API, retry framework, lifecycle table, migration, background-job system, repository abstraction, provider branch, generalized multi-tenancy, or object-content migration/move change.
+- PostgreSQL remains the complete supported default; optional object storage is not required.
+- Keep complexity at existing asymptotic work with no per-chunk transaction or query fan-out.
+- Use behavior-first red/green/refactor cycles and one resumable Claude session.
+- Stop and coordinate before expanding beyond the ingestion failure seam or files likely owned by slice 2.
+
+## Acceptance Criteria
+
+- Focused tests fail on the frozen base for the intended data-integrity reason.
+- Existing knowledge survives representative extraction, chunking, embedding, and zero-text failures while the processing attempt is `FAILED`.
+- A new-document failure leaves no partially visible knowledge.
+- Transaction and session ownership are explicit and remote/model I/O does not move into a long database transaction.
+- Targeted tests, relevant real PostgreSQL integration, whole-backend type/format checks, exact-diff Claude commit gate, PR review, and required CI pass.
+- Docs impact is recorded; no documentation is changed unless current source proves operator or user behavior needs it.
+- The PR links an existing equivalent development task under epic #549, or a single new task created only after a verified search finds none.
+- The exact reviewed PR head is merged into `develop`.
+
+## Risk And Recovery
+
+The primary risk is incorrect session/savepoint scope that either rolls back the failure record or keeps partial knowledge. Recovery is to revert the single bounded PR; no schema or data migration is permitted in this tranche.
+
+## Stop Rule
+
+Stop when the tranche audit passes, all safe local work is blocked, or continuing would require owner input, credentials, destructive operations, or strategy the board cannot decide.
+
+Do not stop after planning, discovery, or Judge selection while a safe Worker task can be activated.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/knowledge-ingestion-failure-safety/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/knowledge-ingestion-failure-safety/goal.md through the first safe verified implementation slice. Do not stop after planning unless blocked.
+```
+
+## PM Loop
+
+On every continuation:
+
+1. Read this charter and `state.yaml`.
+2. Work only on the active board task.
+3. Record a compact receipt before selecting the next task.
+4. Finish only after the audit maps current receipts and validation back to the original outcome.

--- a/docs/goals/knowledge-ingestion-failure-safety/notes/T001-source-evidence.md
+++ b/docs/goals/knowledge-ingestion-failure-safety/notes/T001-source-evidence.md
@@ -1,0 +1,73 @@
+# T001: Ingestion Failure Source Evidence
+
+Task: `T001`
+Kind: `scout`
+Status: `done`
+
+## Summary
+
+Upload and transcription use `Worker.function`, which opens one ambient PostgreSQL transaction for the job. `TaskManager` catches ordinary processing exceptions, records `FAILED`, and does not re-raise, so earlier same-title deletion and replacement work commits with the failure. Extraction and transcription failures precede knowledge mutation; chunking and embedding failures follow it; zero chunks currently return success. Live searches found no equivalent bounded failure-safety task, so [#607](https://github.com/eneo-ai/eneo/issues/607) was created as a Task and true sub-issue of epic #549. The larger [#571](https://github.com/eneo-ai/eneo/issues/571) remains open and downstream.
+
+## Verified Evidence
+
+- `backend/src/eneo/worker/routes.py:81-90` registers upload and transcription through `Worker.function`.
+- `backend/src/eneo/worker/worker.py:331-348` owns the ambient session and transaction for those routes.
+- `backend/src/eneo/worker/task_manager.py:90-128` catches ordinary exceptions, writes `FAILED`, and lets the wrapper return normally.
+- `backend/src/eneo/worker/upload_tasks.py:16-91` owns upload/transcription orchestration and calls `TextProcessor` inside the status context.
+- `backend/src/eneo/info_blobs/text_processor.py:29-81` extracts before `process_text`, then creates/replaces the `InfoBlob`, embeds chunks, and updates size.
+- `backend/src/eneo/info_blobs/info_blob_service.py:120-165` deletes same-title knowledge before inserting its replacement.
+- `backend/src/eneo/database/tables/info_blob_chunk_table.py:12-24` makes chunks cascade with the deleted `InfoBlob`.
+- `backend/src/eneo/embedding_models/infrastructure/datastore.py:87-145` chunks after replacement insertion, treats zero chunks as success, performs remote embedding before inserts, and writes chunks in existing batches.
+- `backend/src/eneo/files/text.py:22-58` already owns typed extraction failures; no equivalent typed zero-extractable-text failure exists for upload/transcription.
+- Real integration fixtures in `backend/tests/integration/conftest.py:181-304,400-599,657-756` use disposable PostgreSQL 16 with pgvector and Alembic at head.
+- `backend/.env.template` and `.github/workflows/ci.yml` provide the repository-approved test bootstrap; no canonical-checkout `.env` may be read, copied, or linked.
+
+## Mutation Timeline
+
+1. `Worker.function` opens the ambient transaction and builds the user-scoped container.
+2. `TaskManager` writes `IN_PROGRESS`.
+3. Upload extraction or remote transcription completes before knowledge mutation.
+4. `TextProcessor.process_text` deletes the same-title `InfoBlob`; PostgreSQL cascades its chunks.
+5. The replacement `InfoBlob` is inserted.
+6. Chunking, zero-chunk handling, remote embedding, and batched chunk inserts occur.
+7. On an ordinary exception, `TaskManager` writes `FAILED` but suppresses the exception, so the ambient transaction commits pending knowledge changes.
+8. On zero chunks, processing proceeds to `COMPLETE` with an empty replacement.
+
+## Frozen Scope Disposition
+
+- Reuse and deepen the current upload/transcription ingestion and transaction model.
+- The bounded candidate is a nested savepoint around current destructive publication work so an exception rolls back knowledge mutations before `TaskManager` records `FAILED` in the ambient transaction.
+- Add or reuse one typed failure when chunking yields no extractable text so the savepoint follows the same failure path.
+- Do not split preparation, publication, and status into separate transactions here. That larger and ultimately cleaner shape is already owned by task #571's later generation-based ingestion slices; it would expand slice 0 into the work explicitly required to wait.
+- Do not globally change `Worker.function`, crawler persistence, object-content owners, schema, lifecycle, retry, public contracts, or same-title concurrency semantics.
+
+## RED Proofs To Freeze
+
+- Existing exact `InfoBlob` and chunks survive chunking and embedding exceptions while the job is `FAILED`.
+- Existing exact `InfoBlob` and chunks survive zero extractable text while the job is `FAILED`.
+- A first-attempt chunking, embedding, or zero-text failure publishes no `InfoBlob` or chunks and leaves the job `FAILED`.
+- Extraction failure preserves prior knowledge and records `FAILED` (expected baseline-safe because it precedes mutation).
+- Upload and transcription converge on the same protected `process_text` mutation seam.
+
+## Verification And Planning
+
+- Baseline focused unit tests pass with `cd backend && bash -lc 'set -a; source .env.template; set +a; uv run pytest -q tests/unittests/ai_models/embedding_models/test_datastore.py tests/unittests/info_blobs/test_info_blobs_service.py'`.
+- Baseline Ruff, format, and focused devcontainer Pyright pass.
+- Development-task search: no equivalent bounded failure-safety task existed. [#607](https://github.com/eneo-ai/eneo/issues/607) is the exact Backend/S prerequisite, a real sub-issue of #549 and Project 5 Task with the epic's Backend/P1/2.X/Sundsvalls metadata. [#571](https://github.com/eneo-ai/eneo/issues/571) is referenced only as downstream work and must not be closed by this slice.
+- Documentation impact: no docs change for this internal atomicity correction unless the implementation changes the public job/error contract.
+
+## Stop Conditions
+
+- A migration, generation/lifecycle table, retry framework, public interface, or object-content/crawler owner becomes necessary.
+- The savepoint cannot preserve `FAILED` independently from the rolled-back knowledge work.
+- Tests require a real provider credential or model network call.
+- The implementation needs files outside the Judge-approved reduced set.
+
+## Board Receipt Snippet
+
+```yaml
+receipt:
+  result: done
+  note: notes/T001-source-evidence.md
+  summary: "Verified the defect and savepoint seam, found no exact task, and created bounded task #607 under epic #549 while leaving downstream #571 open."
+```

--- a/docs/goals/knowledge-ingestion-failure-safety/state.yaml
+++ b/docs/goals/knowledge-ingestion-failure-safety/state.yaml
@@ -1,0 +1,261 @@
+version: 2
+
+goal:
+  title: "Preserve Knowledge On Ingestion Failure"
+  slug: "knowledge-ingestion-failure-safety"
+  kind: specific
+  tranche: "Prove, fix, validate, publish, review, and merge the bounded ingestion failure-safety slice."
+  status: active
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+continuity:
+  rotate_threads: false
+  rotation_authorized_by: null
+  rotate_after_completed_write_tasks: 2
+  rotate_after_hours: 6
+  rotate_when_slow: true
+  current_thread_id: "019fa011-95d2-79d1-96b4-f42d6bb6024c"
+  previous_thread_id: "019f64db-c1fa-7250-97d3-e4c12a889f71"
+  rotation_count: 0
+  completed_write_tasks_in_thread: 1
+  handoff_note: notes/handoff.md
+  last_handoff_at: null
+  last_verified_revision: "0c8741c2da1ad3eec210fed55160131f7842d78c"
+
+active_task: T004
+
+tasks:
+  - id: T001
+    type: scout
+    assignee: Scout
+    status: done
+    reasoning_hint: medium
+    objective: "Freeze source evidence for current ingestion ownership, failure mutations, failure types, tests, PostgreSQL setup, validation commands, docs impact, and epic #549 task traceability."
+    inputs:
+      - backend/src/eneo/worker/upload_tasks.py
+      - backend/src/eneo/embedding_models/infrastructure/datastore.py
+      - backend/src/eneo
+      - backend/tests
+      - docs/CONTRIBUTING.md
+      - docs/CODE_QUALITY.md
+      - docs/ARCHITECTURE.md
+      - backend/README.md
+      - GitHub epic #549 and related tasks
+    constraints:
+      - "Read-only outside Goal Maker control files."
+      - "Do not edit implementation or test files."
+      - "Treat the requested canonical direction as a hypothesis to verify."
+      - "Do not inspect or edit object-content migration/move owners."
+      - "Prefer exact file, symbol, transaction, and test evidence."
+    expected_output:
+      - "Canonical owner and caller map"
+      - "Mutation and transaction timeline"
+      - "Existing typed failure inventory"
+      - "Focused RED tests and validation ladder"
+      - "Allowed files and stop conditions"
+      - "Equivalent development task search result under epic #549"
+      - "Docs impact decision"
+    receipt:
+      result: done
+      note: notes/T001-source-evidence.md
+      summary: "Verified the caught-exception commit defect, zero-text success bug, savepoint seam, test bootstrap, docs decision, and the absence of an equivalent bounded task before creating #607 under epic #549."
+      evidence:
+        - backend/src/eneo/worker/worker.py:331-348
+        - backend/src/eneo/worker/task_manager.py:90-128
+        - backend/src/eneo/info_blobs/text_processor.py:29-81
+        - backend/src/eneo/info_blobs/info_blob_service.py:120-165
+        - backend/src/eneo/embedding_models/infrastructure/datastore.py:87-145
+        - https://github.com/eneo-ai/eneo/issues/607
+        - https://github.com/eneo-ai/eneo/issues/571
+
+  - id: T002
+    type: judge
+    assignee: Judge
+    status: done
+    reasoning_hint: high
+    objective: "Challenge the frozen evidence and Claude plan pass, then select the smallest safe owner-level implementation."
+    inputs:
+      - "T001 receipt"
+      - "Claude plan pass from session knowledge-ingestion-failure-safety"
+    constraints:
+      - "Read-only outside Goal Maker control files."
+      - "Reject scope expansion into migrations, lifecycle redesign, object-content move owners, or slice 2 product work."
+      - "Keep remote/model I/O outside long PostgreSQL transactions."
+    expected_output:
+      - "Decision"
+      - "Exact Worker objective"
+      - "allowed_files"
+      - "verify"
+      - "stop_if"
+      - "Finding disposition ledger"
+    receipt:
+      result: done
+      decision: "Use narrowed Hypothesis B: task-level pre-mutation blank-text guards and nested savepoints around process_text only; keep Datastore and global transaction owners unchanged."
+      next_allowed_task: T003
+      allowed_files:
+        - backend/src/eneo/files/text.py
+        - backend/src/eneo/worker/upload_tasks.py
+        - backend/tests/integration/test_ingestion_failure_safety.py
+      prior_claude_disposition:
+        - "Accepted P0: keep zero-text failure out of Datastore and use the upload/transcription task seam."
+        - "Accepted P0: select Hypothesis B."
+        - "Accepted P1: require committed readback from a fresh PostgreSQL session."
+        - "Resolved P2: charter now defers transaction separation to #571."
+        - "Accepted P2 rationale comment; rejected a helper abstraction."
+        - "Rejected optional P3 TextProcessor annotations as scope expansion."
+      summary: "Claude plan pass changes_required/6 and verified source led to a three-file Worker slice with no unrelated caller or public-contract changes."
+
+  - id: T003
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Prove committed ingestion failure behavior red, then add the typed blank-text guard and task-level savepoints without changing other ingestion callers."
+    allowed_files:
+      - backend/src/eneo/files/text.py
+      - backend/src/eneo/worker/upload_tasks.py
+      - backend/tests/integration/test_ingestion_failure_safety.py
+    verify:
+      - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run pytest -q -m integration tests/integration/test_ingestion_failure_safety.py'"
+      - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run pytest -q tests/unittests/files/test_text_extractor.py tests/unittests/ai_models/embedding_models/test_datastore.py tests/unittests/info_blobs/test_info_blobs_service.py'"
+      - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run ruff check src/eneo tests/integration/test_ingestion_failure_safety.py'"
+      - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run ruff format --check src/eneo tests/integration/test_ingestion_failure_safety.py'"
+      - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run pyright'"
+      - "git diff --check"
+      - "git status --short"
+    stop_if:
+      - "The targeted base run does not fail for the intended committed-state invariant."
+      - "Fresh-session readback cannot observe FAILED after the ambient transaction closes."
+      - "A non-whitespace worker input can still produce zero chunks, making the task guard insufficient."
+      - "Any provider credential or real model/network call is required."
+      - "Any file outside allowed_files is needed."
+      - "A migration, generation/lifecycle/status-publication split, retry/public interface change, TaskManager/Worker change, crawler change, or object-content change is required."
+      - "The same verification failure repeats twice."
+    receipt:
+      result: done
+      changed_files:
+        - backend/src/eneo/files/text.py
+        - backend/src/eneo/worker/upload_tasks.py
+        - backend/tests/integration/test_ingestion_failure_safety.py
+      red: "8 failed on the frozen base: chunking and embedding committed destructive replacements, and blank upload/transcription completed with empty replacements."
+      green: "Real PostgreSQL integration 8 passed; focused unit tests 64 passed; Ruff, format, Pyright, and git diff --check passed."
+      commands:
+        - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run pytest -q -m integration tests/integration/test_ingestion_failure_safety.py'"
+        - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run pytest -q tests/unittests/files/test_text_extractor.py tests/unittests/ai_models/embedding_models/test_datastore.py tests/unittests/info_blobs/test_info_blobs_service.py'"
+        - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run ruff check src/eneo tests/integration/test_ingestion_failure_safety.py'"
+        - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run ruff format --check src/eneo tests/integration/test_ingestion_failure_safety.py'"
+        - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run pyright'"
+        - "git diff --check"
+      summary: "Added the typed blank-content failure and isolated only process_text in nested savepoints; fresh sessions prove FAILED commits while prior rows survive and failed first attempts publish nothing."
+
+  - id: T004
+    type: pm
+    assignee: PM
+    status: active
+    reasoning_hint: high
+    objective: "Run the final validation ladder and exact-diff Claude commit gate, publish the reviewable PR, resolve current review/CI evidence, and merge the exact accepted head."
+    inputs:
+      - "T003 receipt"
+      - "Current full diff including untracked files"
+      - "One resumable Claude session"
+      - "Bounded development task #607 under epic #549; #571 is downstream only"
+    constraints:
+      - "Control files, validation, git, and GitHub metadata only unless a verified review finding requires returning to a bounded Worker task."
+      - "Require GREEN_LIGHT yes and MIN_SCORE >= 8 before every commit."
+      - "Require a fresh top-level /review on every changed PR head."
+      - "Merge only the immutable accepted head with all required CI green."
+    expected_output:
+      - "Validation evidence"
+      - "Claude session and verdict"
+      - "Commit and PR"
+      - "Review and CI disposition"
+      - "Merge evidence"
+    review_cycles: 1
+    receipt: null
+
+  - id: T005
+    type: worker
+    assignee: Worker
+    status: done
+    reasoning_hint: default
+    objective: "Close the first Claude commit-gate proof gap without expanding the failure-safety slice."
+    inputs:
+      - "Claude commit-gate iteration 2: changes_required, GREEN_LIGHT no, MIN_SCORE 7"
+      - ".codex/artifacts/claude-peer-loop-knowledge-ingestion-failure-safety-20260726T205133Z.md"
+    allowed_files:
+      - backend/src/eneo/worker/upload_tasks.py
+      - backend/tests/integration/test_ingestion_failure_safety.py
+    constraints:
+      - "Add one real-PostgreSQL successful upload proof using the existing test helpers and a fake embedding seam; assert COMPLETE and committed replacement blob/chunks."
+      - "For blank cases, assert the persisted job error comes from NoExtractableTextError and that embeddings were not awaited."
+      - "Delete unreachable embedding mock setup and move a stable invariant-only savepoint rationale to the first occurrence; remove issue-number/history leakage from product comments."
+      - "Do not add a helper abstraction, NamedTuple, unit-test file, product owner, migration, public contract, or retry behavior."
+    verify:
+      - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run pytest -q -m integration tests/integration/test_ingestion_failure_safety.py'"
+      - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run ruff check src/eneo tests/integration/test_ingestion_failure_safety.py'"
+      - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run ruff format --check src/eneo tests/integration/test_ingestion_failure_safety.py'"
+      - "cd backend && bash -lc 'set -a; source .env.template; set +a; uv run pyright'"
+      - "rg -n '(slice[[:space:]]*[0-9]+|M[0-9]+\\.[0-9]+|WI-[A-Za-z0-9-]+|T[0-9]{3,}|PR[[:space:]]*#?[0-9]+|#[0-9]+)' backend/src/eneo/files/text.py backend/src/eneo/worker/upload_tasks.py backend/tests/integration/test_ingestion_failure_safety.py"
+      - "git diff --check"
+    stop_if:
+      - "A file outside allowed_files is required."
+      - "A real provider credential or model/network call is required."
+      - "The successful publication proof cannot use the existing datastore contract and integration fixtures."
+      - "The same verification failure repeats twice."
+    receipt:
+      result: done
+      changed_files:
+        - backend/src/eneo/worker/upload_tasks.py
+        - backend/tests/integration/test_ingestion_failure_safety.py
+      commands:
+        - "Tracked-template real PostgreSQL integration: 9 passed in 21.53s"
+        - "Ruff check and whole-backend format check: passed"
+        - "Whole-backend Pyright: 0 errors, 0 warnings"
+        - "Product naming scan: no matches"
+        - "git diff --check: passed"
+      summary: "Proved successful committed replacement, made the blank-content typed failure observable, removed dead mocks, and removed coordination/history leakage from the product comment."
+
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: queued
+    reasoning_hint: high
+    objective: "Audit whether the merged slice satisfies the original ingestion failure-safety outcome."
+    inputs:
+      - "All done task receipts"
+      - "Merged immutable PR head"
+      - "Current validation and review evidence"
+    constraints:
+      - "Do not implement."
+      - "Reject completion if required Worker work is queued or active."
+    expected_output:
+      - "complete | not_complete"
+      - "Acceptance mapping"
+      - "Missing evidence"
+      - "Next task if not complete"
+    receipt: null
+
+checks:
+  dirty_fingerprint: unknown
+  last_verification:
+    result: passed
+    task: T003
+    commands:
+      - "Tracked-template real PostgreSQL integration: 8 passed"
+      - "Focused unit tests: 64 passed"
+      - "Ruff check and format check: passed"
+      - "Whole-backend Pyright: 0 errors, 0 warnings"
+      - "git diff --check: passed"


### PR DESCRIPTION
## Summary

- Preserve the active InfoBlob and chunks when upload or transcription refresh fails during extraction, chunking, or embedding.
- Reject content with no extractable text as a typed failed job before knowledge mutation.
- Publish successful replacement knowledge atomically inside the existing worker transaction model.
- Keep PostgreSQL as the complete supported default; optional object storage is unaffected and remains unnecessary to run Eneo.

## Why

The upload/transcription task owner previously deleted same-title knowledge before chunking and embedding had safely finished. Because job failures are recorded inside the existing ambient worker transaction, a failed refresh could commit a damaged replacement alongside `FAILED`. The task seam now owns the temporary savepoint that lets knowledge publication roll back while the failure record commits.

Image-only or scanned content that yields no text previously produced an empty InfoBlob with a `COMPLETE` job. It now records a clear failed job stating that the file contains no extractable text.

## What changed

- Extended the existing extraction error family with `NoExtractableTextError`.
- Hoisted upload extraction and guarded upload/transcription blank content before mutation.
- Wrapped only `TextProcessor.process_text` in nested savepoints at the two task entry points.
- Added real PostgreSQL coverage for committed failure preservation, first-attempt invisibility, typed blank failures, and successful replacement publication.

## What was deliberately not changed

- No generation API, retry framework, lifecycle table, migration, background-job system, or broad repository abstraction.
- No changes to Datastore, crawler ingestion, object-content migration/move owners, Flow work, or unrelated metadata.
- No change to the current ambient worker transaction owner; later ingestion work owns separating preparation, publication, and status transactions.
- No public API or generated-client contract change.

## Deletion / consolidation

- Reused the current extraction failure owner and task/session owners.
- Kept the two savepoints explicit instead of adding a one-use helper or new abstraction.
- Removed dead embedding mock setup after review; no compatibility path was added.

## Risk and rollback

Risk is limited to upload/transcription processing. A wrong savepoint boundary could either lose the failure record or fail to publish successful knowledge; committed-state PostgreSQL tests cover both directions. Roll back by reverting this commit. There is no schema or data migration to reverse.

## Validation

- Real PostgreSQL integration: `9 passed`.
- Focused unit tests: `64 passed`.
- Whole-backend Ruff format: `837 files already formatted`.
- Ruff check: passed.
- Strict Pyright: `0 errors, 0 warnings`.
- `uv lock --check`: passed.
- Product naming scan: no roadmap or coordination identifiers in product/test names, errors, or comments.
- Pre-commit and tracked-template pre-push schema-drift hooks: passed.
- Claude exact-diff commit gate: `GREEN_LIGHT: yes`, `MIN_SCORE: 8`.

## Tracking

Fixes #607

Parent epic: #549

Downstream generation-based ingestion: #571
