### PR TITLE
feat(knowledge): keep documents available during updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
         run: bun run build
         env:
           # The Svelte production build exceeds Node's default heap on GitHub-hosted runners.
-          NODE_OPTIONS: --max-old-space-size=6144
+          NODE_OPTIONS: --max-old-space-size=8192
 
   frontend-e2e:
     name: Frontend E2E
@@ -405,7 +405,7 @@ jobs:
         working-directory: frontend/apps/web
         env:
           SVELTE_KIT_OUT_DIR: .svelte-kit-e2e
-          NODE_OPTIONS: --max-old-space-size=6144
+          NODE_OPTIONS: --max-old-space-size=8192
         run: bun run build
 
       - name: Run E2E tests

--- a/backend/alembic/versions/202607271000_add_info_blob_versions.py
+++ b/backend/alembic/versions/202607271000_add_info_blob_versions.py
@@ -26,6 +26,7 @@ _SOURCE_NOT_NULL = "ck_info_blobs_source_id_not_null"
 _STATE_NOT_NULL = "ck_info_blobs_version_state_not_null"
 _ACTIVE_SOURCE_INDEX = "uq_info_blobs_active_source"
 _SOURCE_INDEX = "ix_info_blobs_source_id"
+_INCOMPLETE_VERSION_PREDICATE = "(source_id IS NULL OR version_state IS NULL)"
 
 
 def _backfill_versions() -> None:
@@ -38,7 +39,7 @@ def _backfill_versions() -> None:
                 WITH batch AS (
                     SELECT id
                     FROM {_TABLE}
-                    WHERE source_id IS NULL OR version_state IS NULL
+                    WHERE {_INCOMPLETE_VERSION_PREDICATE}
                       AND (:last_id IS NULL OR id > CAST(:last_id AS UUID))
                     ORDER BY id
                     LIMIT :batch_size

--- a/backend/alembic/versions/202607271000_add_info_blob_versions.py
+++ b/backend/alembic/versions/202607271000_add_info_blob_versions.py
@@ -30,28 +30,35 @@ _SOURCE_INDEX = "ix_info_blobs_source_id"
 
 def _backfill_versions() -> None:
     bind = op.get_bind()
+    last_id = None
     while True:
-        result = bind.execute(
+        batch_size, last_id = bind.execute(
             sa.text(
                 f"""
                 WITH batch AS (
-                    SELECT ctid
+                    SELECT id
                     FROM {_TABLE}
                     WHERE source_id IS NULL OR version_state IS NULL
-                    ORDER BY ctid
+                      AND (:last_id IS NULL OR id > CAST(:last_id AS UUID))
+                    ORDER BY id
                     LIMIT :batch_size
                     FOR UPDATE
+                ), updated AS (
+                    UPDATE {_TABLE} AS info_blob
+                    SET source_id = COALESCE(info_blob.source_id, info_blob.id),
+                        version_state = COALESCE(info_blob.version_state, 'active')
+                    FROM batch
+                    WHERE info_blob.id = batch.id
+                    RETURNING info_blob.id
                 )
-                UPDATE {_TABLE} AS info_blob
-                SET source_id = COALESCE(info_blob.source_id, info_blob.id),
-                    version_state = COALESCE(info_blob.version_state, 'active')
-                FROM batch
-                WHERE info_blob.ctid = batch.ctid
+                SELECT
+                    (SELECT count(*) FROM updated),
+                    (SELECT id FROM batch ORDER BY id DESC LIMIT 1)
                 """
             ),
-            {"batch_size": _BACKFILL_BATCH_SIZE},
-        )
-        if result.rowcount < _BACKFILL_BATCH_SIZE:
+            {"batch_size": _BACKFILL_BATCH_SIZE, "last_id": last_id},
+        ).one()
+        if batch_size < _BACKFILL_BATCH_SIZE:
             break
 
     remaining = bind.execute(

--- a/backend/alembic/versions/202607271000_add_info_blob_versions.py
+++ b/backend/alembic/versions/202607271000_add_info_blob_versions.py
@@ -1,0 +1,163 @@
+"""preserve complete InfoBlob versions during replacement
+
+Revision ID: 202607271000
+Revises: 202607262200
+
+Downgrade is lossless only before a replacement creates history. Once a source
+has a superseded row or more than one version, recover forward or restore a
+matching pre-upgrade database backup rather than discarding versions.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "202607271000"
+down_revision: str | tuple[str, str] | None = "202607262200"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "info_blobs"
+_BACKFILL_BATCH_SIZE = 1_000
+_STATE_CONSTRAINT = "ck_info_blobs_version_state"
+_SOURCE_NOT_NULL = "ck_info_blobs_source_id_not_null"
+_STATE_NOT_NULL = "ck_info_blobs_version_state_not_null"
+_ACTIVE_SOURCE_INDEX = "uq_info_blobs_active_source"
+_SOURCE_INDEX = "ix_info_blobs_source_id"
+
+
+def _backfill_versions() -> None:
+    bind = op.get_bind()
+    while True:
+        result = bind.execute(
+            sa.text(
+                f"""
+                WITH batch AS (
+                    SELECT ctid
+                    FROM {_TABLE}
+                    WHERE source_id IS NULL OR version_state IS NULL
+                    ORDER BY ctid
+                    LIMIT :batch_size
+                    FOR UPDATE
+                )
+                UPDATE {_TABLE} AS info_blob
+                SET source_id = COALESCE(info_blob.source_id, info_blob.id),
+                    version_state = COALESCE(info_blob.version_state, 'active')
+                FROM batch
+                WHERE info_blob.ctid = batch.ctid
+                """
+            ),
+            {"batch_size": _BACKFILL_BATCH_SIZE},
+        )
+        if result.rowcount < _BACKFILL_BATCH_SIZE:
+            break
+
+    remaining = bind.execute(
+        sa.text(
+            f"""
+            SELECT count(*)
+            FROM {_TABLE}
+            WHERE source_id IS NULL OR version_state IS NULL
+            """
+        )
+    ).scalar_one()
+    if remaining:
+        raise RuntimeError(
+            f"InfoBlob version backfill left {remaining} rows incomplete"
+        )
+
+
+def _create_indexes() -> None:
+    op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_ACTIVE_SOURCE_INDEX}")
+    op.execute(
+        f"""
+        CREATE UNIQUE INDEX CONCURRENTLY {_ACTIVE_SOURCE_INDEX}
+        ON {_TABLE} (source_id)
+        WHERE version_state = 'active'
+        """
+    )
+    op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_SOURCE_INDEX}")
+    op.execute(f"CREATE INDEX CONCURRENTLY {_SOURCE_INDEX} ON {_TABLE} (source_id)")
+
+
+def upgrade() -> None:
+    # Deployments stop backend and worker writers for this producer-sensitive
+    # migration. Autocommit keeps each bounded backfill/index phase restartable
+    # and prevents a table-wide transaction from retaining row locks.
+    with op.get_context().autocommit_block():
+        op.execute(
+            f"""
+            ALTER TABLE {_TABLE}
+                ADD COLUMN IF NOT EXISTS source_id UUID,
+                ADD COLUMN IF NOT EXISTS version_state VARCHAR(16)
+            """
+        )
+        _backfill_versions()
+        op.execute(
+            f"""
+            ALTER TABLE {_TABLE}
+                DROP CONSTRAINT IF EXISTS {_STATE_CONSTRAINT},
+                DROP CONSTRAINT IF EXISTS {_SOURCE_NOT_NULL},
+                DROP CONSTRAINT IF EXISTS {_STATE_NOT_NULL},
+                ADD CONSTRAINT {_STATE_CONSTRAINT}
+                    CHECK (version_state IN ('active', 'superseded')) NOT VALID,
+                ADD CONSTRAINT {_SOURCE_NOT_NULL}
+                    CHECK (source_id IS NOT NULL) NOT VALID,
+                ADD CONSTRAINT {_STATE_NOT_NULL}
+                    CHECK (version_state IS NOT NULL) NOT VALID
+            """
+        )
+        for constraint in (
+            _STATE_CONSTRAINT,
+            _SOURCE_NOT_NULL,
+            _STATE_NOT_NULL,
+        ):
+            op.execute(f"ALTER TABLE {_TABLE} VALIDATE CONSTRAINT {constraint}")
+        op.execute(
+            f"""
+            ALTER TABLE {_TABLE}
+                ALTER COLUMN source_id SET NOT NULL,
+                ALTER COLUMN version_state SET NOT NULL,
+                DROP CONSTRAINT {_SOURCE_NOT_NULL},
+                DROP CONSTRAINT {_STATE_NOT_NULL}
+            """
+        )
+        _create_indexes()
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1
+                    FROM {_TABLE}
+                    WHERE version_state <> 'active'
+                ) OR EXISTS (
+                    SELECT source_id
+                    FROM {_TABLE}
+                    GROUP BY source_id
+                    HAVING count(*) > 1
+                ) THEN
+                    RAISE EXCEPTION
+                        'cannot remove InfoBlob version history; recover forward or restore a matching backup'
+                        USING ERRCODE = '23514';
+                END IF;
+            END;
+            $$
+            """
+        )
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_SOURCE_INDEX}")
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_ACTIVE_SOURCE_INDEX}")
+        op.execute(
+            f"""
+            ALTER TABLE {_TABLE}
+                DROP CONSTRAINT IF EXISTS {_STATE_CONSTRAINT},
+                DROP COLUMN IF EXISTS version_state,
+                DROP COLUMN IF EXISTS source_id
+            """
+        )

--- a/backend/alembic/versions/202607271000_add_info_blob_versions.py
+++ b/backend/alembic/versions/202607271000_add_info_blob_versions.py
@@ -69,6 +69,81 @@ def _backfill_versions() -> None:
         )
 
 
