### PR TITLE
fix: let administrators move content back to PostgreSQL during an object storage outage

### DIFF
--- a/backend/src/eneo/object_content/deployment_policy_router.py
+++ b/backend/src/eneo/object_content/deployment_policy_router.py
@@ -310,15 +310,16 @@ async def queue_object_content_moves(
     request: MoveQueueRequest,
     container: _PolicyAdminContainer,
 ) -> MoveQueuePublic:
-    object_store_capability = next(
-        fact
-        for fact in await object_content_runtime.storage_capabilities()
-        if fact.target is StorageKind.OBJECT_STORE
-    )
-    if not object_store_capability.selectable:
-        raise ObjectContentUnavailableError(
-            "Compatible object storage is not ready for a new move command"
+    if request.target is StorageKind.OBJECT_STORE:
+        object_store_capability = next(
+            fact
+            for fact in await object_content_runtime.storage_capabilities()
+            if fact.target is StorageKind.OBJECT_STORE
         )
+        if not object_store_capability.selectable:
+            raise ObjectContentUnavailableError(
+                "Compatible object storage is not ready for a new move command"
+            )
     maximum_bytes = (
         object_content_runtime.inline_maximum_bytes
         if request.target is StorageKind.POSTGRES_INLINE

--- a/backend/tests/integration/object_content/test_deployment_policy_integration.py
+++ b/backend/tests/integration/object_content/test_deployment_policy_integration.py
@@ -217,11 +217,15 @@ async def test_global_inventory_requires_platform_admin_authority(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_privileged_policy_routes_reject_user_api_keys(
+async def test_policy_routes_enforce_api_key_auth_asymmetry(
     client,
     admin_user_api_key,
 ) -> None:
     headers = {"X-API-Key": admin_user_api_key.key}
+    policy = await client.get(
+        "/api/v1/admin/object-content-policy",
+        headers=headers,
+    )
     inventory = await client.get(
         "/api/v1/admin/object-content-inventory",
         headers=headers,
@@ -253,6 +257,7 @@ async def test_privileged_policy_routes_reject_user_api_keys(
         json={"expected_revision": 1, "moves_paused": True},
     )
 
+    assert policy.status_code == 200, policy.text
     for response in (inventory, replacement, moves, queue, pause):
         assert response.status_code == 403, response.text
         assert "session token" in response.text.lower()

--- a/backend/tests/integration/object_content/test_moves.py
+++ b/backend/tests/integration/object_content/test_moves.py
@@ -138,6 +138,65 @@ async def _create_inline_content(
         return prepared.id, user_id
 
 
+async def _create_object_store_content(
+    database: DatabaseSessionManager,
+    *,
+    payload: bytes,
+    idempotency_key: str,
+) -> tuple[UUID, UUID]:
+    content_id = uuid4()
+    digest = sha256(payload).digest()
+    async with database.session() as session, session.begin():
+        tenant_id = (await session.scalars(select(Tenants.id))).one()
+        user_id = (await session.scalars(select(Users.id))).one()
+        owner = Files(
+            name=f"{idempotency_key}.bin",
+            mimetype="application/octet-stream",
+            file_type="text",
+            tenant_id=tenant_id,
+            user_id=user_id,
+            parent_file_id=None,
+        )
+        session.add(owner)
+        await session.flush()
+        session.add(
+            ObjectContents(
+                id=content_id,
+                tenant_id=tenant_id,
+                created_by_user_id=user_id,
+                storage_kind=StorageKind.OBJECT_STORE.value,
+                state=ContentState.AVAILABLE.value,
+                access_class=ContentAccessClass.PRIVATE_RESOURCE.value,
+                sha256=digest,
+                size_bytes=len(payload),
+                declared_media_type="application/octet-stream",
+                verified_media_type="application/octet-stream",
+                idempotency_key=idempotency_key,
+                request_fingerprint=digest,
+                available_at=func.now(),
+            )
+        )
+        await session.flush()
+        session.add(
+            ObjectStoreObjects(
+                content_id=content_id,
+                storage_kind=StorageKind.OBJECT_STORE.value,
+                object_key=f"test/object-content/{content_id.hex}",
+                verification_chunk_size_bytes=max(len(payload), 1),
+                verification_chunk_sha256=digest,
+            )
+        )
+        session.add(
+            FileContentReferences(
+                file_id=owner.id,
+                content_id=content_id,
+                variant="original",
+                ordinal=0,
+            )
+        )
+    return content_id, user_id
+
+
 async def _queue_move(
     database: DatabaseSessionManager,
     *,
@@ -346,6 +405,105 @@ async def test_admin_command_requires_readiness_before_queueing(
         assert move is not None
         assert content.storage_kind == StorageKind.POSTGRES_INLINE.value
         assert move.target_kind == StorageKind.OBJECT_STORE.value
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_degraded_store_still_queues_moves_back_to_postgres(
+    object_content_database: DatabaseSessionManager,
+    real_object_store: RealObjectStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    content_id, actor_id = await _create_object_store_content(
+        object_content_database,
+        payload=b"move back despite degraded store",
+        idempotency_key=f"move-{uuid4().hex}",
+    )
+
+    class Runtime:
+        inline_maximum_bytes = real_object_store.settings.inline_maximum_bytes
+        object_store_maximum_bytes = real_object_store.settings.maximum_multipart_bytes
+
+        async def storage_capabilities(self) -> tuple[StorageCapability, ...]:
+            return (
+                StorageCapability(
+                    target=StorageKind.OBJECT_STORE,
+                    configured=True,
+                    selectable=False,
+                    readiness_code=ObjectContentReadinessCode.STORE_DEGRADED,
+                ),
+            )
+
+    monkeypatch.setattr(
+        deployment_policy_router,
+        "object_content_runtime",
+        Runtime(),
+    )
+    async with object_content_database.session() as session:
+        container = cast(
+            Container,
+            SimpleNamespace(
+                session=lambda: session,
+                user=lambda: SimpleNamespace(id=actor_id),
+            ),
+        )
+        queued = await deployment_policy_router.queue_object_content_moves(
+            MoveQueueRequest(target=StorageKind.POSTGRES_INLINE, limit=1),
+            container,
+        )
+        async with session.begin():
+            move = await session.get(ObjectContentMoves, content_id)
+
+            assert queued.queued_count == 1
+            assert move is not None
+            assert move.target_kind == StorageKind.POSTGRES_INLINE.value
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_unconfigured_store_queue_toward_postgres_reports_reality(
+    object_content_database: DatabaseSessionManager,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Runtime:
+        inline_maximum_bytes = 1024
+        object_store_maximum_bytes = None
+        configured = False
+        selectable = False
+
+        async def storage_capabilities(self) -> tuple[StorageCapability, ...]:
+            return (
+                StorageCapability(
+                    target=StorageKind.OBJECT_STORE,
+                    configured=self.configured,
+                    selectable=self.selectable,
+                    readiness_code=(
+                        ObjectContentReadinessCode.OBJECT_STORE_NOT_CONFIGURED
+                    ),
+                ),
+            )
+
+    monkeypatch.setattr(
+        deployment_policy_router,
+        "object_content_runtime",
+        Runtime(),
+    )
+    async with object_content_database.session() as session, session.begin():
+        actor_id = (await session.scalars(select(Users.id))).one()
+    async with object_content_database.session() as session:
+        container = cast(
+            Container,
+            SimpleNamespace(
+                session=lambda: session,
+                user=lambda: SimpleNamespace(id=actor_id),
+            ),
+        )
+        queued = await deployment_policy_router.queue_object_content_moves(
+            MoveQueueRequest(target=StorageKind.POSTGRES_INLINE, limit=1),
+            container,
+        )
+
+    assert queued.queued_count == 0
 
 
 @pytest.mark.integration

--- a/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
+++ b/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
@@ -369,6 +369,12 @@ It never moves the full installation automatically, falls back during an
 outage, or treats both placements as writable. Interrupted work resumes from
 its stored intent.
 
+Moves toward PostgreSQL stay available while the object store is degraded, so
+you can bring content back inline during an outage; queueing toward the
+degraded store remains blocked. Individual items still need the store
+reachable to copy their bytes, and retry with a typed failure reason until it
+is.
+
 Before removing object-store configuration, move eligible content inline and
 leave the worker and endpoint running through the configured orphan grace and
 two complete inventory observations. This lets the existing cleanup lifecycle

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -214,7 +214,7 @@
   "storage_moves_status_paused": "Paused",
   "storage_moves_status_running": "Processing",
   "storage_moves_store_unavailable": "Object storage is not available",
-  "storage_moves_store_unavailable_description": "PostgreSQL remains fully supported. Set up compatible object storage and wait until it is available before queueing new moves. Moves already queued remain in place.",
+  "storage_moves_store_unavailable_description": "PostgreSQL remains fully supported, and moves to PostgreSQL can still be queued. Set up compatible object storage and wait until it is available before queueing moves to it. Moves already queued remain in place.",
   "storage_moves_stale_title": "Move settings changed in another session",
   "storage_moves_stale_description": "Reload the latest storage settings before pausing or resuming again.",
   "storage_moves_action_error_title": "The move command could not be completed",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -214,7 +214,7 @@
   "storage_moves_status_paused": "Pausad",
   "storage_moves_status_running": "I gång",
   "storage_moves_store_unavailable": "Objektlagringen är inte tillgänglig",
-  "storage_moves_store_unavailable_description": "PostgreSQL har fortsatt fullt stöd. Konfigurera en kompatibel objektlagring och vänta tills den är tillgänglig innan du köar nya flyttar. Flyttar som redan har köats ligger kvar.",
+  "storage_moves_store_unavailable_description": "PostgreSQL har fortsatt fullt stöd, och flyttar till PostgreSQL kan fortfarande köas. Konfigurera en kompatibel objektlagring och vänta tills den är tillgänglig innan du köar flyttar till den. Flyttar som redan har köats ligger kvar.",
   "storage_moves_stale_title": "Flyttinställningarna ändrades i en annan session",
   "storage_moves_stale_description": "Läs in de senaste lagringsinställningarna innan du pausar eller återupptar igen.",
   "storage_moves_action_error_title": "Flyttkommandot kunde inte slutföras",

--- a/frontend/apps/web/src/routes/(app)/admin/storage/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/storage/+page.svelte
@@ -112,6 +112,7 @@
       return false;
 
     deploymentPolicy = next;
+    if (currentRevision === undefined) moveTarget = next.policy.new_write_storage_target;
     if (!preserveDraft) {
       storageTarget = next.policy.new_write_storage_target;
       sessionFileLimitBytes = next.policy.session_file_limit_bytes;
@@ -277,7 +278,7 @@
   async function queueContentMoves() {
     if (
       !canEdit ||
-      objectStoreUnavailable ||
+      (moveTarget === "object_store" && objectStoreUnavailable) ||
       !validMoveLimit ||
       moveStatus !== "idle" ||
       moveActionPending !== null
@@ -947,7 +948,7 @@
               <div class="flex flex-wrap gap-3">
                 <Button
                   type="button"
-                  disabled={objectStoreUnavailable ||
+                  disabled={(moveTarget === "object_store" && objectStoreUnavailable) ||
                     !validMoveLimit ||
                     moveStatus !== "idle" ||
                     moveActionPending !== null}

--- a/frontend/apps/web/src/routes/(app)/admin/storage/storage-page.svelte.test.ts
+++ b/frontend/apps/web/src/routes/(app)/admin/storage/storage-page.svelte.test.ts
@@ -727,7 +727,7 @@ describe("admin storage settings page", () => {
     });
   });
 
-  test("disables new move commands while compatible object storage is unavailable", async () => {
+  test("disables moves toward object storage while it is unavailable", async () => {
     testUser.isPlatformAdmin = true;
     const loadedPolicy = policy();
     getPolicy.mockResolvedValue(

--- a/frontend/apps/web/src/routes/(app)/admin/storage/storage-page.svelte.test.ts
+++ b/frontend/apps/web/src/routes/(app)/admin/storage/storage-page.svelte.test.ts
@@ -220,7 +220,12 @@ describe("admin storage settings page", () => {
 
   test("queues a bounded page and pauses or resumes through revision-fenced commands", async () => {
     testUser.isPlatformAdmin = true;
+    const loadedPolicy = policy();
     const initial = policy({
+      policy: {
+        ...loadedPolicy.policy,
+        new_write_storage_target: "object_store"
+      },
       capabilities: [
         {
           target: "postgres_inline",
@@ -265,6 +270,33 @@ describe("admin storage settings page", () => {
       expected_revision: 5,
       moves_paused: false
     });
+  });
+
+  test("queues moves to PostgreSQL while object storage is unavailable", async () => {
+    testUser.isPlatformAdmin = true;
+    getPolicy.mockResolvedValue(policy());
+    queueMoves.mockResolvedValue({ queued_count: 1, target_too_large_count: 0 });
+
+    render(StoragePage);
+
+    await page.getByLabelText("storage_moves_target").click();
+    await page.getByRole("option", { name: "storage_target_postgres_inline" }).click();
+    const queueButton = page.getByRole("button", { name: "storage_moves_queue" });
+    await expect.element(queueButton).toBeEnabled();
+    await queueButton.click();
+
+    expect(queueMoves).toHaveBeenCalledWith({ target: "postgres_inline", limit: 25 });
+  });
+
+  test("defaults the move destination to the current policy target", async () => {
+    testUser.isPlatformAdmin = true;
+    getPolicy.mockResolvedValue(policy());
+
+    render(StoragePage);
+
+    await expect
+      .element(page.getByLabelText("storage_moves_target"))
+      .toHaveTextContent("storage_target_postgres_inline");
   });
 
   test("shows progress only on the move action that is running", async () => {
@@ -367,8 +399,13 @@ describe("admin storage settings page", () => {
 
   test("keeps the selected destination and limit when readiness rejects queueing", async () => {
     testUser.isPlatformAdmin = true;
+    const loadedPolicy = policy();
     getPolicy.mockResolvedValue(
       policy({
+        policy: {
+          ...loadedPolicy.policy,
+          new_write_storage_target: "object_store"
+        },
         capabilities: [
           {
             target: "postgres_inline",
@@ -692,7 +729,15 @@ describe("admin storage settings page", () => {
 
   test("disables new move commands while compatible object storage is unavailable", async () => {
     testUser.isPlatformAdmin = true;
-    getPolicy.mockResolvedValue(policy());
+    const loadedPolicy = policy();
+    getPolicy.mockResolvedValue(
+      policy({
+        policy: {
+          ...loadedPolicy.policy,
+          new_write_storage_target: "object_store"
+        }
+      })
+    );
 
     render(StoragePage);
 


### PR DESCRIPTION
## Changes

- The move-queue endpoint now checks object-store readiness only for moves toward the object store; moves toward PostgreSQL queue normally while the store is degraded.
- The admin storage page enables the queue action based on the selected destination, and the destination defaults to the installation's current storage target on first load.
- The outage alert in both languages now says PostgreSQL-bound moves stay available instead of telling administrators to wait entirely.
- The deliberate read-only-policy API-key asymmetry is pinned by a contract test, and the operator guide documents the outage behavior.

## Why

During an object storage outage, the one recovery action an administrator actually needs is moving existing content back to PostgreSQL. Both the backend guard and the UI blocked exactly that action whenever the store was unavailable, while item-level moves and the no-fallback rules already handled outages correctly.

## Planning

- Task: Fixes #630

## Testing

- Backend: `uv run pytest tests/integration/object_content/test_moves.py tests/integration/object_content/test_deployment_policy_integration.py -q` — 22 passed against real PostgreSQL 13 + SeaweedFS (testcontainers). New tests: degraded-store move-back, unconfigured-store pin, auth-asymmetry contract. `uv run pyright` 0 errors; ruff check and format clean.
- Frontend: `bun run test:unit -- storage-page` — 28 passed (the 2 new tests failed first for the right reason). `bun run check` clean. Three existing tests adjusted: the blanket-disable test rescoped to the object-store destination, and two tests' policy setup made explicitly object-store (they previously relied on the old hardcoded default).
- Docs build green.
- Peer commit gate: green, minimum score 8.

## Screenshots

No visual changes beyond alert copy; the moves form renders as before with destination-dependent enablement.
