### PR TITLE
Stop Frontend E2E failing by hardware speed instead of correctness

### DIFF
--- a/frontend/apps/web/playwright.config.ts
+++ b/frontend/apps/web/playwright.config.ts
@@ -29,6 +29,16 @@ export default defineConfig({
   reporter: process.env.CI
     ? [["list"], ["html", { open: "never" }], ["github"]]
     : [["list"], ["html", { open: "never" }]],
+  // Playwright's 5s default assumes a fast local app. These specs drive
+  // authenticated SSR against a containerised backend on a shared 2-core
+  // runner, where the personal chat workspace measured 5.6s against that 5s
+  // budget — while the same page renders in 0.55s on a developer machine and
+  // still passes with the budget cut to 400ms. The margin therefore decides
+  // pass/fail by hardware speed, not by correctness, and with retries
+  // deliberately off (see below) every run is a coin flip. 15s keeps ~3x
+  // headroom over the slowest observed CI render while still failing a
+  // genuinely broken assertion promptly.
+  expect: { timeout: 15_000 },
   use: {
     baseURL: `http://localhost:${PORT}`,
     // There are no automatic E2E retries. Retain the original failure trace so


### PR DESCRIPTION
## TL;DR

`Frontend E2E` fails intermittently on `authenticated user lands in the personal
chat workspace`. The page is not broken — it is racing Playwright's 5s default
assertion budget on a shared runner that needs 5.6s to render it.

Raise the assertion budget to 15s. Nothing is weakened: the same elements are
still required to appear, and retries stay off.

## Evidence

| Where | Time for that test | Result |
| --- | --- | --- |
| CI, 2 workers, shared 2-core runner | 5.6s | **fails** at the 5000ms budget |
| Developer machine, alone | 0.55s | passes |
| Developer machine, 7 and 10 workers | 5.8s / 13.5s suite | passes |
| Developer machine, budget cut to **400ms** | 0.55s | still passes |

The last row is the point: locally the element appears in well under half a
second, so there is no slow code path to fix. The runner is simply ~10x slower
per core, and `getByRole("navigation")` on the heaviest authenticated SSR page
lands either side of 5s depending on the machine.

Because `retries` is deliberately 0 — the config keeps the original failure
trace diagnosable, which is the right call — a single miss fails the job. So
every run was a coin flip.

I could **not** reproduce the failure locally; this hardware is too fast. That
is stated rather than papered over: the fix is justified by the measured CI
render time, and CI is the only place the condition exists.

## Why a global budget rather than a per-assertion timeout

Every spec here drives authenticated SSR against a containerised backend. The
exposure belongs to the suite, not to one assertion, so the next slow page would
have hit the same wall. A single documented budget also beats scattering magic
numbers through the specs.

15s is roughly 3x the slowest observed CI render — enough headroom to stop the
coin flip, small enough that a genuinely broken assertion still fails promptly.

## Alternatives rejected

- **Enabling retries.** The config argues against them on purpose, to retain
  the failure trace. Retries would also mask a real regression as a flake.
- **Reducing CI workers.** CI already runs 2. The constraint is per-core speed,
  not contention.
- **Weakening the assertion.** Asserting the authenticated shell rendered is
  exactly what this test is for.

## Testing

Ran the full suite against the same isolated stack CI uses
(`docker-compose.e2e.ci.yml`, all four services healthy), the same pinned
`playwright@1.61.1`, the same `SVELTE_KIT_OUT_DIR=.svelte-kit-e2e` production
build, and the same `E2E_MANAGE_STACK=0` / `E2E_BACKEND_URL` / `E2E_JWT_SECRET`:

- `bun run test:e2e` — **12 passed**
- `--workers=1` and `--workers=16` — 12 passed both ways
- Prettier and ESLint on the changed file — clean