+def _normalize_duplicate_identity(
+    *,
+    predicate: str,
+    partition_by: str,
+) -> None:
+    op.execute(
+        f"""
+        WITH ranked AS (
+            SELECT
+                id,
+                first_value(id) OVER publication AS canonical_source_id,
+                row_number() OVER publication AS version_position,
+                count(*) OVER (
+                    PARTITION BY {partition_by}
+                ) AS version_count
+            FROM {_TABLE}
+            WHERE {predicate}
+            WINDOW publication AS (
+                PARTITION BY {partition_by}
+                ORDER BY updated_at DESC, created_at DESC, id DESC
+            )
+        )
+        UPDATE {_TABLE} AS info_blob
+        SET source_id = ranked.canonical_source_id,
+            version_state = CASE
+                WHEN ranked.version_position = 1 THEN 'active'
+                ELSE 'superseded'
+            END
+        FROM ranked
+        WHERE info_blob.id = ranked.id
+          AND ranked.version_count > 1
+          AND (
+              info_blob.source_id IS DISTINCT FROM ranked.canonical_source_id
+              OR info_blob.version_state IS DISTINCT FROM CASE
+                  WHEN ranked.version_position = 1 THEN 'active'
+                  ELSE 'superseded'
+              END
+          )
+        """
+    )
+
+
+def _normalize_legacy_duplicate_versions() -> None:
+    # Publication ownership follows the same precedence as InfoBlobRepository.
+    # Missing and blank identities stay independent rather than being collapsed.
+    _normalize_duplicate_identity(
+        predicate=("group_id IS NOT NULL AND NULLIF(BTRIM(title), '') IS NOT NULL"),
+        partition_by="group_id, title",
+    )
+    _normalize_duplicate_identity(
+        predicate=(
+            "group_id IS NULL AND website_id IS NOT NULL "
+            "AND NULLIF(BTRIM(title), '') IS NOT NULL"
+        ),
+        partition_by="website_id, title",
+    )
+    _normalize_duplicate_identity(
+        predicate=(
+            "group_id IS NULL AND website_id IS NULL "
+            "AND integration_knowledge_id IS NOT NULL "
+            "AND NULLIF(BTRIM(sharepoint_item_id), '') IS NOT NULL"
+        ),
+        partition_by="integration_knowledge_id, sharepoint_item_id",
+    )
+    _normalize_duplicate_identity(
+        predicate=(
+            "group_id IS NULL AND website_id IS NULL "
+            "AND integration_knowledge_id IS NOT NULL "
+            "AND NULLIF(BTRIM(sharepoint_item_id), '') IS NULL "
+            "AND NULLIF(BTRIM(title), '') IS NOT NULL"
+        ),
+        partition_by="integration_knowledge_id, title",
+    )
+
+
 def _create_indexes() -> None:
     op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_ACTIVE_SOURCE_INDEX}")
     op.execute(
@@ -95,6 +170,7 @@ def upgrade() -> None:
             """
         )
         _backfill_versions()
+        _normalize_legacy_duplicate_versions()
         op.execute(
             f"""
             ALTER TABLE {_TABLE}

--- a/backend/alembic/versions/202607271100_merge_info_blob_and_debug_permission.py
+++ b/backend/alembic/versions/202607271100_merge_info_blob_and_debug_permission.py
@@ -1,0 +1,20 @@
+"""merge InfoBlob versions and assistant debug permission heads
+
+Revision ID: 202607271100
+Revises: 202607271000, 202607261730
+"""
+
+from collections.abc import Sequence
+
+revision: str = "202607271100"
+down_revision: str | tuple[str, str] | None = ("202607271000", "202607261730")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/202607271100_merge_info_blob_and_develop_heads.py
+++ b/backend/alembic/versions/202607271100_merge_info_blob_and_develop_heads.py
@@ -1,13 +1,13 @@
-"""merge InfoBlob versions and assistant debug permission heads
+"""merge InfoBlob versions with the current develop migration head
 
 Revision ID: 202607271100
-Revises: 202607271000, 202607261730
+Revises: 202607271000, 202607271416
 """
 
 from collections.abc import Sequence
 
 revision: str = "202607271100"
-down_revision: str | tuple[str, str] | None = ("202607271000", "202607261730")
+down_revision: str | tuple[str, str] | None = ("202607271000", "202607271416")
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/src/eneo/admin/quota_service.py
+++ b/backend/src/eneo/admin/quota_service.py
@@ -3,6 +3,20 @@ from eneo.main.exceptions import QuotaExceededException
 from eneo.users.user import UserInDB
 
 
+def ensure_quota_capacity(
+    *,
+    tenant_usage: int,
+    tenant_limit: int,
+    user_usage: int,
+    user_limit: int | None,
+    size_in_bytes: int,
+) -> None:
+    if tenant_usage + size_in_bytes > tenant_limit:
+        raise QuotaExceededException("Tenant quota limit exceeded.")
+    if user_limit is not None and user_usage + size_in_bytes > user_limit:
+        raise QuotaExceededException("User quota limit exceeded.")
+
+
 class QuotaService:
     def __init__(self, user: UserInDB, info_blob_repo: InfoBlobRepository):
         super().__init__()
@@ -13,17 +27,21 @@ class QuotaService:
         return len(text.encode("utf-8"))
 
     async def ensure_capacity(self, size_in_bytes: int) -> None:
-        tenant_limit = self.user.tenant.quota_limit
-        tenant_usage = await self.info_blob_repo.get_total_size_of_tenant(
+        tenant_usage = await self.info_blob_repo.get_retained_size_of_tenant(
             self.user.tenant.id
         )
-        if tenant_usage + size_in_bytes > tenant_limit:
-            raise QuotaExceededException("Tenant quota limit exceeded.")
-
-        if self.user.quota_limit is not None:
-            user_usage = await self.info_blob_repo.get_total_size_of_user(self.user.id)
-            if user_usage + size_in_bytes > self.user.quota_limit:
-                raise QuotaExceededException("User quota limit exceeded.")
+        user_usage = (
+            await self.info_blob_repo.get_retained_size_of_user(self.user.id)
+            if self.user.quota_limit is not None
+            else 0
+        )
+        ensure_quota_capacity(
+            tenant_usage=tenant_usage,
+            tenant_limit=self.user.tenant.quota_limit,
+            user_usage=user_usage,
+            user_limit=self.user.quota_limit,
+            size_in_bytes=size_in_bytes,
+        )
 
     async def add_text(self, text_to_add: str) -> int:
         size_of_text = self._size_of_text(text_to_add)

--- a/backend/src/eneo/assistants/assistant_repo.py
+++ b/backend/src/eneo/assistants/assistant_repo.py
@@ -24,7 +24,7 @@ from eneo.database.tables.collections_table import CollectionsTable
 from eneo.database.tables.help_assistant_assignment_history_table import (
     HelpAssistantAssignmentHistory,
 )
-from eneo.database.tables.info_blobs_table import InfoBlobs
+from eneo.database.tables.info_blobs_table import InfoBlobs, active_info_blob_version
 from eneo.database.tables.integration_table import IntegrationKnowledge
 from eneo.database.tables.integration_table import (
     TenantIntegration as TenantIntegrationDBModel,
@@ -394,7 +394,13 @@ class AssistantRepository:
                 CollectionsTable,
                 sa.func.coalesce(sa.func.count(InfoBlobs.id).label("infoblob_count")),
             )
-            .outerjoin(InfoBlobs, CollectionsTable.id == InfoBlobs.group_id)
+            .outerjoin(
+                InfoBlobs,
+                sa.and_(
+                    CollectionsTable.id == InfoBlobs.group_id,
+                    active_info_blob_version(),
+                ),
+            )
             .outerjoin(
                 AssistantsGroups, AssistantsGroups.group_id == CollectionsTable.id
             )

--- a/backend/src/eneo/database/tables/info_blobs_table.py
+++ b/backend/src/eneo/database/tables/info_blobs_table.py
@@ -1,8 +1,10 @@
+from enum import StrEnum
 from typing import Optional
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, LargeBinary
+from sqlalchemy import CheckConstraint, ForeignKey, Index, LargeBinary, String, text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql.elements import ColumnElement
 
 from eneo.database.tables.ai_models_table import EmbeddingModels
 from eneo.database.tables.base_class import BasePublic
@@ -13,7 +15,26 @@ from eneo.database.tables.users_table import Users
 from eneo.database.tables.websites_table import Websites
 
 
+class InfoBlobVersionState(StrEnum):
+    ACTIVE = "active"
+    SUPERSEDED = "superseded"
+
+
 class InfoBlobs(BasePublic):
+    __table_args__ = (
+        CheckConstraint(
+            "version_state IN ('active', 'superseded')",
+            name="ck_info_blobs_version_state",
+        ),
+        Index(
+            "uq_info_blobs_active_source",
+            "source_id",
+            unique=True,
+            postgresql_where=text("version_state = 'active'"),
+        ),
+        Index("ix_info_blobs_source_id", "source_id"),
+    )
+
     text: Mapped[str] = mapped_column()
     title: Mapped[Optional[str]] = mapped_column()
     url: Mapped[Optional[str]] = mapped_column()
@@ -22,6 +43,8 @@ class InfoBlobs(BasePublic):
         LargeBinary(length=32),
         comment="SHA-256 hash of normalized content for change detection",
     )
+    source_id: Mapped[UUID] = mapped_column(nullable=False)
+    version_state: Mapped[str] = mapped_column(String(16), nullable=False)
 
     # Foreign keys
     user_id: Mapped[UUID] = mapped_column(
@@ -47,3 +70,7 @@ class InfoBlobs(BasePublic):
     website: Mapped[Websites] = relationship()
     embedding_model: Mapped[Optional[EmbeddingModels]] = relationship()
     integration_knowledge: Mapped[Optional[IntegrationKnowledge]] = relationship()
+
+
+def active_info_blob_version() -> ColumnElement[bool]:
+    return InfoBlobs.version_state == InfoBlobVersionState.ACTIVE.value

--- a/backend/src/eneo/embedding_models/infrastructure/datastore.py
+++ b/backend/src/eneo/embedding_models/infrastructure/datastore.py
@@ -131,10 +131,9 @@ class Datastore:
         info_blob_chunks = self._chunk_text(info_blob)
 
         if not info_blob_chunks:
-            logger.warning(
-                f"Info Blob {info_blob.id} did not yield any chunks after splitting."
+            raise ValueError(
+                f"InfoBlob {info_blob.id} did not yield searchable content"
             )
-            return
 
         logger.debug(f"Embedding {len(info_blob_chunks)} info-blob chunks.")
         chunk_embedding_list = await self.create_embeddings_service.get_embeddings(

--- a/backend/src/eneo/groups_legacy/api/group_router.py
+++ b/backend/src/eneo/groups_legacy/api/group_router.py
@@ -25,7 +25,6 @@ from eneo.groups_legacy.api.group_models import (
 from eneo.info_blobs import info_blob_protocol
 from eneo.info_blobs.info_blob import (
     InfoBlobAdd,
-    InfoBlobInDB,
     InfoBlobPublic,
     InfoBlobPublicNoText,
 )
@@ -247,7 +246,6 @@ async def add_info_blobs(
     if len(info_blobs.info_blobs) > 128:
         raise BadRequestException("Too many info-blobs!")
 
-    datastore = container.datastore()
     group_service = container.group_service()
     group = await group_service.get_group(id)
 
@@ -264,18 +262,10 @@ async def add_info_blobs(
 
     service = container.info_blob_service()
     info_blobs_added = await service.add_info_blobs(
-        group_id=id, info_blobs=info_blobs_to_add
+        group_id=id,
+        info_blobs=info_blobs_to_add,
+        embedding_model=group.embedding_model,
     )
-
-    # Add to datastore
-    info_blobs_updated: list[InfoBlobInDB] = []
-    for info_blob in info_blobs_added:
-        await datastore.add(
-            info_blob=info_blob,
-            embedding_model=group.embedding_model,
-        )
-        info_blob_updated = await service.update_info_blob_size(info_blob.id)
-        info_blobs_updated.append(info_blob_updated)
 
     # Audit logging for info blob additions
     from eneo.audit.domain.action_types import ActionType
@@ -298,7 +288,7 @@ async def add_info_blobs(
         action=ActionType.FILE_UPLOADED,
         entity_type=EntityType.FILE,
         entity_id=id,  # Group ID
-        description=f"Added {len(info_blobs_updated)} info blobs to collection/group",
+        description=f"Added {len(info_blobs_added)} info blobs to collection/group",
         metadata={
             "actor": {
                 "id": str(current_user.id),
@@ -310,13 +300,13 @@ async def add_info_blobs(
                 "group_name": group.name,
                 "space_id": str(group.space_id) if group.space_id else None,
                 "space_name": space.name if space else None,
-                "blobs_count": len(info_blobs_updated),
+                "blobs_count": len(info_blobs_added),
             },
         },
     )
 
     info_blobs_public = [
-        info_blob_protocol.to_info_blob_public(blob) for blob in info_blobs_updated
+        info_blob_protocol.to_info_blob_public(blob) for blob in info_blobs_added
     ]
 
     return protocol.to_paginated_response(info_blobs_public)

--- a/backend/src/eneo/groups_legacy/group_repo.py
+++ b/backend/src/eneo/groups_legacy/group_repo.py
@@ -10,7 +10,7 @@ from eneo.database.repositories.base import BaseRepositoryDelegate
 from eneo.database.tables.assistant_table import AssistantsGroups
 from eneo.database.tables.collections_table import CollectionsTable
 from eneo.database.tables.groups_spaces_table import GroupsSpaces
-from eneo.database.tables.info_blobs_table import InfoBlobs
+from eneo.database.tables.info_blobs_table import InfoBlobs, active_info_blob_version
 from eneo.database.tables.service_table import ServicesGroups
 from eneo.database.tables.users_table import Users
 from eneo.groups_legacy.api.group_models import Group, GroupCreate, GroupUpdate
@@ -57,7 +57,7 @@ class GroupRepository:
     async def update_group_size(self, group_id: UUID) -> Group | None:
         info_blobs_size_subquery = (
             sa.select(sa.func.coalesce(sa.func.sum(InfoBlobs.size), 0))
-            .where(InfoBlobs.group_id == group_id)
+            .where(InfoBlobs.group_id == group_id, active_info_blob_version())
             .scalar_subquery()
         )
 

--- a/backend/src/eneo/info_blobs/info_blob.py
+++ b/backend/src/eneo/info_blobs/info_blob.py
@@ -48,6 +48,14 @@ class InfoBlobAdd(InfoBlobBase, InfoBlobMetadataUpsertPublic):
 
 class InfoBlobAddToDB(InfoBlobAdd):
     embedding_model_id: UUID
+    source_id: UUID
+    version_state: str
+
+    @model_validator(mode="after")
+    def require_content_hash(self) -> "InfoBlobAddToDB":
+        if self.content_hash is None:
+            raise ValueError("Published InfoBlob content requires a SHA-256 digest")
+        return self
 
 
 class InfoBlobUpdatePublic(BaseModel):
@@ -72,6 +80,8 @@ class InfoBlobInDBNoText(InDB):
     integration_knowledge_id: Optional[UUID] = None
     sharepoint_item_id: Optional[str] = None
     content_hash: Optional[bytes] = None
+    source_id: UUID
+    version_state: str
 
     group: Optional[GroupInDBBase] = None
     website: Optional[WebsiteInDBBase] = None

--- a/backend/src/eneo/info_blobs/info_blob_chunk_repo.py
+++ b/backend/src/eneo/info_blobs/info_blob_chunk_repo.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import defer
 from eneo.database.database import AsyncSession
 from eneo.database.repositories.base import BaseRepositoryDelegate
 from eneo.database.tables.info_blob_chunk_table import InfoBlobChunks
-from eneo.database.tables.info_blobs_table import InfoBlobs
+from eneo.database.tables.info_blobs_table import InfoBlobs, active_info_blob_version
 from eneo.info_blobs.info_blob import (
     InfoBlobChunkInDB,
     InfoBlobChunkInDBWithScore,
@@ -96,6 +96,7 @@ class InfoBlobChunkRepo:
                 InfoBlobs.title,
             )
             .join(InfoBlobs)
+            .where(active_info_blob_version())
             .options(defer(InfoBlobChunks.embedding))
             .order_by(InfoBlobChunks.embedding.cosine_distance(embedding))
             .limit(limit)
@@ -130,7 +131,9 @@ class InfoBlobChunkRepo:
     ):
         stmt = (
             sa.select(InfoBlobChunks)
+            .join(InfoBlobs)
             .filter(InfoBlobChunks.text.match(search_string))
+            .where(active_info_blob_version())
             .limit(limit)
         )
 

--- a/backend/src/eneo/info_blobs/info_blob_repo.py
+++ b/backend/src/eneo/info_blobs/info_blob_repo.py
@@ -1,5 +1,5 @@
 from typing import Any, List
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import sqlalchemy as sa
 from sqlalchemy.orm import defer, selectinload
@@ -9,7 +9,11 @@ from eneo.database.database import AsyncSession
 from eneo.database.repositories.base import BaseRepositoryDelegate
 from eneo.database.tables.collections_table import CollectionsTable
 from eneo.database.tables.info_blob_chunk_table import InfoBlobChunks
-from eneo.database.tables.info_blobs_table import InfoBlobs
+from eneo.database.tables.info_blobs_table import (
+    InfoBlobs,
+    InfoBlobVersionState,
+    active_info_blob_version,
+)
 from eneo.database.tables.integration_table import IntegrationKnowledge
 from eneo.database.tables.users_table import Users
 from eneo.database.tables.websites_table import Websites
@@ -60,7 +64,13 @@ class InfoBlobRepository:
 
         return knowledge
 
-    async def add(self, info_blob: InfoBlobAdd):
+    async def add(
+        self,
+        info_blob: InfoBlobAdd,
+        *,
+        source_id: UUID | None = None,
+        version_state: InfoBlobVersionState = InfoBlobVersionState.ACTIVE,
+    ) -> InfoBlobInDB:
         if info_blob.group_id is not None:
             group = await self._get_group(info_blob.group_id)
             assert group is not None
@@ -85,120 +95,86 @@ class InfoBlobRepository:
                 "InfoBlob must reference a group, website, or integration_knowledge"
             )
 
+        if info_blob.content_hash is None:
+            raise ValueError("Published InfoBlob content requires a SHA-256 digest")
+
         info_blob_to_db = InfoBlobAddToDB(
             **info_blob.model_dump(),
             embedding_model_id=embedding_model_id,
+            source_id=source_id or uuid4(),
+            version_state=version_state.value,
         )
 
         record = await self.delegate.add(info_blob_to_db)
         return InfoBlobInDB.model_validate(record)
 
-    async def upsert_by_title_and_integration_knowledge(
+    async def lock_publication_identity(self, info_blob: InfoBlobAdd) -> None:
+        identity = self._publication_identity(info_blob)
+        await self.session.execute(
+            sa.text("SELECT pg_advisory_xact_lock(hashtextextended(:identity, 0))"),
+            {"identity": identity},
+        )
+
+    @staticmethod
+    def _publication_identity(info_blob: InfoBlobAdd) -> str:
+        if info_blob.group_id is not None:
+            return f"group:{info_blob.group_id}:title:{info_blob.title}"
+        if info_blob.website_id is not None:
+            return f"website:{info_blob.website_id}:title:{info_blob.title}"
+        if info_blob.integration_knowledge_id is not None:
+            source = info_blob.sharepoint_item_id or info_blob.title
+            return f"integration:{info_blob.integration_knowledge_id}:source:{source}"
+        raise ValueError("InfoBlob publication requires a source owner")
+
+    async def get_active_for_publication(
         self, info_blob: InfoBlobAdd
-    ) -> InfoBlobInDB:
-        """Idempotent upsert for integration_knowledge blobs.
-
-        If a blob with the same title already exists, update it.
-        Otherwise, create a new one.
-
-        This handles duplicate webhooks from Microsoft by ensuring
-        we never create duplicates - just update existing ones.
-        """
-        if not info_blob.integration_knowledge_id or not info_blob.title:
-            raise ValueError(
-                "title and integration_knowledge_id are required for upsert"
+    ) -> InfoBlobInDB | None:
+        conditions = [active_info_blob_version()]
+        if info_blob.group_id is not None:
+            conditions.extend(
+                [
+                    InfoBlobs.group_id == info_blob.group_id,
+                    InfoBlobs.title == info_blob.title,
+                ]
             )
-
-        # Check if blob already exists
-        existing = await self.get_by_title_and_integration_knowledge(
-            title=info_blob.title,
-            integration_knowledge_id=info_blob.integration_knowledge_id,
-        )
-
-        if existing:
-            # Update existing blob - update both text and metadata
-            stmt = (
-                sa.update(InfoBlobs)
-                .where(InfoBlobs.id == existing.id)
-                .values(
-                    text=info_blob.text,
-                    title=info_blob.title,
-                    url=info_blob.url,
-                    size=info_blob.size,  # Update size as well
-                    content_hash=info_blob.content_hash,
-                    updated_at=sa.func.now(),
+        elif info_blob.website_id is not None:
+            conditions.extend(
+                [
+                    InfoBlobs.website_id == info_blob.website_id,
+                    InfoBlobs.title == info_blob.title,
+                ]
+            )
+        elif info_blob.integration_knowledge_id is not None:
+            conditions.append(
+                InfoBlobs.integration_knowledge_id == info_blob.integration_knowledge_id
+            )
+            if info_blob.sharepoint_item_id is not None:
+                conditions.append(
+                    InfoBlobs.sharepoint_item_id == info_blob.sharepoint_item_id
                 )
-                .returning(InfoBlobs)
-            )
-            result = await self.session.execute(stmt)
-            updated_blob = result.scalar_one()
-            return InfoBlobInDB.model_validate(updated_blob)
+            else:
+                conditions.append(InfoBlobs.title == info_blob.title)
         else:
-            # Create new blob
-            return await self.add(info_blob)
+            raise ValueError("InfoBlob publication requires a source owner")
 
-    async def upsert_by_sharepoint_item_and_integration_knowledge(
-        self,
-        info_blob: InfoBlobAdd,
-    ) -> InfoBlobInDB:
-        """Idempotent upsert keyed by sharepoint_item_id + integration_knowledge_id."""
-        if not info_blob.integration_knowledge_id or not info_blob.sharepoint_item_id:
-            raise ValueError(
-                "sharepoint_item_id and integration_knowledge_id are required for SharePoint upsert"
-            )
-
-        stmt = sa.select(InfoBlobs).where(
-            sa.and_(
-                InfoBlobs.sharepoint_item_id == info_blob.sharepoint_item_id,
-                InfoBlobs.integration_knowledge_id
-                == info_blob.integration_knowledge_id,
-            )
+        record = await self.session.scalar(
+            sa.select(InfoBlobs).where(*conditions).with_for_update()
         )
-        result = await self.session.execute(stmt)
-        existing = result.scalars().all()
+        return InfoBlobInDB.model_validate(record) if record is not None else None
 
-        if existing:
-            primary = existing[0]
-
-            # Cleanup any historical duplicates for the same SharePoint item.
-            for duplicate in existing[1:]:
-                await self.delegate.delete(duplicate.id)
-
-            update_stmt = (
-                sa.update(InfoBlobs)
-                .where(InfoBlobs.id == primary.id)
-                .values(
-                    text=info_blob.text,
-                    title=info_blob.title,
-                    url=info_blob.url,
-                    size=info_blob.size,
-                    sharepoint_item_id=info_blob.sharepoint_item_id,
-                    content_hash=info_blob.content_hash,
-                    updated_at=sa.func.now(),
-                )
-                .returning(InfoBlobs)
+    async def supersede(self, info_blob_id: UUID) -> bool:
+        result = await self.session.execute(
+            sa.update(InfoBlobs)
+            .where(
+                InfoBlobs.id == info_blob_id,
+                active_info_blob_version(),
             )
-            update_result = await self.session.execute(update_stmt)
-            updated_blob = update_result.scalar_one()
-            return InfoBlobInDB.model_validate(updated_blob)
-
-        return await self.add(info_blob)
+            .values(version_state=InfoBlobVersionState.SUPERSEDED.value)
+        )
+        return affected_row_count(result) == 1
 
     async def update(self, info_blob: InfoBlobUpdate) -> InfoBlobInDB:
         record = await self.delegate.update(info_blob)
-        return InfoBlobInDB.model_validate(record)
-
-    async def update_content_hash(
-        self, *, info_blob_id: UUID, content_hash: bytes
-    ) -> InfoBlobInDB:
-        stmt = (
-            sa.update(InfoBlobs)
-            .where(InfoBlobs.id == info_blob_id)
-            .values(content_hash=content_hash, updated_at=sa.func.now())
-            .returning(InfoBlobs)
-        )
-        result = await self.session.execute(stmt)
-        record = result.scalar_one()
         return InfoBlobInDB.model_validate(record)
 
     async def update_size(self, info_blob_id: UUID) -> InfoBlobInDB | None:
@@ -231,7 +207,7 @@ class InfoBlobRepository:
     async def get_by_user(self, user_id: UUID):
         query = (
             sa.select(InfoBlobs)
-            .where(InfoBlobs.user_id == user_id)
+            .where(InfoBlobs.user_id == user_id, active_info_blob_version())
             .order_by(InfoBlobs.created_at)
             .options(selectinload(InfoBlobs.group))
             .options(selectinload(InfoBlobs.embedding_model))
@@ -286,7 +262,7 @@ class InfoBlobRepository:
 
         query = (
             sa.select(InfoBlobs)
-            .where(InfoBlobs.user_id == user_id)
+            .where(InfoBlobs.user_id == user_id, active_info_blob_version())
             .where(sa.or_(*space_conditions))
             .order_by(InfoBlobs.created_at)
             .options(selectinload(InfoBlobs.group))
@@ -303,8 +279,12 @@ class InfoBlobRepository:
     async def get_by_title_and_group(
         self, title: str, group_id: UUID
     ) -> InfoBlobInDB | None:
-        record = await self.delegate.get_by(
-            conditions={InfoBlobs.title: title, InfoBlobs.group_id: group_id}
+        record = await self.session.scalar(
+            sa.select(InfoBlobs).where(
+                InfoBlobs.title == title,
+                InfoBlobs.group_id == group_id,
+                active_info_blob_version(),
+            )
         )
         return InfoBlobInDB.model_validate(record) if record is not None else None
 
@@ -358,7 +338,7 @@ class InfoBlobRepository:
 
         query = (
             sa.select(InfoBlobs)
-            .where(sa.or_(*conditions))
+            .where(sa.or_(*conditions), active_info_blob_version())
             .options(selectinload(InfoBlobs.group))
             .options(selectinload(InfoBlobs.embedding_model))
             .options(selectinload(InfoBlobs.website))
@@ -376,47 +356,6 @@ class InfoBlobRepository:
         records = await self.delegate.get_records_from_query(query)
         return [InfoBlobInDBNoText.model_validate(record) for record in records]
 
-    async def delete_by_title_and_group(
-        self, title: str, group_id: UUID
-    ) -> InfoBlobInDB | None:
-        record = await self.delegate.delete_by(
-            conditions={InfoBlobs.title: title, InfoBlobs.group_id: group_id}
-        )
-        return InfoBlobInDB.model_validate(record) if record is not None else None
-
-    async def delete_by_title_and_website(
-        self, title: str, website_id: UUID
-    ) -> InfoBlobInDB | None:
-        record = await self.delegate.delete_by(
-            conditions={InfoBlobs.title: title, InfoBlobs.website_id: website_id}
-        )
-        return InfoBlobInDB.model_validate(record) if record is not None else None
-
-    async def delete_by_title_and_integration_knowledge(
-        self, title: str, integration_knowledge_id: UUID
-    ) -> List[InfoBlobInDB]:
-        """Delete ALL info_blobs with given title and integration_knowledge_id.
-
-        Returns list of deleted blobs (can be multiple if duplicates exist).
-        """
-        # First, get all matching blobs
-        stmt = sa.select(InfoBlobs).where(
-            sa.and_(
-                InfoBlobs.title == title,
-                InfoBlobs.integration_knowledge_id == integration_knowledge_id,
-            )
-        )
-        result = await self.session.execute(stmt)
-        blobs_to_delete = result.scalars().all()
-
-        # Delete each one
-        deleted: list[InfoBlobInDB] = []
-        for blob in blobs_to_delete:
-            deleted_blob = await self.delegate.delete(blob.id)
-            deleted.append(InfoBlobInDB.model_validate(deleted_blob))
-
-        return deleted
-
     async def delete_by_sharepoint_item_and_integration_knowledge(
         self,
         sharepoint_item_id: str,
@@ -430,15 +369,18 @@ class InfoBlobRepository:
             )
         )
         result = await self.session.execute(stmt)
-        blobs_to_delete = result.scalars().all()
-
-        deleted: list[InfoBlobInDB] = []
-        for blob in blobs_to_delete:
-            deleted_blob = await self.delegate.delete(blob.id)
-            if deleted_blob is not None:
-                deleted.append(deleted_blob)
-
-        return deleted
+        active_blobs = [
+            InfoBlobInDB.model_validate(blob)
+            for blob in result.scalars().all()
+            if blob.version_state == InfoBlobVersionState.ACTIVE.value
+        ]
+        await self.session.execute(
+            sa.delete(InfoBlobs).where(
+                InfoBlobs.sharepoint_item_id == sharepoint_item_id,
+                InfoBlobs.integration_knowledge_id == integration_knowledge_id,
+            )
+        )
+        return active_blobs
 
     async def delete_by_website(self, website_id: UUID):
         await self.delegate.delete_by(conditions={InfoBlobs.website_id: website_id})
@@ -453,11 +395,12 @@ class InfoBlobRepository:
         self, title: str, integration_knowledge_id: UUID
     ) -> InfoBlobInDB | None:
         """Get an info_blob by title and integration_knowledge_id."""
-        record = await self.delegate.get_by(
-            conditions={
-                InfoBlobs.title: title,
-                InfoBlobs.integration_knowledge_id: integration_knowledge_id,
-            }
+        record = await self.session.scalar(
+            sa.select(InfoBlobs).where(
+                InfoBlobs.title == title,
+                InfoBlobs.integration_knowledge_id == integration_knowledge_id,
+                active_info_blob_version(),
+            )
         )
         return InfoBlobInDB.model_validate(record) if record is not None else None
 
@@ -467,17 +410,19 @@ class InfoBlobRepository:
         integration_knowledge_id: UUID,
     ) -> InfoBlobInDB | None:
         """Get an info_blob by sharepoint_item_id and integration_knowledge_id."""
-        return await self.delegate.get_by(
-            conditions={
-                InfoBlobs.sharepoint_item_id: sharepoint_item_id,
-                InfoBlobs.integration_knowledge_id: integration_knowledge_id,
-            }
+        record = await self.session.scalar(
+            sa.select(InfoBlobs).where(
+                InfoBlobs.sharepoint_item_id == sharepoint_item_id,
+                InfoBlobs.integration_knowledge_id == integration_knowledge_id,
+                active_info_blob_version(),
+            )
         )
+        return InfoBlobInDB.model_validate(record) if record is not None else None
 
     async def get_by_group(self, group_id: UUID) -> list[InfoBlobInDB]:
         query = (
             sa.select(InfoBlobs)
-            .where(InfoBlobs.group_id == group_id)
+            .where(InfoBlobs.group_id == group_id, active_info_blob_version())
             .order_by(InfoBlobs.created_at)
             .options(selectinload(InfoBlobs.group))
             .options(selectinload(InfoBlobs.embedding_model))
@@ -486,20 +431,39 @@ class InfoBlobRepository:
         return [InfoBlobInDB.model_validate(record) for record in records]
 
     async def get_by_website(self, website_id: UUID) -> list[InfoBlobInDB]:
-        records = await self.delegate.filter_by(
-            conditions={InfoBlobs.website_id: website_id}
+        records = await self.session.scalars(
+            sa.select(InfoBlobs).where(
+                InfoBlobs.website_id == website_id,
+                active_info_blob_version(),
+            )
         )
         return [InfoBlobInDB.model_validate(record) for record in records]
 
     async def delete(self, id: UUID) -> InfoBlobInDB:
-        record = await self.delegate.delete(id)
-        return InfoBlobInDB.model_validate(record)
+        source_id = await self.session.scalar(
+            sa.select(InfoBlobs.source_id).where(InfoBlobs.id == id)
+        )
+        if source_id is None:
+            raise ValueError(f"InfoBlob {id} does not exist")
+        active = await self.session.scalar(
+            sa.select(InfoBlobs).where(
+                InfoBlobs.source_id == source_id,
+                active_info_blob_version(),
+            )
+        )
+        if active is None:
+            raise ValueError(f"InfoBlob source {source_id} has no active version")
+        deleted = InfoBlobInDB.model_validate(active)
+        await self.session.execute(
+            sa.delete(InfoBlobs).where(InfoBlobs.source_id == source_id)
+        )
+        return deleted
 
     async def get_count_of_group(self, group_id: UUID):
         stmt = (
             sa.select(sa.func.count())
             .select_from(InfoBlobs)
-            .where(InfoBlobs.group_id == group_id)
+            .where(InfoBlobs.group_id == group_id, active_info_blob_version())
         )
 
         return await self.session.scalar(stmt)
@@ -509,7 +473,10 @@ class InfoBlobRepository:
         stmt = (
             sa.select(sa.func.count())
             .select_from(InfoBlobs)
-            .where(InfoBlobs.integration_knowledge_id == integration_knowledge_id)
+            .where(
+                InfoBlobs.integration_knowledge_id == integration_knowledge_id,
+                active_info_blob_version(),
+            )
         )
 
         return await self.session.scalar(stmt)
@@ -520,7 +487,10 @@ class InfoBlobRepository:
         """Get all info_blobs for a specific integration_knowledge."""
         query = (
             sa.select(InfoBlobs)
-            .where(InfoBlobs.integration_knowledge_id == integration_knowledge_id)
+            .where(
+                InfoBlobs.integration_knowledge_id == integration_knowledge_id,
+                active_info_blob_version(),
+            )
             .options(selectinload(InfoBlobs.embedding_model))
         )
         records = await self.delegate.get_models_from_query(query)
@@ -538,13 +508,18 @@ class InfoBlobRepository:
             sa.and_(
                 InfoBlobs.integration_knowledge_id == integration_knowledge_id,
                 InfoBlobs.sharepoint_item_id.is_not(None),
+                active_info_blob_version(),
             )
         )
         result = await self.session.execute(stmt)
         return [(row[0], row[1]) for row in result.all()]
 
     def _sum_stmt(self):
-        return sa.select(sa.func.sum(InfoBlobs.size)).select_from(InfoBlobs)
+        return (
+            sa.select(sa.func.sum(InfoBlobs.size))
+            .select_from(InfoBlobs)
+            .where(active_info_blob_version())
+        )
 
     async def get_total_size_of_group(self, group_id: UUID):
         stmt = self._sum_stmt().where(InfoBlobs.group_id == group_id)
@@ -555,6 +530,16 @@ class InfoBlobRepository:
             return 0
 
         return size
+
+    async def get_total_size_of_integration_knowledge(
+        self, integration_knowledge_id: UUID
+    ) -> int:
+        size = await self.session.scalar(
+            self._sum_stmt().where(
+                InfoBlobs.integration_knowledge_id == integration_knowledge_id
+            )
+        )
+        return size or 0
 
     async def get_total_size_of_user(self, user_id: UUID):
         stmt = self._sum_stmt().where(InfoBlobs.user_id == user_id)
@@ -577,14 +562,17 @@ class InfoBlobRepository:
         return size
 
     async def get_ids(self):
-        stmt = sa.select(InfoBlobs.id)
+        stmt = sa.select(InfoBlobs.id).where(active_info_blob_version())
 
         ids = await self.session.scalars(stmt)
 
         return set(ids)
 
     async def get_titles_of_website(self, website_id: UUID) -> list[str]:
-        stmt = sa.select(InfoBlobs.title).where(InfoBlobs.website_id == website_id)
+        stmt = sa.select(InfoBlobs.title).where(
+            InfoBlobs.website_id == website_id,
+            active_info_blob_version(),
+        )
         result = await self.session.scalars(stmt)
         return [title for title in result if title is not None]
 
@@ -606,14 +594,20 @@ class InfoBlobRepository:
         if not titles:
             return 0
 
-        # Use SQLAlchemy's .in_() method for array-based deletion
-        # This is more efficient than N individual DELETE queries
+        active_count = await self.session.scalar(
+            sa.select(sa.func.count())
+            .select_from(InfoBlobs)
+            .where(
+                InfoBlobs.website_id == website_id,
+                InfoBlobs.title.in_(titles),
+                active_info_blob_version(),
+            )
+        )
         stmt = sa.delete(InfoBlobs).where(
             InfoBlobs.website_id == website_id, InfoBlobs.title.in_(titles)
         )
-
-        result = await self.session.execute(stmt)
-        return affected_row_count(result)
+        await self.session.execute(stmt)
+        return active_count or 0
 
     async def get_content_hash(self, website_id: UUID, title: str) -> bytes | None:
         """Get content hash for a specific page.
@@ -629,7 +623,9 @@ class InfoBlobRepository:
             32-byte SHA-256 hash or None if page doesn't exist or hash not computed
         """
         stmt = sa.select(InfoBlobs.content_hash).where(
-            InfoBlobs.website_id == website_id, InfoBlobs.title == title
+            InfoBlobs.website_id == website_id,
+            InfoBlobs.title == title,
+            active_info_blob_version(),
         )
         result = await self.session.scalar(stmt)
         return result

--- a/backend/src/eneo/info_blobs/info_blob_repo.py
+++ b/backend/src/eneo/info_blobs/info_blob_repo.py
@@ -399,13 +399,12 @@ class InfoBlobRepository:
             sa.and_(
                 InfoBlobs.sharepoint_item_id == sharepoint_item_id,
                 InfoBlobs.integration_knowledge_id == integration_knowledge_id,
+                active_info_blob_version(),
             )
         )
         result = await self.session.execute(stmt)
         active_blobs = [
-            InfoBlobInDB.model_validate(blob)
-            for blob in result.scalars().all()
-            if blob.version_state == InfoBlobVersionState.ACTIVE.value
+            InfoBlobInDB.model_validate(blob) for blob in result.scalars().all()
         ]
         await self.session.execute(
             sa.delete(InfoBlobs).where(

--- a/backend/src/eneo/info_blobs/info_blob_repo.py
+++ b/backend/src/eneo/info_blobs/info_blob_repo.py
@@ -175,7 +175,7 @@ class InfoBlobRepository:
         else:
             raise ValueError("InfoBlob publication requires a source owner")
 
-        record = await self.session.scalar(
+        record = await self.delegate.get_record_from_query(
             sa.select(InfoBlobs).where(*conditions).with_for_update()
         )
         return InfoBlobInDB.model_validate(record) if record is not None else None

--- a/backend/src/eneo/info_blobs/info_blob_repo.py
+++ b/backend/src/eneo/info_blobs/info_blob_repo.py
@@ -110,25 +110,40 @@ class InfoBlobRepository:
 
     async def lock_publication_identity(self, info_blob: InfoBlobAdd) -> None:
         identity = self._publication_identity(info_blob)
+        if identity is None:
+            return
         await self.session.execute(
             sa.text("SELECT pg_advisory_xact_lock(hashtextextended(:identity, 0))"),
             {"identity": identity},
         )
 
     @staticmethod
-    def _publication_identity(info_blob: InfoBlobAdd) -> str:
+    def _publication_identity(info_blob: InfoBlobAdd) -> str | None:
+        title = info_blob.title if info_blob.title and info_blob.title.strip() else None
         if info_blob.group_id is not None:
-            return f"group:{info_blob.group_id}:title:{info_blob.title}"
+            return f"group:{info_blob.group_id}:title:{title}" if title else None
         if info_blob.website_id is not None:
-            return f"website:{info_blob.website_id}:title:{info_blob.title}"
+            return f"website:{info_blob.website_id}:title:{title}" if title else None
         if info_blob.integration_knowledge_id is not None:
-            source = info_blob.sharepoint_item_id or info_blob.title
-            return f"integration:{info_blob.integration_knowledge_id}:source:{source}"
+            item_id = (
+                info_blob.sharepoint_item_id
+                if info_blob.sharepoint_item_id and info_blob.sharepoint_item_id.strip()
+                else None
+            )
+            source = item_id or title
+            return (
+                f"integration:{info_blob.integration_knowledge_id}:source:{source}"
+                if source
+                else None
+            )
         raise ValueError("InfoBlob publication requires a source owner")
 
     async def get_active_for_publication(
         self, info_blob: InfoBlobAdd
     ) -> InfoBlobInDB | None:
+        if self._publication_identity(info_blob) is None:
+            return None
+
         conditions = [active_info_blob_version()]
         if info_blob.group_id is not None:
             conditions.extend(
@@ -148,7 +163,10 @@ class InfoBlobRepository:
             conditions.append(
                 InfoBlobs.integration_knowledge_id == info_blob.integration_knowledge_id
             )
-            if info_blob.sharepoint_item_id is not None:
+            if (
+                info_blob.sharepoint_item_id is not None
+                and info_blob.sharepoint_item_id.strip()
+            ):
                 conditions.append(
                     InfoBlobs.sharepoint_item_id == info_blob.sharepoint_item_id
                 )
@@ -161,6 +179,21 @@ class InfoBlobRepository:
             sa.select(InfoBlobs).where(*conditions).with_for_update()
         )
         return InfoBlobInDB.model_validate(record) if record is not None else None
+
+    async def refresh_publication_metadata(
+        self,
+        info_blob_id: UUID,
+        info_blob: InfoBlobAdd,
+    ) -> InfoBlobInDB:
+        record = await self.session.scalar(
+            sa.update(InfoBlobs)
+            .where(InfoBlobs.id == info_blob_id, active_info_blob_version())
+            .values(title=info_blob.title, url=info_blob.url)
+            .returning(InfoBlobs)
+        )
+        if record is None:
+            raise RuntimeError("The active knowledge version changed during publish")
+        return InfoBlobInDB.model_validate(record)
 
     async def supersede(self, info_blob_id: UUID) -> bool:
         result = await self.session.execute(
@@ -521,6 +554,9 @@ class InfoBlobRepository:
             .where(active_info_blob_version())
         )
 
+    def _retained_sum_stmt(self):
+        return sa.select(sa.func.sum(InfoBlobs.size)).select_from(InfoBlobs)
+
     async def get_total_size_of_group(self, group_id: UUID):
         stmt = self._sum_stmt().where(InfoBlobs.group_id == group_id)
 
@@ -551,6 +587,12 @@ class InfoBlobRepository:
 
         return size
 
+    async def get_retained_size_of_user(self, user_id: UUID) -> int:
+        size = await self.session.scalar(
+            self._retained_sum_stmt().where(InfoBlobs.user_id == user_id)
+        )
+        return size or 0
+
     async def get_total_size_of_tenant(self, tenant_id: UUID):
         stmt = self._sum_stmt().join(Users).where(Users.tenant_id == tenant_id)
 
@@ -560,6 +602,12 @@ class InfoBlobRepository:
             return 0
 
         return size
+
+    async def get_retained_size_of_tenant(self, tenant_id: UUID) -> int:
+        size = await self.session.scalar(
+            self._retained_sum_stmt().join(Users).where(Users.tenant_id == tenant_id)
+        )
+        return size or 0
 
     async def get_ids(self):
         stmt = sa.select(InfoBlobs.id).where(active_info_blob_version())

--- a/backend/src/eneo/info_blobs/info_blob_service.py
+++ b/backend/src/eneo/info_blobs/info_blob_service.py
@@ -1,3 +1,4 @@
+from hashlib import sha256
 from typing import TYPE_CHECKING, Optional
 from uuid import UUID
 
@@ -19,19 +20,18 @@ from eneo.main.exceptions import (
     NotFoundException,
     UnauthorizedException,
 )
-from eneo.main.logging import get_logger
 from eneo.spaces.utils.space_utils import effective_space_ids
 from eneo.users.user import UserInDB
 
 if TYPE_CHECKING:
     from eneo.actors import ActorManager
+    from eneo.embedding_models.domain.embedding_model import EmbeddingModel
+    from eneo.embedding_models.infrastructure.datastore import Datastore
     from eneo.spaces.space_repo import SpaceRepository
     from eneo.spaces.space_service import SpaceService
     from eneo.websites.infrastructure.update_website_size_service import (
         UpdateWebsiteSizeService,
     )
-
-logger = get_logger(__name__)
 
 
 class InfoBlobService:
@@ -46,6 +46,7 @@ class InfoBlobService:
         update_website_size_service: "UpdateWebsiteSizeService",
         space_service: "SpaceService",
         actor_manager: "ActorManager",
+        datastore: "Datastore",
     ) -> None:
         super().__init__()
         self.repo = repo
@@ -56,6 +57,7 @@ class InfoBlobService:
         self.quota_service = quota_service
         self.space_service = space_service
         self.actor_manager = actor_manager
+        self.datastore = datastore
 
     async def _get_actor(
         self, info_blob: Optional[InfoBlobInDB], group_id: Optional[UUID]
@@ -117,92 +119,53 @@ class InfoBlobService:
             case _:
                 pass  # Other SpaceAction values are not applicable to info blobs
 
-    async def _delete_if_same_title(self, info_blob: InfoBlobAdd):
-        if info_blob.title:
-            if info_blob.group_id:
-                info_blob_deleted = await self.repo.delete_by_title_and_group(
-                    info_blob.title, info_blob.group_id
-                )
-
-                if info_blob_deleted is not None:
-                    logger.debug(
-                        f"Info blob ({info_blob_deleted.title}) in group "
-                        f"({info_blob.group_id}) was replaced"
-                    )
-
-            elif info_blob.website_id:
-                info_blob_deleted = await self.repo.delete_by_title_and_website(
-                    info_blob.title, info_blob.website_id
-                )
-
-                if info_blob_deleted is not None:
-                    logger.debug(
-                        f"Info blob ({info_blob_deleted.title}) in website "
-                        f"({info_blob.website_id}) was replaced"
-                    )
-
-            elif info_blob.integration_knowledge_id:
-                info_blobs_deleted = (
-                    await self.repo.delete_by_title_and_integration_knowledge(
-                        info_blob.title, info_blob.integration_knowledge_id
-                    )
-                )
-
-                if info_blobs_deleted:
-                    logger.debug(
-                        f"Replaced {len(info_blobs_deleted)} info blob(s) with title '{info_blob.title}' "
-                        f"from integration {info_blob.integration_knowledge_id}"
-                    )
-
-    async def add_info_blob_without_validation(
-        self, info_blob: InfoBlobAdd
-    ) -> InfoBlobInDB:
-        await self._delete_if_same_title(info_blob)
-        size_of_text = await self.quota_service.add_text(info_blob.text)
-        info_blob.size = size_of_text
-        info_blob_in_db = await self.repo.add(info_blob)
-
-        return info_blob_in_db
-
-    async def upsert_info_blob_by_title_and_integration(
-        self, info_blob: InfoBlobAdd
-    ) -> InfoBlobInDB:
-        """Idempotent upsert for integration_knowledge blobs.
-
-        Handles duplicate webhooks by updating existing blobs instead of creating duplicates.
-        Automatically calculates size via quota_service.
-        """
-        # Calculate size
-        size_of_text = await self.quota_service.add_text(info_blob.text)
-        info_blob.size = size_of_text
-
-        # Use repo's upsert method
-        return await self.repo.upsert_by_title_and_integration_knowledge(info_blob)
-
-    async def upsert_info_blob_by_sharepoint_item_and_integration(
+    async def publish_info_blob_without_validation(
         self,
         info_blob: InfoBlobAdd,
+        *,
+        embedding_model: "EmbeddingModel",
     ) -> InfoBlobInDB:
-        """Idempotent upsert for SharePoint content keyed by item ID."""
-        size_of_text = await self.quota_service.add_text(info_blob.text)
-        info_blob.size = size_of_text
-        return await self.repo.upsert_by_sharepoint_item_and_integration_knowledge(
-            info_blob
-        )
+        if info_blob.content_hash is None:
+            info_blob.content_hash = sha256(info_blob.text.encode("utf-8")).digest()
 
-    async def add_info_blob(self, info_blob: InfoBlobAdd) -> InfoBlobInDB:
-        info_blob_in_db = await self.add_info_blob_without_validation(info_blob)
+        async with self.repo.session.begin_nested():
+            await self.repo.lock_publication_identity(info_blob)
+            active = await self.repo.get_active_for_publication(info_blob)
+            if active is not None and active.content_hash == info_blob.content_hash:
+                return active
 
-        await self._validate(info_blob_in_db)
+            source_id = active.source_id if active is not None else None
+            if active is not None and not await self.repo.supersede(active.id):
+                raise RuntimeError(
+                    "The active knowledge version changed during publish"
+                )
 
-        return info_blob_in_db
+            size_of_text = await self.quota_service.add_text(info_blob.text)
+            info_blob.size = size_of_text
+            published = await self.repo.add(info_blob, source_id=source_id)
+            await self.datastore.add(
+                info_blob=published,
+                embedding_model=embedding_model,
+            )
+            updated = await self.update_info_blob_size(published.id)
+            return updated
 
     async def add_info_blobs(
-        self, group_id: UUID, info_blobs: list[InfoBlobAdd]
+        self,
+        group_id: UUID,
+        info_blobs: list[InfoBlobAdd],
+        *,
+        embedding_model: "EmbeddingModel",
     ) -> list[InfoBlobInDB]:
         await self._can_perform_action(group_id=group_id, action=SpaceAction.CREATE)
 
-        return [await self.add_info_blob(blob) for blob in info_blobs]
+        return [
+            await self.publish_info_blob_without_validation(
+                blob,
+                embedding_model=embedding_model,
+            )
+            for blob in info_blobs
+        ]
 
     async def update_info_blob(self, info_blob: InfoBlobUpdate):
         current_info_blob = await self.repo.get(info_blob.id)

--- a/backend/src/eneo/info_blobs/info_blob_service.py
+++ b/backend/src/eneo/info_blobs/info_blob_service.py
@@ -131,7 +131,11 @@ class InfoBlobService:
         async with self.repo.session.begin_nested():
             await self.repo.lock_publication_identity(info_blob)
             active = await self.repo.get_active_for_publication(info_blob)
-            if active is not None and active.content_hash == info_blob.content_hash:
+            if (
+                active is not None
+                and active.content_hash == info_blob.content_hash
+                and active.embedding_model_id == embedding_model.id
+            ):
                 return await self.repo.refresh_publication_metadata(
                     active.id,
                     info_blob,

--- a/backend/src/eneo/info_blobs/info_blob_service.py
+++ b/backend/src/eneo/info_blobs/info_blob_service.py
@@ -132,7 +132,10 @@ class InfoBlobService:
             await self.repo.lock_publication_identity(info_blob)
             active = await self.repo.get_active_for_publication(info_blob)
             if active is not None and active.content_hash == info_blob.content_hash:
-                return active
+                return await self.repo.refresh_publication_metadata(
+                    active.id,
+                    info_blob,
+                )
 
             source_id = active.source_id if active is not None else None
             if active is not None and not await self.repo.supersede(active.id):
@@ -148,6 +151,7 @@ class InfoBlobService:
                 embedding_model=embedding_model,
             )
             updated = await self.update_info_blob_size(published.id)
+            await self.quota_service.ensure_capacity(0)
             return updated
 
     async def add_info_blobs(

--- a/backend/src/eneo/info_blobs/text_processor.py
+++ b/backend/src/eneo/info_blobs/text_processor.py
@@ -2,7 +2,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from eneo.embedding_models.infrastructure.datastore import Datastore
 from eneo.files.text import TextExtractor
 from eneo.info_blobs.info_blob import InfoBlobAdd
 from eneo.info_blobs.info_blob_service import InfoBlobService
@@ -17,13 +16,11 @@ class TextProcessor:
         self,
         user: UserInDB,
         extractor: TextExtractor,
-        datastore: Datastore,
         info_blob_service: InfoBlobService,
     ):
         super().__init__()
         self.user = user
         self.extractor = extractor
-        self.datastore = datastore
         self.info_blob_service = info_blob_service
 
     async def process_file(
@@ -70,12 +67,7 @@ class TextProcessor:
             content_hash=content_hash,  # Used by files for hash checking
         )
 
-        info_blob = await self.info_blob_service.add_info_blob_without_validation(
-            info_blob_add
+        return await self.info_blob_service.publish_info_blob_without_validation(
+            info_blob_add,
+            embedding_model=embedding_model,
         )
-        await self.datastore.add(info_blob=info_blob, embedding_model=embedding_model)
-        info_blob_updated = await self.info_blob_service.update_info_blob_size(
-            info_blob.id
-        )
-
-        return info_blob_updated

--- a/backend/src/eneo/integration/infrastructure/content_service/confluence_content_service.py
+++ b/backend/src/eneo/integration/infrastructure/content_service/confluence_content_service.py
@@ -3,7 +3,6 @@ from uuid import UUID
 
 import aiohttp
 
-from eneo.embedding_models.infrastructure.datastore import Datastore
 from eneo.info_blobs.info_blob import InfoBlobAdd
 from eneo.integration.domain.entities.oauth_token import ConfluenceToken, OauthToken
 from eneo.integration.infrastructure.clients.confluence_content_client import (
@@ -39,7 +38,6 @@ class ConfluenceContentService:
         oauth_token_repo: "OauthTokenRepository",
         user_integration_repo: "UserIntegrationRepository",
         user: "UserInDB",
-        datastore: "Datastore",
         info_blob_service: "InfoBlobService",
         integration_knowledge_repo: "IntegrationKnowledgeRepository",
         oauth_token_service: "OauthTokenService",
@@ -49,7 +47,6 @@ class ConfluenceContentService:
         self.oauth_token_repo = oauth_token_repo
         self.user_integration_repo = user_integration_repo
         self.user = user
-        self.datastore = datastore
         self.info_blob_service = info_blob_service
         self.integration_knowledge_repo = integration_knowledge_repo
         self.oauth_token_service = oauth_token_service
@@ -118,7 +115,6 @@ class ConfluenceContentService:
         integration_knowledge = await self.integration_knowledge_repo.one(
             id=integration_knowledge_id
         )
-        integration_knowledge_size = integration_knowledge.size
         for item in results:
             body = item.get("body")
             body_dict: dict[str, object] = (
@@ -144,17 +140,16 @@ class ConfluenceContentService:
                 integration_knowledge_id=integration_knowledge_id,
             )
 
-            info_blob = await self.info_blob_service.add_info_blob_without_validation(
-                info_blob_add
-            )
-            await self.datastore.add(
-                info_blob=info_blob,
+            await self.info_blob_service.publish_info_blob_without_validation(
+                info_blob_add,
                 embedding_model=integration_knowledge.embedding_model,
             )
 
-            integration_knowledge_size += info_blob.size
-
-        integration_knowledge.size = integration_knowledge_size
+        integration_knowledge.size = (
+            await self.info_blob_service.repo.get_total_size_of_integration_knowledge(
+                integration_knowledge_id
+            )
+        )
         await self.integration_knowledge_repo.update(obj=integration_knowledge)
 
     @staticmethod

--- a/backend/src/eneo/integration/infrastructure/content_service/sharepoint_content_service.py
+++ b/backend/src/eneo/integration/infrastructure/content_service/sharepoint_content_service.py
@@ -6,11 +6,8 @@ from typing import TYPE_CHECKING, Optional, cast
 from urllib.parse import unquote
 from uuid import UUID
 
-import sqlalchemy as sa
 from sqlalchemy import event
 
-from eneo.database.tables.info_blob_chunk_table import InfoBlobChunks
-from eneo.embedding_models.infrastructure.datastore import Datastore
 from eneo.info_blobs.info_blob import InfoBlobAdd, InfoBlobUpdate
 from eneo.integration.domain.entities.oauth_token import OauthToken
 from eneo.integration.domain.entities.sync_log import SyncLog
@@ -154,7 +151,6 @@ class SharePointContentService:
         oauth_token_repo: "OauthTokenRepository",
         user_integration_repo: "UserIntegrationRepository",
         user: "UserInDB",
-        datastore: "Datastore",
         info_blob_service: "InfoBlobService",
         integration_knowledge_repo: "IntegrationKnowledgeRepository",
         oauth_token_service: "OauthTokenService",
@@ -170,7 +166,6 @@ class SharePointContentService:
         self.oauth_token_repo = oauth_token_repo
         self.user_integration_repo = user_integration_repo
         self.user = user
-        self.datastore = datastore
         self.info_blob_service = info_blob_service
         self.integration_knowledge_repo = integration_knowledge_repo
         self.oauth_token_service = oauth_token_service
@@ -1220,42 +1215,13 @@ class SharePointContentService:
             tenant_id=self.user.tenant_id,
             integration_knowledge_id=integration_knowledge.id,
             sharepoint_item_id=sharepoint_item_id,
-            content_hash=None,
+            content_hash=content_hash,
         )
 
-        if sharepoint_item_id:
-            info_blob = await self.info_blob_service.upsert_info_blob_by_sharepoint_item_and_integration(
-                info_blob_add
-            )
-        else:
-            info_blob = (
-                await self.info_blob_service.upsert_info_blob_by_title_and_integration(
-                    info_blob_add
-                )
-            )
-
-        try:
-            await self.info_blob_service.repo.session.execute(
-                sa.delete(InfoBlobChunks).where(
-                    InfoBlobChunks.info_blob_id == info_blob.id
-                )
-            )
-            logger.debug(f"Cleared old chunks for {title}")
-        except Exception as e:
-            logger.warning(f"Could not delete old chunks for {title}: {e}")
-
-        try:
-            await self.datastore.add(
-                info_blob=info_blob,
-                embedding_model=integration_knowledge.embedding_model,
-            )
-        except Exception as e:
-            logger.debug(f"Could not add embedding for {title}: {e}")
-        else:
-            await self.info_blob_service.repo.update_content_hash(
-                info_blob_id=info_blob.id,
-                content_hash=content_hash,
-            )
+        info_blob = await self.info_blob_service.publish_info_blob_without_validation(
+            info_blob_add,
+            embedding_model=integration_knowledge.embedding_model,
+        )
 
         current_size = safe_int(getattr(integration_knowledge, "size", 0))
         new_blob_size = safe_int(getattr(info_blob, "size", 0))

--- a/backend/src/eneo/main/container/container.py
+++ b/backend/src/eneo/main/container/container.py
@@ -1162,6 +1162,7 @@ class Container(containers.DeclarativeContainer):
         group_service=group_service,
         space_service=space_service,
         actor_manager=actor_manager,
+        datastore=datastore,
     )
     prompt_service = providers.Factory(
         PromptService, user=user, repo=prompt_repo, factory=prompt_factory
@@ -1486,7 +1487,6 @@ class Container(containers.DeclarativeContainer):
         user_integration_repo=user_integration_repo,
         user=user,
         oauth_token_service=oauth_token_service,
-        datastore=datastore,
         info_blob_service=info_blob_service,
         integration_knowledge_repo=integration_knowledge_repo,
     )
@@ -1501,7 +1501,6 @@ class Container(containers.DeclarativeContainer):
         user_integration_repo=user_integration_repo,
         user=user,
         oauth_token_service=oauth_token_service,
-        datastore=datastore,
         info_blob_service=info_blob_service,
         integration_knowledge_repo=integration_knowledge_repo,
         session=session,
@@ -1603,7 +1602,6 @@ class Container(containers.DeclarativeContainer):
         TextProcessor,
         user=user,
         extractor=text_extractor,
-        datastore=datastore,
         info_blob_service=info_blob_service,
     )
     transcriber = providers.Factory(

--- a/backend/src/eneo/spaces/space_repo.py
+++ b/backend/src/eneo/spaces/space_repo.py
@@ -25,7 +25,7 @@ from eneo.database.tables.group_chats_table import (
     GroupChatsTable,
 )
 from eneo.database.tables.groups_spaces_table import GroupsSpaces
-from eneo.database.tables.info_blobs_table import InfoBlobs
+from eneo.database.tables.info_blobs_table import InfoBlobs, active_info_blob_version
 from eneo.database.tables.info_blobs_table import InfoBlobs as InfoBlobsTable
 from eneo.database.tables.integration_knowledge_spaces_table import (
     IntegrationKnowledgesSpaces,
@@ -253,7 +253,7 @@ class SpaceRepository:
 
         ib_count_sq = (
             sa.select(sa.func.count(sa.distinct(ib.id)))
-            .where(ib.group_id == c.id)
+            .where(ib.group_id == c.id, active_info_blob_version())
             .correlate(c)
             .scalar_subquery()
         )
@@ -645,7 +645,10 @@ class SpaceRepository:
         def _set_size_subquery(collection: "Collection"):
             return (
                 sa.select(sa.func.coalesce(sa.func.sum(InfoBlobsTable.size), 0))
-                .where(InfoBlobsTable.group_id == collection.id)
+                .where(
+                    InfoBlobsTable.group_id == collection.id,
+                    active_info_blob_version(),
+                )
                 .scalar_subquery()
             )
 
@@ -723,7 +726,10 @@ class SpaceRepository:
         def _set_size_subquery(website: "Website"):
             return (
                 sa.select(sa.func.coalesce(sa.func.sum(InfoBlobsTable.size), 0))
-                .where(InfoBlobsTable.website_id == website.id)
+                .where(
+                    InfoBlobsTable.website_id == website.id,
+                    active_info_blob_version(),
+                )
                 .scalar_subquery()
             )
 

--- a/backend/src/eneo/websites/infrastructure/update_website_size_service.py
+++ b/backend/src/eneo/websites/infrastructure/update_website_size_service.py
@@ -2,7 +2,12 @@ from typing import TYPE_CHECKING
 
 import sqlalchemy as sa
 
-from eneo.database.tables.info_blobs_table import InfoBlobs as InfoBlobsTable
+from eneo.database.tables.info_blobs_table import (
+    InfoBlobs as InfoBlobsTable,
+)
+from eneo.database.tables.info_blobs_table import (
+    active_info_blob_version,
+)
 from eneo.database.tables.websites_table import Websites as WebsitesTable
 
 if TYPE_CHECKING:
@@ -19,7 +24,10 @@ class UpdateWebsiteSizeService:
     async def update_website_size(self, website_id: "UUID") -> None:
         update_size_stmt = (
             sa.select(sa.func.coalesce(sa.func.sum(InfoBlobsTable.size), 0))
-            .where(InfoBlobsTable.website_id == website_id)
+            .where(
+                InfoBlobsTable.website_id == website_id,
+                active_info_blob_version(),
+            )
             .scalar_subquery()
         )
 

--- a/backend/src/eneo/worker/crawl/persistence.py
+++ b/backend/src/eneo/worker/crawl/persistence.py
@@ -20,6 +20,7 @@ from dependency_injector import providers
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from typing_extensions import TypedDict
 
+from eneo.admin.quota_service import ensure_quota_capacity
 from eneo.completion_models.infrastructure.context_builder import count_tokens
 from eneo.database.tables.info_blob_chunk_table import InfoBlobChunks
 from eneo.database.tables.info_blobs_table import (
@@ -27,7 +28,10 @@ from eneo.database.tables.info_blobs_table import (
     InfoBlobVersionState,
     active_info_blob_version,
 )
+from eneo.database.tables.tenant_table import Tenants
+from eneo.database.tables.users_table import Users
 from eneo.info_blobs.info_blob import InfoBlobChunk
+from eneo.info_blobs.info_blob_repo import InfoBlobRepository
 from eneo.main.config import get_settings
 from eneo.main.logging import get_logger
 from eneo.worker.crawl_context import (
@@ -390,6 +394,27 @@ async def persist_batch(
     try:
         async with asyncio.timeout(ctx.max_transaction_wall_time_seconds):
             async with sessionmanager.session() as session, session.begin():
+                tenant_limit, user_limit = (
+                    await session.execute(
+                        sa.select(Tenants.quota_limit, Users.quota_limit)
+                        .select_from(Users)
+                        .join(Tenants, Tenants.id == Users.tenant_id)
+                        .where(
+                            Users.id == ctx.user_id,
+                            Tenants.id == ctx.tenant_id,
+                        )
+                    )
+                ).one()
+                quota_repo = InfoBlobRepository(session)
+                tenant_usage = await quota_repo.get_retained_size_of_tenant(
+                    ctx.tenant_id
+                )
+                user_usage = (
+                    await quota_repo.get_retained_size_of_user(ctx.user_id)
+                    if user_limit is not None
+                    else 0
+                )
+
                 for prepared in prepared_pages:
                     # Per-page savepoint keeps the previous complete version visible
                     # unless the replacement and all of its chunks are ready together.
@@ -432,6 +457,23 @@ async def persist_batch(
                             successful_urls.append(prepared.url)
                             continue
 
+                        chunk_sizes = [
+                            len(chunk_text.encode("utf-8")) + len(embedding) * 4
+                            for chunk_text, embedding in zip(
+                                prepared.chunks,
+                                prepared.embeddings,
+                            )
+                        ]
+                        stored_size = len(prepared.content.encode("utf-8")) + sum(
+                            chunk_sizes
+                        )
+                        ensure_quota_capacity(
+                            tenant_usage=tenant_usage,
+                            tenant_limit=tenant_limit,
+                            user_usage=user_usage,
+                            user_limit=user_limit,
+                            size_in_bytes=stored_size,
+                        )
                         source_id = (
                             existing.source_id if existing is not None else uuid4()
                         )
@@ -453,7 +495,7 @@ async def persist_batch(
                             "text": prepared.content,
                             "title": prepared.title,
                             "url": prepared.url,
-                            "size": len(prepared.content.encode("utf-8")),
+                            "size": stored_size,
                             "content_hash": prepared.content_hash,
                             "user_id": prepared.user_id,
                             "tenant_id": prepared.tenant_id,
@@ -477,13 +519,17 @@ async def persist_batch(
                             {
                                 "text": chunk_text,
                                 "chunk_no": i,
-                                "size": len(chunk_text.encode("utf-8")),
+                                "size": chunk_size,
                                 "embedding": embedding,
                                 "info_blob_id": info_blob_id,
                                 "tenant_id": prepared.tenant_id,
                             }
-                            for i, (chunk_text, embedding) in enumerate(
-                                zip(prepared.chunks, prepared.embeddings)
+                            for i, (chunk_text, embedding, chunk_size) in enumerate(
+                                zip(
+                                    prepared.chunks,
+                                    prepared.embeddings,
+                                    chunk_sizes,
+                                )
                             )
                         ]
 
@@ -497,6 +543,8 @@ async def persist_batch(
                         await session.execute(insert_chunks_stmt)
 
                         await savepoint.commit()
+                        tenant_usage += stored_size
+                        user_usage += stored_size
                         success_count += 1
                         successful_urls.append(
                             prepared.url

--- a/backend/src/eneo/worker/crawl/persistence.py
+++ b/backend/src/eneo/worker/crawl/persistence.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 from typing import TYPE_CHECKING, Any, cast
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import sqlalchemy as sa
 from dependency_injector import providers
@@ -93,7 +93,7 @@ async def persist_batch(
     ctx: CrawlContext,
     embedding_model: EmbeddingModelSpec | None,
     container: "Container",
-    existing_content_hashes: dict[str, bytes] | None = None,
+    existing_publications: dict[str, tuple[bytes, UUID]] | None = None,
 ) -> tuple[int, int, list[str], dict[str, list[str]]]:
     """
     Persist a batch of pages using the TWO-PHASE pattern.
@@ -243,7 +243,10 @@ async def persist_batch(
             try:
                 # 1. Compute content hash (local operation)
                 content_hash = hashlib.sha256(content.encode("utf-8")).digest()
-                if (existing_content_hashes or {}).get(url) == content_hash:
+                if (existing_publications or {}).get(url) == (
+                    content_hash,
+                    embedding_model.id,
+                ):
                     success_count += 1
                     successful_urls.append(url)
                     continue
@@ -439,6 +442,7 @@ async def persist_batch(
                                     InfoBlobs.id,
                                     InfoBlobs.source_id,
                                     InfoBlobs.content_hash,
+                                    InfoBlobs.embedding_model_id,
                                 )
                                 .where(
                                     InfoBlobs.title == prepared.title,
@@ -451,6 +455,8 @@ async def persist_batch(
                         if (
                             existing is not None
                             and existing.content_hash == prepared.content_hash
+                            and existing.embedding_model_id
+                            == prepared.embedding_model_id
                         ):
                             await savepoint.commit()
                             success_count += 1

--- a/backend/src/eneo/worker/crawl/persistence.py
+++ b/backend/src/eneo/worker/crawl/persistence.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 from typing import TYPE_CHECKING, Any, cast
+from uuid import uuid4
 
 import sqlalchemy as sa
 from dependency_injector import providers
@@ -21,7 +22,11 @@ from typing_extensions import TypedDict
 
 from eneo.completion_models.infrastructure.context_builder import count_tokens
 from eneo.database.tables.info_blob_chunk_table import InfoBlobChunks
-from eneo.database.tables.info_blobs_table import InfoBlobs
+from eneo.database.tables.info_blobs_table import (
+    InfoBlobs,
+    InfoBlobVersionState,
+    active_info_blob_version,
+)
 from eneo.info_blobs.info_blob import InfoBlobChunk
 from eneo.main.config import get_settings
 from eneo.main.logging import get_logger
@@ -84,6 +89,7 @@ async def persist_batch(
     ctx: CrawlContext,
     embedding_model: EmbeddingModelSpec | None,
     container: "Container",
+    existing_content_hashes: dict[str, bytes] | None = None,
 ) -> tuple[int, int, list[str], dict[str, list[str]]]:
     """
     Persist a batch of pages using the TWO-PHASE pattern.
@@ -101,9 +107,9 @@ async def persist_batch(
     PHASE 2 (Short-lived Session - ~50-300ms):
         - Open fresh session from pool
         - For each prepared page:
-            - Create savepoint for atomic delete+insert
-            - Delete existing by (title, website_id) for deduplication
-            - Insert InfoBlob
+            - Lock the page identity
+            - Supersede the previous active version
+            - Insert the replacement InfoBlob
             - Bulk insert InfoBlobChunks with embeddings
             - Commit savepoint
         - Return connection to pool immediately
@@ -118,12 +124,12 @@ async def persist_batch(
         Tuple of (success_count, failed_count, successful_urls, failures_by_reason)
         - success_count: Number of pages successfully persisted
         - failed_count: Number of pages that failed to persist
-        - successful_urls: List of URLs that were ACTUALLY persisted (for accurate tracking)
+        - successful_urls: List of URLs persisted or confirmed unchanged
         - failures_by_reason: Dict mapping FailureReason codes to lists of failed URLs
 
     Note:
-        - Deduplication uses delete-then-insert pattern (not idempotent across workers)
-        - For true idempotency, add UNIQUE constraint on (tenant_id, website_id, title)
+        - Publication serializes concurrent updates for the same website page.
+        - A failed replacement rolls back to the previous active version.
         - CRITICAL: Only URLs in successful_urls should be marked as crawled
         - CRITICAL: URLs in failures_by_reason should NOT be deleted as stale
     """
@@ -233,6 +239,10 @@ async def persist_batch(
             try:
                 # 1. Compute content hash (local operation)
                 content_hash = hashlib.sha256(content.encode("utf-8")).digest()
+                if (existing_content_hashes or {}).get(url) == content_hash:
+                    success_count += 1
+                    successful_urls.append(url)
+                    continue
 
                 # 2. Chunk the text (local operation)
                 raw_chunks = splitter.split_text(content)
@@ -352,12 +362,18 @@ async def persist_batch(
         # This returns the connection to the pool before Phase 2 starts
         await embedding_session.close()
 
+    confirmed_unchanged_urls = successful_urls.copy()
     if not prepared_pages:
-        logger.warning(
-            "No pages prepared after Phase 1",
-            extra={"website_id": str(ctx.website_id), "failed_count": failed_count},
+        log = logger.debug if successful_urls else logger.warning
+        log(
+            "No pages require publication after Phase 1",
+            extra={
+                "website_id": str(ctx.website_id),
+                "unchanged_count": len(successful_urls),
+                "failed_count": failed_count,
+            },
         )
-        return success_count, failed_count, [], failures_by_reason
+        return success_count, failed_count, successful_urls, failures_by_reason
 
     # PHASE 2: Persist to DB (SHORT-LIVED SESSION)
     # This is the only part that holds a database connection.
@@ -375,20 +391,64 @@ async def persist_batch(
         async with asyncio.timeout(ctx.max_transaction_wall_time_seconds):
             async with sessionmanager.session() as session, session.begin():
                 for prepared in prepared_pages:
-                    # Per-page savepoint for atomic delete+insert
+                    # Per-page savepoint keeps the previous complete version visible
+                    # unless the replacement and all of its chunks are ready together.
                     savepoint = await session.begin_nested()
                     try:
-                        # 1. DEDUPLICATION: Delete existing by (title, website_id)
-                        # This matches the existing _delete_if_same_title() pattern
-                        delete_stmt = sa.delete(InfoBlobs).where(
-                            sa.and_(
-                                InfoBlobs.title == prepared.title,
-                                InfoBlobs.website_id == prepared.website_id,
-                            )
+                        await session.execute(
+                            sa.text(
+                                "SELECT pg_advisory_xact_lock("
+                                "hashtextextended(:identity, 0))"
+                            ),
+                            {
+                                "identity": (
+                                    f"website:{prepared.website_id}:"
+                                    f"title:{prepared.title}"
+                                )
+                            },
                         )
-                        await session.execute(delete_stmt)
 
-                        # 2. Insert new InfoBlob
+                        existing = (
+                            await session.execute(
+                                sa.select(
+                                    InfoBlobs.id,
+                                    InfoBlobs.source_id,
+                                    InfoBlobs.content_hash,
+                                )
+                                .where(
+                                    InfoBlobs.title == prepared.title,
+                                    InfoBlobs.website_id == prepared.website_id,
+                                    active_info_blob_version(),
+                                )
+                                .with_for_update()
+                            )
+                        ).one_or_none()
+                        if (
+                            existing is not None
+                            and existing.content_hash == prepared.content_hash
+                        ):
+                            await savepoint.commit()
+                            success_count += 1
+                            successful_urls.append(prepared.url)
+                            continue
+
+                        source_id = (
+                            existing.source_id if existing is not None else uuid4()
+                        )
+                        if existing is not None:
+                            await session.execute(
+                                sa.update(InfoBlobs)
+                                .where(
+                                    InfoBlobs.id == existing.id,
+                                    active_info_blob_version(),
+                                )
+                                .values(
+                                    version_state=(
+                                        InfoBlobVersionState.SUPERSEDED.value
+                                    )
+                                )
+                            )
+
                         info_blob_values = {
                             "text": prepared.content,
                             "title": prepared.title,
@@ -401,6 +461,8 @@ async def persist_batch(
                             "embedding_model_id": prepared.embedding_model_id,
                             "group_id": None,  # Website crawls don't have group_id
                             "integration_knowledge_id": None,
+                            "source_id": source_id,
+                            "version_state": InfoBlobVersionState.ACTIVE.value,
                         }
 
                         insert_blob_stmt = (
@@ -411,7 +473,6 @@ async def persist_batch(
                         result = await session.execute(insert_blob_stmt)
                         info_blob_id = result.scalar_one()
 
-                        # 3. Bulk insert chunks with embeddings
                         chunk_values = [
                             {
                                 "text": chunk_text,
@@ -426,11 +487,14 @@ async def persist_batch(
                             )
                         ]
 
-                        if chunk_values:
-                            insert_chunks_stmt = sa.insert(InfoBlobChunks).values(
-                                chunk_values
+                        if not chunk_values:
+                            raise ValueError(
+                                f"Crawled page {prepared.url} has no searchable chunks"
                             )
-                            await session.execute(insert_chunks_stmt)
+                        insert_chunks_stmt = sa.insert(InfoBlobChunks).values(
+                            chunk_values
+                        )
+                        await session.execute(insert_chunks_stmt)
 
                         await savepoint.commit()
                         success_count += 1
@@ -471,10 +535,11 @@ async def persist_batch(
             },
         )
         # Mark all unpersisted pages as failed with DB_ERROR
-        for p in prepared_pages:
-            if p.url not in successful_urls:
-                add_failure(FailureReason.DB_ERROR, p.url)
-        failed_count += len(prepared_pages) - success_count
+        successful_urls = confirmed_unchanged_urls
+        success_count = len(confirmed_unchanged_urls)
+        for page in prepared_pages:
+            add_failure(FailureReason.DB_ERROR, page.url)
+        failed_count += len(prepared_pages)
 
     except Exception as e:
         logger.error(
@@ -485,9 +550,10 @@ async def persist_batch(
             },
         )
         # Mark all unpersisted pages as failed with DB_ERROR
-        for p in prepared_pages:
-            if p.url not in successful_urls:
-                add_failure(FailureReason.DB_ERROR, p.url)
-        failed_count += len(prepared_pages) - success_count
+        successful_urls = confirmed_unchanged_urls
+        success_count = len(confirmed_unchanged_urls)
+        for page in prepared_pages:
+            add_failure(FailureReason.DB_ERROR, page.url)
+        failed_count += len(prepared_pages)
 
     return success_count, failed_count, successful_urls, failures_by_reason

--- a/backend/src/eneo/worker/crawl_tasks.py
+++ b/backend/src/eneo/worker/crawl_tasks.py
@@ -1201,6 +1201,7 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
                         crawled_titles.add(filename)
 
                     except Exception:
+                        failed_titles.add(filename)
                         logger.exception(
                             "Exception while uploading file",
                             extra={

--- a/backend/src/eneo/worker/crawl_tasks.py
+++ b/backend/src/eneo/worker/crawl_tasks.py
@@ -718,13 +718,16 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
             # session returns to pool immediately. This prevents holding a connection
             # for 5-30 minutes during the actual crawl operation.
             from eneo.database.database import sessionmanager
-            from eneo.database.tables.info_blobs_table import InfoBlobs
+            from eneo.database.tables.info_blobs_table import (
+                InfoBlobs,
+                active_info_blob_version,
+            )
             from eneo.database.tables.websites_table import Websites as WebsitesTable
 
             # These will be populated by bootstrap
             crawl_context: CrawlContext
             existing_titles: list[str] = []
-            existing_file_hashes: dict[str, bytes] = {}
+            existing_content_hashes: dict[str, bytes] = {}
             website_url: str = ""  # For logging after session closes
 
             start = time.time()
@@ -912,16 +915,16 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
 
                 # Fetch existing titles for stale detection and file hashes for skip optimization
                 stmt = sa.select(InfoBlobs.title, InfoBlobs.content_hash).where(
-                    InfoBlobs.website_id == params.website_id
+                    InfoBlobs.website_id == params.website_id,
+                    active_info_blob_version(),
                 )
                 blob_result = await bootstrap_session.execute(stmt)
 
                 # Build lookups for O(1) operations
                 for title, hash_bytes in blob_result:
                     existing_titles.append(title)
-                    # Only store hashes for files (not URLs)
-                    if hash_bytes is not None and not title.startswith("http"):
-                        existing_file_hashes[title] = hash_bytes
+                    if hash_bytes is not None:
+                        existing_content_hashes[title] = hash_bytes
 
             finally:
                 # Always close the bootstrap session to return connection to pool
@@ -1079,6 +1082,7 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
                             ctx=crawl_context,
                             embedding_model=embedding_model_spec,
                             container=container,
+                            existing_content_hashes=existing_content_hashes,
                         )
                         crawled_titles.update(successful_urls)
                         # Aggregate failure reasons and track failed URLs
@@ -1110,6 +1114,7 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
                         ctx=crawl_context,
                         embedding_model=embedding_model_spec,
                         container=container,
+                        existing_content_hashes=existing_content_hashes,
                     )
                     crawled_titles.update(successful_urls)
                     # Aggregate failure reasons and track failed URLs
@@ -1143,7 +1148,7 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
                         file_bytes = file.read_bytes()
                         new_file_hash = hashlib.sha256(file_bytes).digest()
 
-                        existing_file_hash = existing_file_hashes.get(filename)
+                        existing_file_hash = existing_content_hashes.get(filename)
 
                         if (
                             existing_file_hash is not None
@@ -1254,10 +1259,16 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
                 from eneo.database.tables.info_blobs_table import (
                     InfoBlobs as InfoBlobsTable,
                 )
+                from eneo.database.tables.info_blobs_table import (
+                    active_info_blob_version,
+                )
 
                 update_size_stmt = (
                     sa.select(sa.func.coalesce(sa.func.sum(InfoBlobsTable.size), 0))
-                    .where(InfoBlobsTable.website_id == crawl_context.website_id)
+                    .where(
+                        InfoBlobsTable.website_id == crawl_context.website_id,
+                        active_info_blob_version(),
+                    )
                     .scalar_subquery()
                 )
                 stmt = (

--- a/backend/src/eneo/worker/crawl_tasks.py
+++ b/backend/src/eneo/worker/crawl_tasks.py
@@ -727,7 +727,7 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
             # These will be populated by bootstrap
             crawl_context: CrawlContext
             existing_titles: list[str] = []
-            existing_content_hashes: dict[str, bytes] = {}
+            existing_publications: dict[str, tuple[bytes, UUID]] = {}
             website_url: str = ""  # For logging after session closes
 
             start = time.time()
@@ -914,17 +914,21 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
                 )
 
                 # Fetch existing titles for stale detection and file hashes for skip optimization
-                stmt = sa.select(InfoBlobs.title, InfoBlobs.content_hash).where(
+                stmt = sa.select(
+                    InfoBlobs.title,
+                    InfoBlobs.content_hash,
+                    InfoBlobs.embedding_model_id,
+                ).where(
                     InfoBlobs.website_id == params.website_id,
                     active_info_blob_version(),
                 )
                 blob_result = await bootstrap_session.execute(stmt)
 
                 # Build lookups for O(1) operations
-                for title, hash_bytes in blob_result:
+                for title, hash_bytes, model_id in blob_result:
                     existing_titles.append(title)
-                    if hash_bytes is not None:
-                        existing_content_hashes[title] = hash_bytes
+                    if hash_bytes is not None and model_id is not None:
+                        existing_publications[title] = (hash_bytes, model_id)
 
             finally:
                 # Always close the bootstrap session to return connection to pool
@@ -1082,7 +1086,7 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
                             ctx=crawl_context,
                             embedding_model=embedding_model_spec,
                             container=container,
-                            existing_content_hashes=existing_content_hashes,
+                            existing_publications=existing_publications,
                         )
                         crawled_titles.update(successful_urls)
                         # Aggregate failure reasons and track failed URLs
@@ -1114,7 +1118,7 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
                         ctx=crawl_context,
                         embedding_model=embedding_model_spec,
                         container=container,
-                        existing_content_hashes=existing_content_hashes,
+                        existing_publications=existing_publications,
                     )
                     crawled_titles.update(successful_urls)
                     # Aggregate failure reasons and track failed URLs
@@ -1148,11 +1152,11 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
                         file_bytes = file.read_bytes()
                         new_file_hash = hashlib.sha256(file_bytes).digest()
 
-                        existing_file_hash = existing_content_hashes.get(filename)
+                        existing_file = existing_publications.get(filename)
 
-                        if (
-                            existing_file_hash is not None
-                            and new_file_hash == existing_file_hash
+                        if embedding_model_spec is not None and existing_file == (
+                            new_file_hash,
+                            embedding_model_spec.id,
                         ):
                             # File unchanged - skip processing
                             num_skipped_files += 1

--- a/backend/tests/integration/embedding_models/test_embedding_model_lifecycle.py
+++ b/backend/tests/integration/embedding_models/test_embedding_model_lifecycle.py
@@ -10,12 +10,14 @@ re-embedding, not repointing), so the lifecycle is soft-delete only:
 """
 
 from datetime import datetime, timezone
+from hashlib import sha256
+from uuid import uuid4
 
 import pytest
 from sqlalchemy import select
 
 from eneo.database.tables.ai_models_table import EmbeddingModels
-from eneo.database.tables.info_blobs_table import InfoBlobs
+from eneo.database.tables.info_blobs_table import InfoBlobs, InfoBlobVersionState
 from eneo.database.tables.model_providers_table import ModelProviders
 from eneo.database.tables.spaces_table import SpacesEmbeddingModels
 from eneo.embedding_models.domain.embedding_model_repo import (
@@ -124,6 +126,9 @@ class TestEmbeddingModelSoftDelete:
             info_blob = InfoBlobs(
                 text="historical chunk",
                 size=10,
+                content_hash=sha256(b"historical chunk").digest(),
+                source_id=uuid4(),
+                version_state=InfoBlobVersionState.ACTIVE.value,
                 user_id=admin_user.id,
                 tenant_id=admin_user.tenant_id,
                 embedding_model_id=model_id,
@@ -222,6 +227,9 @@ class TestEmbeddingModelCleanupWorker:
                 InfoBlobs(
                     text="historical chunk",
                     size=10,
+                    content_hash=sha256(b"historical chunk").digest(),
+                    source_id=uuid4(),
+                    version_state=InfoBlobVersionState.ACTIVE.value,
                     user_id=admin_user.id,
                     tenant_id=admin_user.tenant_id,
                     embedding_model_id=model_id,

--- a/backend/tests/integration/info_blobs/test_info_blob_version_publication.py
+++ b/backend/tests/integration/info_blobs/test_info_blob_version_publication.py
@@ -4,6 +4,7 @@ from hashlib import sha256
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
+import pytest
 import sqlalchemy as sa
 from dependency_injector import providers
 
@@ -16,9 +17,17 @@ from eneo.database.tables.info_blobs_table import (
 )
 from eneo.database.tables.spaces_table import Spaces
 from eneo.files.chunk_embedding_list import ChunkEmbeddingList
+from eneo.info_blobs.info_blob import InfoBlobAdd
+from eneo.main.exceptions import QuotaExceededException
 
 
-async def _seed_active_document(container, *, text: str, title: str):
+async def _seed_active_document(
+    container,
+    *,
+    text: str,
+    title: str,
+    url: str | None = None,
+):
     session = container.session()
     user = container.user()
     embedding_model = (await session.scalars(sa.select(EmbeddingModels).limit(1))).one()
@@ -43,6 +52,7 @@ async def _seed_active_document(container, *, text: str, title: str):
     source_id = uuid4()
     blob = InfoBlobs(
         title=title,
+        url=url,
         text=text,
         size=len(text.encode("utf-8")),
         content_hash=sha256(text.encode("utf-8")).digest(),
@@ -205,6 +215,152 @@ async def test_unchanged_document_reuses_active_version_without_embedding(
         ]
         assert [chunk.id for chunk in chunks] == [active_chunk.id]
         embeddings.get_embeddings.assert_not_awaited()
+
+
+async def test_unchanged_document_refreshes_citation_metadata(db_container) -> None:
+    title = "moved-knowledge.txt"
+    text = "Knowledge whose source location changed"
+    old_url = "https://example.test/old"
+    new_url = "https://example.test/new"
+
+    async with db_container() as container:
+        group, embedding_model, active, active_chunk = await _seed_active_document(
+            container,
+            text=text,
+            title=title,
+            url=old_url,
+        )
+        embeddings = AsyncMock()
+        container.create_embeddings_service.override(providers.Object(embeddings))
+
+        published = await container.text_processor().process_text(
+            text=text,
+            title=title,
+            url=new_url,
+            embedding_model=embedding_model,
+            group_id=group.id,
+        )
+
+        persisted = await container.info_blob_repo().get(active.id)
+        chunks = (
+            await container.session().scalars(
+                sa.select(InfoBlobChunks).where(
+                    InfoBlobChunks.info_blob_id == active.id
+                )
+            )
+        ).all()
+        assert published.id == active.id
+        assert published.url == new_url
+        assert persisted.url == new_url
+        assert [chunk.id for chunk in chunks] == [active_chunk.id]
+        embeddings.get_embeddings.assert_not_awaited()
+
+
+async def test_untitled_documents_remain_independent_and_searchable(
+    db_container,
+) -> None:
+    async with db_container() as container:
+        group, embedding_model, _, _ = await _seed_active_document(
+            container,
+            text="Existing titled knowledge",
+            title="existing.txt",
+        )
+        embeddings = AsyncMock()
+        embeddings.get_embeddings.side_effect = _embedding_result
+        container.create_embeddings_service.override(providers.Object(embeddings))
+        service = container.info_blob_service()
+        user = container.user()
+
+        first = await service.publish_info_blob_without_validation(
+            InfoBlobAdd(
+                text="First titleless publication",
+                title=None,
+                user_id=user.id,
+                tenant_id=user.tenant_id,
+                group_id=group.id,
+            ),
+            embedding_model=embedding_model,
+        )
+        second = await service.publish_info_blob_without_validation(
+            InfoBlobAdd(
+                text="Second titleless publication",
+                title=None,
+                user_id=user.id,
+                tenant_id=user.tenant_id,
+                group_id=group.id,
+            ),
+            embedding_model=embedding_model,
+        )
+
+        titleless = (
+            await container.session().scalars(
+                sa.select(InfoBlobs).where(
+                    InfoBlobs.id.in_([first.id, second.id]),
+                    InfoBlobs.version_state == InfoBlobVersionState.ACTIVE.value,
+                )
+            )
+        ).all()
+        first_matches = await container.info_blob_chunk_repo().keyword_search(
+            "First titleless",
+            group_ids=[group.id],
+        )
+        second_matches = await container.info_blob_chunk_repo().keyword_search(
+            "Second titleless",
+            group_ids=[group.id],
+        )
+        assert {blob.id for blob in titleless} == {first.id, second.id}
+        assert first.source_id != second.source_id
+        assert [chunk.info_blob_id for chunk in first_matches] == [first.id]
+        assert [chunk.info_blob_id for chunk in second_matches] == [second.id]
+
+
+async def test_retained_versions_consume_quota_until_family_deletion(
+    db_container,
+) -> None:
+    async with db_container() as container:
+        group, embedding_model, _, _ = await _seed_active_document(
+            container,
+            text="Initial retained knowledge",
+            title="quota-history.txt",
+        )
+        embeddings = AsyncMock()
+        embeddings.get_embeddings.side_effect = _embedding_result
+        container.create_embeddings_service.override(providers.Object(embeddings))
+        user = container.user()
+        user.tenant.quota_limit = 1_000_000
+
+        published = await container.text_processor().process_text(
+            text="First replacement retained in history",
+            title="quota-history.txt",
+            embedding_model=embedding_model,
+            group_id=group.id,
+        )
+        retained_usage = await container.info_blob_repo().get_retained_size_of_tenant(
+            user.tenant_id
+        )
+        rejected_text = "Replacement that exceeds retained capacity"
+        user.tenant.quota_limit = (
+            retained_usage + len(rejected_text.encode("utf-8")) - 1
+        )
+
+        with pytest.raises(QuotaExceededException, match="Tenant quota limit exceeded"):
+            await container.text_processor().process_text(
+                text=rejected_text,
+                title="quota-history.txt",
+                embedding_model=embedding_model,
+                group_id=group.id,
+            )
+
+        visible = await container.info_blob_repo().get_by_group(group.id)
+        assert [blob.id for blob in visible if blob.title == "quota-history.txt"] == [
+            published.id
+        ]
+
+        await container.info_blob_repo().delete(published.id)
+        assert (
+            await container.info_blob_repo().get_retained_size_of_tenant(user.tenant_id)
+            == 0
+        )
 
 
 async def test_failed_replacement_preserves_the_active_version(db_container) -> None:

--- a/backend/tests/integration/info_blobs/test_info_blob_version_publication.py
+++ b/backend/tests/integration/info_blobs/test_info_blob_version_publication.py
@@ -304,15 +304,14 @@ async def test_same_content_is_reembedded_after_model_change(db_container) -> No
         assert published.embedding_model_id != old_model.id
         versions = (
             await container.session().scalars(
-                sa.select(InfoBlobs)
-                .where(InfoBlobs.source_id == active.source_id)
-                .order_by(InfoBlobs.created_at, InfoBlobs.id)
+                sa.select(InfoBlobs).where(InfoBlobs.source_id == active.source_id)
             )
         ).all()
-        assert [version.version_state for version in versions] == [
-            InfoBlobVersionState.SUPERSEDED.value,
-            InfoBlobVersionState.ACTIVE.value,
-        ]
+        states_by_id = {version.id: version.version_state for version in versions}
+        assert states_by_id == {
+            active.id: InfoBlobVersionState.SUPERSEDED.value,
+            published.id: InfoBlobVersionState.ACTIVE.value,
+        }
         matches = await container.info_blob_chunk_repo().semantic_search(
             [0.7, 0.8, 0.9],
             group_ids=[group.id],

--- a/backend/tests/integration/info_blobs/test_info_blob_version_publication.py
+++ b/backend/tests/integration/info_blobs/test_info_blob_version_publication.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from hashlib import sha256
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import sqlalchemy as sa
+from dependency_injector import providers
+
+from eneo.database.tables.ai_models_table import EmbeddingModels
+from eneo.database.tables.collections_table import CollectionsTable
+from eneo.database.tables.info_blob_chunk_table import InfoBlobChunks
+from eneo.database.tables.info_blobs_table import (
+    InfoBlobs,
+    InfoBlobVersionState,
+)
+from eneo.database.tables.spaces_table import Spaces
+from eneo.files.chunk_embedding_list import ChunkEmbeddingList
+
+
+async def _seed_active_document(container, *, text: str, title: str):
+    session = container.session()
+    user = container.user()
+    embedding_model = (await session.scalars(sa.select(EmbeddingModels).limit(1))).one()
+    space = Spaces(
+        name=f"Knowledge version space {uuid4().hex[:8]}",
+        tenant_id=user.tenant_id,
+        user_id=user.id,
+    )
+    session.add(space)
+    await session.flush()
+    group = CollectionsTable(
+        name=f"Knowledge version group {uuid4().hex[:8]}",
+        size=0,
+        user_id=user.id,
+        tenant_id=user.tenant_id,
+        embedding_model_id=embedding_model.id,
+        space_id=space.id,
+    )
+    session.add(group)
+    await session.flush()
+
+    source_id = uuid4()
+    blob = InfoBlobs(
+        title=title,
+        text=text,
+        size=len(text.encode("utf-8")),
+        content_hash=sha256(text.encode("utf-8")).digest(),
+        source_id=source_id,
+        version_state=InfoBlobVersionState.ACTIVE.value,
+        user_id=user.id,
+        tenant_id=user.tenant_id,
+        group_id=group.id,
+        embedding_model_id=embedding_model.id,
+    )
+    session.add(blob)
+    await session.flush()
+    chunk = InfoBlobChunks(
+        info_blob_id=blob.id,
+        tenant_id=user.tenant_id,
+        chunk_no=0,
+        text=text,
+        size=len(text.encode("utf-8")),
+        embedding=[0.1, 0.2, 0.3],
+    )
+    session.add(chunk)
+    await session.flush()
+    return group, embedding_model, blob, chunk
+
+
+def _embedding_result(*, model, chunks):
+    result = ChunkEmbeddingList()
+    result.add(chunks, [[0.7, 0.8, 0.9] for _ in chunks])
+    return result
+
+
+async def test_changed_document_publishes_one_active_version_and_keeps_history(
+    db_container,
+) -> None:
+    title = "versioned-knowledge.txt"
+    previous_text = "Previously published knowledge"
+    replacement_text = "Updated knowledge that should become searchable"
+
+    async with db_container() as container:
+        group, embedding_model, previous, previous_chunk = await _seed_active_document(
+            container,
+            text=previous_text,
+            title=title,
+        )
+        embeddings = AsyncMock()
+        embeddings.get_embeddings.side_effect = _embedding_result
+        container.create_embeddings_service.override(providers.Object(embeddings))
+
+        published = await container.text_processor().process_text(
+            text=replacement_text,
+            title=title,
+            embedding_model=embedding_model,
+            group_id=group.id,
+        )
+
+        versions = (
+            await container.session().scalars(
+                sa.select(InfoBlobs)
+                .where(InfoBlobs.source_id == previous.source_id)
+                .order_by(InfoBlobs.created_at, InfoBlobs.id)
+            )
+        ).all()
+        assert {version.id: version.version_state for version in versions} == {
+            previous.id: InfoBlobVersionState.SUPERSEDED.value,
+            published.id: InfoBlobVersionState.ACTIVE.value,
+        }
+        assert published.id != previous.id
+        assert published.source_id == previous.source_id
+
+        chunk_rows = (
+            await container.session().scalars(
+                sa.select(InfoBlobChunks).where(
+                    InfoBlobChunks.info_blob_id.in_([previous.id, published.id])
+                )
+            )
+        ).all()
+        assert {chunk.info_blob_id for chunk in chunk_rows} == {
+            previous.id,
+            published.id,
+        }
+        assert any(chunk.id == previous_chunk.id for chunk in chunk_rows)
+
+        visible = await container.info_blob_repo().get_by_group(group.id)
+        historical = await container.info_blob_repo().get(previous.id)
+        assert [blob.id for blob in visible] == [published.id]
+        assert historical.id == previous.id
+        assert await container.info_blob_repo().get_count_of_group(group.id) == 1
+        assert (
+            await container.info_blob_repo().get_total_size_of_group(group.id)
+            == published.size
+        )
+
+        semantic_matches = await container.info_blob_chunk_repo().semantic_search(
+            [0.7, 0.8, 0.9],
+            group_ids=[group.id],
+        )
+        current_keyword_matches = await container.info_blob_chunk_repo().keyword_search(
+            "Updated",
+            group_ids=[group.id],
+        )
+        previous_keyword_matches = (
+            await container.info_blob_chunk_repo().keyword_search(
+                "Previously",
+                group_ids=[group.id],
+            )
+        )
+        assert [chunk.info_blob_id for chunk in semantic_matches] == [published.id]
+        assert [chunk.info_blob_id for chunk in current_keyword_matches] == [
+            published.id
+        ]
+        assert previous_keyword_matches == []
+
+        deleted = await container.info_blob_repo().delete(published.id)
+        remaining_versions = (
+            await container.session().scalars(
+                sa.select(InfoBlobs).where(InfoBlobs.source_id == previous.source_id)
+            )
+        ).all()
+        assert deleted.id == published.id
+        assert remaining_versions == []
+
+
+async def test_unchanged_document_reuses_active_version_without_embedding(
+    db_container,
+) -> None:
+    title = "unchanged-knowledge.txt"
+    text = "Knowledge that has not changed"
+
+    async with db_container() as container:
+        group, embedding_model, active, active_chunk = await _seed_active_document(
+            container,
+            text=text,
+            title=title,
+        )
+        embeddings = AsyncMock()
+        container.create_embeddings_service.override(providers.Object(embeddings))
+
+        published = await container.text_processor().process_text(
+            text=text,
+            title=title,
+            embedding_model=embedding_model,
+            group_id=group.id,
+        )
+
+        versions = (
+            await container.session().scalars(
+                sa.select(InfoBlobs).where(InfoBlobs.source_id == active.source_id)
+            )
+        ).all()
+        chunks = (
+            await container.session().scalars(
+                sa.select(InfoBlobChunks).where(
+                    InfoBlobChunks.info_blob_id == active.id
+                )
+            )
+        ).all()
+        assert published.id == active.id
+        assert [(version.id, version.version_state) for version in versions] == [
+            (active.id, InfoBlobVersionState.ACTIVE.value)
+        ]
+        assert [chunk.id for chunk in chunks] == [active_chunk.id]
+        embeddings.get_embeddings.assert_not_awaited()
+
+
+async def test_failed_replacement_preserves_the_active_version(db_container) -> None:
+    title = "failed-replacement.txt"
+    previous_text = "Published knowledge remains available"
+
+    async with db_container() as container:
+        group, embedding_model, active, active_chunk = await _seed_active_document(
+            container,
+            text=previous_text,
+            title=title,
+        )
+        embeddings = AsyncMock()
+        embeddings.get_embeddings.side_effect = RuntimeError("embedding unavailable")
+        container.create_embeddings_service.override(providers.Object(embeddings))
+        active_id = active.id
+        active_source_id = active.source_id
+        active_chunk_id = active_chunk.id
+
+        try:
+            await container.text_processor().process_text(
+                text="Replacement that cannot be embedded",
+                title=title,
+                embedding_model=embedding_model,
+                group_id=group.id,
+            )
+        except RuntimeError as exc:
+            assert str(exc) == "embedding unavailable"
+        else:
+            raise AssertionError("Expected the replacement to fail")
+
+        versions = (
+            await container.session().scalars(
+                sa.select(InfoBlobs).where(InfoBlobs.source_id == active_source_id)
+            )
+        ).all()
+        chunks = (
+            await container.session().scalars(
+                sa.select(InfoBlobChunks).where(
+                    InfoBlobChunks.info_blob_id == active_id
+                )
+            )
+        ).all()
+        assert [(version.id, version.version_state) for version in versions] == [
+            (active_id, InfoBlobVersionState.ACTIVE.value)
+        ]
+        assert [chunk.id for chunk in chunks] == [active_chunk_id]

--- a/backend/tests/integration/info_blobs/test_info_blob_version_publication.py
+++ b/backend/tests/integration/info_blobs/test_info_blob_version_publication.py
@@ -15,6 +15,7 @@ from eneo.database.tables.info_blobs_table import (
     InfoBlobs,
     InfoBlobVersionState,
 )
+from eneo.database.tables.integration_table import IntegrationKnowledge
 from eneo.database.tables.spaces_table import Spaces
 from eneo.files.chunk_embedding_list import ChunkEmbeddingList
 from eneo.info_blobs.info_blob import InfoBlobAdd
@@ -254,6 +255,145 @@ async def test_unchanged_document_refreshes_citation_metadata(db_container) -> N
         assert persisted.url == new_url
         assert [chunk.id for chunk in chunks] == [active_chunk.id]
         embeddings.get_embeddings.assert_not_awaited()
+
+
+async def test_same_content_is_reembedded_after_model_change(db_container) -> None:
+    title = "model-change.txt"
+    text = "Knowledge retained while its embedding model changes"
+
+    async with db_container() as container:
+        group, old_model, active, _ = await _seed_active_document(
+            container,
+            text=text,
+            title=title,
+        )
+        new_model = EmbeddingModels(
+            name=f"replacement-embedding-{uuid4().hex[:8]}",
+            open_source=True,
+            dimensions=3,
+            max_input=8_192,
+            max_batch_size=32,
+            family="test",
+            stability="stable",
+            hosting="self-hosted",
+        )
+        container.session().add(new_model)
+        await container.session().flush()
+        await container.session().execute(
+            sa.update(CollectionsTable)
+            .where(CollectionsTable.id == group.id)
+            .values(embedding_model_id=new_model.id)
+            .execution_options(synchronize_session=False)
+        )
+        await container.session().refresh(group)
+        active.group = group
+
+        embeddings = AsyncMock()
+        embeddings.get_embeddings.side_effect = _embedding_result
+        container.create_embeddings_service.override(providers.Object(embeddings))
+
+        published = await container.text_processor().process_text(
+            text=text,
+            title=title,
+            embedding_model=new_model,
+            group_id=group.id,
+        )
+
+        assert published.id != active.id
+        assert published.embedding_model_id == new_model.id
+        assert published.embedding_model_id != old_model.id
+        versions = (
+            await container.session().scalars(
+                sa.select(InfoBlobs)
+                .where(InfoBlobs.source_id == active.source_id)
+                .order_by(InfoBlobs.created_at, InfoBlobs.id)
+            )
+        ).all()
+        assert [version.version_state for version in versions] == [
+            InfoBlobVersionState.SUPERSEDED.value,
+            InfoBlobVersionState.ACTIVE.value,
+        ]
+        matches = await container.info_blob_chunk_repo().semantic_search(
+            [0.7, 0.8, 0.9],
+            group_ids=[group.id],
+        )
+        assert [match.info_blob_id for match in matches] == [published.id]
+
+
+async def test_sharepoint_family_delete_reads_only_active_version(
+    db_container,
+    user_integration_factory,
+) -> None:
+    async with db_container() as container:
+        group, embedding_model, _, _ = await _seed_active_document(
+            container,
+            text="Fixture knowledge",
+            title="fixture.txt",
+        )
+        session = container.session()
+        user = container.user()
+        user_integration = await user_integration_factory(
+            session,
+            tenant_id=user.tenant_id,
+        )
+        knowledge = IntegrationKnowledge(
+            name="SharePoint version deletion",
+            url="https://example.test/sharepoint",
+            space_id=group.space_id,
+            tenant_id=user.tenant_id,
+            embedding_model_id=embedding_model.id,
+            user_integration_id=user_integration.id,
+            size=321,
+        )
+        session.add(knowledge)
+        await session.flush()
+
+        source_id = uuid4()
+        item_id = f"sharepoint-{uuid4().hex}"
+        history = [
+            InfoBlobs(
+                title="retained.docx",
+                text=f"retained version {index}",
+                size=index + 1,
+                content_hash=sha256(str(index).encode()).digest(),
+                source_id=source_id,
+                version_state=InfoBlobVersionState.SUPERSEDED.value,
+                user_id=user.id,
+                tenant_id=user.tenant_id,
+                integration_knowledge_id=knowledge.id,
+                embedding_model_id=embedding_model.id,
+                sharepoint_item_id=item_id,
+            )
+            for index in range(32)
+        ]
+        active = InfoBlobs(
+            title="retained.docx",
+            text="current version",
+            size=321,
+            content_hash=sha256(b"current version").digest(),
+            source_id=source_id,
+            version_state=InfoBlobVersionState.ACTIVE.value,
+            user_id=user.id,
+            tenant_id=user.tenant_id,
+            integration_knowledge_id=knowledge.id,
+            embedding_model_id=embedding_model.id,
+            sharepoint_item_id=item_id,
+        )
+        session.add_all([*history, active])
+        await session.flush()
+
+        deleted = await container.info_blob_repo().delete_by_sharepoint_item_and_integration_knowledge(
+            item_id,
+            knowledge.id,
+        )
+
+        assert [(blob.id, blob.size) for blob in deleted] == [(active.id, 321)]
+        remaining = await session.scalar(
+            sa.select(sa.func.count())
+            .select_from(InfoBlobs)
+            .where(InfoBlobs.source_id == source_id)
+        )
+        assert remaining == 0
 
 
 async def test_untitled_documents_remain_independent_and_searchable(

--- a/backend/tests/integration/info_blobs/test_info_blob_version_publication.py
+++ b/backend/tests/integration/info_blobs/test_info_blob_version_publication.py
@@ -17,9 +17,11 @@ from eneo.database.tables.info_blobs_table import (
 )
 from eneo.database.tables.integration_table import IntegrationKnowledge
 from eneo.database.tables.spaces_table import Spaces
+from eneo.database.tables.websites_table import Websites
 from eneo.files.chunk_embedding_list import ChunkEmbeddingList
 from eneo.info_blobs.info_blob import InfoBlobAdd
 from eneo.main.exceptions import QuotaExceededException
+from eneo.websites.domain.crawl_run import CrawlType
 
 
 async def _seed_active_document(
@@ -317,6 +319,76 @@ async def test_same_content_is_reembedded_after_model_change(db_container) -> No
             group_ids=[group.id],
         )
         assert [match.info_blob_id for match in matches] == [published.id]
+
+
+async def test_changed_website_file_publishes_from_a_fresh_session(
+    db_container,
+) -> None:
+    title = "downloaded-website-file.txt"
+    previous_text = "Previous downloaded file content"
+    replacement_text = "Replacement downloaded file content"
+
+    async with db_container() as container:
+        session = container.session()
+        user = container.user()
+        embedding_model_id = await session.scalar(
+            sa.select(EmbeddingModels.id).limit(1)
+        )
+        assert embedding_model_id is not None
+        website = Websites(
+            name="Knowledge version website",
+            url="https://knowledge-version.example.com",
+            download_files=True,
+            crawl_type=CrawlType.CRAWL,
+            update_interval="never",
+            size=0,
+            tenant_id=user.tenant_id,
+            user_id=user.id,
+            embedding_model_id=embedding_model_id,
+        )
+        session.add(website)
+        await session.flush()
+        previous = InfoBlobs(
+            title=title,
+            text=previous_text,
+            size=len(previous_text.encode("utf-8")),
+            content_hash=sha256(previous_text.encode("utf-8")).digest(),
+            source_id=uuid4(),
+            version_state=InfoBlobVersionState.ACTIVE.value,
+            user_id=user.id,
+            tenant_id=user.tenant_id,
+            website_id=website.id,
+            embedding_model_id=embedding_model_id,
+        )
+        session.add(previous)
+        await session.flush()
+        website_id = website.id
+        previous_id = previous.id
+        source_id = previous.source_id
+
+    async with db_container() as container:
+        embedding_model = await container.embedding_model_repo2().one(
+            embedding_model_id
+        )
+        embeddings = AsyncMock()
+        embeddings.get_embeddings.side_effect = _embedding_result
+        container.create_embeddings_service.override(providers.Object(embeddings))
+
+        published = await container.text_processor().process_text(
+            text=replacement_text,
+            title=title,
+            embedding_model=embedding_model,
+            website_id=website_id,
+        )
+        versions = (
+            await container.session().scalars(
+                sa.select(InfoBlobs).where(InfoBlobs.source_id == source_id)
+            )
+        ).all()
+        assert {version.id: version.version_state for version in versions} == {
+            previous_id: InfoBlobVersionState.SUPERSEDED.value,
+            published.id: InfoBlobVersionState.ACTIVE.value,
+        }
 
 
 async def test_sharepoint_family_delete_reads_only_active_version(

--- a/backend/tests/integration/migrations/test_info_blob_versions.py
+++ b/backend/tests/integration/migrations/test_info_blob_versions.py
@@ -107,6 +107,212 @@ def _seed_legacy_info_blob(connection) -> UUID:
     return info_blob_id
 
 
+def _seed_legacy_duplicate_identities(
+    connection,
+    *,
+    legacy_id: UUID,
+) -> tuple[dict[str, tuple[UUID, UUID]], tuple[UUID, UUID]]:
+    with connection, connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT user_id, tenant_id, embedding_model_id
+            FROM info_blobs
+            WHERE id = %s
+            """,
+            (str(legacy_id),),
+        )
+        user_id, tenant_id, embedding_model_id = cursor.fetchone()
+
+        group_id = uuid4()
+        website_id = uuid4()
+        space_id = uuid4()
+        integration_id = uuid4()
+        tenant_integration_id = uuid4()
+        user_integration_id = uuid4()
+        integration_knowledge_id = uuid4()
+        cursor.execute(
+            """
+            INSERT INTO groups (
+                id, name, size, user_id, tenant_id, embedding_model_id
+            ) VALUES (%s, 'legacy duplicates', 0, %s, %s, %s)
+            """,
+            (str(group_id), user_id, tenant_id, embedding_model_id),
+        )
+        cursor.execute(
+            """
+            INSERT INTO websites (
+                id, name, url, download_files, crawl_type, update_interval, size,
+                tenant_id, user_id, embedding_model_id
+            ) VALUES (
+                %s, 'legacy website', 'https://example.test', false, 'CRAWL',
+                'never', 0, %s, %s, %s
+            )
+            """,
+            (str(website_id), tenant_id, user_id, embedding_model_id),
+        )
+        cursor.execute(
+            """
+            INSERT INTO spaces (id, name, tenant_id, user_id)
+            VALUES (%s, 'legacy integration space', %s, %s)
+            """,
+            (str(space_id), tenant_id, user_id),
+        )
+        cursor.execute(
+            """
+            INSERT INTO integrations (id, name, description)
+            VALUES (%s, %s, 'migration test integration')
+            """,
+            (str(integration_id), f"migration-{integration_id}"),
+        )
+        cursor.execute(
+            """
+            INSERT INTO tenant_integrations (id, tenant_id, integration_id)
+            VALUES (%s, %s, %s)
+            """,
+            (str(tenant_integration_id), tenant_id, str(integration_id)),
+        )
+        cursor.execute(
+            """
+            INSERT INTO user_integrations (
+                id, user_id, tenant_id, tenant_integration_id, authenticated
+            ) VALUES (%s, %s, %s, %s, true)
+            """,
+            (
+                str(user_integration_id),
+                user_id,
+                tenant_id,
+                str(tenant_integration_id),
+            ),
+        )
+        cursor.execute(
+            """
+            INSERT INTO integration_knowledge (
+                id, name, url, space_id, embedding_model_id, tenant_id,
+                user_integration_id, size
+            ) VALUES (%s, 'legacy integration knowledge', NULL, %s, %s, %s, %s, 0)
+            """,
+            (
+                str(integration_knowledge_id),
+                str(space_id),
+                embedding_model_id,
+                tenant_id,
+                str(user_integration_id),
+            ),
+        )
+
+        identities: dict[str, tuple[UUID, UUID]] = {}
+        rows: list[
+            tuple[
+                UUID, str, str | None, UUID | None, UUID | None, UUID | None, str | None
+            ]
+        ] = []
+        for name, title, owner in (
+            ("group", "group-title", (group_id, None, None)),
+            ("website", "website-title", (None, website_id, None)),
+            (
+                "integration-title",
+                "integration-title",
+                (None, None, integration_knowledge_id),
+            ),
+        ):
+            older_id, newer_id = uuid4(), uuid4()
+            identities[name] = (older_id, newer_id)
+            rows.extend(
+                [
+                    (older_id, f"older {name}", title, *owner, None),
+                    (newer_id, f"newer {name}", title, *owner, None),
+                ]
+            )
+
+        older_item_id, newer_item_id = uuid4(), uuid4()
+        identities["integration-item"] = (older_item_id, newer_item_id)
+        rows.extend(
+            [
+                (
+                    older_item_id,
+                    "older integration item",
+                    "old provider title",
+                    None,
+                    None,
+                    integration_knowledge_id,
+                    "provider-item-1",
+                ),
+                (
+                    newer_item_id,
+                    "newer integration item",
+                    "new provider title",
+                    None,
+                    None,
+                    integration_knowledge_id,
+                    "provider-item-1",
+                ),
+            ]
+        )
+
+        untitled_ids = (uuid4(), uuid4())
+        rows.extend(
+            [
+                (untitled_ids[0], "null title", None, group_id, None, None, None),
+                (untitled_ids[1], "blank title", "   ", group_id, None, None, None),
+            ]
+        )
+        cursor.executemany(
+            """
+            INSERT INTO info_blobs (
+                id, text, title, size, user_id, tenant_id, embedding_model_id,
+                group_id, website_id, integration_knowledge_id,
+                sharepoint_item_id, created_at, updated_at
+            ) VALUES (
+                %s, %s, %s, 10, %s, %s, %s, %s, %s, %s, %s,
+                NOW() - INTERVAL '1 day', NOW() - INTERVAL '1 day'
+            )
+            """,
+            [
+                (
+                    str(row[0]),
+                    row[1],
+                    row[2],
+                    user_id,
+                    tenant_id,
+                    embedding_model_id,
+                    str(row[3]) if row[3] is not None else None,
+                    str(row[4]) if row[4] is not None else None,
+                    str(row[5]) if row[5] is not None else None,
+                    row[6],
+                )
+                for row in rows[::2]
+            ],
+        )
+        cursor.executemany(
+            """
+            INSERT INTO info_blobs (
+                id, text, title, size, user_id, tenant_id, embedding_model_id,
+                group_id, website_id, integration_knowledge_id,
+                sharepoint_item_id, created_at, updated_at
+            ) VALUES (
+                %s, %s, %s, 10, %s, %s, %s, %s, %s, %s, %s,
+                NOW(), NOW()
+            )
+            """,
+            [
+                (
+                    str(row[0]),
+                    row[1],
+                    row[2],
+                    user_id,
+                    tenant_id,
+                    embedding_model_id,
+                    str(row[3]) if row[3] is not None else None,
+                    str(row[4]) if row[4] is not None else None,
+                    str(row[5]) if row[5] is not None else None,
+                    row[6],
+                )
+                for row in rows[1::2]
+            ],
+        )
+    return identities, untitled_ids
+
+
 def _assert_orm_parity(database_url: str) -> None:
     engine = create_engine(database_url)
     try:
@@ -127,6 +333,10 @@ def test_info_blob_version_schema_round_trip_and_history_fence(
     connection = psycopg2.connect(database_url)
     try:
         legacy_id = _seed_legacy_info_blob(connection)
+        duplicate_identities, untitled_ids = _seed_legacy_duplicate_identities(
+            connection,
+            legacy_id=legacy_id,
+        )
 
         command.upgrade(config, _VERSION_REVISION)
 
@@ -140,6 +350,37 @@ def test_info_blob_version_schema_round_trip_and_history_fence(
                 (str(legacy_id),),
             )
             assert cursor.fetchone() == (str(legacy_id), "active")
+
+            for older_id, newer_id in duplicate_identities.values():
+                cursor.execute(
+                    """
+                    SELECT id, source_id, version_state
+                    FROM info_blobs
+                    WHERE id IN (%s, %s)
+                    ORDER BY created_at, id
+                    """,
+                    (str(older_id), str(newer_id)),
+                )
+                assert cursor.fetchall() == [
+                    (str(older_id), str(newer_id), "superseded"),
+                    (str(newer_id), str(newer_id), "active"),
+                ]
+
+            cursor.execute(
+                """
+                SELECT id, source_id, version_state
+                FROM info_blobs
+                WHERE id IN (%s, %s)
+                ORDER BY id
+                """,
+                tuple(str(value) for value in untitled_ids),
+            )
+            assert cursor.fetchall() == sorted(
+                [
+                    (str(untitled_ids[0]), str(untitled_ids[0]), "active"),
+                    (str(untitled_ids[1]), str(untitled_ids[1]), "active"),
+                ]
+            )
 
             cursor.execute(
                 """
@@ -228,6 +469,16 @@ def test_info_blob_version_schema_round_trip_and_history_fence(
                 )
 
         connection.rollback()
+        normalized_ids = [
+            value for identity in duplicate_identities.values() for value in identity
+        ]
+        normalized_ids.extend(untitled_ids)
+        with connection, connection.cursor() as cursor:
+            cursor.execute(
+                "DELETE FROM info_blobs WHERE id = ANY(%s::uuid[])",
+                ([str(value) for value in normalized_ids],),
+            )
+
         _assert_orm_parity(database_url)
 
         command.downgrade(config, "-1")

--- a/backend/tests/integration/migrations/test_info_blob_versions.py
+++ b/backend/tests/integration/migrations/test_info_blob_versions.py
@@ -1,0 +1,270 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import psycopg2
+import pytest
+from sqlalchemy import create_engine, inspect
+from testcontainers.postgres import PostgresContainer
+
+from alembic import command
+from alembic.config import Config
+from eneo.database.tables.info_blobs_table import InfoBlobs
+
+pytestmark = [pytest.mark.integration, pytest.mark.migration_isolation]
+
+_POSTGRES_13_IMAGE = (
+    "pgvector/pgvector:pg13@"
+    "sha256:751a89c96f7c32cb8133472f711c274853378fb5f8b55dd9fa0e9d3f1471bfc3"
+)
+_PARENT_REVISION = "202607262200"
+_VERSION_REVISION = "202607271000"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def override_settings_for_session() -> Generator[None, None, None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def cleanup_database() -> Generator[None, None, None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def seed_default_models() -> Generator[None, None, None]:
+    yield
+
+
+def _alembic_config(database_url: str) -> Config:
+    backend_dir = Path(__file__).resolve().parents[3]
+    config = Config(str(backend_dir / "alembic.ini"))
+    config.set_main_option("script_location", str(backend_dir / "alembic"))
+    config.set_main_option("sqlalchemy.url", database_url)
+    return config
+
+
+@pytest.fixture(scope="module")
+def migration_database() -> Generator[tuple[str, Config], None, None]:
+    postgres = PostgresContainer(
+        image=_POSTGRES_13_IMAGE,
+        username="info_blob_versions",
+        password="info_blob_versions_password",
+        dbname="info_blob_versions",
+    )
+    with postgres:
+        database_url = postgres.get_connection_url()
+        config = _alembic_config(database_url)
+        command.upgrade(config, _PARENT_REVISION)
+        yield database_url.replace("+psycopg2", ""), config
+
+
+def _seed_legacy_info_blob(connection) -> UUID:
+    tenant_id = uuid4()
+    user_id = uuid4()
+    embedding_model_id = uuid4()
+    info_blob_id = uuid4()
+    with connection, connection.cursor() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO tenants (id, name, quota_limit, state)
+            VALUES (%s, %s, 1000000, 'active')
+            """,
+            (str(tenant_id), f"info-blob-versions-{tenant_id.hex[:8]}"),
+        )
+        cursor.execute(
+            """
+            INSERT INTO users (id, tenant_id, email, used_tokens, state)
+            VALUES (%s, %s, %s, 0, 'active')
+            """,
+            (str(user_id), str(tenant_id), f"{user_id.hex}@example.test"),
+        )
+        cursor.execute(
+            """
+            INSERT INTO embedding_models (
+                id, name, open_source, family, stability, hosting
+            )
+            VALUES (%s, 'migration model', true, 'openai', 'stable', 'self-hosted')
+            """,
+            (str(embedding_model_id),),
+        )
+        cursor.execute(
+            """
+            INSERT INTO info_blobs (
+                id, text, title, size, user_id, tenant_id, embedding_model_id
+            )
+            VALUES (%s, 'legacy text', 'legacy.txt', 11, %s, %s, %s)
+            """,
+            (
+                str(info_blob_id),
+                str(user_id),
+                str(tenant_id),
+                str(embedding_model_id),
+            ),
+        )
+    return info_blob_id
+
+
+def _assert_orm_parity(database_url: str) -> None:
+    engine = create_engine(database_url)
+    try:
+        database_columns = {
+            str(column["name"])
+            for column in inspect(engine).get_columns(InfoBlobs.__tablename__)
+        }
+        orm_columns = {column.name for column in InfoBlobs.__table__.columns}
+        assert database_columns == orm_columns
+    finally:
+        engine.dispose()
+
+
+def test_info_blob_version_schema_round_trip_and_history_fence(
+    migration_database,
+) -> None:
+    database_url, config = migration_database
+    connection = psycopg2.connect(database_url)
+    try:
+        legacy_id = _seed_legacy_info_blob(connection)
+
+        command.upgrade(config, _VERSION_REVISION)
+
+        with connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT source_id, version_state
+                FROM info_blobs
+                WHERE id = %s
+                """,
+                (str(legacy_id),),
+            )
+            assert cursor.fetchone() == (str(legacy_id), "active")
+
+            cursor.execute(
+                """
+                SELECT column_default
+                FROM information_schema.columns
+                WHERE table_name = 'info_blobs'
+                  AND column_name IN ('source_id', 'version_state')
+                ORDER BY column_name
+                """
+            )
+            assert cursor.fetchall() == [(None,), (None,)]
+
+            cursor.execute(
+                """
+                SELECT user_id, tenant_id, embedding_model_id
+                FROM info_blobs
+                WHERE id = %s
+                """,
+                (str(legacy_id),),
+            )
+            user_id, tenant_id, embedding_model_id = cursor.fetchone()
+
+        connection.rollback()
+        with connection, connection.cursor() as cursor:
+            with pytest.raises(psycopg2.errors.NotNullViolation):
+                cursor.execute(
+                    """
+                    INSERT INTO info_blobs (
+                        text, title, size, user_id, tenant_id, embedding_model_id
+                    )
+                    VALUES ('missing version', 'missing.txt', 1, %s, %s, %s)
+                    """,
+                    (user_id, tenant_id, embedding_model_id),
+                )
+
+        connection.rollback()
+        with connection, connection.cursor() as cursor:
+            with pytest.raises(psycopg2.errors.CheckViolation):
+                cursor.execute(
+                    """
+                    INSERT INTO info_blobs (
+                        text, title, size, user_id, tenant_id, embedding_model_id,
+                        source_id, version_state
+                    )
+                    VALUES ('invalid', 'invalid.txt', 1, %s, %s, %s, %s, 'building')
+                    """,
+                    (user_id, tenant_id, embedding_model_id, str(uuid4())),
+                )
+
+        connection.rollback()
+        superseded_id = uuid4()
+        replacement_id = uuid4()
+        with connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO info_blobs (
+                    id, text, title, size, user_id, tenant_id, embedding_model_id,
+                    source_id, version_state
+                )
+                VALUES (%s, 'history', 'legacy.txt', 7, %s, %s, %s, %s, 'superseded')
+                """,
+                (
+                    str(superseded_id),
+                    user_id,
+                    tenant_id,
+                    embedding_model_id,
+                    str(legacy_id),
+                ),
+            )
+            with pytest.raises(psycopg2.errors.UniqueViolation):
+                cursor.execute(
+                    """
+                    INSERT INTO info_blobs (
+                        id, text, title, size, user_id, tenant_id,
+                        embedding_model_id, source_id, version_state
+                    )
+                    VALUES (%s, 'second active', 'legacy.txt', 13, %s, %s, %s, %s, 'active')
+                    """,
+                    (
+                        str(replacement_id),
+                        user_id,
+                        tenant_id,
+                        embedding_model_id,
+                        str(legacy_id),
+                    ),
+                )
+
+        connection.rollback()
+        _assert_orm_parity(database_url)
+
+        command.downgrade(config, "-1")
+        command.upgrade(config, _VERSION_REVISION)
+
+        with connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE info_blobs
+                SET version_state = 'superseded'
+                WHERE id = %s
+                """,
+                (str(legacy_id),),
+            )
+            cursor.execute(
+                """
+                INSERT INTO info_blobs (
+                    text, title, size, user_id, tenant_id, embedding_model_id,
+                    source_id, version_state
+                )
+                VALUES ('replacement', 'legacy.txt', 11, %s, %s, %s, %s, 'active')
+                """,
+                (user_id, tenant_id, embedding_model_id, str(legacy_id)),
+            )
+
+        with pytest.raises(Exception, match="cannot remove InfoBlob version history"):
+            command.downgrade(config, "-1")
+
+        with connection, connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT count(*)
+                FROM information_schema.columns
+                WHERE table_name = 'info_blobs'
+                  AND column_name IN ('source_id', 'version_state')
+                """
+            )
+            assert cursor.fetchone() == (2,)
+    finally:
+        connection.close()

--- a/backend/tests/integration/migrations/test_info_blob_versions.py
+++ b/backend/tests/integration/migrations/test_info_blob_versions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import runpy
 from collections.abc import Generator
 from pathlib import Path
 from uuid import UUID, uuid4
@@ -145,6 +146,42 @@ def _seed_multi_batch_legacy_rows(
             ],
         )
     return ids
+
+
+def _assert_backfill_cursor_applies_to_every_incomplete_row(
+    connection,
+    *,
+    last_id: UUID,
+) -> None:
+    migration_path = (
+        Path(__file__).resolve().parents[3]
+        / "alembic/versions/202607271000_add_info_blob_versions.py"
+    )
+    predicate = runpy.run_path(str(migration_path))["_INCOMPLETE_VERSION_PREDICATE"]
+
+    with connection, connection.cursor() as cursor:
+        cursor.execute(
+            """
+            ALTER TABLE info_blobs
+                ADD COLUMN IF NOT EXISTS source_id UUID,
+                ADD COLUMN IF NOT EXISTS version_state VARCHAR(16)
+            """
+        )
+        cursor.execute(
+            f"""
+            SELECT id
+            FROM info_blobs
+            WHERE {predicate}
+              AND id > %s
+            ORDER BY id
+            LIMIT 1000
+            """,
+            (str(last_id),),
+        )
+        selected_ids = [UUID(row[0]) for row in cursor.fetchall()]
+
+    assert selected_ids
+    assert all(selected_id > last_id for selected_id in selected_ids)
 
 
 def _seed_legacy_duplicate_identities(
@@ -380,6 +417,11 @@ def test_info_blob_version_schema_round_trip_and_history_fence(
         duplicate_identities, untitled_ids = _seed_legacy_duplicate_identities(
             connection,
             legacy_id=legacy_id,
+        )
+
+        _assert_backfill_cursor_applies_to_every_incomplete_row(
+            connection,
+            last_id=sorted(multi_batch_ids)[499],
         )
 
         command.upgrade(config, _VERSION_REVISION)

--- a/backend/tests/integration/migrations/test_info_blob_versions.py
+++ b/backend/tests/integration/migrations/test_info_blob_versions.py
@@ -6,6 +6,7 @@ from uuid import UUID, uuid4
 
 import psycopg2
 import pytest
+from psycopg2.extras import execute_values
 from sqlalchemy import create_engine, inspect
 from testcontainers.postgres import PostgresContainer
 
@@ -105,6 +106,45 @@ def _seed_legacy_info_blob(connection) -> UUID:
             ),
         )
     return info_blob_id
+
+
+def _seed_multi_batch_legacy_rows(
+    connection,
+    *,
+    legacy_id: UUID,
+) -> list[UUID]:
+    with connection, connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT user_id, tenant_id, embedding_model_id
+            FROM info_blobs
+            WHERE id = %s
+            """,
+            (str(legacy_id),),
+        )
+        user_id, tenant_id, embedding_model_id = cursor.fetchone()
+        ids = [uuid4() for _ in range(1_001)]
+        execute_values(
+            cursor,
+            """
+            INSERT INTO info_blobs (
+                id, text, title, size, user_id, tenant_id, embedding_model_id
+            ) VALUES %s
+            """,
+            [
+                (
+                    str(info_blob_id),
+                    "legacy batch text",
+                    f"legacy-batch-{index}.txt",
+                    17,
+                    user_id,
+                    tenant_id,
+                    embedding_model_id,
+                )
+                for index, info_blob_id in enumerate(ids)
+            ],
+        )
+    return ids
 
 
 def _seed_legacy_duplicate_identities(
@@ -333,6 +373,10 @@ def test_info_blob_version_schema_round_trip_and_history_fence(
     connection = psycopg2.connect(database_url)
     try:
         legacy_id = _seed_legacy_info_blob(connection)
+        multi_batch_ids = _seed_multi_batch_legacy_rows(
+            connection,
+            legacy_id=legacy_id,
+        )
         duplicate_identities, untitled_ids = _seed_legacy_duplicate_identities(
             connection,
             legacy_id=legacy_id,
@@ -350,6 +394,18 @@ def test_info_blob_version_schema_round_trip_and_history_fence(
                 (str(legacy_id),),
             )
             assert cursor.fetchone() == (str(legacy_id), "active")
+
+            cursor.execute(
+                """
+                SELECT count(*)
+                FROM info_blobs
+                WHERE id = ANY(%s::uuid[])
+                  AND source_id = id
+                  AND version_state = 'active'
+                """,
+                ([str(value) for value in multi_batch_ids],),
+            )
+            assert cursor.fetchone() == (len(multi_batch_ids),)
 
             for older_id, newer_id in duplicate_identities.values():
                 cursor.execute(
@@ -473,6 +529,7 @@ def test_info_blob_version_schema_round_trip_and_history_fence(
             value for identity in duplicate_identities.values() for value in identity
         ]
         normalized_ids.extend(untitled_ids)
+        normalized_ids.extend(multi_batch_ids)
         with connection, connection.cursor() as cursor:
             cursor.execute(
                 "DELETE FROM info_blobs WHERE id = ANY(%s::uuid[])",

--- a/backend/tests/integration/object_content/test_reference_fence.py
+++ b/backend/tests/integration/object_content/test_reference_fence.py
@@ -10,7 +10,7 @@ from sqlalchemy.exc import DBAPIError
 from eneo.database.database import DatabaseSessionManager
 from eneo.database.tables.files_table import Files
 from eneo.database.tables.icons_table import Icons
-from eneo.database.tables.info_blobs_table import InfoBlobs
+from eneo.database.tables.info_blobs_table import InfoBlobs, InfoBlobVersionState
 from eneo.database.tables.object_content_table import (
     FileContentReferences,
     IconContentReferences,
@@ -217,7 +217,9 @@ async def test_info_blob_pending_content_accepts_its_first_reference_at_creation
             title="owned extracted text",
             url=None,
             size=0,
-            content_hash=None,
+            content_hash=sha256(b"").digest(),
+            source_id=uuid4(),
+            version_state=InfoBlobVersionState.ACTIVE.value,
             user_id=user_id,
             tenant_id=tenant_id,
             group_id=None,

--- a/backend/tests/integration/test_api_key_scope_integration.py
+++ b/backend/tests/integration/test_api_key_scope_integration.py
@@ -14,6 +14,7 @@ Scope enforcement defaults to True (env flag + feature flag fail-closed).
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from hashlib import sha256
 from io import BytesIO
 from uuid import UUID, uuid4
 
@@ -176,6 +177,7 @@ async def _seed_info_blob(
                 user_id=user_id,
                 tenant_id=tenant_id,
                 group_id=UUID(group_id),
+                content_hash=sha256(text.encode("utf-8")).digest(),
             )
         )
     return str(blob.id)

--- a/backend/tests/integration/test_ingestion_failure_safety.py
+++ b/backend/tests/integration/test_ingestion_failure_safety.py
@@ -1,4 +1,5 @@
 import struct
+from hashlib import sha256
 from pathlib import Path
 from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
@@ -11,7 +12,11 @@ from eneo.database.database import sessionmanager
 from eneo.database.tables.ai_models_table import EmbeddingModels
 from eneo.database.tables.collections_table import CollectionsTable
 from eneo.database.tables.info_blob_chunk_table import InfoBlobChunks
-from eneo.database.tables.info_blobs_table import InfoBlobs
+from eneo.database.tables.info_blobs_table import (
+    InfoBlobs,
+    InfoBlobVersionState,
+    active_info_blob_version,
+)
 from eneo.database.tables.job_table import Jobs
 from eneo.database.tables.spaces_table import Spaces, SpacesTranscriptionModels
 from eneo.embedding_models.infrastructure.datastore import Datastore
@@ -79,6 +84,9 @@ async def _seed_attempt(container, *, with_existing: bool = True):
             title=TITLE,
             text=OLD_TEXT,
             size=777,
+            content_hash=sha256(OLD_TEXT.encode("utf-8")).digest(),
+            source_id=uuid4(),
+            version_state=InfoBlobVersionState.ACTIVE.value,
             user_id=user.id,
             tenant_id=user.tenant_id,
             group_id=group.id,
@@ -119,11 +127,19 @@ async def _committed_state(job_id: UUID):
             )
         ).one()
         blobs = (
-            await session.scalars(sa.select(InfoBlobs).where(InfoBlobs.title == TITLE))
+            await session.scalars(
+                sa.select(InfoBlobs).where(
+                    InfoBlobs.title == TITLE,
+                    active_info_blob_version(),
+                )
+            )
         ).all()
         chunks = (
             await session.scalars(
-                sa.select(InfoBlobChunks).order_by(InfoBlobChunks.chunk_no)
+                sa.select(InfoBlobChunks)
+                .join(InfoBlobs)
+                .where(active_info_blob_version())
+                .order_by(InfoBlobChunks.chunk_no)
             )
         ).all()
         return (

--- a/backend/tests/unittests/admin/test_quota_service.py
+++ b/backend/tests/unittests/admin/test_quota_service.py
@@ -11,8 +11,8 @@ from eneo.users.user import UserInDB
 @pytest.fixture
 async def quota_service(user: UserInDB):
     info_blobs_repo = AsyncMock()
-    info_blobs_repo.get_total_size_of_user.return_value = 5
-    info_blobs_repo.get_total_size_of_tenant.return_value = 5
+    info_blobs_repo.get_retained_size_of_user.return_value = 5
+    info_blobs_repo.get_retained_size_of_tenant.return_value = 5
     return QuotaService(user, info_blobs_repo)
 
 

--- a/backend/tests/unittests/info_blobs/test_info_blobs_service.py
+++ b/backend/tests/unittests/info_blobs/test_info_blobs_service.py
@@ -30,6 +30,7 @@ def setup():
         update_website_size_service=AsyncMock(),
         space_service=AsyncMock(),
         actor_manager=MagicMock(),
+        datastore=AsyncMock(),
     )
 
     setup = Setup(repo=repo, service=service, group_service=group_service)

--- a/backend/tests/unittests/integration/test_sharepoint_content_service.py
+++ b/backend/tests/unittests/integration/test_sharepoint_content_service.py
@@ -92,7 +92,6 @@ def mock_dependencies(mock_user, mock_integration_knowledge):
         "oauth_token_repo": AsyncMock(),
         "user_integration_repo": AsyncMock(),
         "user": mock_user,
-        "datastore": AsyncMock(),
         "info_blob_service": AsyncMock(),
         "integration_knowledge_repo": AsyncMock(),
         "oauth_token_service": AsyncMock(),
@@ -332,10 +331,7 @@ class TestProcessInfoBlobSizeAccounting:
         )
         mock_dependencies[
             "info_blob_service"
-        ].upsert_info_blob_by_sharepoint_item_and_integration = AsyncMock(
-            return_value=updated_blob
-        )
-        mock_dependencies["datastore"].add = AsyncMock()
+        ].publish_info_blob_without_validation = AsyncMock(return_value=updated_blob)
         mock_dependencies["integration_knowledge_repo"].update = AsyncMock()
         mock_dependencies["info_blob_service"].repo.session.execute = AsyncMock()
 
@@ -371,10 +367,7 @@ class TestProcessInfoBlobSizeAccounting:
         )
         mock_dependencies[
             "info_blob_service"
-        ].upsert_info_blob_by_sharepoint_item_and_integration = AsyncMock(
-            return_value=updated_blob
-        )
-        mock_dependencies["datastore"].add = AsyncMock()
+        ].publish_info_blob_without_validation = AsyncMock(return_value=updated_blob)
         mock_dependencies["integration_knowledge_repo"].update = AsyncMock()
         mock_dependencies["info_blob_service"].repo.session.execute = AsyncMock()
 
@@ -417,8 +410,7 @@ class TestProcessInfoBlobSizeAccounting:
         repo.update = AsyncMock()
         mock_dependencies[
             "info_blob_service"
-        ].upsert_info_blob_by_sharepoint_item_and_integration = AsyncMock()
-        mock_dependencies["datastore"].add = AsyncMock()
+        ].publish_info_blob_without_validation = AsyncMock()
         mock_dependencies["integration_knowledge_repo"].update = AsyncMock()
 
         await service._process_info_blob(
@@ -429,13 +421,12 @@ class TestProcessInfoBlobSizeAccounting:
             sharepoint_item_id="item-123",
         )
 
-        # Unchanged content + metadata: no upsert, no chunk delete, no embedding,
+        # Unchanged content + metadata: no publication, no embedding,
         # no metadata update, no size update.
         mock_dependencies[
             "info_blob_service"
-        ].upsert_info_blob_by_sharepoint_item_and_integration.assert_not_called()
+        ].publish_info_blob_without_validation.assert_not_called()
         repo.update.assert_not_called()
-        mock_dependencies["datastore"].add.assert_not_called()
         mock_dependencies["integration_knowledge_repo"].update.assert_not_called()
 
     async def test_refreshes_metadata_on_hash_match_when_renamed(
@@ -464,7 +455,9 @@ class TestProcessInfoBlobSizeAccounting:
             return_value=existing_blob
         )
         repo.update = AsyncMock()
-        mock_dependencies["datastore"].add = AsyncMock()
+        mock_dependencies[
+            "info_blob_service"
+        ].publish_info_blob_without_validation = AsyncMock()
 
         await service._process_info_blob(
             title="New name.docx",
@@ -474,12 +467,14 @@ class TestProcessInfoBlobSizeAccounting:
             sharepoint_item_id="item-123",
         )
 
-        # Metadata refreshed, but NOT re-embedded.
+        # Metadata refreshed, but no replacement is published.
         repo.update.assert_awaited_once()
         update_arg = repo.update.await_args.args[0]
         assert update_arg.title == "New name.docx"
         assert update_arg.url == "https://example.com/new"
-        mock_dependencies["datastore"].add.assert_not_called()
+        mock_dependencies[
+            "info_blob_service"
+        ].publish_info_blob_without_validation.assert_not_called()
 
     async def test_reembeds_when_content_hash_differs(
         self, service, mock_dependencies, mock_integration_knowledge
@@ -499,10 +494,7 @@ class TestProcessInfoBlobSizeAccounting:
         )
         mock_dependencies[
             "info_blob_service"
-        ].upsert_info_blob_by_sharepoint_item_and_integration = AsyncMock(
-            return_value=updated_blob
-        )
-        mock_dependencies["datastore"].add = AsyncMock()
+        ].publish_info_blob_without_validation = AsyncMock(return_value=updated_blob)
         mock_dependencies["integration_knowledge_repo"].update = AsyncMock()
         mock_dependencies["info_blob_service"].repo.session.execute = AsyncMock()
 
@@ -514,7 +506,9 @@ class TestProcessInfoBlobSizeAccounting:
             sharepoint_item_id="item-123",
         )
 
-        mock_dependencies["datastore"].add.assert_called_once()
+        mock_dependencies[
+            "info_blob_service"
+        ].publish_info_blob_without_validation.assert_awaited_once()
 
     async def test_persists_content_hash_after_embedding_succeeds(
         self, service, mock_dependencies, mock_integration_knowledge
@@ -539,7 +533,7 @@ class TestProcessInfoBlobSizeAccounting:
         ).digest()
         upserted: list = []
 
-        async def upsert(info_blob):
+        async def publish(info_blob, *, embedding_model):
             upserted.append(info_blob)
             return updated_blob
 
@@ -547,14 +541,9 @@ class TestProcessInfoBlobSizeAccounting:
         repo.get_by_sharepoint_item_and_integration_knowledge = AsyncMock(
             return_value=existing_blob
         )
-        repo.session.execute = AsyncMock()
-        repo.update_content_hash = AsyncMock(return_value=updated_blob)
         mock_dependencies[
             "info_blob_service"
-        ].upsert_info_blob_by_sharepoint_item_and_integration = AsyncMock(
-            side_effect=upsert
-        )
-        mock_dependencies["datastore"].add = AsyncMock()
+        ].publish_info_blob_without_validation = AsyncMock(side_effect=publish)
 
         await service._process_info_blob(
             title="Doc",
@@ -564,53 +553,33 @@ class TestProcessInfoBlobSizeAccounting:
             sharepoint_item_id="item-123",
         )
 
-        assert upserted[0].content_hash is None
-        repo.update_content_hash.assert_called_once_with(
-            info_blob_id=updated_blob.id,
-            content_hash=expected_hash,
-        )
+        assert upserted[0].content_hash == expected_hash
 
-    async def test_embedding_failure_leaves_content_hash_unset_for_retry(
+    async def test_embedding_failure_propagates_for_transaction_rollback(
         self, service, mock_dependencies, mock_integration_knowledge
     ):
         existing_blob = MagicMock()
         existing_blob.size = 100
         existing_blob.content_hash = b"old-hash"
 
-        updated_blob = MagicMock()
-        updated_blob.id = uuid4()
-        updated_blob.size = 100
-        upserted: list = []
-
-        async def upsert(info_blob):
-            upserted.append(info_blob)
-            return updated_blob
-
         repo = mock_dependencies["info_blob_service"].repo
         repo.get_by_sharepoint_item_and_integration_knowledge = AsyncMock(
             return_value=existing_blob
         )
-        repo.session.execute = AsyncMock()
-        repo.update_content_hash = AsyncMock()
         mock_dependencies[
             "info_blob_service"
-        ].upsert_info_blob_by_sharepoint_item_and_integration = AsyncMock(
-            side_effect=upsert
-        )
-        mock_dependencies["datastore"].add = AsyncMock(
-            side_effect=Exception("embedding service unavailable")
+        ].publish_info_blob_without_validation = AsyncMock(
+            side_effect=RuntimeError("embedding service unavailable")
         )
 
-        await service._process_info_blob(
-            title="Doc",
-            text="Fresh content",
-            url="https://example.com",
-            integration_knowledge=mock_integration_knowledge,
-            sharepoint_item_id="item-123",
-        )
-
-        assert upserted[0].content_hash is None
-        repo.update_content_hash.assert_not_called()
+        with pytest.raises(RuntimeError, match="embedding service unavailable"):
+            await service._process_info_blob(
+                title="Doc",
+                text="Fresh content",
+                url="https://example.com",
+                integration_knowledge=mock_integration_knowledge,
+                sharepoint_item_id="item-123",
+            )
 
 
 class TestBuildSummaryStats:
@@ -1779,7 +1748,7 @@ class TestPostCommitChangeKeys:
         """No event listener is registered when there is nothing to flush."""
         with patch(
             "eneo.integration.infrastructure.content_service."
-            "sharepoint_content_service.sa.event.listen"
+            "sharepoint_content_service.event.listen"
         ) as mock_listen:
             service._schedule_post_commit_change_keys([])
 

--- a/backend/tests/unittests/worker/test_persist_batch_logic.py
+++ b/backend/tests/unittests/worker/test_persist_batch_logic.py
@@ -895,12 +895,52 @@ class TestPhaseIsolation:
                 ctx=crawl_context,
                 embedding_model=embedding_model_spec,
                 container=create_mock_container(mock_embeddings_service),
-                existing_content_hashes={url: sha256(content.encode("utf-8")).digest()},
+                existing_publications={
+                    url: (
+                        sha256(content.encode("utf-8")).digest(),
+                        embedding_model_spec.id,
+                    )
+                },
             )
 
         assert (success, failed, persisted_urls, failures) == (1, 0, [url], {})
         mock_embeddings_service.get_embeddings.assert_not_awaited()
         mock_sm.session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_matching_content_with_a_new_model_is_reembedded(
+        self, crawl_context, embedding_model_spec, mock_embeddings_service
+    ):
+        url = "https://example.com/model-change"
+        content = "Content published with an older embedding model"
+        mock_session = create_mock_session()
+        mock_session.execute = AsyncMock(return_value=create_mock_result())
+        mock_sm = create_mock_sessionmanager(mock_session)
+
+        with (
+            patch(
+                "eneo.worker.crawl.persistence._get_embedding_semaphore",
+                return_value=asyncio.Semaphore(10),
+            ),
+            patch("eneo.database.database.sessionmanager", mock_sm),
+        ):
+            from eneo.worker.crawl_tasks import persist_batch
+
+            success, failed, persisted_urls, failures = await persist_batch(
+                page_buffer=[{"url": url, "content": content}],
+                ctx=crawl_context,
+                embedding_model=embedding_model_spec,
+                container=create_mock_container(mock_embeddings_service),
+                existing_publications={
+                    url: (
+                        sha256(content.encode("utf-8")).digest(),
+                        uuid4(),
+                    )
+                },
+            )
+
+        assert (success, failed, persisted_urls, failures) == (1, 0, [url], {})
+        mock_embeddings_service.get_embeddings.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_no_session_opened_during_phase_1(

--- a/backend/tests/unittests/worker/test_persist_batch_logic.py
+++ b/backend/tests/unittests/worker/test_persist_batch_logic.py
@@ -11,20 +11,20 @@ Core Invariants Tested:
 4. Embedding bytes cap triggers early Phase 1 exit
 5. Each page gets its own savepoint in Phase 2
 6. Delete and insert happen within the same savepoint (atomic)
-7. successful_urls contains ONLY URLs that committed successfully
+7. successful_urls contains only published or confirmed-unchanged URLs
 
 Run with: pytest tests/unittests/worker/test_persist_batch_logic.py -v
 """
 
 import asyncio
 from contextlib import asynccontextmanager
+from hashlib import sha256
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 
 from eneo.worker.crawl_context import CrawlContext, EmbeddingModelSpec
-
 
 # =============================================================================
 # HELPER: Mock Session Manager
@@ -560,16 +560,16 @@ class TestPhase2SavepointBehavior:
         )
 
     @pytest.mark.asyncio
-    async def test_delete_and_insert_within_same_savepoint(
+    async def test_supersede_and_insert_within_same_savepoint(
         self, crawl_context, embedding_model_spec, mock_embeddings_service
     ):
         """
-        INVARIANT: Delete (deduplication) and insert must happen within same savepoint.
+        INVARIANT: Version lookup, demotion and insert happen within one savepoint.
 
         This ensures atomic operation: either both succeed or both rollback.
 
         Scenario: 1 page
-        Expected: DELETE and INSERT execute between begin_nested() and commit()
+        Expected: SELECT and INSERT execute between begin_nested() and commit()
         """
         page_buffer = [{"url": "https://example.com/page1", "content": "Test content"}]
 
@@ -582,10 +582,11 @@ class TestPhase2SavepointBehavior:
 
         savepoint_mock.commit = AsyncMock(side_effect=track_commit)
 
-        async def track_execute(stmt):
+        async def track_execute(stmt, params=None):
             stmt_str = str(stmt)
-            if "DELETE" in stmt_str:
-                operation_order.append("DELETE")
+            if "SELECT" in stmt_str and "info_blobs" in stmt_str:
+                operation_order.append("SELECT")
+                return MagicMock(one_or_none=lambda: None)
             elif "INSERT" in stmt_str:
                 operation_order.append("INSERT")
             return MagicMock(scalar_one=lambda: uuid4())
@@ -618,18 +619,18 @@ class TestPhase2SavepointBehavior:
                 container=create_mock_container(mock_embeddings_service),
             )
 
-        # Verify order: BEGIN_NESTED -> DELETE -> INSERT (blob) -> INSERT (chunks) -> COMMIT
+        # Verify order: BEGIN_NESTED -> SELECT -> INSERTs -> COMMIT
         assert operation_order[0] == "BEGIN_NESTED", "Savepoint must start first"
-        assert "DELETE" in operation_order, "DELETE must occur"
+        assert "SELECT" in operation_order, "Active-version lookup must occur"
         assert "INSERT" in operation_order, "INSERT must occur"
-        delete_idx = operation_order.index("DELETE")
+        select_idx = operation_order.index("SELECT")
         first_insert_idx = next(
             i for i, op in enumerate(operation_order) if op == "INSERT"
         )
         commit_idx = operation_order.index("COMMIT")
 
-        assert delete_idx > 0, "DELETE must be after BEGIN_NESTED"
-        assert first_insert_idx > delete_idx, "INSERT must be after DELETE"
+        assert select_idx > 0, "SELECT must be after BEGIN_NESTED"
+        assert first_insert_idx > select_idx, "INSERT must be after SELECT"
         assert commit_idx > first_insert_idx, "COMMIT must be after INSERTs"
 
 
@@ -738,8 +739,8 @@ class TestSuccessfulUrlsTracking:
         """
         INVARIANT: When embedding_model is None, all pages fail with NO_EMBEDDING_MODEL reason.
         """
-        from eneo.worker.crawl_tasks import persist_batch
         from eneo.worker.crawl_context import FailureReason
+        from eneo.worker.crawl_tasks import persist_batch
 
         page_buffer = [
             {"url": "https://example.com/page1", "content": "Content 1"},
@@ -827,6 +828,30 @@ class TestSuccessfulUrlsTracking:
 
 class TestPhaseIsolation:
     """Tests that verify Phase 1 has ZERO database operations."""
+
+    @pytest.mark.asyncio
+    async def test_unchanged_page_skips_embedding_and_database_write(
+        self, crawl_context, embedding_model_spec, mock_embeddings_service
+    ):
+        url = "https://example.com/unchanged"
+        content = "Already published content"
+        mock_session = create_mock_session()
+        mock_sm = create_mock_sessionmanager(mock_session)
+
+        with patch("eneo.database.database.sessionmanager", mock_sm):
+            from eneo.worker.crawl_tasks import persist_batch
+
+            success, failed, persisted_urls, failures = await persist_batch(
+                page_buffer=[{"url": url, "content": content}],
+                ctx=crawl_context,
+                embedding_model=embedding_model_spec,
+                container=create_mock_container(mock_embeddings_service),
+                existing_content_hashes={url: sha256(content.encode("utf-8")).digest()},
+            )
+
+        assert (success, failed, persisted_urls, failures) == (1, 0, [url], {})
+        mock_embeddings_service.get_embeddings.assert_not_awaited()
+        mock_sm.session.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_no_session_opened_during_phase_1(

--- a/backend/tests/unittests/worker/test_persist_batch_logic.py
+++ b/backend/tests/unittests/worker/test_persist_batch_logic.py
@@ -62,9 +62,18 @@ def create_mock_session():
 
     # These methods ARE coroutines, so use AsyncMock
     mock_session.execute = AsyncMock()
+    mock_session.scalar = AsyncMock(return_value=0)
     mock_session.begin_nested = AsyncMock(return_value=AsyncMock())
 
     return mock_session
+
+
+def create_mock_result():
+    return MagicMock(
+        one=lambda: (1_000_000, None),
+        one_or_none=lambda: None,
+        scalar_one=lambda: uuid4(),
+    )
 
 
 def create_mock_sessionmanager(mock_session):
@@ -297,9 +306,7 @@ class TestEmbeddingSemaphoreBehavior:
 
         # CRITICAL: Use create_mock_session() NOT AsyncMock() - see helper docstring
         mock_session = create_mock_session()
-        mock_session.execute = AsyncMock(
-            return_value=MagicMock(scalar_one=lambda: uuid4())
-        )
+        mock_session.execute = AsyncMock(return_value=create_mock_result())
         mock_sm = create_mock_sessionmanager(mock_session)
 
         with (
@@ -377,9 +384,7 @@ class TestEmbeddingSemaphoreBehavior:
 
         # CRITICAL: Use create_mock_session() NOT AsyncMock() - see helper docstring
         mock_session = create_mock_session()
-        mock_session.execute = AsyncMock(
-            return_value=MagicMock(scalar_one=lambda: uuid4())
-        )
+        mock_session.execute = AsyncMock(return_value=create_mock_result())
 
         mock_sm = create_mock_sessionmanager(mock_session)
 
@@ -474,9 +479,7 @@ class TestMemoryCapsEnforcement:
 
         # CRITICAL: Use create_mock_session() NOT AsyncMock() - see helper docstring
         mock_session = create_mock_session()
-        mock_session.execute = AsyncMock(
-            return_value=MagicMock(scalar_one=lambda: uuid4())
-        )
+        mock_session.execute = AsyncMock(return_value=create_mock_result())
 
         mock_sm = create_mock_sessionmanager(mock_session)
 
@@ -532,9 +535,7 @@ class TestPhase2SavepointBehavior:
         # CRITICAL: Use create_mock_session() NOT AsyncMock() - see helper docstring
         mock_session = create_mock_session()
         mock_session.begin_nested = AsyncMock(return_value=savepoint_mock)
-        mock_session.execute = AsyncMock(
-            return_value=MagicMock(scalar_one=lambda: uuid4())
-        )
+        mock_session.execute = AsyncMock(return_value=create_mock_result())
 
         mock_sm = create_mock_sessionmanager(mock_session)
 
@@ -589,7 +590,7 @@ class TestPhase2SavepointBehavior:
                 return MagicMock(one_or_none=lambda: None)
             elif "INSERT" in stmt_str:
                 operation_order.append("INSERT")
-            return MagicMock(scalar_one=lambda: uuid4())
+            return create_mock_result()
 
         # CRITICAL: Use create_mock_session() NOT AsyncMock() - see helper docstring
         mock_session = create_mock_session()
@@ -632,6 +633,58 @@ class TestPhase2SavepointBehavior:
         assert select_idx > 0, "SELECT must be after BEGIN_NESTED"
         assert first_insert_idx > select_idx, "INSERT must be after SELECT"
         assert commit_idx > first_insert_idx, "COMMIT must be after INSERTs"
+
+    @pytest.mark.asyncio
+    async def test_retained_quota_rejects_page_before_publication(
+        self, crawl_context, embedding_model_spec, mock_embeddings_service
+    ):
+        page_buffer = [
+            {
+                "url": "https://example.com/over-quota",
+                "content": "Content that cannot fit",
+            }
+        ]
+        statements: list[str] = []
+        savepoint = AsyncMock()
+        savepoint.commit = AsyncMock()
+        savepoint.rollback = AsyncMock()
+        mock_session = create_mock_session()
+        mock_session.begin_nested = AsyncMock(return_value=savepoint)
+        mock_session.scalar = AsyncMock(side_effect=[9, 0])
+
+        async def execute(stmt, params=None):
+            statement = str(stmt)
+            statements.append(statement)
+            if "tenants" in statement and "users" in statement:
+                return MagicMock(one=lambda: (10, None))
+            if "FROM info_blobs" in statement:
+                return MagicMock(one_or_none=lambda: None)
+            return create_mock_result()
+
+        mock_session.execute = AsyncMock(side_effect=execute)
+        mock_sm = create_mock_sessionmanager(mock_session)
+
+        with (
+            patch(
+                "eneo.worker.crawl.persistence._get_embedding_semaphore",
+                return_value=asyncio.Semaphore(10),
+            ),
+            patch("eneo.database.database.sessionmanager", mock_sm),
+        ):
+            from eneo.worker.crawl_tasks import persist_batch
+
+            success, failed, urls, _ = await persist_batch(
+                page_buffer=page_buffer,
+                ctx=crawl_context,
+                embedding_model=embedding_model_spec,
+                container=create_mock_container(mock_embeddings_service),
+            )
+
+        assert (success, failed, urls) == (0, 1, [])
+        assert not any(
+            "INSERT INTO info_blobs" in statement for statement in statements
+        )
+        savepoint.rollback.assert_awaited_once()
 
 
 # =============================================================================
@@ -682,9 +735,7 @@ class TestSuccessfulUrlsTracking:
         # CRITICAL: Use create_mock_session() NOT AsyncMock() - see helper docstring
         mock_session = create_mock_session()
         mock_session.begin_nested = AsyncMock(side_effect=create_savepoint)
-        mock_session.execute = AsyncMock(
-            return_value=MagicMock(scalar_one=lambda: uuid4())
-        )
+        mock_session.execute = AsyncMock(return_value=create_mock_result())
 
         mock_sm = create_mock_sessionmanager(mock_session)
 
@@ -788,9 +839,7 @@ class TestSuccessfulUrlsTracking:
         # CRITICAL: Use create_mock_session() NOT AsyncMock() - see helper docstring
         mock_session = create_mock_session()
         mock_session.begin_nested = AsyncMock(return_value=savepoint)
-        mock_session.execute = AsyncMock(
-            return_value=MagicMock(scalar_one=lambda: uuid4())
-        )
+        mock_session.execute = AsyncMock(return_value=create_mock_result())
 
         mock_sm = create_mock_sessionmanager(mock_session)
 
@@ -910,9 +959,7 @@ class TestPhaseIsolation:
             # CRITICAL: Use MagicMock for session (not AsyncMock) - see create_mock_session() docstring
             mock_session = MagicMock()
             mock_session.begin_nested = AsyncMock(return_value=AsyncMock())
-            mock_session.execute = AsyncMock(
-                return_value=MagicMock(scalar_one=lambda: uuid4())
-            )
+            mock_session.execute = AsyncMock(return_value=create_mock_result())
 
             # session.begin() returns an async context manager
             @asynccontextmanager
@@ -994,7 +1041,7 @@ class TestTransactionWallTimeGuard:
             persist_count += 1
             if persist_count >= 2:
                 await asyncio.sleep(2)  # Will trigger timeout
-            return MagicMock(scalar_one=lambda: uuid4())
+            return create_mock_result()
 
         # CRITICAL: Use create_mock_session() NOT AsyncMock() - see helper docstring
         mock_session = create_mock_session()

--- a/docs/goals/knowledge-document-versions/goal.md
+++ b/docs/goals/knowledge-document-versions/goal.md
@@ -1,0 +1,48 @@
+# Knowledge document versions
+
+## Objective
+
+Give every knowledge document exactly one active complete version while preserving historical citations and the last working searchable version when rebuilding fails. Keep the change independent of byte placement so PostgreSQL remains complete by default and compatible object storage remains optional.
+
+## Goal Kind
+
+`specific`
+
+## Current Tranche
+
+Re-verify the green preflight against the merged ingestion-failure and verified-move prerequisites, settle the smallest durable version owner, implement it with behavior-first PostgreSQL tests, document the operator and product behavior concisely, and deliver one reviewable PR.
+
+## Non-Negotiable Constraints
+
+- Product changes require an active bounded Worker task and a frozen path map.
+- Reuse existing `InfoBlob` rows and ownership unless source evidence disproves the hypothesis.
+- Exactly one complete version may be active; failed builds must never replace the active version.
+- PostgreSQL remains the complete default and object storage remains optional; identity does not depend on storage placement.
+- The merged ingestion-failure slice owns task-level failure preservation; this slice owns version visibility and publication.
+- No chunks/citations rewrite, generic generation framework, retry UI, retrieval ranking change, robust ingestion/publication/deletion expansion, Flow work, or unrelated metadata/crawler cleanup.
+
+## Stop Rule
+
+Stop only after the implementation is merged, current review has no blocking findings, required CI is green, and the final Goal audit maps the result to this objective.
+
+## Canonical Board
+
+Machine truth lives at:
+
+`docs/goals/knowledge-document-versions/state.yaml`
+
+If this charter and `state.yaml` disagree, `state.yaml` wins for task status, active task, receipts, verification freshness, and completion truth.
+
+## Run Command
+
+```text
+/goal Follow docs/goals/knowledge-document-versions/goal.md through the first safe verified implementation slice. Do not stop after planning unless blocked.
+```
+
+## PM Loop
+
+1. Read this charter and `state.yaml`.
+2. Work only on the active task.
+3. Keep source read-only unless the active board task explicitly authorizes its paths.
+4. Record compact receipts and exact validation evidence.
+5. Continue through the next safe verified task until the tranche audit passes or a real blocker remains.

--- a/docs/goals/knowledge-document-versions/notes/T001-preflight-receipt.md
+++ b/docs/goals/knowledge-document-versions/notes/T001-preflight-receipt.md
@@ -33,8 +33,8 @@ text, chunks, embeddings, and version state remain in PostgreSQL/pgvector.
    and update size within one savepoint/transaction.
 4. Roll back the whole replacement on quota, embedding, chunking, database, or
    timeout failure.
-5. Product lists, retrieval, counts, sizes, quotas, crawler bootstrap, and stale
-   cleanup use active versions only.
+5. Product lists, retrieval, counts, sizes, crawler bootstrap, and stale cleanup
+   use active versions only; quota enforcement includes retained versions.
 6. Saved Question/Session/Analysis references and exact-ID authorization may
    read a superseded row.
 7. Explicit deletion and source-owner cascades remove every version and chunk.

--- a/docs/goals/knowledge-document-versions/notes/T001-preflight-receipt.md
+++ b/docs/goals/knowledge-document-versions/notes/T001-preflight-receipt.md
@@ -1,0 +1,79 @@
+# Knowledge document versions — implementation contract
+
+## Outcome
+
+Eneo keeps one complete searchable version active for each logical knowledge
+document. A replacement becomes active only after its text, chunks, and
+embeddings are ready in one transaction. Failure preserves the previous active
+version. Byte-identical input is a no-op.
+
+PostgreSQL remains a complete default deployment. Compatible object storage is
+optional and only affects original file-byte placement; searchable knowledge
+text, chunks, embeddings, and version state remain in PostgreSQL/pgvector.
+
+## Canonical owners
+
+- `InfoBlobs` stores complete versions using `source_id` and
+  `active|superseded` state.
+- The partial unique index on active `source_id` is the final concurrency fence.
+- `InfoBlobService.publish_info_blob_without_validation` owns non-crawler
+  publication.
+- `persist_batch` retains the crawler's existing bounded two-phase embedding and
+  publication path.
+- Repository queries own active-only product projections and whole-family
+  deletion.
+- Exact historical IDs remain readable for saved citations and authorization
+  until an authorized deletion removes the complete source family.
+
+## Required behavior
+
+1. Lock the logical source identity and current active row.
+2. Return the existing row without embedding when the SHA-256 digest is equal.
+3. Otherwise supersede the current row, insert the replacement and all chunks,
+   and update size within one savepoint/transaction.
+4. Roll back the whole replacement on quota, embedding, chunking, database, or
+   timeout failure.
+5. Product lists, retrieval, counts, sizes, quotas, crawler bootstrap, and stale
+   cleanup use active versions only.
+6. Saved Question/Session/Analysis references and exact-ID authorization may
+   read a superseded row.
+7. Explicit deletion and source-owner cascades remove every version and chunk.
+8. An unchanged crawler page remains in stale reconciliation even when another
+   prepared page later rolls back.
+
+## Migration and recovery
+
+Legacy rows are backfilled as `source_id=id, version_state=active` in bounded
+PostgreSQL batches. The schema adds validated checks, non-null columns, an
+indexed source lookup, and a partial unique active-source index without server
+defaults. A separate no-op Alembic merge revision joins the parallel assistant
+permission migration, so rolling versioning back does not undo unrelated
+permissions.
+
+Downgrade is allowed before any source has history. Once a replacement creates
+a superseded row, downgrade fails closed; recover forward or restore the paired
+pre-upgrade database backup.
+
+## Deliberate non-goals
+
+- no generation/job table, leases, retry pipeline, or automatic cleanup;
+- no provider-specific storage behavior or object-storage requirement;
+- no public API for browsing version history;
+- no per-tenant storage routing or multi-tenancy expansion;
+- no Flow adoption or migration of original file bytes;
+- no speculative vector-index tuning without measured query evidence.
+
+## Verification evidence
+
+- PostgreSQL publication/failure/reference packet: 25 passed.
+- PostgreSQL 13 migration upgrade/downgrade/re-upgrade/history fence: 1 passed.
+- Backend non-integration suite: 4,077 passed, 1,309 deselected.
+- Whole-backend Pyright: 0 errors, 0 warnings, 0 informations.
+- Changed Python Ruff/format, OpenAPI generated-schema drift, docs build, diff
+  check, and Goal-board checker: green.
+- Resumable Claude session `knowledge-document-versions`, planning iteration 4
+  and final commit-gate iteration 5: `GREEN_LIGHT: yes`, `MIN_SCORE: 8`.
+
+Follow-up #571 work may add a durable ingestion pipeline, retention, and
+publication UI only when those product requirements are implemented. They are
+not compatibility requirements for this slice.

--- a/docs/goals/knowledge-document-versions/notes/T001-preflight-receipt.md
+++ b/docs/goals/knowledge-document-versions/notes/T001-preflight-receipt.md
@@ -5,7 +5,7 @@
 Eneo keeps one complete searchable version active for each logical knowledge
 document. A replacement becomes active only after its text, chunks, and
 embeddings are ready in one transaction. Failure preserves the previous active
-version. Byte-identical input is a no-op.
+version. Byte-identical input is a no-op while the embedding model is unchanged.
 
 PostgreSQL remains a complete default deployment. Compatible object storage is
 optional and only affects original file-byte placement; searchable knowledge
@@ -28,7 +28,8 @@ text, chunks, embeddings, and version state remain in PostgreSQL/pgvector.
 ## Required behavior
 
 1. Lock the logical source identity and current active row.
-2. Return the existing row without embedding when the SHA-256 digest is equal.
+2. Return the existing row without embedding when the SHA-256 digest and
+   embedding model are unchanged.
 3. Otherwise supersede the current row, insert the replacement and all chunks,
    and update size within one savepoint/transaction.
 4. Roll back the whole replacement on quota, embedding, chunking, database, or

--- a/docs/goals/knowledge-document-versions/state.yaml
+++ b/docs/goals/knowledge-document-versions/state.yaml
@@ -1,0 +1,137 @@
+# Goal Maker v2 state.yaml
+# Compact board truth; the bounded implementation contract is in notes/T001-preflight-receipt.md.
+
+version: 2
+
+goal:
+  title: "Keep working knowledge available during updates"
+  slug: "knowledge-document-versions"
+  kind: specific
+  tranche: "Publish one complete active knowledge version per document, preserve the last working version on failure, and deliver one reviewable PR without starting the later ingestion pipeline."
+  status: active
+
+rules:
+  pm_owns_state: true
+  one_active_task: true
+  max_write_workers: 1
+  no_implementation_without_worker_or_pm_task: true
+  no_completion_without_judge_or_pm_audit: true
+  planning_is_not_completion: true
+  queued_required_worker_blocks_completion: true
+
+agents:
+  scout: installed
+  worker: installed
+  judge: installed
+
+continuity:
+  rotate_threads: false
+  rotation_authorized_by: null
+  rotate_after_completed_write_tasks: 2
+  rotate_after_hours: 6
+  rotate_when_slow: true
+  current_thread_id: "019fa011-95cf-7912-85d3-4bbde889653f"
+  previous_thread_id: null
+  rotation_count: 0
+  completed_write_tasks_in_thread: 0
+  handoff_note: null
+  last_handoff_at: null
+  last_verified_revision: "7abc3fcef4789949a8434a0faf6b19dbfedbd7ea"
+
+active_task: T010
+
+tasks:
+  - id: T001
+    type: pm
+    assignee: PM
+    status: done
+    reasoning_hint: high
+    objective: "Freeze the smallest safe document-version contract from current source, consumers, migration graph, issue #571, and epic #549."
+    inputs:
+      - "Live origin/develop and current InfoBlob, chunk, crawler, integration, quota, citation, and deletion owners"
+      - "Issue #571 and epic #549"
+    constraints:
+      - "Reuse existing owners before adding schema or modules."
+      - "Keep PostgreSQL complete by default and object storage optional."
+      - "Do not start retries, leases, retention cleanup, public version history, provider branches, multi-tenant routing, or Flow adoption."
+    expected_output:
+      - "One canonical publication owner and consumer classification"
+      - "Migration, failure, concurrency, complexity, tests, and rollback contract"
+    receipt:
+      result: done
+      note: notes/T001-preflight-receipt.md
+      summary: "Approved two complete persisted states, active-only product projections, exact-ID historical citations, whole-family deletion, unchanged no-op, and failure-preserving atomic publication. Same Claude session planning iteration 4 was green with MIN_SCORE 8."
+
+  - id: T010
+    type: worker
+    assignee: Worker
+    status: active
+    reasoning_hint: default
+    objective: "Implement, validate, document, review, publish, and merge the bounded knowledge-version slice."
+    allowed_files:
+      - backend/alembic/versions/202607271000_add_info_blob_versions.py
+      - backend/alembic/versions/202607271100_merge_info_blob_and_debug_permission.py
+      - backend/src/eneo/database/tables/info_blobs_table.py
+      - backend/src/eneo/info_blobs/**
+      - backend/src/eneo/embedding_models/infrastructure/datastore.py
+      - backend/src/eneo/worker/crawl/**
+      - backend/src/eneo/worker/crawl_tasks.py
+      - backend/src/eneo/integration/infrastructure/content_service/**
+      - backend/src/eneo/groups_legacy/**
+      - backend/src/eneo/assistants/assistant_repo.py
+      - backend/src/eneo/spaces/space_repo.py
+      - backend/src/eneo/websites/infrastructure/update_website_size_service.py
+      - backend/src/eneo/main/container/container.py
+      - backend/tests/integration/info_blobs/**
+      - backend/tests/integration/migrations/test_info_blob_versions.py
+      - backend/tests/integration/embedding_models/test_embedding_model_lifecycle.py
+      - backend/tests/integration/object_content/test_reference_fence.py
+      - backend/tests/integration/test_ingestion_failure_safety.py
+      - backend/tests/unittests/info_blobs/**
+      - backend/tests/unittests/integration/test_sharepoint_content_service.py
+      - backend/tests/unittests/worker/test_persist_batch_logic.py
+      - frontend/apps/docs-site/src/content/docs/architecture.mdx
+      - frontend/apps/docs-site/src/content/guides/document-processing.mdx
+      - frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
+      - docs/goals/knowledge-document-versions/**
+    verify:
+      - "Real PostgreSQL publication, failure preservation, retrieval, citation, deletion, and crawler behavior"
+      - "PostgreSQL 13 migration upgrade/downgrade/re-upgrade/history fence and one Alembic head"
+      - "Whole-backend Pyright 0/0, changed Python Ruff/format, backend non-integration suite"
+      - "OpenAPI/generated schema parity, docs build, diff/secret/pre-push checks"
+      - "Same-session Claude exact-diff gate green with MIN_SCORE >= 8"
+      - "Fresh GitHub /review; merge only exact green CI head with no critical current finding"
+    stop_if:
+      - "The change requires a public version-history contract or another persistence owner."
+      - "The change begins the later ingestion pipeline, retention cleanup, Flow work, or provider-specific storage behavior."
+      - "A genuine data-loss, migration, concurrency, security, or material performance blocker remains."
+    receipt: null
+
+  - id: T999
+    type: judge
+    assignee: Judge
+    status: queued
+    reasoning_hint: high
+    objective: "Audit the immutable PR head, current review, CI, merge, issue links, docs, and non-goals before closing this tranche."
+    inputs:
+      - "T001 contract and T010 implementation evidence"
+    constraints:
+      - "Do not add product scope."
+      - "Non-critical review nits do not reopen the implementation loop."
+    expected_output:
+      - "complete | not_complete"
+      - "Smallest next task if incomplete"
+    receipt: null
+
+checks:
+  dirty_fingerprint: "Dirty implementation diff from origin/develop 7abc3fcef; no unrelated source paths or staged files."
+  last_verification:
+    result: pass
+    task: T010
+    commands:
+      - "25 real PostgreSQL publication/failure/reference tests passed"
+      - "1 PostgreSQL 13 migration round-trip/history-fence test passed; Alembic head 202607271100 only"
+      - "4077 backend non-integration tests passed; 1309 deselected"
+      - "whole-backend Pyright 0 errors/0 warnings/0 informations"
+      - "changed Python Ruff/format, OpenAPI generated-schema drift, docs-site build, diff and Goal checker passed"
+      - "Claude session knowledge-document-versions iteration 5: GREEN_LIGHT yes, MIN_SCORE 8, no blockers"

--- a/docs/goals/knowledge-document-versions/state.yaml
+++ b/docs/goals/knowledge-document-versions/state.yaml
@@ -72,6 +72,7 @@ tasks:
       - backend/alembic/versions/202607271000_add_info_blob_versions.py
       - backend/alembic/versions/202607271100_merge_info_blob_and_debug_permission.py
       - backend/src/eneo/database/tables/info_blobs_table.py
+      - backend/src/eneo/admin/quota_service.py
       - backend/src/eneo/info_blobs/**
       - backend/src/eneo/embedding_models/infrastructure/datastore.py
       - backend/src/eneo/worker/crawl/**
@@ -87,6 +88,7 @@ tasks:
       - backend/tests/integration/embedding_models/test_embedding_model_lifecycle.py
       - backend/tests/integration/object_content/test_reference_fence.py
       - backend/tests/integration/test_ingestion_failure_safety.py
+      - backend/tests/unittests/admin/test_quota_service.py
       - backend/tests/unittests/info_blobs/**
       - backend/tests/unittests/integration/test_sharepoint_content_service.py
       - backend/tests/unittests/worker/test_persist_batch_logic.py
@@ -129,9 +131,10 @@ checks:
     result: pass
     task: T010
     commands:
-      - "25 real PostgreSQL publication/failure/reference tests passed"
+      - "Review 1 F1-F4 verified and fixed in existing migration, repository, quota, service, and crawler owners"
+      - "9 focused unit/real PostgreSQL publication tests and 24 crawler persistence tests passed"
       - "1 PostgreSQL 13 migration round-trip/history-fence test passed; Alembic head 202607271100 only"
-      - "4077 backend non-integration tests passed; 1309 deselected"
+      - "4078 backend non-integration tests passed; 1312 deselected"
       - "whole-backend Pyright 0 errors/0 warnings/0 informations"
       - "changed Python Ruff/format, OpenAPI generated-schema drift, docs-site build, diff and Goal checker passed"
       - "Claude session knowledge-document-versions iteration 5: GREEN_LIGHT yes, MIN_SCORE 8, no blockers"

--- a/frontend/apps/docs-site/src/content/docs/architecture.mdx
+++ b/frontend/apps/docs-site/src/content/docs/architecture.mdx
@@ -371,13 +371,18 @@ Save conversation to database
 
 </div>
 
-1. User uploads file via `POST /api/v1/files/`
-2. Backend saves metadata to `InfoBlobs` table and enqueues processing task
-3. Worker picks up task from Redis (ARQ)
-4. Processing pipeline: extract text → chunk (200 tokens) → generate embeddings
-5. Store chunks and vectors in `InfoBlobChunks` (pgvector)
-6. Update job status to `COMPLETE` or `FAILED`
-7. Frontend polls or receives WebSocket notification
+1. User uploads a File; its bytes follow the deployment's selected storage policy.
+2. Backend enqueues document processing.
+3. Worker extracts text, creates chunks, and generates embeddings.
+4. One short transaction publishes the new `InfoBlobs` version and every
+   `InfoBlobChunks` vector, then supersedes the previous version.
+5. Retrieval reads only the active version. Exact historical references remain
+   readable until the document is deleted.
+6. A failed replacement rolls back; the previous complete version remains active.
+7. The job records `COMPLETE` or `FAILED` for the frontend.
+
+PostgreSQL owns searchable text, version state, and pgvector data regardless of
+where Eneo stores the original File bytes. Object storage remains optional.
 
 ---
 
@@ -386,6 +391,7 @@ Save conversation to database
 ### Authentication Layers
 
 1. **Session-based** (default)
+
    - JWT tokens stored in httpOnly cookies
    - CSRF protection
    - Token refresh mechanism

--- a/frontend/apps/docs-site/src/content/guides/document-processing.mdx
+++ b/frontend/apps/docs-site/src/content/guides/document-processing.mdx
@@ -5,16 +5,26 @@ Eneo's document processing capabilities allow you to create AI-powered knowledge
 ## Overview
 
 Eneo can process and extract knowledge from:
+
 - **Documents**: PDF, Word (.docx), PowerPoint (.pptx), Excel (.xlsx, .csv)
 - **Websites**: Automated crawling and content extraction
 - **Text files**: Plain text, Markdown
 
 All content is:
+
 1. **Extracted** from source format
 2. **Chunked** into optimal segments
 3. **Embedded** as vectors for semantic search
-4. **Stored** in PostgreSQL with pgvector
+4. **Published** as one searchable version in PostgreSQL with pgvector
 5. **Retrieved** when relevant to queries
+
+Updating a document does not remove the working knowledge first. Eneo publishes
+the replacement text and all vectors together. If extraction or embedding
+fails, search continues to use the previous complete version. Uploading the
+same content again reuses the current version without another embedding call.
+
+This is separate from file-byte placement. PostgreSQL remains the complete
+default; compatible object storage is optional and does not replace pgvector.
 
 ---
 
@@ -46,34 +56,30 @@ Documents belong to collaborative spaces in Eneo:
 3. Click **Upload**
 
 The worker service will process files in the background. You'll see:
+
 - ✓ **Uploaded**: File received
 - ⏳ **Processing**: Content extraction in progress
 - ✓ **Completed**: Ready for queries
 
 ### Supported Formats
 
-| Format | Extension | Notes |
-|--------|-----------|-------|
-| PDF | `.pdf` | Text-based PDFs work best; OCR not yet supported |
-| Word | `.docx` | Modern Word documents |
-| PowerPoint | `.pptx` | Extracts text from slides |
-| Excel | `.xlsx`, `.csv` | Extracts data as text |
-| Text | `.txt`, `.md` | Plain text and Markdown |
+| Format     | Extension       | Notes                                            |
+| ---------- | --------------- | ------------------------------------------------ |
+| PDF        | `.pdf`          | Text-based PDFs work best; OCR not yet supported |
+| Word       | `.docx`         | Modern Word documents                            |
+| PowerPoint | `.pptx`         | Extracts text from slides                        |
+| Excel      | `.xlsx`, `.csv` | Extracts data as text                            |
+| Text       | `.txt`, `.md`   | Plain text and Markdown                          |
 
 ### File Size Limits
 
-Default maximum file size: **50MB per file**
+Platform admins set the knowledge-file limit in **Admin > Storage**. Changes
+apply without restarting backend or worker. Operators keep a deployment safety
+ceiling for PostgreSQL rows or the optional object-store transport; Eneo uses
+the lower effective limit and shows which setting constrains it.
 
-To increase limits, add to `env_backend.env`:
-
-```bash
-MAX_UPLOAD_SIZE_MB=100
-```
-
-Then restart:
-```bash
-docker compose restart backend
-```
+See [Choose Content Storage](/guides/object-content-storage#admin-and-operator-responsibilities)
+for the exact responsibility split.
 
 ---
 
@@ -95,6 +101,7 @@ Automatically extract content from websites.
 ### Step 2: Monitor Progress
 
 The crawler will:
+
 1. Fetch the initial page
 2. Extract links (if configured)
 3. Process each page in the background
@@ -103,6 +110,7 @@ The crawler will:
 ### Crawling Configuration
 
 **Shallow crawl** (single page):
+
 ```
 URL: https://example.com/documentation
 Max Depth: 0
@@ -110,6 +118,7 @@ Max Pages: 1
 ```
 
 **Deep crawl** (entire section):
+
 ```
 URL: https://example.com/docs
 Max Depth: 3
@@ -151,6 +160,7 @@ response = requests.post(
 ### 1. Extraction
 
 Content is extracted from source formats:
+
 - **PDF**: Text extraction using pdfplumber
 - **Word**: XML parsing of .docx structure
 - **PowerPoint**: Slide text extraction
@@ -174,6 +184,7 @@ Chunk 3:                      [..................] (chars 1600-2600)
 ### 3. Embedding
 
 Each chunk is converted to a vector embedding:
+
 - **Model**: Configurable embedding model (default: OpenAI text-embedding-3-small)
 - **Dimensions**: 1536 dimensions (OpenAI) or model-specific
 - **Storage**: Stored in PostgreSQL with pgvector extension
@@ -181,6 +192,7 @@ Each chunk is converted to a vector embedding:
 ### 4. Retrieval
 
 When users query:
+
 1. Query is converted to an embedding
 2. Vector similarity search finds relevant chunks
 3. Top-k most relevant chunks are retrieved (default: k=5)
@@ -195,11 +207,13 @@ When users query:
 Adjust chunk size based on your content:
 
 **Large chunks** (1500-2000 chars):
+
 - ✓ Better for long-form content
 - ✓ More context per chunk
 - ✗ Less precise retrieval
 
 **Small chunks** (500-800 chars):
+
 - ✓ More precise retrieval
 - ✓ Better for factual Q&A
 - ✗ May lose context
@@ -216,16 +230,19 @@ CHUNK_OVERLAP=200
 Choose the right embedding model:
 
 **OpenAI text-embedding-3-small** (default):
+
 - Fast and cost-effective
 - 1536 dimensions
 - Good for general purpose
 
 **OpenAI text-embedding-3-large**:
+
 - Higher quality
 - 3072 dimensions
 - Better for complex queries
 
 Configure in `env_backend.env`:
+
 ```bash
 EMBEDDING_MODEL=text-embedding-3-small
 ```
@@ -258,19 +275,16 @@ Higher threshold = more precise but may miss relevant content
 ### Search Documents
 
 Use the search bar to find specific documents:
+
 ```
 Search: "quarterly report"
 ```
 
 ### Update Documents
 
-To update a document:
-1. Delete the old version
-2. Upload the new version
-
-Or use versioning:
-1. Keep both versions
-2. Mark old version as archived
+Upload the document again with the same title. Eneo builds the replacement
+first and makes it searchable only when its text and embeddings are complete.
+If processing fails, the previous version remains available.
 
 ### Delete Documents
 
@@ -279,6 +293,7 @@ Or use versioning:
 3. Confirm deletion
 
 Deletion removes:
+
 - Original document
 - All chunks
 - All embeddings
@@ -294,10 +309,10 @@ Deletion removes:
 ```yaml
 worker:
   deploy:
-    replicas: 2  # Run 2 worker instances
+    replicas: 2 # Run 2 worker instances
     resources:
       limits:
-        cpus: '2'
+        cpus: "2"
         memory: 2G
 ```
 
@@ -340,18 +355,21 @@ CACHE_TTL_SECONDS=3600
 ### Files Not Processing
 
 **Check worker status:**
+
 ```bash
 docker compose ps worker
 docker compose logs worker
 ```
 
 **Common issues:**
+
 - Worker not running
 - Insufficient memory
 - Unsupported file format
 - Corrupted file
 
 **Solution:**
+
 ```bash
 docker compose restart worker
 ```
@@ -359,17 +377,20 @@ docker compose restart worker
 ### Web Crawling Fails
 
 **Check error messages:**
+
 ```bash
 docker compose logs worker | grep crawl
 ```
 
 **Common issues:**
+
 - Website blocks crawlers (check robots.txt)
 - Authentication required
 - Rate limiting
 - Network issues
 
 **Solution:**
+
 - Use specific URLs instead of root domains
 - Reduce max_pages and max_depth
 - Add delays between requests
@@ -377,6 +398,7 @@ docker compose logs worker | grep crawl
 ### Poor Retrieval Quality
 
 **Symptoms:**
+
 - AI doesn't use uploaded documents
 - Irrelevant chunks retrieved
 - Missing important information
@@ -384,16 +406,19 @@ docker compose logs worker | grep crawl
 **Solutions:**
 
 1. **Check chunk size:**
+
    - Too large = less precise
    - Too small = loses context
 
 2. **Adjust retrieval parameters:**
+
    ```bash
    RETRIEVAL_K=10  # Retrieve more chunks
    RETRIEVAL_THRESHOLD=0.6  # Lower threshold
    ```
 
 3. **Use better embeddings:**
+
    ```bash
    EMBEDDING_MODEL=text-embedding-3-large
    ```
@@ -413,10 +438,11 @@ worker:
   deploy:
     resources:
       limits:
-        memory: 1G  # Reduce from 2G
+        memory: 1G # Reduce from 2G
 ```
 
 **Process fewer documents simultaneously:**
+
 ```bash
 # env_backend.env
 MAX_CONCURRENT_TASKS=2  # Reduce from default

--- a/frontend/apps/docs-site/src/content/guides/document-processing.mdx
+++ b/frontend/apps/docs-site/src/content/guides/document-processing.mdx
@@ -21,7 +21,9 @@ All content is:
 Updating a document does not remove the working knowledge first. Eneo publishes
 the replacement text and all vectors together. If extraction or embedding
 fails, search continues to use the previous complete version. Uploading the
-same content again reuses the current version without another embedding call.
+same content again with the same embedding model reuses the current version
+without another embedding call. Changing the model builds compatible vectors
+before the replacement becomes searchable.
 
 This is separate from file-byte placement. PostgreSQL remains the complete
 default; compatible object storage is optional and does not replace pgvector.

--- a/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
+++ b/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
@@ -56,13 +56,14 @@ Object storage and RAG solve different problems:
 
 ### What is adopted now?
 
-| Product content                                   | Current behavior                                                                                        |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| Eligible new File and Icon bytes                  | Use the deployment-wide target selected in **Admin > Storage**                                          |
-| Existing File and Icon bytes                      | Copied, SHA-256 verified, switched to typed references, then removed from legacy columns during upgrade |
-| InfoBlob knowledge generations and Flow artifacts | Remain separate follow-up work                                                                          |
-| Changing the selected target                      | Affects eligible new writes without a restart; existing content stays where it is                       |
-| Moving existing content                           | Requires a separate explicit, verified migration                                                        |
+| Product content                  | Current behavior                                                                                        |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Eligible new File and Icon bytes | Use the deployment-wide target selected in **Admin > Storage**                                          |
+| Existing File and Icon bytes     | Copied, SHA-256 verified, switched to typed references, then removed from legacy columns during upgrade |
+| Searchable knowledge versions    | Live in PostgreSQL/pgvector; only a complete replacement becomes active                                 |
+| Flow artifacts                   | Remain separate follow-up work                                                                          |
+| Changing the selected target     | Affects eligible new writes without a restart; existing content stays where it is                       |
+| Moving existing content          | Requires a separate explicit, verified migration                                                        |
 
 Enabling an endpoint makes the optional byte plane available; it does not move
 existing content or change producer placement by itself. A platform admin must

--- a/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
+++ b/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
@@ -65,6 +65,10 @@ Object storage and RAG solve different problems:
 | Changing the selected target     | Affects eligible new writes without a restart; existing content stays where it is                       |
 | Moving existing content          | Requires a separate explicit, verified migration                                                        |
 
+Replacing searchable knowledge keeps the previous complete version as
+recovery history. Retained versions continue to count toward the configured
+knowledge-storage quota until the document family is deleted.
+
 Enabling an endpoint makes the optional byte plane available; it does not move
 existing content or change producer placement by itself. A platform admin must
 select it after Eneo reports it compatible and ready.


### PR DESCRIPTION
## Summary

- Keeps the last working knowledge document searchable while an update is processed.
- Publishes changed text, chunks, and embeddings together; a failed update changes nothing visible.
- Reuses unchanged embeddings while still refreshing citation metadata such as the source URL.
- Keeps PostgreSQL as a complete default. Compatible object storage remains optional and independent of searchable knowledge data.

```mermaid
flowchart LR
    current["Current searchable document"] --> process["Process updated document"]
    process --> ready{"Text and embeddings complete?"}
    ready -- "Yes" --> publish["Publish replacement together"]
    ready -- "No" --> current
    publish --> next["New searchable document"]
```

## Why

Previously, an update could overwrite or delete working knowledge before its replacement was fully searchable. A parsing, embedding, or database failure could therefore leave users with missing or partial results. This change gives publication one clear rule: only a complete replacement becomes active.

## What changed

- `InfoBlobService` owns atomic publication for uploads and integrations; the crawler keeps its bounded batch path with the same publication guarantee.
- `InfoBlobs` records active and superseded complete versions. A database constraint permits only one active version per logical document.
- Search, lists, counts, sizes, and stale-page reconciliation use the active version. Retained versions count toward storage quota until the document family is deleted.
- Saved citations can resolve their exact historical version. Republishing unchanged content refreshes its mutable citation metadata without re-embedding.
- Untitled uploads remain independent documents. The migration deterministically normalizes legacy duplicates with stable group, website, integration-title, or provider-item identities before creating the active-source index.
- Explicit deletion removes the complete document family. SharePoint and Confluence use the same publication owner instead of separate update-and-embed sequences.
- The docs site explains update behavior and the separation between original file bytes and searchable knowledge.

## What was deliberately not changed

- No object-storage requirement, Amazon-specific behavior, or migration of original file bytes.
- No public version-history UI or API, retention automation, generic ingestion framework, worker replacement, or Flow adoption.
- No per-tenant storage routing or speculative vector-index tuning.

## Deletion / consolidation

- Removed duplicate embedding ownership from the upload router and `TextProcessor`.
- Removed SharePoint's manual chunk deletion and swallowed embedding failure path.
- Replaced Confluence's incremental size bookkeeping with the canonical active-content query.

## Risk and rollback

The main risk is classifying an old query incorrectly as active-only or historical. Real PostgreSQL tests cover retrieval, saved references, quotas, counts, sizes, failure rollback, crawler publication, and whole-family deletion.

The migration can downgrade while every document still has one version. If migration normalizes legacy duplicates or a later replacement creates history, downgrade refuses to discard version meaning; recover forward or restore the matching pre-upgrade database backup.

## Planning

- Knowledge ingestion task: Part of #571
- File-storage epic: #549

This PR delivers the safe publication foundation. Durable background ingestion, retention decisions, and lifecycle UI remain later bounded work in #571.

## Validation

- Backend non-integration suite — 4,078 passed, 1,312 deselected.
- Focused quota, crawler, and real PostgreSQL publication tests — 33 passed.
- PostgreSQL 13 migration upgrade/downgrade/re-upgrade/history-fence test — passed; one Alembic head.
- `uv run pyright` — 0 errors, 0 warnings, 0 informations.
- Changed Python Ruff and format checks — passed.
- OpenAPI-to-generated-client schema drift — exact match.
- Docs-site production build — 32 pages built, 28 indexed.
- `python3 scripts/pre_push_check.py` with `.env.template` — passed.

## Screenshots

No product UI changed.
