### PR TITLE
Stop a 2-second backend keep-alive from turning the workspace into a 500 page

### DIFF
--- a/backend/run.sh
+++ b/backend/run.sh
@@ -22,4 +22,8 @@ fi
 
 echo "Starting Eneo backend with $workers workers"
 
-exec gunicorn src.eneo.server.main:app --workers $workers --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:8000
+# keepalive must outlive every client's idle connection pool (Node/undici
+# holds SSR sockets ~4s; gunicorn's default is 2s and it sends no
+# Keep-Alive hint), otherwise the server closes a socket the client still
+# considers live and an in-flight SSR fetch dies with ECONNRESET.
+exec gunicorn src.eneo.server.main:app --workers $workers --worker-class uvicorn.workers.UvicornWorker --keep-alive 75 --bind 0.0.0.0:8000

--- a/docker-compose.e2e.ci.yml
+++ b/docker-compose.e2e.ci.yml
@@ -111,7 +111,7 @@ services:
         python /e2e/seed.py          # seed mock completion model
         exec gunicorn src.eneo.server.main:app \
           --workers 1 --worker-class uvicorn.workers.UvicornWorker \
-          --bind 0.0.0.0:8000
+          --keep-alive 75 --bind 0.0.0.0:8000
     volumes:
       - ./e2e:/e2e:ro
     ports:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -99,7 +99,7 @@ services:
         python /workspace/e2e/seed.py  # seed mock completion model
         exec gunicorn src.eneo.server.main:app \
           --workers 1 --worker-class uvicorn.workers.UvicornWorker \
-          --bind 0.0.0.0:8000
+          --keep-alive 75 --bind 0.0.0.0:8000
     ports:
       - "8124:8000"
     volumes:

