### PR TITLE
fix(insights): authorize message logging before loading details

### DIFF
--- a/backend/src/eneo/analysis/analysis_service.py
+++ b/backend/src/eneo/analysis/analysis_service.py
@@ -573,6 +573,33 @@ class AnalysisService:
                 f"Need permission {Permission.INSIGHTS.value} in order to access"
             )
 
+    @validate_permissions(Permission.INSIGHTS)
+    async def get_message_for_insights(self, *, message_id: UUID) -> Question:
+        partner = await self.question_repo.get_session_partner(
+            id=message_id,
+            tenant_id=self.user.tenant_id,
+        )
+        if partner is None or (partner.assistant_id is None) == (
+            partner.group_chat_id is None
+        ):
+            raise NotFoundException("Message not found")
+
+        try:
+            await self._check_insight_access(
+                assistant_id=partner.assistant_id,
+                group_chat_id=partner.group_chat_id,
+            )
+        except (BadRequestException, NotFoundException, UnauthorizedException) as exc:
+            raise NotFoundException("Message not found") from exc
+
+        question = await self.question_repo.get(
+            id=message_id,
+            tenant_id=self.user.tenant_id,
+        )
+        if question is None:
+            raise NotFoundException("Message not found")
+        return question
+
     async def _check_insight_access(
         self,
         group_chat_id: UUID | None = None,

--- a/backend/src/eneo/analysis/analysis_service.py
+++ b/backend/src/eneo/analysis/analysis_service.py
@@ -592,7 +592,7 @@ class AnalysisService:
         except (BadRequestException, NotFoundException, UnauthorizedException) as exc:
             raise NotFoundException("Message not found") from exc
 
-        question = await self.question_repo.get(
+        question = await self.question_repo.get_for_tenant(
             id=message_id,
             tenant_id=self.user.tenant_id,
         )

--- a/backend/src/eneo/authentication/auth_dependencies.py
+++ b/backend/src/eneo/authentication/auth_dependencies.py
@@ -149,7 +149,10 @@ async def require_session_auth(
     if getattr(request.state, "api_key", None) is not None:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="This endpoint requires a session token.",
+            detail={
+                "code": "session_auth_required",
+                "message": "This endpoint requires a session token.",
+            },
         )
 
 

--- a/backend/src/eneo/logging/logging_router.py
+++ b/backend/src/eneo/logging/logging_router.py
@@ -5,31 +5,30 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends
 
-from eneo.authentication.auth_dependencies import get_current_active_user
-from eneo.main.exceptions import BadRequestException, NotFoundException
+from eneo.authentication.auth_dependencies import require_session_auth
+from eneo.main.container.container import Container
+from eneo.main.exceptions import BadRequestException
 from eneo.questions.question import MessageLogging
 from eneo.questions.question_protocol import to_question_logging
-from eneo.questions.questions_factory import get_questions_repo
-from eneo.questions.questions_repo import QuestionRepository
+from eneo.server.dependencies.container import get_container
 from eneo.server.protocol import responses
 
-router = APIRouter(dependencies=[Depends(get_current_active_user)])
-
-_QuestionRepo = Annotated[QuestionRepository, Depends(get_questions_repo)]
+router = APIRouter(dependencies=[Depends(require_session_auth)])
 
 
 @router.get(
     "/{message_id}/",
     response_model=MessageLogging,
     description="Get the logging details for a single message by id.",
-    responses=responses.get_responses([400, 404]),
+    responses=responses.get_responses([400, 403, 404]),
 )
 async def get_logging_details(
-    message_id: UUID, question_repo: _QuestionRepo
+    message_id: UUID,
+    container: Annotated[Container, Depends(get_container(with_user=True))],
 ) -> MessageLogging:
-    question = await question_repo.get(message_id)
-    if question is None:
-        raise NotFoundException("Question not found")
+    question = await container.analysis_service().get_message_for_insights(
+        message_id=message_id
+    )
 
     if question.logging_details is None:
         raise BadRequestException("Question was not logged.")

--- a/backend/src/eneo/questions/questions_repo.py
+++ b/backend/src/eneo/questions/questions_repo.py
@@ -191,7 +191,13 @@ class QuestionRepository:
 
         await self.session.execute(stmt)
 
-    async def get(self, *, id: UUID, tenant_id: UUID) -> Question | None:
+    async def get(self, id: UUID) -> Question | None:
+        question = await self.delegate.get(id)
+        if question is None:
+            return None
+        return (await self._hydrate_questions([question]))[0]
+
+    async def get_for_tenant(self, *, id: UUID, tenant_id: UUID) -> Question | None:
         question = await self.delegate.get_model_from_query(
             sa.select(Questions).where(
                 Questions.id == id,
@@ -445,10 +451,7 @@ class QuestionRepository:
             logging_details = result.scalar_one()  # pyright: ignore[reportUnknownVariableType]  # dynamic table scalar
             question_record.logging_details = logging_details
 
-        return await self.get(
-            id=question_record.id,
-            tenant_id=question.tenant_id,
-        )
+        return await self.get(question_record.id)
 
     async def get_by_service(self, service_id: UUID):
         stmt = (

--- a/backend/src/eneo/questions/questions_repo.py
+++ b/backend/src/eneo/questions/questions_repo.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from uuid import UUID
 
 import sqlalchemy as sa
@@ -43,6 +43,11 @@ if TYPE_CHECKING:
 
 
 _SKILL_PROVENANCE_ADAPTER = TypeAdapter(tuple[SkillExecutionReference, ...])
+
+
+class QuestionSessionPartner(NamedTuple):
+    assistant_id: UUID | None
+    group_chat_id: UUID | None
 
 
 class QuestionRepository:
@@ -186,11 +191,40 @@ class QuestionRepository:
 
         await self.session.execute(stmt)
 
-    async def get(self, id: UUID):
-        question = await self.delegate.get(id)
+    async def get(self, *, id: UUID, tenant_id: UUID) -> Question | None:
+        question = await self.delegate.get_model_from_query(
+            sa.select(Questions).where(
+                Questions.id == id,
+                Questions.tenant_id == tenant_id,
+            )
+        )
         if question is None:
             return None
         return (await self._hydrate_questions([question]))[0]
+
+    async def get_session_partner(
+        self,
+        *,
+        id: UUID,
+        tenant_id: UUID,
+    ) -> QuestionSessionPartner | None:
+        result = await self.session.execute(
+            sa.select(Sessions.assistant_id, Sessions.group_chat_id)
+            .select_from(Questions)
+            .join(Sessions, Sessions.id == Questions.session_id)
+            .where(
+                Questions.id == id,
+                Questions.tenant_id == tenant_id,
+            )
+        )
+        row = result.one_or_none()
+        if row is None:
+            return None
+        assistant_id, group_chat_id = row
+        return QuestionSessionPartner(
+            assistant_id=assistant_id,
+            group_chat_id=group_chat_id,
+        )
 
     async def get_with_skill_activation(
         self,
@@ -411,7 +445,10 @@ class QuestionRepository:
             logging_details = result.scalar_one()  # pyright: ignore[reportUnknownVariableType]  # dynamic table scalar
             question_record.logging_details = logging_details
 
-        return await self.get(question_record.id)
+        return await self.get(
+            id=question_record.id,
+            tenant_id=question.tenant_id,
+        )
 
     async def get_by_service(self, service_id: UUID):
         stmt = (

--- a/backend/tests/integration/test_api_key_access_matrix.py
+++ b/backend/tests/integration/test_api_key_access_matrix.py
@@ -333,6 +333,10 @@ def _compute_expected(
     is_admin_scope = endpoint.get("is_admin_scope", False)
     target_resource_key = endpoint.get("target_resource_key")
     is_unguarded = endpoint.get("is_unguarded", False)
+    session_only = endpoint.get("session_only", False)
+
+    if session_only:
+        return "deny"
 
     # Unguarded endpoints: any authenticated key should access them
     if is_unguarded:
@@ -1192,6 +1196,7 @@ def _build_probes(resource_ids: dict) -> list[dict]:
             "is_admin_scope": True,
             "requires_admin_perm": False,
             "target_resource_key": None,
+            "session_only": True,
         },
         # =================================================================
         # SPECIAL: API KEY MANAGEMENT (admin scope, no admin perm guard)

--- a/backend/tests/integration/test_api_key_create_authorization.py
+++ b/backend/tests/integration/test_api_key_create_authorization.py
@@ -125,4 +125,6 @@ async def test_api_key_caller_cannot_mint_new_key(client, default_user_token):
         headers={"X-API-Key": secret},
     )
     assert spawn_response.status_code == 403, spawn_response.text
-    assert "session token" in spawn_response.json().get("detail", "").lower()
+    error = spawn_response.json()
+    assert error.get("code") == "session_auth_required"
+    assert "session token" in error.get("message", "").lower()

--- a/backend/tests/integration/test_api_key_governance_isolation.py
+++ b/backend/tests/integration/test_api_key_governance_isolation.py
@@ -508,7 +508,7 @@ async def test_tenant_key_matrix_for_governance_and_diagnostics(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_tenant_read_key_logging_missing_message_returns_404_not_scope_error(
+async def test_tenant_read_key_logging_requires_bearer_session(
     client,
     default_user_token,
 ):
@@ -527,10 +527,10 @@ async def test_tenant_read_key_logging_missing_message_returns_404_not_scope_err
             "X-Correlation-ID": request_id,
         },
     )
-    assert response.status_code == 404, response.text
+    assert response.status_code == 403, response.text
     detail = _error_detail(response)
     assert detail.get("request_id") == request_id, response.text
-    assert detail.get("code") != "insufficient_scope", response.text
+    assert detail.get("code") == "session_auth_required", response.text
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/test_multi_tenant_data_isolation_adversarial.py
+++ b/backend/tests/integration/test_multi_tenant_data_isolation_adversarial.py
@@ -18,11 +18,18 @@ Security Model:
 from __future__ import annotations
 
 import asyncio
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
+import sqlalchemy as sa
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from eneo.database.database import sessionmanager
+from eneo.database.tables.questions_table import Questions
+from eneo.database.tables.sessions_table import Sessions
+from eneo.logging.logging import LoggingDetails
+from eneo.logging.logging_repo import LoggingRepository
 
 
 async def _create_tenant(client: AsyncClient, super_api_key: str, name: str) -> dict:
@@ -47,6 +54,8 @@ async def _create_user(
     tenant_id: str,
     email: str,
     password: str,
+    *,
+    is_admin: bool = False,
 ) -> dict:
     """Helper to create a test user."""
     payload = {
@@ -61,7 +70,27 @@ async def _create_user(
         headers={"X-API-Key": super_api_key},
     )
     assert response.status_code == 200, response.text
-    return response.json()
+    user = response.json()
+
+    if is_admin:
+        async with sessionmanager.session() as session, session.begin():
+            role_id = await session.scalar(
+                sa.text(
+                    "SELECT id FROM roles "
+                    "WHERE predefined_source = 'Owner' AND tenant_id = :tenant_id"
+                ),
+                {"tenant_id": tenant_id},
+            )
+            assert role_id is not None
+            await session.execute(
+                sa.text(
+                    "INSERT INTO users_roles (user_id, role_id) "
+                    "VALUES (:user_id, :role_id) ON CONFLICT DO NOTHING"
+                ),
+                {"user_id": user["id"], "role_id": role_id},
+            )
+
+    return user
 
 
 async def _login_user(client: AsyncClient, email: str, password: str) -> str:
@@ -93,6 +122,27 @@ async def _create_space(
     )
     assert response.status_code in (200, 201), response.text
     return response.json()
+
+
+async def _create_assistant(
+    client: AsyncClient,
+    token: str,
+    space_id: str,
+) -> dict:
+    response = await client.post(
+        "/api/v1/assistants/",
+        json={"name": f"insights-assistant-{uuid4().hex[:8]}", "space_id": space_id},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 200, response.text
+    assistant = response.json()
+    update_response = await client.post(
+        f"/api/v1/assistants/{assistant['id']}/",
+        json={"insight_enabled": True},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert update_response.status_code == 200, update_response.text
+    return update_response.json()
 
 
 async def _put_tenant_credential(
@@ -183,6 +233,90 @@ async def test_user_cannot_access_other_tenant_space_via_id_manipulation(
         assert "tenant" not in error_detail.lower(), (
             "Error message leaks tenant information"
         )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_insights_logging_never_hydrates_another_tenants_message(
+    client: AsyncClient,
+    super_admin_token: str,
+    patch_auth_service_jwt,
+    mock_transcription_models,
+):
+    tenant_a = await _create_tenant(
+        client, super_admin_token, f"logging-tenant-a-{uuid4().hex[:6]}"
+    )
+    tenant_b = await _create_tenant(
+        client, super_admin_token, f"logging-tenant-b-{uuid4().hex[:6]}"
+    )
+    user_a = await _create_user(
+        client,
+        super_admin_token,
+        tenant_a["id"],
+        f"logging-a-{uuid4().hex[:6]}@example.com",
+        "PasswordA123!",
+        is_admin=True,
+    )
+    user_b = await _create_user(
+        client,
+        super_admin_token,
+        tenant_b["id"],
+        f"logging-b-{uuid4().hex[:6]}@example.com",
+        "PasswordB123!",
+        is_admin=True,
+    )
+    token_a = await _login_user(client, user_a["email"], "PasswordA123!")
+    token_b = await _login_user(client, user_b["email"], "PasswordB123!")
+    space_b = await _create_space(client, token_b, f"logging-space-{uuid4().hex[:6]}")
+    assistant_b = await _create_assistant(client, token_b, space_b["id"])
+
+    async with sessionmanager.session() as session, session.begin():
+        logging_details = await LoggingRepository(session).add(
+            LoggingDetails(
+                context="tenant-b-private-context",
+                model_kwargs={"model": "private-model"},
+                json_body='{"private":"tenant-b"}',
+            )
+        )
+        chat_session = Sessions(
+            user_id=UUID(user_b["id"]),
+            name="Tenant B private session",
+            assistant_id=UUID(assistant_b["id"]),
+        )
+        session.add(chat_session)
+        await session.flush()
+        question = Questions(
+            question="Tenant B private question",
+            answer="Tenant B private answer",
+            num_tokens_question=5,
+            num_tokens_answer=5,
+            tenant_id=UUID(tenant_b["id"]),
+            session_id=chat_session.id,
+            assistant_id=UUID(assistant_b["id"]),
+            logging_details_id=logging_details.id,
+        )
+        session.add(question)
+        await session.flush()
+        message_id = question.id
+
+    authorized_response = await client.get(
+        f"/api/v1/logging/{message_id}/",
+        headers={"Authorization": f"Bearer {token_b}"},
+    )
+    assert authorized_response.status_code == 200, authorized_response.text
+    assert (
+        authorized_response.json()["logging_details"]["context"]
+        == "tenant-b-private-context"
+    )
+
+    response = await client.get(
+        f"/api/v1/logging/{message_id}/",
+        headers={"Authorization": f"Bearer {token_a}"},
+    )
+
+    assert response.status_code == 404, response.text
+    assert "tenant" not in response.text.lower()
+    assert "private" not in response.text.lower()
 
 
 @pytest.fixture

--- a/backend/tests/integration/test_service_key_endpoint_gates.py
+++ b/backend/tests/integration/test_service_key_endpoint_gates.py
@@ -197,6 +197,21 @@ async def test_api_key_lifecycle_mutations_reject_service_keys(
     assert "session token" in resp.text.lower()
 
 
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_logging_details_rejects_service_key(
+    client,
+    tenant_read_service_secret,
+):
+    response = await client.get(
+        f"/api/v1/logging/{uuid4()}/",
+        headers={"X-API-Key": tenant_read_service_secret},
+    )
+
+    assert response.status_code == 403, response.text
+    assert response.json().get("code") == "session_auth_required"
+
+
 # ---------------------------------------------------------------------------
 # 3. User-identity gate — (b)-class endpoints reject service keys
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_api_key_route_coverage.py
+++ b/backend/tests/unit/test_api_key_route_coverage.py
@@ -112,7 +112,7 @@ INTENTIONALLY_UNGUARDED = {
     "/integrations": "Tenant admin scope + admin key guards (TENANT_ADMIN_API_KEY_GUARDS)",
     "/jobs": "Tenant-scope guard (TENANT_ADMIN_SCOPE_GUARDS); service-layer authorization",
     "/analysis": "Tenant-scope guard (TENANT_ADMIN_SCOPE_GUARDS); service-layer role checks",
-    "/logging": "Tenant-scope guard (TENANT_ADMIN_SCOPE_GUARDS); router-level auth",
+    "/logging": "Tenant-scope guard plus session-only authentication",
     "/completion-models": "Model catalog endpoints are mounted with admin scope + admin key guards",
     "/embedding-models": "Model catalog endpoints are mounted with admin scope + admin key guards",
     "/transcription-models": "Model catalog endpoints are mounted with admin scope + admin key guards",
@@ -575,6 +575,12 @@ class TestHighRiskExactRouteGuards:
         assert not _route_has_dep_name(route, "_api_key_permission_dep"), (
             f"{label} should not require _api_key_permission_dep"
         )
+
+    def test_logging_details_requires_bearer_session(self):
+        route = _find_route_by_method_and_paths(
+            "GET", "/logging/{message_id}/", "/logging/{message_id}"
+        )
+        assert _route_has_dep_name(route, "require_session_auth")
 
     def test_files_routes_have_scope_resource_and_delete_scope_guards(self):
         list_route = _find_route_by_method_and_paths("GET", "/files/", "/files")

--- a/backend/tests/unittests/analysis.py/test_analysis_service.py
+++ b/backend/tests/unittests/analysis.py/test_analysis_service.py
@@ -120,13 +120,13 @@ async def test_get_message_for_insights_authorizes_assistant_before_hydration(
         assistant_id=assistant_id,
         group_chat_id=None,
     )
-    service.question_repo.get.return_value = question
+    service.question_repo.get_for_tenant.return_value = question
 
     result = await service.get_message_for_insights(message_id=message_id)
 
     assert result is question
     mock_actor.can_access_insight_assistant.assert_called_once()
-    service.question_repo.get.assert_awaited_once_with(
+    service.question_repo.get_for_tenant.assert_awaited_once_with(
         id=message_id,
         tenant_id=service.user.tenant_id,
     )
@@ -144,13 +144,13 @@ async def test_get_message_for_insights_authorizes_group_chat_before_hydration(
         assistant_id=None,
         group_chat_id=group_chat_id,
     )
-    service.question_repo.get.return_value = question
+    service.question_repo.get_for_tenant.return_value = question
 
     result = await service.get_message_for_insights(message_id=message_id)
 
     assert result is question
     mock_actor.can_access_insight_group_chat.assert_called_once()
-    service.question_repo.get.assert_awaited_once_with(
+    service.question_repo.get_for_tenant.assert_awaited_once_with(
         id=message_id,
         tenant_id=service.user.tenant_id,
     )
@@ -174,7 +174,7 @@ async def test_get_message_for_insights_hides_missing_or_malformed_session(
     with pytest.raises(NotFoundException, match="Message not found"):
         await service.get_message_for_insights(message_id=uuid4())
 
-    service.question_repo.get.assert_not_awaited()
+    service.question_repo.get_for_tenant.assert_not_awaited()
 
 
 async def test_get_message_for_insights_hides_denied_actor_before_hydration(
@@ -191,7 +191,7 @@ async def test_get_message_for_insights_hides_denied_actor_before_hydration(
     with pytest.raises(NotFoundException, match="Message not found"):
         await service.get_message_for_insights(message_id=uuid4())
 
-    service.question_repo.get.assert_not_awaited()
+    service.question_repo.get_for_tenant.assert_not_awaited()
 
 
 async def test_get_message_for_insights_requires_permission_before_projection(
@@ -203,7 +203,7 @@ async def test_get_message_for_insights_requires_permission_before_projection(
         await service.get_message_for_insights(message_id=uuid4())
 
     service.question_repo.get_session_partner.assert_not_awaited()
-    service.question_repo.get.assert_not_awaited()
+    service.question_repo.get_for_tenant.assert_not_awaited()
 
 
 async def test_ask_question_not_in_space(service: AnalysisService):

--- a/backend/tests/unittests/analysis.py/test_analysis_service.py
+++ b/backend/tests/unittests/analysis.py/test_analysis_service.py
@@ -4,6 +4,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from eneo.actors import SpaceActor
 from eneo.ai_models.completion_models.completion_model import (
     CompletionModel,
 )
@@ -13,7 +14,12 @@ from eneo.analysis.analysis_service import (
     NO_QUESTIONS_ANSWER,
     AnalysisService,
 )
-from eneo.main.exceptions import BadRequestException, UnauthorizedException
+from eneo.main.exceptions import (
+    BadRequestException,
+    NotFoundException,
+    UnauthorizedException,
+)
+from eneo.questions.questions_repo import QuestionSessionPartner
 from eneo.roles.permissions import Permission
 from tests.fixtures import TEST_UUID
 
@@ -42,9 +48,9 @@ def user():
 
 @pytest.fixture(name="mock_actor")
 def mock_actor():
-    """Create a mock actor with the necessary methods."""
-    actor = MagicMock()
-    actor.can_access_insights.return_value = True
+    actor = MagicMock(spec=SpaceActor)
+    actor.can_access_insight_assistant.return_value = True
+    actor.can_access_insight_group_chat.return_value = True
     return actor
 
 
@@ -100,6 +106,104 @@ def analysis_service(user, mock_space_service):
         group_chat_service=group_chat_service,
         completion_service=AsyncMock(),
     )
+
+
+async def test_get_message_for_insights_authorizes_assistant_before_hydration(
+    service: AnalysisService,
+    mock_actor,
+):
+    message_id = uuid4()
+    assistant_id = uuid4()
+    question = MagicMock()
+    service.user.permissions = [Permission.INSIGHTS]
+    service.question_repo.get_session_partner.return_value = QuestionSessionPartner(
+        assistant_id=assistant_id,
+        group_chat_id=None,
+    )
+    service.question_repo.get.return_value = question
+
+    result = await service.get_message_for_insights(message_id=message_id)
+
+    assert result is question
+    mock_actor.can_access_insight_assistant.assert_called_once()
+    service.question_repo.get.assert_awaited_once_with(
+        id=message_id,
+        tenant_id=service.user.tenant_id,
+    )
+
+
+async def test_get_message_for_insights_authorizes_group_chat_before_hydration(
+    service: AnalysisService,
+    mock_actor,
+):
+    message_id = uuid4()
+    group_chat_id = uuid4()
+    question = MagicMock()
+    service.user.permissions = [Permission.INSIGHTS]
+    service.question_repo.get_session_partner.return_value = QuestionSessionPartner(
+        assistant_id=None,
+        group_chat_id=group_chat_id,
+    )
+    service.question_repo.get.return_value = question
+
+    result = await service.get_message_for_insights(message_id=message_id)
+
+    assert result is question
+    mock_actor.can_access_insight_group_chat.assert_called_once()
+    service.question_repo.get.assert_awaited_once_with(
+        id=message_id,
+        tenant_id=service.user.tenant_id,
+    )
+
+
+@pytest.mark.parametrize(
+    "partner",
+    [
+        None,
+        QuestionSessionPartner(assistant_id=None, group_chat_id=None),
+        QuestionSessionPartner(assistant_id=uuid4(), group_chat_id=uuid4()),
+    ],
+)
+async def test_get_message_for_insights_hides_missing_or_malformed_session(
+    service: AnalysisService,
+    partner: QuestionSessionPartner | None,
+):
+    service.user.permissions = [Permission.INSIGHTS]
+    service.question_repo.get_session_partner.return_value = partner
+
+    with pytest.raises(NotFoundException, match="Message not found"):
+        await service.get_message_for_insights(message_id=uuid4())
+
+    service.question_repo.get.assert_not_awaited()
+
+
+async def test_get_message_for_insights_hides_denied_actor_before_hydration(
+    service: AnalysisService,
+    mock_actor,
+):
+    service.user.permissions = [Permission.INSIGHTS]
+    service.question_repo.get_session_partner.return_value = QuestionSessionPartner(
+        assistant_id=uuid4(),
+        group_chat_id=None,
+    )
+    mock_actor.can_access_insight_assistant.return_value = False
+
+    with pytest.raises(NotFoundException, match="Message not found"):
+        await service.get_message_for_insights(message_id=uuid4())
+
+    service.question_repo.get.assert_not_awaited()
+
+
+async def test_get_message_for_insights_requires_permission_before_projection(
+    service: AnalysisService,
+):
+    service.user.permissions = []
+
+    with pytest.raises(UnauthorizedException):
+        await service.get_message_for_insights(message_id=uuid4())
+
+    service.question_repo.get_session_partner.assert_not_awaited()
+    service.question_repo.get.assert_not_awaited()
 
 
 async def test_ask_question_not_in_space(service: AnalysisService):

--- a/backend/tests/unittests/authentication/test_auth_dependencies.py
+++ b/backend/tests/unittests/authentication/test_auth_dependencies.py
@@ -1,0 +1,20 @@
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from eneo.authentication.auth_dependencies import require_session_auth
+
+
+async def test_require_session_auth_returns_structured_api_key_denial():
+    request = MagicMock()
+    request.state.api_key = MagicMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await require_session_auth(MagicMock(), request)
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == {
+        "code": "session_auth_required",
+        "message": "This endpoint requires a session token.",
+    }

--- a/backend/tests/unittests/logging/test_logging_router.py
+++ b/backend/tests/unittests/logging/test_logging_router.py
@@ -1,0 +1,47 @@
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from eneo.logging import logging_router
+from eneo.main.exceptions import BadRequestException
+
+
+async def test_get_logging_details_uses_authorized_analysis_read(monkeypatch):
+    message_id = uuid4()
+    question = MagicMock(logging_details=MagicMock())
+    response = MagicMock()
+    analysis_service = AsyncMock()
+    analysis_service.get_message_for_insights.return_value = question
+    container = MagicMock()
+    container.analysis_service.return_value = analysis_service
+    monkeypatch.setattr(
+        logging_router, "to_question_logging", MagicMock(return_value=response)
+    )
+
+    result = await logging_router.get_logging_details(
+        message_id=message_id,
+        container=container,
+    )
+
+    assert result is response
+    analysis_service.get_message_for_insights.assert_awaited_once_with(
+        message_id=message_id
+    )
+    logging_router.to_question_logging.assert_called_once_with(question)
+
+
+async def test_get_logging_details_preserves_unlogged_bad_request():
+    message_id = uuid4()
+    analysis_service = AsyncMock()
+    analysis_service.get_message_for_insights.return_value = MagicMock(
+        logging_details=None
+    )
+    container = MagicMock()
+    container.analysis_service.return_value = analysis_service
+
+    with pytest.raises(BadRequestException, match="Question was not logged"):
+        await logging_router.get_logging_details(
+            message_id=message_id,
+            container=container,
+        )

--- a/backend/tests/unittests/questions/test_questions_repo.py
+++ b/backend/tests/unittests/questions/test_questions_repo.py
@@ -62,13 +62,13 @@ async def test_get_session_partner_uses_tenant_scoped_scalar_join():
     assert tenant_id in compiled.params.values()
 
 
-async def test_get_is_tenant_scoped_before_hydration():
+async def test_get_for_tenant_is_scoped_before_hydration():
     question_id = uuid4()
     tenant_id = uuid4()
     repo = QuestionRepository(AsyncMock())
     repo.delegate.get_model_from_query = AsyncMock(return_value=None)
 
-    question = await repo.get(id=question_id, tenant_id=tenant_id)
+    question = await repo.get_for_tenant(id=question_id, tenant_id=tenant_id)
 
     assert question is None
     statement = repo.delegate.get_model_from_query.await_args.args[0]

--- a/backend/tests/unittests/questions/test_questions_repo.py
+++ b/backend/tests/unittests/questions/test_questions_repo.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 from sqlalchemy.dialects import postgresql
 
 from eneo.questions.question import QuestionAdd
-from eneo.questions.questions_repo import QuestionRepository
+from eneo.questions.questions_repo import QuestionRepository, QuestionSessionPartner
 from eneo.skills.domain.skill import (
     SkillActivationEvidenceV1,
     SkillActivationReference,
@@ -29,6 +29,55 @@ async def test_get_by_tenant_filters_out_questions_without_session_id():
     compiled = str(stmt.compile(dialect=postgresql.dialect()))
 
     assert "questions.session_id IS NOT NULL" in compiled
+
+
+async def test_get_session_partner_uses_tenant_scoped_scalar_join():
+    question_id = uuid4()
+    tenant_id = uuid4()
+    assistant_id = uuid4()
+    result = MagicMock()
+    result.one_or_none.return_value = (assistant_id, None)
+    session = AsyncMock()
+    session.execute.return_value = result
+    repo = QuestionRepository(session)
+
+    partner = await repo.get_session_partner(
+        id=question_id,
+        tenant_id=tenant_id,
+    )
+
+    assert partner == QuestionSessionPartner(
+        assistant_id=assistant_id,
+        group_chat_id=None,
+    )
+    statement = session.execute.await_args.args[0]
+    compiled = statement.compile(dialect=postgresql.dialect())
+    sql = str(compiled)
+    assert "FROM questions JOIN sessions" in sql
+    assert "questions.id =" in sql
+    assert "questions.tenant_id =" in sql
+    assert "questions.question" not in sql
+    assert "questions.answer" not in sql
+    assert question_id in compiled.params.values()
+    assert tenant_id in compiled.params.values()
+
+
+async def test_get_is_tenant_scoped_before_hydration():
+    question_id = uuid4()
+    tenant_id = uuid4()
+    repo = QuestionRepository(AsyncMock())
+    repo.delegate.get_model_from_query = AsyncMock(return_value=None)
+
+    question = await repo.get(id=question_id, tenant_id=tenant_id)
+
+    assert question is None
+    statement = repo.delegate.get_model_from_query.await_args.args[0]
+    compiled = statement.compile(dialect=postgresql.dialect())
+    sql = str(compiled)
+    assert "questions.id =" in sql
+    assert "questions.tenant_id =" in sql
+    assert question_id in compiled.params.values()
+    assert tenant_id in compiled.params.values()
 
 
 async def test_add_serializes_skill_provenance_as_json_safe_revision_references():

--- a/docs/goals/enterprise-skills-rollout/state.yaml
+++ b/docs/goals/enterprise-skills-rollout/state.yaml
@@ -30,12 +30,12 @@ continuity:
   current_thread_id: "019f8f85-2ea6-7030-8c48-6d90143da5e0"
   previous_thread_id: "019f84c4-21db-7a00-b2cd-ae3d294d14ba"
   rotation_count: 1
-  completed_write_tasks_in_thread: 6
+  completed_write_tasks_in_thread: 7
   handoff_note: null
   last_handoff_at: null
-  last_verified_revision: "5d54e242a0edd878ef0768c00ea35b63c827e50a"
+  last_verified_revision: "d528ec0af6d15a9343090e3e04303d74ce530d9b"
 
-active_task: T016
+active_task: T021
 
 tasks:
   - id: T001
@@ -1043,10 +1043,10 @@ tasks:
   - id: T016
     type: worker
     assignee: Worker
-    status: active
+    status: done
     reasoning_hint: high
     objective: "Implement Task #553 slice 5A: Assistant binding-mode save contracts, admin runtime-policy UI, honest activation controls, and the shared fit/activatability owner."
-    tracking_issue: "https://github.com/eneo-ai/eneo/issues/602"
+    tracking_issue: "https://github.com/eneo-ai/eneo/issues/604"
     inputs:
       - "Completed T015 receipt"
       - "docs/enterprise-skills-roadmap.md slice 5 contract"
@@ -1083,6 +1083,108 @@ tasks:
     stop_if:
       - "Fit or activatability would be calculated in more than one owner."
       - "The UI needs a second design system or Apps would gain on-demand behavior."
+    receipt:
+      result: done
+      summary: "Shipped Assistant Always/On demand controls and tenant-admin runtime-policy controls through the shared backend activatability owner, while preserving eager-only App and Personal Chat contracts."
+      tracking_issue: "https://github.com/eneo-ai/eneo/issues/604"
+      merged_pr: 606
+      source_head: "17fc26fb377b2fe25a6cc5136be3d80835b3969b"
+      merge_commit: "a3652e59fbf057c1b7607cf6b5b8c9992c76d9be"
+      merged_at: "2026-07-26T20:33:16Z"
+      github_checks: "All required checks passed, including Frontend, Frontend E2E, schema drift, coverage diff, dependency review, and all Docker builds."
+      final_review: "Review 3 confirmed F1 resolved and found no current in-scope findings with complete changed-file coverage."
+      review_url: "https://github.com/eneo-ai/eneo/pull/606#issuecomment-5085238909"
+      changed_files:
+        - "frontend/apps/web/src/lib/features/skills/SkillBindingsEditor.svelte"
+        - "frontend/apps/web/src/lib/features/skills/SkillRuntimePolicySettings.svelte"
+        - "frontend/apps/web/src/lib/features/skills/skillBindings.ts"
+        - "frontend/apps/web/src/lib/features/skills/skillRuntimePolicy.ts"
+        - "frontend/apps/web/src/routes/(app)/admin/"
+        - "frontend/apps/web/src/routes/(app)/spaces/[spaceId]/assistants/[assistantId]/edit/"
+        - "frontend/packages/eneo-js/src/endpoints/settings.js"
+        - "frontend/packages/eneo-js/src/endpoints/skills.js"
+        - "frontend/apps/docs-site/src/content/guides/skills.mdx"
+      commands:
+        - "bunx vitest run <five affected web test files>"
+        - "node --test settings.test.js skills.test.js"
+        - "bun run --filter @eneo/web check"
+        - "bun run --filter @eneo/web lint"
+        - "NODE_OPTIONS='--max-old-space-size=8192' bun run --filter @eneo/web build"
+        - "bun run build (docs-site)"
+        - "pre-push hook"
+      verification:
+        - "frontend: 26 affected web tests passed"
+        - "SDK: 13 endpoint tests passed; compatibility follow-up passed 17 eneo-js tests"
+        - "Svelte check: 0 errors and 0 warnings"
+        - "frontend and SDK lint, web production build, docs build, schema drift, and pre-push hooks passed"
+        - "Impeccable detector found no changed-surface findings"
+        - "Claude pre-commit and post-fix verification passed, final score 8"
+
+  - id: T021
+    type: worker
+    assignee: Worker
+    status: active
+    reasoning_hint: high
+    objective: "Secure the existing Admin Insights message-logging endpoint with tenant-scoped, body-free authorization before any message or attachment hydration."
+    tracking_issue: "https://github.com/eneo-ai/eneo/issues/608"
+    inputs:
+      - "Current /logging/{message_id}/ Admin Insights contract"
+      - "Canonical Permission.INSIGHTS and SpaceActor authorization"
+      - ".codex/artifacts/claude-peer-loop-secure-insights-message-logging-access-20260726T213646Z.md"
+    allowed_files:
+      - "backend/src/eneo/analysis/analysis_service.py"
+      - "backend/src/eneo/authentication/auth_dependencies.py"
+      - "backend/src/eneo/logging/logging_router.py"
+      - "backend/src/eneo/questions/questions_repo.py"
+      - "backend/tests/"
+      - "frontend/apps/docs-site/src/content/docs/api-key-management.mdx"
+      - "frontend/packages/eneo-js/src/types/schema.d.ts"
+      - "docs/goals/enterprise-skills-rollout/"
+    constraints:
+      - "Preserve the public MessageLogging response and the authorized unlogged-message 400 behavior."
+      - "Require bearer-session authentication and canonical Insights permission; API keys and service principals remain denied."
+      - "Authorize a bounded tenant-scoped session-partner projection before Question, attachment, relationship, or logging-body hydration."
+      - "Use the existing SpaceActor insight authorization; personal Space, foreign tenant, disabled Insights, malformed sessions, and unauthorized resources fail with generic denial."
+      - "Do not create a diagnostics service, generic observability framework, UI change, migration, or MessageLogging payload change; regenerate the SDK schema for explicit 403 route metadata."
+    verify:
+      - "Authorized Assistant and group-chat Insights access preserves the existing response shape"
+      - "Foreign tenant, personal Space, disabled Insights, missing permission, malformed session, API key, and service principal fail closed"
+      - "Denied paths never hydrate Question bodies, files, relationships, or provider logging payloads"
+      - "Route metadata, focused unit/integration tests, Ruff, Pyright, schema drift, concise docs-site guidance, CI, Claude verification, and fresh /review"
+    stop_if:
+      - "The change requires a second Insights authorization owner or a public payload change."
+      - "Authorization cannot be proven before full message hydration."
+    receipt: null
+
+  - id: T020
+    type: worker
+    assignee: Worker
+    status: queued
+    reasoning_hint: high
+    objective: "Add permission-gated, body-free Skill activation evidence to the existing chat debug panel without changing normal chat behavior."
+    tracking_issue: "https://github.com/eneo-ai/eneo/issues/605"
+    inputs:
+      - "Completed T016 and T021 receipts"
+      - "Existing SHOW_CHAT_DEBUG_PANEL feature flag and generic chat debug panel"
+      - "Persisted body-free Question Skill activation evidence from T013-T015"
+      - "Current chat page and shadcn-svelte Sheet primitives"
+    constraints:
+      - "Normal chat requests never enable capture, extended logging, or provider-body hydration."
+      - "Keep /logging/{message_id}/ and MessageLogging owned by Admin Insights; T020 uses a separate, narrow conversation diagnostics endpoint."
+      - "Authorize the session partner and current Assistant access before reading one message's scalar Skill evidence."
+      - "Preserve generic model, token, MCP/tool, knowledge, and file diagnostics already available from the loaded conversation turn."
+      - "Never expose message bodies, Skill instructions, administrator incident reasons, credentials, hidden reasoning, tool arguments/results, or file contents."
+      - "Use installed shadcn-svelte components and the existing design system; no new UI dependency or parallel debug store."
+    verify:
+      - "Available, always-active, activated-on-demand, blocked, rejected, fallback, token-source, model, round, latency, ordering, and empty/error states"
+      - "Ordinary response non-disclosure plus flag, permission, API-key, tenant, session, partner, revoked-access, and group-chat authorization boundaries"
+      - "Generic model/token/MCP/tool/knowledge/file sections remain useful and body-free"
+      - "Migration upgrade/downgrade and generated OpenAPI/SDK contracts"
+      - "Keyboard, focus, stale-request, long-name, long-list, loading, and narrow-screen behavior"
+      - "Natural Swedish/English copy, docs build, backend/frontend suites, CI, Claude verification, and fresh /review"
+    stop_if:
+      - "The implementation would duplicate runtime activation decisions, persist a second evidence representation, or expose bodies or hidden reasoning."
+      - "The diagnostics route cannot remain narrow, scalar, and independent of Admin Insights logging."
     receipt: null
 
   - id: T019

--- a/frontend/apps/docs-site/src/content/docs/api-key-management.mdx
+++ b/frontend/apps/docs-site/src/content/docs/api-key-management.mdx
@@ -64,6 +64,9 @@ Two related guardrails come from the same principle:
 
 - **Cannot use user-identity endpoints** (`/me`, info-blob updates): `403` with `code: "user_identity_required"`.
 - **Cannot manage other API keys**: API-key mutations require a session login; any API key, including a tenant-admin service key, is rejected.
+- **Cannot read Admin Insights message details**: These endpoints require an
+  interactive session. Every API key receives `403` with
+  `code: "session_auth_required"`.
 
 **Why service keys exist**: In production environments, integrations should not break when an employee leaves the organization. With user keys, deactivating a departing employee's account would silently break every integration that used their key. Service keys solve this by decoupling key validity from any individual user's lifecycle.
 

--- a/frontend/packages/eneo-js/src/types/schema.d.ts
+++ b/frontend/packages/eneo-js/src/types/schema.d.ts
@@ -27038,6 +27038,15 @@ export interface operations {
           "application/json": components["schemas"]["GeneralError"];
         };
       };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
       /** @description Not Found */
       404: {
         headers: {


### PR DESCRIPTION
## Summary
- Require an interactive user session for Insights message logging.
- Check the existing Insights permission and Space access before loading message bodies, files, relationships, or logging details.
- Preserve successful logging responses and the existing 400 response for authorized messages without logging data.
- Return a stable `session_auth_required` code when an API key reaches a session-only route.

## Why
The logging route previously loaded a message before the canonical Insights authorization path ran. `AnalysisService` and `SpaceActor` now remain the owners of Insights access, while `QuestionRepository` exposes only the small projections needed to authorize first and hydrate later.

## What changed
- The logging route now uses `require_session_auth` and the container-owned `AnalysisService`.
- `AnalysisService` checks `Permission.INSIGHTS` and existing `SpaceActor` access before full message hydration.
- `QuestionRepository` keeps its established internal read contract and adds explicit tenant-scoped hydration plus a scalar Assistant/group-chat projection for this security boundary.
- API-key guards, PostgreSQL isolation coverage, route metadata, generated SDK schema, and concise docs were updated.

## What was deliberately not changed
- No new endpoint, payload field, migration, diagnostics framework, or UI.
- No new multi-tenancy abstraction; the existing tenant predicate is used only as the current data-security boundary.
- No refactor of unrelated access-matrix fixtures.

## Deletion / consolidation
The direct logging-repository read was removed. Authorization now reuses the existing Insights service and `SpaceActor` path instead of creating a second security owner.

## Risk and rollback
The compatibility change is the structured `session_auth_required` response on routes already protected by `require_session_auth`. Successful logging responses are unchanged and there is no schema migration. Reverting this PR restores the previous behavior.

## Validation
- 82 focused unit and contract tests passed; the compatibility fix added a separate 39-test focused pass.
- 5 focused PostgreSQL integration checks passed, including authorized and denied cross-boundary access and the existing object-content hydration path.
- 42 route-coverage tests passed.
- Ruff, Ruff format, Pyright with 0 errors, diff checks, Goal Maker validation, schema drift, and pre-push hooks passed.
- Claude verification returned green with score 8.
- Fresh Review 2 found no current in-scope findings on commit `87010d995`.
- GitHub docs build and all completed CI jobs are green; the backend integration job remains the final merge gate.

Fixes #608
