### PR TITLE
fix(ci): add swap to frontend image publish

### DIFF
--- a/.github/workflows/build_and_push_images.yml
+++ b/.github/workflows/build_and_push_images.yml
@@ -179,6 +179,13 @@ jobs:
           push-to-registry: true
 
       # Frontend build and push
+      - name: Add swap for frontend image build
+        run: |
+          sudo fallocate --length 4G /mnt/eneo-frontend.swap
+          sudo chmod 600 /mnt/eneo-frontend.swap
+          sudo mkswap /mnt/eneo-frontend.swap
+          sudo swapon /mnt/eneo-frontend.swap
+
       - name: Extract frontend metadata
         id: meta-frontend
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5


### PR DESCRIPTION
## Changes

Add a bounded 4 GB swap file to the `build-and-push` job in
`.github/workflows/build_and_push_images.yml`, immediately before the frontend
Docker build.

The step is byte-identical to the one `ci.yml` already runs in its
`docker-builds` job for the `frontend` matrix entry.

## Why

Every push to `develop` currently fails **Build and Push Docker Images**:

```
#15 ERROR: process "/bin/sh -c bun run build" did not complete successfully: cannot allocate memory
ERROR: failed to build: failed to solve: ResourceExhausted: ...
```

`frontend/Dockerfile` sets `NODE_OPTIONS=--max-old-space-size=8192`. The hosted
runner cannot back that heap without swap, so `vite build` is SIGKILLed inside
the container.

PR CI hit the same wall and solved it with a swap step in `ci.yml`. The publish
workflow builds the frontend in a separate job and never received that step, so
it kept failing. On `dd5dccd2` the two jobs disagree on the *same commit*:

| Job | Workflow | Result |
| --- | --- | --- |
| Docker builds (frontend) | `ci.yml` (has swap) | passes in 6m |
| build-and-push | `build_and_push_images.yml` (no swap) | OOM after 6m |

This is not a regression from any feature branch — it fails on every `develop`
push and will keep doing so until this lands.

## Planning

No task issue; this is CI infrastructure repair for a currently-red `develop`.

## Testing

- Reproduced from run [30284485080](https://github.com/eneo-ai/eneo/actions/runs/30284485080/job/90038766584): `Dockerfile:13 RUN bun run build`, `ResourceExhausted: cannot allocate memory`.
- The identical swap step is already proven on hosted runners — `CI / Docker builds (frontend)` passes on `dd5dccd2` with it.
- The workflow also accepts `workflow_dispatch`, so the publish path can be dispatched on this branch before merge to confirm end to end. Note that a dispatch pushes a branch-tagged image to ghcr.

## Screenshots

n/a — no UI change.