--- a/frontend/apps/web/playwright.config.ts
+++ b/frontend/apps/web/playwright.config.ts
@@ -29,16 +29,6 @@ export default defineConfig({
   reporter: process.env.CI
     ? [["list"], ["html", { open: "never" }], ["github"]]
     : [["list"], ["html", { open: "never" }]],
-  // Playwright's 5s default assumes a fast local app. These specs drive
-  // authenticated SSR against a containerised backend on a shared 2-core
-  // runner, where the personal chat workspace measured 5.6s against that 5s
-  // budget — while the same page renders in 0.55s on a developer machine and
-  // still passes with the budget cut to 400ms. The margin therefore decides
-  // pass/fail by hardware speed, not by correctness, and with retries
-  // deliberately off (see below) every run is a coin flip. 15s keeps ~3x
-  // headroom over the slowest observed CI render while still failing a
-  // genuinely broken assertion promptly.
-  expect: { timeout: 15_000 },
   use: {
     baseURL: `http://localhost:${PORT}`,
     // There are no automatic E2E retries. Retain the original failure trace so

--- a/frontend/apps/web/src/hooks.server.ts
+++ b/frontend/apps/web/src/hooks.server.ts
@@ -10,6 +10,7 @@ import {
   getBackendUrl,
   getBackendServerUrl
 } from "./lib/core/environment.server";
+import { fetchWithTransientRetry } from "./lib/core/transientFetch.server";
 import { sequence } from "@sveltejs/kit/hooks";
 import { paraglideMiddleware } from "$lib/paraglide/server";
 
@@ -105,5 +106,5 @@ export const handleFetch: HandleFetch = async ({ request, fetch }) => {
     request = new Request(request.url.replace(backendUrl, serverUrl), request);
   }
 
-  return fetch(request);
+  return fetchWithTransientRetry(request, fetch);
 };

--- a/frontend/apps/web/src/lib/core/transientFetch.server.test.ts
+++ b/frontend/apps/web/src/lib/core/transientFetch.server.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchWithTransientRetry, isTransientNetworkError } from "./transientFetch.server";
+
+function socketDeath(): TypeError {
+  // Shape undici produces when a pooled keep-alive socket dies mid-request.
+  return new TypeError("fetch failed", {
+    cause: Object.assign(new Error("other side closed"), { code: "UND_ERR_SOCKET" })
+  });
+}
+
+describe("isTransientNetworkError", () => {
+  it("recognises a dead pooled socket through the cause chain", () => {
+    expect(isTransientNetworkError(socketDeath())).toBe(true);
+    expect(
+      isTransientNetworkError(
+        new TypeError("fetch failed", {
+          cause: Object.assign(new Error("reset"), { code: "ECONNRESET" })
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("does not treat refused connections or plain errors as transient", () => {
+    // ECONNREFUSED means the backend is down — retrying immediately cannot
+    // help and would double the latency of an honest failure.
+    expect(
+      isTransientNetworkError(
+        new TypeError("fetch failed", {
+          cause: Object.assign(new Error("refused"), { code: "ECONNREFUSED" })
+        })
+      )
+    ).toBe(false);
+    expect(isTransientNetworkError(new Error("boom"))).toBe(false);
+    expect(isTransientNetworkError(undefined)).toBe(false);
+  });
+});
+
+describe("fetchWithTransientRetry", () => {
+  it("retries a GET exactly once when the socket dies, on a fresh request", async () => {
+    const ok = new Response("ok");
+    const fetchFn = vi.fn().mockRejectedValueOnce(socketDeath()).mockResolvedValueOnce(ok);
+
+    const response = await fetchWithTransientRetry(
+      new Request("http://backend/api/v1/users/me"),
+      fetchFn as unknown as typeof fetch
+    );
+
+    expect(response).toBe(ok);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("gives up after the second failure", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(socketDeath());
+
+    await expect(
+      fetchWithTransientRetry(
+        new Request("http://backend/api/v1/users/me"),
+        fetchFn as unknown as typeof fetch
+      )
+    ).rejects.toThrow("fetch failed");
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("never retries a non-idempotent method", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(socketDeath());
+
+    await expect(
+      fetchWithTransientRetry(
+        new Request("http://backend/api/v1/conversations/", { method: "POST" }),
+        fetchFn as unknown as typeof fetch
+      )
+    ).rejects.toThrow("fetch failed");
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("never retries an HTTP error response", async () => {
+    const teapot = new Response("no", { status: 418 });
+    const fetchFn = vi.fn().mockResolvedValue(teapot);
+
+    const response = await fetchWithTransientRetry(
+      new Request("http://backend/api/v1/users/me"),
+      fetchFn as unknown as typeof fetch
+    );
+
+    expect(response).toBe(teapot);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows non-transient failures without retrying", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error("certificate error"));
+
+    await expect(
+      fetchWithTransientRetry(
+        new Request("http://backend/api/v1/users/me"),
+        fetchFn as unknown as typeof fetch
+      )
+    ).rejects.toThrow("certificate error");
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/apps/web/src/lib/core/transientFetch.server.ts
+++ b/frontend/apps/web/src/lib/core/transientFetch.server.ts
@@ -1,0 +1,58 @@
+/**
+ * One retry for SSR fetches that die on the wire.
+ *
+ * The app layout fires several parallel backend fetches on every authenticated
+ * page load. Server-side fetch pools keep-alive sockets, and any backend or
+ * proxy that closes an idle socket while a request crosses it produces a
+ * network-level failure ("fetch failed", ECONNRESET) — which used to reject
+ * the whole load and render the 500 page instead of the workspace.
+ *
+ * A closed-socket race is safe to retry exactly when the request could not
+ * have been processed twice: idempotent methods only, network-level errors
+ * only. HTTP error responses are results, not failures, and are never retried.
+ */
+
+const IDEMPOTENT_METHODS = new Set(["GET", "HEAD"]);
+
+/** Transport-level codes undici surfaces when a pooled socket dies. */
+const TRANSIENT_CODES = new Set(["ECONNRESET", "EPIPE", "UND_ERR_SOCKET", "UND_ERR_INFO"]);
+
+export function isTransientNetworkError(error: unknown): boolean {
+  let current: unknown = error;
+  // fetch wraps the transport error: TypeError("fetch failed") -> cause chain.
+  for (let depth = 0; current && depth < 5; depth++) {
+    if (current instanceof AggregateError) {
+      return current.errors.some((inner) => isTransientNetworkError(inner));
+    }
+    if (typeof current === "object") {
+      const code = (current as { code?: unknown }).code;
+      if (typeof code === "string" && TRANSIENT_CODES.has(code)) {
+        return true;
+      }
+      current = (current as { cause?: unknown }).cause;
+    } else {
+      break;
+    }
+  }
+  return false;
+}
+
+export async function fetchWithTransientRetry(
+  request: Request,
+  fetchFn: typeof fetch
+): Promise<Response> {
+  if (!IDEMPOTENT_METHODS.has(request.method)) {
+    return fetchFn(request);
+  }
+  // A Request is consumed by fetch even without a body; keep a copy to resend.
+  const retryRequest = request.clone();
+  try {
+    return await fetchFn(request);
+  } catch (error) {
+    if (!isTransientNetworkError(error)) {
+      throw error;
+    }
+    // The failed socket is gone from the pool; the retry gets a fresh one.
+    return fetchFn(retryRequest);
+  }
+}


### PR DESCRIPTION
## TL;DR

The intermittent `Frontend E2E` failure was never a slow page and never a flaky
test. It was a real production bug: the backend closes idle keep-alive sockets
after **2 seconds** (gunicorn's default, with no `Keep-Alive` hint), while the
SSR server's fetch pool considers sockets live for ~4 seconds. A request that
crosses that close dies with `fetch failed`, the app layout's `Promise.all` of
five backend fetches rejects, and the user gets the 500 error page instead of
their workspace.

Three changes: fix the mismatch at the server, make SSR tolerate the class at
its one fetch seam, and revert #622's timeout bump, whose diagnosis this
disproves.

## The evidence chain

1. The failed run's Playwright snapshot shows the assertion waiting on a page
   that rendered the **error boundary** — *"Fel 0: fetch failed"* — not a slow
   shell. The trace shows `GET /spaces/personal/chat → 500`.
2. A raw socket against the E2E backend measures the server closing idle
   keep-alive connections at **exactly 2.0 s**, sending no `Keep-Alive:
   timeout` hint, so the client cannot know. Node's undici pools idle sockets
   for ~4 s by default.
3. `(app)/+layout.ts` fires `users.me`, `tenant`, `version`, `limits` and
   `settings` in one `Promise.all` on every authenticated page load — five
   chances per navigation to dispatch onto a socket the server is closing. One
   loss rejects the whole load.
4. The same failure signature appears on run 30285691538, before any of the
   recent branches existed, and recurs at roughly 2 in 12 runs.
5. `backend/run.sh` — production — execs gunicorn with the same missing flag,
   so this race exists for real users, not just CI.

## Changes

**Server (root cause).** `--keep-alive 75` on gunicorn in `backend/run.sh` and
both E2E composes, so the server's idle window outlives every client pool.
75 s is the conventional upstream value. (The first attempt used gunicorn's
config-file spelling `--keepalive`; the E2E stack immediately crash-looped on
the unrecognised flag, which is exactly why it is validated here before it can
reach a production container.)

**SSR seam (resilience).** `handleFetch` — the module that already owns every
server-side fetch — now retries **once**, only for idempotent methods
(GET/HEAD), and only on transport-level socket death (`ECONNRESET`, `EPIPE`,
`UND_ERR_SOCKET`). HTTP error responses are results and are never retried;
`ECONNREFUSED` (backend actually down) is not retried either, so an honest
outage still fails fast. This protects production against any proxy or backend
idle-close, not just this gunicorn default. Logic lives in
`transientFetch.server.ts` with 7 behaviour tests.

**Revert #622.** The 15 s assertion budget was my fix for a misdiagnosis: the
"5.6 s render" it cites was the 5 s budget plus overhead, measured while
waiting for an element an error page was never going to show. With the real
cause fixed, the default budget is right, and failures surface in 5 s again
instead of 15.

## Verification

| Measurement | Broken stack | Fixed stack |
| --- | --- | --- |
| Idle socket closed after | 2.0 s, no `Keep-Alive` hint | 75.5 s |
| Requests dispatched at the 2.0 s boundary | **8/192 failed**, `UND_ERR_SOCKET` | **0/192 failed** |
| Full Playwright suite | intermittent 500 → error page | 12 passed |

(The broken-stack sweep overlapped a stack restart, so its count is indicative;
its first failure was a genuine `UND_ERR_SOCKET`, not `ECONNREFUSED`.)

- Raw-socket measurement on the fixed stack: idle close at 75.5 s (was 2.0 s).
- `vitest run transientFetch.server.test.ts`: 7 passed — retry on socket death,
  single retry only, no retry for POST, no retry for HTTP errors, no retry for
  `ECONNREFUSED`.
- `svelte-check` 0 errors; ESLint and Prettier clean on the changed files;
  `bash -n backend/run.sh` clean; CI compose validated by running it.

## Risk

`--keep-alive` only holds idle sockets longer; gunicorn caps connections per
worker independently. The retry is bounded to one attempt on a narrow error
class for idempotent methods. Reverting the expect budget returns the suite to
its long-standing default.
