### PR TITLE
feat: deliver committed knowledge jobs reliably after crashes between database and queue

### DIFF
--- a/backend/alembic/versions/202607281600_add_durable_job_dispatch.py
+++ b/backend/alembic/versions/202607281600_add_durable_job_dispatch.py
@@ -3,6 +3,10 @@
 Revision ID: 202607281600
 Revises: 202607281340
 Create Date: 2026-07-28 16:00:00.000000
+
+The partial index is built concurrently so upgrades do not block job writes.
+If a build fails, rerun the migration: column creation is idempotent and the
+explicit concurrent drop removes any invalid index before retrying.
 """
 
 from collections.abc import Sequence
@@ -24,6 +28,7 @@ def upgrade() -> None:
     op.add_column(
         "jobs",
         sa.Column("dispatch_envelope", postgresql.JSONB(), nullable=True),
+        if_not_exists=True,
     )
     op.add_column(
         "jobs",
@@ -32,19 +37,23 @@ def upgrade() -> None:
             sa.DateTime(timezone=True),
             nullable=True,
         ),
+        if_not_exists=True,
     )
-    op.execute(
-        f"""
-        CREATE INDEX {_INDEX}
-        ON jobs (dispatch_attempted_at ASC NULLS FIRST, id ASC)
-        WHERE status = 'queued'
-          AND dispatch_envelope IS NOT NULL
-          AND task IN ('upload_info_blob', 'transcription')
-        """
-    )
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX}")
+        op.execute(
+            f"""
+            CREATE INDEX CONCURRENTLY {_INDEX}
+            ON jobs (dispatch_attempted_at ASC NULLS FIRST, id ASC)
+            WHERE status = 'queued'
+              AND dispatch_envelope IS NOT NULL
+              AND task IN ('upload_info_blob', 'transcription')
+            """
+        )
 
 
 def downgrade() -> None:
-    op.drop_index(_INDEX, table_name="jobs")
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX}")
     op.drop_column("jobs", "dispatch_attempted_at")
     op.drop_column("jobs", "dispatch_envelope")

--- a/backend/alembic/versions/202607281600_add_durable_job_dispatch.py
+++ b/backend/alembic/versions/202607281600_add_durable_job_dispatch.py
@@ -53,6 +53,28 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    pending_count = int(
+        op.get_bind()
+        .execute(
+            sa.text(
+                """
+                SELECT count(*)
+                FROM jobs
+                WHERE dispatch_envelope IS NOT NULL
+                  AND status IN ('queued', 'in progress')
+                  AND task IN ('upload_info_blob', 'transcription')
+                """
+            )
+        )
+        .scalar_one()
+    )
+    if pending_count:
+        raise RuntimeError(
+            "Cannot downgrade durable job dispatch while "
+            f"{pending_count} queued or in-progress envelope jobs remain. "
+            "Drain them or explicitly fail them before retrying."
+        )
+
     with op.get_context().autocommit_block():
         op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX}")
     op.drop_column("jobs", "dispatch_attempted_at")

--- a/backend/alembic/versions/202607281600_add_durable_job_dispatch.py
+++ b/backend/alembic/versions/202607281600_add_durable_job_dispatch.py
@@ -1,0 +1,50 @@
+"""add durable job dispatch state
+
+Revision ID: 202607281600
+Revises: 202607281340
+Create Date: 2026-07-28 16:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "202607281600"
+down_revision: str | None = "202607281340"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_INDEX = "ix_jobs_durable_dispatch"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column("dispatch_envelope", postgresql.JSONB(), nullable=True),
+    )
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "dispatch_attempted_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.execute(
+        f"""
+        CREATE INDEX {_INDEX}
+        ON jobs (dispatch_attempted_at ASC NULLS FIRST, id ASC)
+        WHERE status = 'queued'
+          AND dispatch_envelope IS NOT NULL
+          AND task IN ('upload_info_blob', 'transcription')
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(_INDEX, table_name="jobs")
+    op.drop_column("jobs", "dispatch_attempted_at")
+    op.drop_column("jobs", "dispatch_envelope")

--- a/backend/alembic/versions/202607281600_add_durable_job_dispatch.py
+++ b/backend/alembic/versions/202607281600_add_durable_job_dispatch.py
@@ -7,6 +7,8 @@ Create Date: 2026-07-28 16:00:00.000000
 The partial index is built concurrently so upgrades do not block job writes.
 If a build fails, rerun the migration: column creation is idempotent and the
 explicit concurrent drop removes any invalid index before retrying.
+Downgrade intentionally blocks job writers so its envelope guard and destructive
+DDL run atomically.
 """
 
 from collections.abc import Sequence
@@ -53,6 +55,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    op.execute("LOCK TABLE jobs IN ACCESS EXCLUSIVE MODE")
     pending_count = int(
         op.get_bind()
         .execute(
@@ -75,7 +78,6 @@ def downgrade() -> None:
             "Drain them or explicitly fail them before retrying."
         )
 
-    with op.get_context().autocommit_block():
-        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX}")
+    op.execute(f"DROP INDEX IF EXISTS {_INDEX}")
     op.drop_column("jobs", "dispatch_attempted_at")
     op.drop_column("jobs", "dispatch_envelope")

--- a/backend/src/eneo/database/tables/job_table.py
+++ b/backend/src/eneo/database/tables/job_table.py
@@ -3,6 +3,7 @@ from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
 from eneo.database.tables.base_class import BasePublic
@@ -16,3 +17,7 @@ class Jobs(BasePublic):
     result_location: Mapped[Optional[str]] = mapped_column()
     name: Mapped[Optional[str]] = mapped_column()
     finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
+    dispatch_envelope: Mapped[Optional[dict[str, object]]] = mapped_column(JSONB)
+    dispatch_attempted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True)
+    )

--- a/backend/src/eneo/jobs/durable_dispatch.py
+++ b/backend/src/eneo/jobs/durable_dispatch.py
@@ -1,0 +1,87 @@
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+import sqlalchemy as sa
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from eneo.database.tables.job_table import Jobs
+from eneo.jobs.job_models import Task
+from eneo.jobs.task_models import TaskParams, validate_dispatch_envelope
+from eneo.main.logging import get_logger
+from eneo.main.models import Status
+
+logger = get_logger(__name__)
+
+DISPATCH_PAGE_SIZE = 50
+DISPATCH_STALE_AFTER = timedelta(minutes=5)
+_DURABLE_TASKS = (Task.UPLOAD_FILE.value, Task.TRANSCRIPTION.value)
+Enqueue = Callable[[Task, UUID, TaskParams], Awaitable[object]]
+
+
+@dataclass(frozen=True)
+class RedispatchResult:
+    claimed: int
+    enqueued: int
+    failed: int
+
+
+async def redispatch_stale_jobs(
+    session: AsyncSession,
+    *,
+    enqueue: Enqueue,
+    now: datetime | None = None,
+) -> RedispatchResult:
+    attempted_at = now or datetime.now(timezone.utc)
+    stale_before = attempted_at - DISPATCH_STALE_AFTER
+    statement = (
+        sa.select(Jobs)
+        .where(Jobs.status == Status.QUEUED.value)
+        .where(Jobs.dispatch_envelope.is_not(None))
+        .where(Jobs.task.in_(_DURABLE_TASKS))
+        .where(Jobs.created_at <= stale_before)
+        .where(
+            sa.or_(
+                Jobs.dispatch_attempted_at.is_(None),
+                Jobs.dispatch_attempted_at <= stale_before,
+            )
+        )
+        .order_by(Jobs.dispatch_attempted_at.asc().nullsfirst(), Jobs.id.asc())
+        .limit(DISPATCH_PAGE_SIZE)
+        .with_for_update(skip_locked=True)
+    )
+    jobs = list((await session.scalars(statement)).all())
+    for job in jobs:
+        job.dispatch_attempted_at = attempted_at
+    await session.flush()
+
+    enqueued = 0
+    failed = 0
+    for job in jobs:
+        try:
+            envelope = validate_dispatch_envelope(job.dispatch_envelope)
+            task = Task(job.task)
+            if envelope.task != task:
+                raise ValueError("task does not match the persisted job")
+            if envelope.params.user_id != job.user_id:
+                raise ValueError("user does not match the persisted job")
+        except (ValidationError, ValueError) as exc:
+            reason = f"Invalid dispatch envelope: {exc}"
+            job.status = Status.FAILED.value
+            job.finished_at = attempted_at
+            job.result_location = reason[:512]
+            failed += 1
+            logger.warning(
+                "Durable job dispatch envelope is invalid",
+                extra={"job_id": str(job.id), "reason": reason},
+            )
+            continue
+
+        result = await enqueue(task, job.id, envelope.params)
+        if result is not None:
+            enqueued += 1
+
+    await session.flush()
+    return RedispatchResult(claimed=len(jobs), enqueued=enqueued, failed=failed)

--- a/backend/src/eneo/jobs/durable_dispatch.py
+++ b/backend/src/eneo/jobs/durable_dispatch.py
@@ -24,7 +24,12 @@ logger = get_logger(__name__)
 
 DISPATCH_PAGE_SIZE = 50
 DISPATCH_STALE_AFTER = timedelta(minutes=5)
-_DURABLE_TASKS = (Task.UPLOAD_FILE.value, Task.TRANSCRIPTION.value)
+# Prepared plans must see the fixed predicate used by the partial index.
+_QUEUED_SQL = sa.literal_column("'queued'", type_=sa.String())
+_DURABLE_TASKS_SQL = (
+    sa.literal_column("'upload_info_blob'", type_=sa.String()),
+    sa.literal_column("'transcription'", type_=sa.String()),
+)
 Enqueue = Callable[[Task, UUID, TaskParams], Awaitable[ArqJob | None]]
 
 
@@ -39,7 +44,8 @@ def build_knowledge_dispatch_params(
     params: UploadInfoBlob | Transcription, job_id: UUID
 ) -> UploadInfoBlob | Transcription:
     payload = params.model_copy()
-    # Remove after the next release once the ARQ queue TTL and rollback window pass.
+    # Remove only when the minimum upgrade source includes this release, pre-bridge
+    # ARQ backlog has drained (TTL ~24h), and no rollback window remains.
     object.__setattr__(payload, "filepath", str(job_staging_path(job_id)))
     return payload
 
@@ -50,9 +56,9 @@ def stale_dispatch_statement(
     stale_before = attempted_at - DISPATCH_STALE_AFTER
     return (
         sa.select(Jobs)
-        .where(Jobs.status == Status.QUEUED.value)
+        .where(Jobs.status == _QUEUED_SQL)
         .where(Jobs.dispatch_envelope.is_not(None))
-        .where(Jobs.task.in_(_DURABLE_TASKS))
+        .where(Jobs.task.in_(_DURABLE_TASKS_SQL))
         .where(Jobs.created_at <= stale_before)
         .where(
             sa.or_(

--- a/backend/src/eneo/jobs/durable_dispatch.py
+++ b/backend/src/eneo/jobs/durable_dispatch.py
@@ -4,12 +4,19 @@ from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 import sqlalchemy as sa
+from arq.jobs import Job as ArqJob
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eneo.database.tables.job_table import Jobs
 from eneo.jobs.job_models import Task
-from eneo.jobs.task_models import TaskParams, validate_dispatch_envelope
+from eneo.jobs.job_staging import job_staging_path
+from eneo.jobs.task_models import (
+    TaskParams,
+    Transcription,
+    UploadInfoBlob,
+    validate_dispatch_envelope,
+)
 from eneo.main.logging import get_logger
 from eneo.main.models import Status
 
@@ -18,7 +25,7 @@ logger = get_logger(__name__)
 DISPATCH_PAGE_SIZE = 50
 DISPATCH_STALE_AFTER = timedelta(minutes=5)
 _DURABLE_TASKS = (Task.UPLOAD_FILE.value, Task.TRANSCRIPTION.value)
-Enqueue = Callable[[Task, UUID, TaskParams], Awaitable[object]]
+Enqueue = Callable[[Task, UUID, TaskParams], Awaitable[ArqJob | None]]
 
 
 @dataclass(frozen=True)
@@ -28,15 +35,20 @@ class RedispatchResult:
     failed: int
 
 
-async def redispatch_stale_jobs(
-    session: AsyncSession,
-    *,
-    enqueue: Enqueue,
-    now: datetime | None = None,
-) -> RedispatchResult:
-    attempted_at = now or datetime.now(timezone.utc)
+def build_knowledge_dispatch_params(
+    params: UploadInfoBlob | Transcription, job_id: UUID
+) -> UploadInfoBlob | Transcription:
+    payload = params.model_copy()
+    # Remove after the next release once the ARQ queue TTL and rollback window pass.
+    object.__setattr__(payload, "filepath", str(job_staging_path(job_id)))
+    return payload
+
+
+def stale_dispatch_statement(
+    attempted_at: datetime,
+) -> sa.Select[tuple[Jobs]]:
     stale_before = attempted_at - DISPATCH_STALE_AFTER
-    statement = (
+    return (
         sa.select(Jobs)
         .where(Jobs.status == Status.QUEUED.value)
         .where(Jobs.dispatch_envelope.is_not(None))
@@ -52,6 +64,16 @@ async def redispatch_stale_jobs(
         .limit(DISPATCH_PAGE_SIZE)
         .with_for_update(skip_locked=True)
     )
+
+
+async def redispatch_stale_jobs(
+    session: AsyncSession,
+    *,
+    enqueue: Enqueue,
+    now: datetime | None = None,
+) -> RedispatchResult:
+    attempted_at = now or datetime.now(timezone.utc)
+    statement = stale_dispatch_statement(attempted_at)
     jobs = list((await session.scalars(statement)).all())
     for job in jobs:
         job.dispatch_attempted_at = attempted_at
@@ -79,7 +101,8 @@ async def redispatch_stale_jobs(
             )
             continue
 
-        result = await enqueue(task, job.id, envelope.params)
+        dispatch_params = build_knowledge_dispatch_params(envelope.params, job.id)
+        result = await enqueue(task, job.id, dispatch_params)
         if result is not None:
             enqueued += 1
 

--- a/backend/src/eneo/jobs/job_manager.py
+++ b/backend/src/eneo/jobs/job_manager.py
@@ -43,7 +43,7 @@ class JobManager:
         if self._redis is None:
             raise NotReadyException("Job manager is not initialized!")
 
-        await self._redis.enqueue_job(task, params, _job_id=str(job_id))
+        return await self._redis.enqueue_job(task, params, _job_id=str(job_id))
 
     async def enqueue_jobless(self, task: Task):
         assert self._redis is not None

--- a/backend/src/eneo/jobs/job_manager.py
+++ b/backend/src/eneo/jobs/job_manager.py
@@ -39,7 +39,7 @@ class JobManager:
         await self._redis.aclose()
         self._redis = None
 
-    async def enqueue(self, task: Task, job_id: UUID, params: TaskParams):
+    async def enqueue(self, task: Task, job_id: UUID, params: TaskParams) -> Job | None:
         if self._redis is None:
             raise NotReadyException("Job manager is not initialized!")
 

--- a/backend/src/eneo/jobs/job_repo.py
+++ b/backend/src/eneo/jobs/job_repo.py
@@ -25,7 +25,7 @@ class JobRepository:
     async def add_job(self, job: Job):
         return await self.delegate.add(job)
 
-    async def add_restart_safe_job(
+    async def add_durable_knowledge_job(
         self,
         job: Job,
         *,

--- a/backend/src/eneo/jobs/job_repo.py
+++ b/backend/src/eneo/jobs/job_repo.py
@@ -9,6 +9,7 @@ from eneo.database.repositories.base import BaseRepositoryDelegate
 from eneo.database.tables.job_table import Jobs
 from eneo.jobs.job_manager import job_manager
 from eneo.jobs.job_models import Job, JobInDb, JobUpdate
+from eneo.jobs.task_models import DispatchEnvelope
 
 
 class JobRepository:
@@ -23,6 +24,19 @@ class JobRepository:
 
     async def add_job(self, job: Job):
         return await self.delegate.add(job)
+
+    async def add_restart_safe_job(
+        self,
+        job: Job,
+        *,
+        job_id: UUID,
+        dispatch_envelope: DispatchEnvelope,
+    ) -> JobInDb:
+        return await self.delegate.add(
+            job,
+            id=job_id,
+            dispatch_envelope=dispatch_envelope.model_dump(mode="json"),
+        )
 
     async def update_job(self, id: UUID, job: JobUpdate):
         stmt = (

--- a/backend/src/eneo/jobs/job_service.py
+++ b/backend/src/eneo/jobs/job_service.py
@@ -1,13 +1,24 @@
+import asyncio
 from datetime import datetime, timezone
-from uuid import UUID
+from uuid import UUID, uuid4
+
+from sqlalchemy import event
 
 from eneo.jobs.job_manager import job_manager
 from eneo.jobs.job_models import Job, JobInDb, JobUpdate, Task
 from eneo.jobs.job_repo import JobRepository
-from eneo.jobs.task_models import TaskParams
+from eneo.jobs.task_models import (
+    TaskParams,
+    Transcription,
+    UploadInfoBlob,
+    build_dispatch_envelope,
+)
 from eneo.main.exceptions import NotFoundException
+from eneo.main.logging import get_logger
 from eneo.main.models import Status
 from eneo.users.user import UserInDB
+
+logger = get_logger(__name__)
 
 
 class JobService:
@@ -29,6 +40,45 @@ class JobService:
         if enqueue:
             await job_manager.enqueue(task, job_in_db.id, task_params)
 
+        return job_in_db
+
+    async def queue_restart_safe_job(
+        self,
+        task: Task,
+        *,
+        name: str,
+        task_params: UploadInfoBlob | Transcription,
+        job_id: UUID | None = None,
+    ) -> JobInDb:
+        if task not in (Task.UPLOAD_FILE, Task.TRANSCRIPTION):
+            raise ValueError(f"Task {task.value} does not support durable dispatch")
+
+        envelope = build_dispatch_envelope(task, task_params)
+        job = Job(task=task, name=name, status=Status.QUEUED, user_id=self.user.id)
+        job_in_db = await self.job_repo.add_restart_safe_job(
+            job,
+            job_id=job_id or uuid4(),
+            dispatch_envelope=envelope,
+        )
+
+        async def dispatch_after_commit() -> None:
+            try:
+                await job_manager.enqueue(task, job_in_db.id, task_params)
+            except Exception:
+                logger.exception(
+                    "Immediate durable job dispatch failed",
+                    extra={"job_id": str(job_in_db.id), "task": task.value},
+                )
+
+        def schedule_dispatch(_session: object) -> None:
+            asyncio.get_running_loop().create_task(dispatch_after_commit())
+
+        event.listen(
+            self.job_repo.delegate.session.sync_session,
+            "after_commit",
+            schedule_dispatch,
+            once=True,
+        )
         return job_in_db
 
     async def set_status(self, job_id: UUID, status: Status):

--- a/backend/src/eneo/jobs/job_service.py
+++ b/backend/src/eneo/jobs/job_service.py
@@ -8,6 +8,7 @@ from eneo.jobs.durable_dispatch import build_knowledge_dispatch_params
 from eneo.jobs.job_manager import job_manager
 from eneo.jobs.job_models import Job, JobInDb, JobUpdate, Task
 from eneo.jobs.job_repo import JobRepository
+from eneo.jobs.job_staging import job_staging_path
 from eneo.jobs.task_models import (
     TaskParams,
     Transcription,
@@ -81,6 +82,15 @@ class JobService:
                     extra={"job_id": str(job_in_db.id), "task": task.value},
                 )
 
+        def cleanup_after_rollback() -> None:
+            try:
+                job_staging_path(job_in_db.id).unlink(missing_ok=True)
+            except Exception:
+                logger.exception(
+                    "Durable job staging cleanup after rollback failed",
+                    extra={"job_id": str(job_in_db.id), "task": task.value},
+                )
+
         outer_committed = False
         active = True
 
@@ -104,6 +114,8 @@ class JobService:
             loop = asyncio.get_running_loop()
             if outer_committed:
                 loop.create_task(dispatch_after_commit())
+            else:
+                cleanup_after_rollback()
             loop.call_soon(remove_listeners)
 
         event.listen(session, "after_commit", after_commit)

--- a/backend/src/eneo/jobs/job_service.py
+++ b/backend/src/eneo/jobs/job_service.py
@@ -4,6 +4,7 @@ from uuid import UUID, uuid4
 
 from sqlalchemy import event
 
+from eneo.jobs.durable_dispatch import build_knowledge_dispatch_params
 from eneo.jobs.job_manager import job_manager
 from eneo.jobs.job_models import Job, JobInDb, JobUpdate, Task
 from eneo.jobs.job_repo import JobRepository
@@ -42,7 +43,7 @@ class JobService:
 
         return job_in_db
 
-    async def queue_restart_safe_job(
+    async def queue_durable_knowledge_job(
         self,
         task: Task,
         *,
@@ -52,10 +53,12 @@ class JobService:
     ) -> JobInDb:
         if task not in (Task.UPLOAD_FILE, Task.TRANSCRIPTION):
             raise ValueError(f"Task {task.value} does not support durable dispatch")
+        if task_params.user_id != self.user.id:
+            raise ValueError("Durable knowledge job user does not match service user")
 
         envelope = build_dispatch_envelope(task, task_params)
         job = Job(task=task, name=name, status=Status.QUEUED, user_id=self.user.id)
-        job_in_db = await self.job_repo.add_restart_safe_job(
+        job_in_db = await self.job_repo.add_durable_knowledge_job(
             job,
             job_id=job_id or uuid4(),
             dispatch_envelope=envelope,
@@ -63,22 +66,44 @@ class JobService:
 
         async def dispatch_after_commit() -> None:
             try:
-                await job_manager.enqueue(task, job_in_db.id, task_params)
+                dispatch_params = build_knowledge_dispatch_params(
+                    task_params, job_in_db.id
+                )
+                await job_manager.enqueue(task, job_in_db.id, dispatch_params)
             except Exception:
                 logger.exception(
                     "Immediate durable job dispatch failed",
                     extra={"job_id": str(job_in_db.id), "task": task.value},
                 )
 
-        def schedule_dispatch(_session: object) -> None:
-            asyncio.get_running_loop().create_task(dispatch_after_commit())
+        session = self.job_repo.delegate.session.sync_session
+        outer_committed = False
+        active = True
 
-        event.listen(
-            self.job_repo.delegate.session.sync_session,
-            "after_commit",
-            schedule_dispatch,
-            once=True,
-        )
+        def after_commit(committed_session: object) -> None:
+            nonlocal outer_committed
+            if active and not session.in_nested_transaction():
+                outer_committed = True
+
+        def remove_listeners() -> None:
+            if event.contains(session, "after_commit", after_commit):
+                event.remove(session, "after_commit", after_commit)
+            if event.contains(session, "after_transaction_end", after_transaction_end):
+                event.remove(session, "after_transaction_end", after_transaction_end)
+
+        def after_transaction_end(_session: object, transaction: object) -> None:
+            nonlocal active
+            if getattr(transaction, "parent", None) is not None:
+                return
+
+            active = False
+            loop = asyncio.get_running_loop()
+            if outer_committed:
+                loop.create_task(dispatch_after_commit())
+            loop.call_soon(remove_listeners)
+
+        event.listen(session, "after_commit", after_commit)
+        event.listen(session, "after_transaction_end", after_transaction_end)
         return job_in_db
 
     async def set_status(self, job_id: UUID, status: Status):

--- a/backend/src/eneo/jobs/job_service.py
+++ b/backend/src/eneo/jobs/job_service.py
@@ -51,6 +51,11 @@ class JobService:
         task_params: UploadInfoBlob | Transcription,
         job_id: UUID | None = None,
     ) -> JobInDb:
+        session = self.job_repo.delegate.session.sync_session
+        if session.in_nested_transaction():
+            raise ValueError(
+                "Durable knowledge jobs cannot be created in a nested transaction"
+            )
         if task not in (Task.UPLOAD_FILE, Task.TRANSCRIPTION):
             raise ValueError(f"Task {task.value} does not support durable dispatch")
         if task_params.user_id != self.user.id:
@@ -76,7 +81,6 @@ class JobService:
                     extra={"job_id": str(job_in_db.id), "task": task.value},
                 )
 
-        session = self.job_repo.delegate.session.sync_session
         outer_committed = False
         active = True
 
@@ -93,7 +97,7 @@ class JobService:
 
         def after_transaction_end(_session: object, transaction: object) -> None:
             nonlocal active
-            if getattr(transaction, "parent", None) is not None:
+            if not active or getattr(transaction, "parent", None) is not None:
                 return
 
             active = False

--- a/backend/src/eneo/jobs/job_staging.py
+++ b/backend/src/eneo/jobs/job_staging.py
@@ -1,0 +1,30 @@
+import asyncio
+import contextlib
+import shutil
+from pathlib import Path
+from typing import IO
+from uuid import UUID
+
+from eneo.main.config import get_settings
+
+
+def job_staging_path(job_id: UUID, *, upload_tmp_dir: Path | None = None) -> Path:
+    root = upload_tmp_dir or get_settings().upload_tmp_dir
+    return root / "job-staging" / str(job_id)
+
+
+async def stage_job_file(file: IO[bytes], job_id: UUID) -> Path:
+    destination = job_staging_path(job_id)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with destination.open("wb") as buffer:
+            await asyncio.to_thread(shutil.copyfileobj, file, buffer)
+    except BaseException:
+        with contextlib.suppress(FileNotFoundError):
+            destination.unlink()
+        raise
+    finally:
+        file.close()
+
+    return destination

--- a/backend/src/eneo/jobs/task_models.py
+++ b/backend/src/eneo/jobs/task_models.py
@@ -1,7 +1,9 @@
-from typing import Optional
+from typing import Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, TypeAdapter
+
+from eneo.jobs.job_models import Task
 
 
 class TaskParams(BaseModel):
@@ -23,7 +25,8 @@ class InfoBlobTask(TaskParams):
 
 
 class UploadTask(InfoBlobTask):
-    filepath: str
+    model_config = ConfigDict(extra="forbid")
+
     filename: str
     mimetype: str
 
@@ -42,6 +45,38 @@ class UploadInfoBlob(UploadTask):
 
 class Transcription(UploadTask):
     pass
+
+
+class UploadInfoBlobDispatchEnvelope(BaseModel):
+    version: Literal[1] = 1
+    task: Literal[Task.UPLOAD_FILE] = Task.UPLOAD_FILE
+    params: UploadInfoBlob
+
+
+class TranscriptionDispatchEnvelope(BaseModel):
+    version: Literal[1] = 1
+    task: Literal[Task.TRANSCRIPTION] = Task.TRANSCRIPTION
+    params: Transcription
+
+
+DispatchEnvelope = UploadInfoBlobDispatchEnvelope | TranscriptionDispatchEnvelope
+_DISPATCH_ENVELOPE_ADAPTER: TypeAdapter[DispatchEnvelope] = TypeAdapter(
+    DispatchEnvelope
+)
+
+
+def build_dispatch_envelope(
+    task: Task, params: UploadInfoBlob | Transcription
+) -> DispatchEnvelope:
+    if task == Task.UPLOAD_FILE and isinstance(params, UploadInfoBlob):
+        return UploadInfoBlobDispatchEnvelope(params=params)
+    if task == Task.TRANSCRIPTION and isinstance(params, Transcription):
+        return TranscriptionDispatchEnvelope(params=params)
+    raise ValueError(f"Unsupported durable dispatch task: {task.value}")
+
+
+def validate_dispatch_envelope(value: object) -> DispatchEnvelope:
+    return _DISPATCH_ENVELOPE_ADAPTER.validate_python(value)
 
 
 class AnalyzeConversationInsightsTask(TaskParams):

--- a/backend/src/eneo/jobs/task_service.py
+++ b/backend/src/eneo/jobs/task_service.py
@@ -121,7 +121,7 @@ class TaskService:
                 )
 
             # Set name of the job to the filename being processed
-            job = await self.job_service.queue_restart_safe_job(
+            job = await self.job_service.queue_durable_knowledge_job(
                 task_type,
                 name=filename,
                 task_params=params,

--- a/backend/src/eneo/jobs/task_service.py
+++ b/backend/src/eneo/jobs/task_service.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import os
 from tempfile import SpooledTemporaryFile
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from eneo.admin.quota_service import QuotaService
 from eneo.files.audio import AudioMimeTypes
@@ -10,7 +10,8 @@ from eneo.files.file_size_service import FileSizeService
 from eneo.files.text import TextMimeTypes
 from eneo.jobs.job_models import JobInDb, Task
 from eneo.jobs.job_service import JobService
-from eneo.jobs.task_models import TaskParams, Transcription, UploadInfoBlob
+from eneo.jobs.job_staging import stage_job_file
+from eneo.jobs.task_models import Transcription, UploadInfoBlob
 from eneo.main.exceptions import FileNotSupportedException, FileTooLargeException
 from eneo.object_content.deployment_policy import (
     UploadAdmissionSnapshot,
@@ -97,12 +98,12 @@ class TaskService:
         await self.validate_file_size(file, task_type)
         await self.ensure_quota(file, task_type)
 
-        filepath = await self.file_size_service.save_file_to_disk(file)
+        job_id = uuid4()
+        filepath = await stage_job_file(file, job_id)
 
         try:
             if task_type == Task.UPLOAD_FILE:
-                params: TaskParams = UploadInfoBlob(
-                    filepath=filepath,
+                params: UploadInfoBlob | Transcription = UploadInfoBlob(
                     filename=filename,
                     user_id=self.user.id,
                     group_id=group_id,
@@ -112,7 +113,6 @@ class TaskService:
             else:
                 # task_type == Task.TRANSCRIPTION (get_task_type raises for any other value)
                 params = Transcription(
-                    filepath=filepath,
                     filename=filename,
                     user_id=self.user.id,
                     group_id=group_id,
@@ -121,8 +121,11 @@ class TaskService:
                 )
 
             # Set name of the job to the filename being processed
-            job = await self.job_service.queue_job(
-                task_type, name=filename, task_params=params
+            job = await self.job_service.queue_restart_safe_job(
+                task_type,
+                name=filename,
+                task_params=params,
+                job_id=job_id,
             )
         except BaseException:
             with contextlib.suppress(FileNotFoundError):

--- a/backend/src/eneo/worker/routes.py
+++ b/backend/src/eneo/worker/routes.py
@@ -10,6 +10,8 @@ from eneo.audit.application.audit_task_params import (
 from eneo.audit.application.audit_worker_task import log_audit_event_task
 from eneo.audit.application.export_worker_task import export_audit_logs_task
 from eneo.database.database import AsyncSession
+from eneo.jobs.durable_dispatch import redispatch_stale_jobs
+from eneo.jobs.job_manager import job_manager
 from eneo.jobs.task_models import (
     AnalyzeConversationInsightsTask,
     Transcription,
@@ -78,16 +80,23 @@ class AuditPurgeResult(TypedDict):
     success: bool
 
 
-@worker.function()
+@worker.function(keep_result=0)
 async def upload_info_blob(job_id: UUID, params: UploadInfoBlob, container: Container):
     return await upload_info_blob_task(
         job_id=job_id, params=params, container=container
     )
 
 
-@worker.function()
+@worker.function(keep_result=0)
 async def transcription(job_id: UUID, params: Transcription, container: Container):
     return await transcription_task(job_id=job_id, params=params, container=container)
+
+
+@worker.cron_job(manages_own_session=True)
+async def redispatch_durable_knowledge_jobs(container: Container) -> None:
+    session = cast(AsyncSession, container.session())
+    async with session.begin():
+        await redispatch_stale_jobs(session, enqueue=job_manager.enqueue)
 
 
 @worker.long_running_function()

--- a/backend/src/eneo/worker/upload_tasks.py
+++ b/backend/src/eneo/worker/upload_tasks.py
@@ -19,7 +19,8 @@ def _remove_file(filepath: Path):
 
 
 def _job_file_path(job_id: UUID, params: UploadInfoBlob | Transcription) -> Path:
-    # Remove after the next release once the ARQ queue TTL and rollback window pass.
+    # Remove only when the minimum upgrade source includes this release, pre-bridge
+    # ARQ backlog has drained (TTL ~24h), and no rollback window remains.
     legacy_path = getattr(params, "filepath", None)
     if isinstance(legacy_path, str) and legacy_path.strip():
         return Path(legacy_path)

--- a/backend/src/eneo/worker/upload_tasks.py
+++ b/backend/src/eneo/worker/upload_tasks.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from eneo.files.text import NoExtractableTextError
+from eneo.jobs.job_staging import job_staging_path
 from eneo.jobs.task_models import Transcription, UploadInfoBlob
 from eneo.main.container.container import Container
 from eneo.main.exceptions import BadRequestException
@@ -25,7 +26,7 @@ async def transcription_task(
 ):
     task_manager = container.task_manager(job_id=job_id)
     async with task_manager.set_status_on_exception():
-        filepath = Path(params.filepath)
+        filepath = job_staging_path(job_id)
 
         # Define cleanup function
         task_manager.cleanup_func = lambda: _remove_file(filepath)
@@ -77,7 +78,7 @@ async def upload_info_blob_task(
 ):
     task_manager = container.task_manager(job_id=job_id)
     async with task_manager.set_status_on_exception():
-        filepath = Path(params.filepath)
+        filepath = job_staging_path(job_id)
 
         # Define cleanup function
         task_manager.cleanup_func = lambda: _remove_file(filepath)

--- a/backend/src/eneo/worker/upload_tasks.py
+++ b/backend/src/eneo/worker/upload_tasks.py
@@ -18,6 +18,14 @@ def _remove_file(filepath: Path):
         os.remove(filepath)
 
 
+def _job_file_path(job_id: UUID, params: UploadInfoBlob | Transcription) -> Path:
+    # Remove after the next release once the ARQ queue TTL and rollback window pass.
+    legacy_path = getattr(params, "filepath", None)
+    if isinstance(legacy_path, str) and legacy_path.strip():
+        return Path(legacy_path)
+    return job_staging_path(job_id)
+
+
 async def transcription_task(
     *,
     job_id: UUID,
@@ -26,7 +34,7 @@ async def transcription_task(
 ):
     task_manager = container.task_manager(job_id=job_id)
     async with task_manager.set_status_on_exception():
-        filepath = job_staging_path(job_id)
+        filepath = _job_file_path(job_id, params)
 
         # Define cleanup function
         task_manager.cleanup_func = lambda: _remove_file(filepath)
@@ -78,7 +86,7 @@ async def upload_info_blob_task(
 ):
     task_manager = container.task_manager(job_id=job_id)
     async with task_manager.set_status_on_exception():
-        filepath = job_staging_path(job_id)
+        filepath = _job_file_path(job_id, params)
 
         # Define cleanup function
         task_manager.cleanup_func = lambda: _remove_file(filepath)

--- a/backend/src/eneo/worker/worker.py
+++ b/backend/src/eneo/worker/worker.py
@@ -10,6 +10,8 @@ from uuid import UUID
 import crochet
 import sqlalchemy as sa
 from arq.cron import cron
+from arq.worker import Function
+from arq.worker import func as arq_func
 from dependency_injector import providers
 from opentelemetry import trace
 
@@ -176,7 +178,7 @@ class Worker:
     def __init__(self):
         super().__init__()
         settings = get_settings()
-        self.functions: list[Callable[..., Any]] = []
+        self.functions: list[Callable[..., Any] | Function] = []
         self.cron_jobs: list[Any] = []
         self.redis_settings = build_arq_redis_settings(settings)
         self.on_startup = self.startup
@@ -328,7 +330,7 @@ class Worker:
 
         await lifespan.shutdown()
 
-    def function(self, with_user: bool = True):
+    def function(self, with_user: bool = True, *, keep_result: int | None = None):
         def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
             @wraps(func)
             async def wrapper(ctx: ARQContext, params: object) -> Any:
@@ -347,7 +349,12 @@ class Worker:
                     assert job_id is not None
                     return await func(job_id, params, container=container)
 
-            self.functions.append(_traced_job("job", wrapper))
+            traced = _traced_job("job", wrapper)
+            self.functions.append(
+                arq_func(traced, keep_result=keep_result)
+                if keep_result is not None
+                else traced
+            )
             return wrapper
 
         return decorator
@@ -530,7 +537,12 @@ class Worker:
 
         logger.debug(
             "Including functions from subworker: %s",
-            [func.__name__ for func in sub_worker.functions],
+            [
+                registered.name
+                if isinstance(registered, Function)
+                else registered.__name__
+                for registered in sub_worker.functions
+            ],
         )
         logger.debug(
             "Including cron jobs from subworker: %s",

--- a/backend/tests/integration/jobs/test_durable_dispatch.py
+++ b/backend/tests/integration/jobs/test_durable_dispatch.py
@@ -8,6 +8,7 @@ from uuid import UUID, uuid4
 
 import pytest
 import sqlalchemy as sa
+from arq.jobs import Job as ArqJob
 from arq.jobs import JobStatus
 
 from eneo.database.database import sessionmanager
@@ -26,6 +27,7 @@ from eneo.jobs.task_models import (
     Transcription,
     UploadInfoBlob,
     build_dispatch_envelope,
+    validate_dispatch_envelope,
 )
 from eneo.main.models import Status
 
@@ -52,9 +54,10 @@ async def _insert_stale_job(
     status: Status = Status.QUEUED,
     attempted_at: datetime | None = None,
     job_id: UUID | None = None,
+    params: UploadInfoBlob | Transcription | None = None,
 ) -> UUID:
     job_id = job_id or uuid4()
-    params = _params(task, user_id)
+    params = params or _params(task, user_id)
     values = {
         "id": job_id,
         "user_id": user_id,
@@ -71,7 +74,7 @@ async def _insert_stale_job(
     return job_id
 
 
-async def test_restart_safe_enqueue_waits_for_commit(admin_user) -> None:
+async def test_durable_enqueue_waits_for_commit(admin_user) -> None:
     params = _params(Task.UPLOAD_FILE, admin_user.id)
     await job_manager.init()
 
@@ -79,7 +82,7 @@ async def test_restart_safe_enqueue_waits_for_commit(admin_user) -> None:
         async with sessionmanager.session() as session:
             async with session.begin():
                 service = JobService(admin_user, JobRepository(session))
-                job = await service.queue_restart_safe_job(
+                job = await service.queue_durable_knowledge_job(
                     Task.UPLOAD_FILE,
                     name=params.filename,
                     task_params=params,
@@ -95,22 +98,74 @@ async def test_restart_safe_enqueue_waits_for_commit(admin_user) -> None:
         await job_manager.close()
 
 
-async def test_redispatch_recovers_lost_delivery_and_advances_attempt(
-    async_session, admin_user
+@pytest.mark.parametrize("task", [Task.UPLOAD_FILE, Task.TRANSCRIPTION])
+async def test_redispatch_recovers_lost_delivery_with_real_redis(
+    async_session, admin_user, task: Task
 ) -> None:
+    params = _params(task, admin_user.id)
     job_id = await _insert_stale_job(
-        async_session, task=Task.UPLOAD_FILE, user_id=admin_user.id
+        async_session,
+        task=task,
+        user_id=admin_user.id,
+        params=params,
     )
-    enqueue = AsyncMock(return_value=None)
+    await job_manager.init()
+    assert await job_manager.get_job_status(job_id) == JobStatus.not_found
 
-    result = await redispatch_stale_jobs(async_session, enqueue=enqueue)
+    assert job_manager._redis is not None
+    arq_job = ArqJob(str(job_id), redis=job_manager._redis)
+    try:
+        result = await redispatch_stale_jobs(async_session, enqueue=job_manager.enqueue)
+        assert await arq_job.status() == JobStatus.queued
+        info = await arq_job.info()
+        assert info is not None
+        assert info.function == task.value
+        assert arq_job.job_id == str(job_id)
+        assert len(info.args) == 1
+        dispatched_params = info.args[0]
+        persisted = await async_session.scalar(
+            sa.select(Jobs.dispatch_envelope).where(Jobs.id == job_id)
+        )
+        envelope = validate_dispatch_envelope(persisted)
+        assert envelope.task == task
+        assert isinstance(dispatched_params, (UploadInfoBlob, Transcription))
+        assert type(dispatched_params) is type(params)
+        assert dispatched_params.model_dump() == envelope.params.model_dump()
+        assert getattr(dispatched_params, "filepath") == str(job_staging_path(job_id))
+    finally:
+        await job_manager.close()
 
     assert result.claimed == 1
-    enqueue.assert_awaited_once()
+    assert result.enqueued == 1
     attempted_at = await async_session.scalar(
         sa.select(Jobs.dispatch_attempted_at).where(Jobs.id == job_id)
     )
     assert attempted_at is not None
+
+
+async def test_redispatch_rejects_envelope_user_mismatch(
+    async_session, admin_user
+) -> None:
+    mismatched_params = _params(Task.UPLOAD_FILE, uuid4())
+    job_id = await _insert_stale_job(
+        async_session,
+        task=Task.UPLOAD_FILE,
+        user_id=admin_user.id,
+        envelope=build_dispatch_envelope(
+            Task.UPLOAD_FILE, mismatched_params
+        ).model_dump(mode="json"),
+    )
+    enqueue = AsyncMock()
+
+    result = await redispatch_stale_jobs(async_session, enqueue=enqueue)
+
+    assert result.failed == 1
+    enqueue.assert_not_awaited()
+    reason = await async_session.scalar(
+        sa.select(Jobs.result_location).where(Jobs.id == job_id)
+    )
+    assert reason is not None
+    assert "user does not match" in reason
 
 
 async def test_redispatch_page_progress_and_cross_task_fairness(

--- a/backend/tests/integration/jobs/test_durable_dispatch.py
+++ b/backend/tests/integration/jobs/test_durable_dispatch.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from arq.jobs import JobStatus
+
+from eneo.database.database import sessionmanager
+from eneo.database.tables.job_table import Jobs
+from eneo.jobs.durable_dispatch import (
+    DISPATCH_PAGE_SIZE,
+    DISPATCH_STALE_AFTER,
+    redispatch_stale_jobs,
+)
+from eneo.jobs.job_manager import job_manager
+from eneo.jobs.job_models import Task
+from eneo.jobs.job_repo import JobRepository
+from eneo.jobs.job_service import JobService
+from eneo.jobs.job_staging import job_staging_path
+from eneo.jobs.task_models import (
+    Transcription,
+    UploadInfoBlob,
+    build_dispatch_envelope,
+)
+from eneo.main.models import Status
+
+pytestmark = pytest.mark.integration
+
+
+def _params(task: Task, user_id: UUID) -> UploadInfoBlob | Transcription:
+    model = UploadInfoBlob if task == Task.UPLOAD_FILE else Transcription
+    return model(
+        filename=f"{task.value}.txt",
+        user_id=user_id,
+        group_id=uuid4(),
+        space_id=uuid4(),
+        mimetype="text/plain",
+    )
+
+
+async def _insert_stale_job(
+    session,
+    *,
+    task: Task,
+    user_id: UUID,
+    envelope: dict[str, object] | None = None,
+    status: Status = Status.QUEUED,
+    attempted_at: datetime | None = None,
+    job_id: UUID | None = None,
+) -> UUID:
+    job_id = job_id or uuid4()
+    params = _params(task, user_id)
+    values = {
+        "id": job_id,
+        "user_id": user_id,
+        "task": task.value,
+        "status": status.value,
+        "name": params.filename,
+        "dispatch_envelope": envelope
+        if envelope is not None
+        else build_dispatch_envelope(task, params).model_dump(mode="json"),
+        "dispatch_attempted_at": attempted_at,
+        "created_at": datetime.now(timezone.utc) - DISPATCH_STALE_AFTER * 2,
+    }
+    await session.execute(sa.insert(Jobs).values(**values))
+    return job_id
+
+
+async def test_restart_safe_enqueue_waits_for_commit(admin_user) -> None:
+    params = _params(Task.UPLOAD_FILE, admin_user.id)
+    await job_manager.init()
+
+    try:
+        async with sessionmanager.session() as session:
+            async with session.begin():
+                service = JobService(admin_user, JobRepository(session))
+                job = await service.queue_restart_safe_job(
+                    Task.UPLOAD_FILE,
+                    name=params.filename,
+                    task_params=params,
+                )
+                assert await job_manager.get_job_status(job.id) == JobStatus.not_found
+
+            for _ in range(50):
+                if await job_manager.get_job_status(job.id) == JobStatus.queued:
+                    break
+                await asyncio.sleep(0.01)
+            assert await job_manager.get_job_status(job.id) == JobStatus.queued
+    finally:
+        await job_manager.close()
+
+
+async def test_redispatch_recovers_lost_delivery_and_advances_attempt(
+    async_session, admin_user
+) -> None:
+    job_id = await _insert_stale_job(
+        async_session, task=Task.UPLOAD_FILE, user_id=admin_user.id
+    )
+    enqueue = AsyncMock(return_value=None)
+
+    result = await redispatch_stale_jobs(async_session, enqueue=enqueue)
+
+    assert result.claimed == 1
+    enqueue.assert_awaited_once()
+    attempted_at = await async_session.scalar(
+        sa.select(Jobs.dispatch_attempted_at).where(Jobs.id == job_id)
+    )
+    assert attempted_at is not None
+
+
+async def test_redispatch_page_progress_and_cross_task_fairness(
+    async_session, admin_user
+) -> None:
+    for offset in range(DISPATCH_PAGE_SIZE):
+        await _insert_stale_job(
+            async_session,
+            task=Task.UPLOAD_FILE,
+            user_id=admin_user.id,
+            job_id=UUID(int=offset + 1),
+        )
+    transcription_id = await _insert_stale_job(
+        async_session,
+        task=Task.TRANSCRIPTION,
+        user_id=admin_user.id,
+        job_id=UUID(int=DISPATCH_PAGE_SIZE + 1),
+    )
+    enqueue = AsyncMock(return_value=None)
+
+    first = await redispatch_stale_jobs(async_session, enqueue=enqueue)
+    second = await redispatch_stale_jobs(async_session, enqueue=enqueue)
+
+    assert first.claimed == DISPATCH_PAGE_SIZE
+    assert second.claimed == 1
+    assert any(call.args[1] == transcription_id for call in enqueue.await_args_list)
+
+
+async def test_redispatch_refusal_advances_but_complete_job_is_ignored(
+    async_session, admin_user
+) -> None:
+    queued_id = await _insert_stale_job(
+        async_session, task=Task.UPLOAD_FILE, user_id=admin_user.id
+    )
+    complete_id = await _insert_stale_job(
+        async_session,
+        task=Task.TRANSCRIPTION,
+        user_id=admin_user.id,
+        status=Status.COMPLETE,
+    )
+    params = _params(Task.UPLOAD_FILE, admin_user.id)
+    await job_manager.init()
+    queued = await job_manager.enqueue(Task.UPLOAD_FILE, queued_id, params)
+    assert queued is not None
+
+    try:
+        result = await redispatch_stale_jobs(async_session, enqueue=job_manager.enqueue)
+    finally:
+        await job_manager.close()
+
+    assert result.claimed == 1
+    assert result.enqueued == 0
+    assert (
+        await async_session.scalar(
+            sa.select(Jobs.dispatch_attempted_at).where(Jobs.id == queued_id)
+        )
+        is not None
+    )
+    assert (
+        await async_session.scalar(
+            sa.select(Jobs.dispatch_attempted_at).where(Jobs.id == complete_id)
+        )
+        is None
+    )
+
+
+async def test_corrupt_envelope_fails_without_enqueue_or_path_influence(
+    async_session, admin_user, tmp_path
+) -> None:
+    hostile_path = tmp_path / "hostile"
+    hostile_path.write_text("untouched")
+    job_id = await _insert_stale_job(
+        async_session,
+        task=Task.UPLOAD_FILE,
+        user_id=admin_user.id,
+        envelope={
+            "version": 1,
+            "task": Task.UPLOAD_FILE.value,
+            "params": {
+                "filepath": str(hostile_path),
+                "filename": "bad.txt",
+                "user_id": str(admin_user.id),
+            },
+        },
+    )
+    enqueue = AsyncMock()
+
+    await redispatch_stale_jobs(async_session, enqueue=enqueue)
+
+    enqueue.assert_not_awaited()
+    row = (
+        await async_session.execute(
+            sa.select(Jobs.status, Jobs.result_location).where(Jobs.id == job_id)
+        )
+    ).one()
+    assert row.status == Status.FAILED.value
+    assert "dispatch envelope" in row.result_location
+    assert hostile_path.read_text() == "untouched"
+
+
+def test_staging_path_depends_only_on_job_id(tmp_path: Path) -> None:
+    job_id = uuid4()
+
+    path = job_staging_path(job_id, upload_tmp_dir=tmp_path)
+
+    assert path == tmp_path / "job-staging" / str(job_id)

--- a/backend/tests/integration/migrations/test_durable_job_dispatch.py
+++ b/backend/tests/integration/migrations/test_durable_job_dispatch.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from datetime import datetime, timezone
 from pathlib import Path
 
 import psycopg2
 import pytest
 from sqlalchemy import create_engine, inspect
+from sqlalchemy.dialects import postgresql
 from testcontainers.postgres import PostgresContainer
 
 from alembic import command
 from alembic.config import Config
+from eneo.jobs.durable_dispatch import stale_dispatch_statement
 
 pytestmark = [pytest.mark.integration, pytest.mark.migration_isolation]
 
@@ -83,24 +86,12 @@ def test_durable_dispatch_migration_round_trip_and_query_plan(
     try:
         with connection.cursor() as cursor:
             cursor.execute("SET enable_seqscan = off")
-            cursor.execute(
-                """
-                EXPLAIN
-                SELECT id
-                FROM jobs
-                WHERE status = 'queued'
-                  AND dispatch_envelope IS NOT NULL
-                  AND task IN ('upload_info_blob', 'transcription')
-                  AND created_at <= now() - interval '5 minutes'
-                  AND (
-                    dispatch_attempted_at IS NULL
-                    OR dispatch_attempted_at <= now() - interval '5 minutes'
-                  )
-                ORDER BY dispatch_attempted_at ASC NULLS FIRST, id ASC
-                LIMIT 50
-                FOR UPDATE SKIP LOCKED
-                """
+            production_query = stale_dispatch_statement(datetime.now(timezone.utc))
+            compiled_query = production_query.compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
             )
+            cursor.execute(f"EXPLAIN {compiled_query}")
             plan = "\n".join(str(row[0]) for row in cursor.fetchall())
         assert _INDEX in plan
     finally:

--- a/backend/tests/integration/migrations/test_durable_job_dispatch.py
+++ b/backend/tests/integration/migrations/test_durable_job_dispatch.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
+from time import monotonic, sleep
 from uuid import uuid4
 
 import psycopg2
@@ -81,6 +83,27 @@ def _prepared_type(value: object) -> str:
     if isinstance(value, int):
         return "integer"
     raise TypeError(f"Unsupported prepared query value: {type(value).__name__}")
+
+
+def _wait_for_downgrade_barrier(connection: psycopg2.extensions.connection) -> None:
+    deadline = monotonic() + 10
+    while monotonic() < deadline:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM pg_stat_activity
+                    WHERE wait_event_type = 'Lock'
+                      AND wait_event = 'advisory'
+                      AND query LIKE 'DROP INDEX%ix_jobs_durable_dispatch%'
+                )
+                """
+            )
+            if cursor.fetchone() == (True,):
+                return
+        sleep(0.05)
+    raise AssertionError("Downgrade did not reach the index-drop barrier")
 
 
 def test_durable_dispatch_migration_round_trip_and_query_plan(
@@ -184,3 +207,103 @@ def test_durable_dispatch_migration_round_trip_and_query_plan(
     columns, indexes = _job_schema(database_url)
     assert {"dispatch_envelope", "dispatch_attempted_at"} <= columns
     assert _INDEX in indexes
+
+
+def test_downgrade_excludes_a_concurrent_durable_insert(
+    migration_database: tuple[str, Config],
+) -> None:
+    database_url, config = migration_database
+    sync_database_url = database_url.replace("+psycopg2", "")
+    command.upgrade(config, "head")
+    writer_job_id = uuid4()
+    barrier_key = 2_026_072_816
+
+    barrier = psycopg2.connect(sync_database_url)
+    barrier.autocommit = True
+    try:
+        with barrier.cursor() as cursor:
+            cursor.execute("ALTER TABLE jobs DISABLE TRIGGER ALL")
+            cursor.execute("SELECT pg_advisory_lock(%s)", (barrier_key,))
+            cursor.execute(
+                f"""
+                CREATE FUNCTION durable_dispatch_downgrade_barrier()
+                RETURNS event_trigger
+                LANGUAGE plpgsql
+                AS $$
+                BEGIN
+                    IF tg_tag = 'DROP INDEX' THEN
+                        PERFORM pg_advisory_lock({barrier_key});
+                        PERFORM pg_advisory_unlock({barrier_key});
+                    END IF;
+                END
+                $$;
+                CREATE EVENT TRIGGER durable_dispatch_downgrade_barrier
+                ON ddl_command_start
+                EXECUTE FUNCTION durable_dispatch_downgrade_barrier();
+                """
+            )
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            downgrade = executor.submit(
+                command.downgrade,
+                config,
+                _PREVIOUS_REVISION,
+            )
+            try:
+                _wait_for_downgrade_barrier(barrier)
+
+                writer_error: Exception | None = None
+                writer = psycopg2.connect(sync_database_url)
+                try:
+                    with writer:
+                        with writer.cursor() as cursor:
+                            cursor.execute("SET LOCAL lock_timeout = '1s'")
+                            cursor.execute(
+                                """
+                                INSERT INTO jobs (
+                                    id, user_id, task, status, dispatch_envelope
+                                )
+                                VALUES (%s::uuid, %s::uuid, %s, %s, %s::jsonb)
+                                """,
+                                (
+                                    str(writer_job_id),
+                                    str(uuid4()),
+                                    "upload_info_blob",
+                                    "queued",
+                                    '{"version": 1}',
+                                ),
+                            )
+                except Exception as exc:
+                    writer_error = exc
+                finally:
+                    writer.close()
+            finally:
+                with barrier.cursor() as cursor:
+                    cursor.execute("SELECT pg_advisory_unlock(%s)", (barrier_key,))
+            downgrade_error = downgrade.exception(timeout=10)
+    finally:
+        with barrier.cursor() as cursor:
+            cursor.execute(
+                "DROP EVENT TRIGGER IF EXISTS durable_dispatch_downgrade_barrier"
+            )
+            cursor.execute(
+                "DROP FUNCTION IF EXISTS durable_dispatch_downgrade_barrier()"
+            )
+            cursor.execute("ALTER TABLE jobs ENABLE TRIGGER ALL")
+            cursor.execute("SELECT pg_advisory_unlock(%s)", (barrier_key,))
+        barrier.close()
+
+    command.upgrade(config, "head")
+    assert downgrade_error is None
+    assert isinstance(writer_error, psycopg2.errors.LockNotAvailable)
+
+    connection = psycopg2.connect(sync_database_url)
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT count(*) FROM jobs WHERE id = %s::uuid",
+                (str(writer_job_id),),
+            )
+            assert cursor.fetchone() == (0,)
+    finally:
+        connection.close()

--- a/backend/tests/integration/migrations/test_durable_job_dispatch.py
+++ b/backend/tests/integration/migrations/test_durable_job_dispatch.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+
+import psycopg2
+import pytest
+from sqlalchemy import create_engine, inspect
+from testcontainers.postgres import PostgresContainer
+
+from alembic import command
+from alembic.config import Config
+
+pytestmark = [pytest.mark.integration, pytest.mark.migration_isolation]
+
+_PREVIOUS_REVISION = "202607281340"
+_INDEX = "ix_jobs_durable_dispatch"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def override_settings_for_session() -> Generator[None, None, None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def cleanup_database() -> Generator[None, None, None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def seed_default_models() -> Generator[None, None, None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def encryption_service() -> Generator[None, None, None]:
+    yield
+
+
+def _alembic_config(database_url: str) -> Config:
+    backend_dir = Path(__file__).resolve().parents[3]
+    config = Config(str(backend_dir / "alembic.ini"))
+    config.set_main_option("script_location", str(backend_dir / "alembic"))
+    config.set_main_option("sqlalchemy.url", database_url)
+    return config
+
+
+@pytest.fixture(scope="module")
+def migration_database() -> Generator[tuple[str, Config], None, None]:
+    postgres = PostgresContainer(
+        image="pgvector/pgvector:pg16",
+        username="durable_dispatch",
+        password="durable_dispatch_password",
+        dbname="durable_dispatch",
+    )
+    with postgres:
+        database_url = postgres.get_connection_url()
+        yield database_url, _alembic_config(database_url)
+
+
+def _job_schema(database_url: str) -> tuple[set[str], set[str]]:
+    engine = create_engine(database_url)
+    try:
+        inspector = inspect(engine)
+        columns = {str(column["name"]) for column in inspector.get_columns("jobs")}
+        indexes = {str(index["name"]) for index in inspector.get_indexes("jobs")}
+        return columns, indexes
+    finally:
+        engine.dispose()
+
+
+def test_durable_dispatch_migration_round_trip_and_query_plan(
+    migration_database: tuple[str, Config],
+) -> None:
+    database_url, config = migration_database
+
+    command.upgrade(config, "head")
+    columns, indexes = _job_schema(database_url)
+    assert {"dispatch_envelope", "dispatch_attempted_at"} <= columns
+    assert _INDEX in indexes
+
+    connection = psycopg2.connect(database_url.replace("+psycopg2", ""))
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SET enable_seqscan = off")
+            cursor.execute(
+                """
+                EXPLAIN
+                SELECT id
+                FROM jobs
+                WHERE status = 'queued'
+                  AND dispatch_envelope IS NOT NULL
+                  AND task IN ('upload_info_blob', 'transcription')
+                  AND created_at <= now() - interval '5 minutes'
+                  AND (
+                    dispatch_attempted_at IS NULL
+                    OR dispatch_attempted_at <= now() - interval '5 minutes'
+                  )
+                ORDER BY dispatch_attempted_at ASC NULLS FIRST, id ASC
+                LIMIT 50
+                FOR UPDATE SKIP LOCKED
+                """
+            )
+            plan = "\n".join(str(row[0]) for row in cursor.fetchall())
+        assert _INDEX in plan
+    finally:
+        connection.close()
+
+    command.downgrade(config, _PREVIOUS_REVISION)
+    columns, indexes = _job_schema(database_url)
+    assert "dispatch_envelope" not in columns
+    assert "dispatch_attempted_at" not in columns
+    assert _INDEX not in indexes
+
+    command.upgrade(config, "head")
+    columns, indexes = _job_schema(database_url)
+    assert {"dispatch_envelope", "dispatch_attempted_at"} <= columns
+    assert _INDEX in indexes

--- a/backend/tests/integration/migrations/test_durable_job_dispatch.py
+++ b/backend/tests/integration/migrations/test_durable_job_dispatch.py
@@ -72,6 +72,16 @@ def _job_schema(database_url: str) -> tuple[set[str], set[str]]:
         engine.dispose()
 
 
+def _prepared_type(value: object) -> str:
+    if isinstance(value, datetime):
+        return "timestamptz"
+    if isinstance(value, str):
+        return "text"
+    if isinstance(value, int):
+        return "integer"
+    raise TypeError(f"Unsupported prepared query value: {type(value).__name__}")
+
+
 def test_durable_dispatch_migration_round_trip_and_query_plan(
     migration_database: tuple[str, Config],
 ) -> None:
@@ -86,12 +96,25 @@ def test_durable_dispatch_migration_round_trip_and_query_plan(
     try:
         with connection.cursor() as cursor:
             cursor.execute("SET enable_seqscan = off")
+            cursor.execute("SET plan_cache_mode = force_generic_plan")
             production_query = stale_dispatch_statement(datetime.now(timezone.utc))
             compiled_query = production_query.compile(
-                dialect=postgresql.dialect(),
-                compile_kwargs={"literal_binds": True},
+                dialect=postgresql.dialect(paramstyle="numeric_dollar"),
+                compile_kwargs={"render_postcompile": True},
             )
-            cursor.execute(f"EXPLAIN {compiled_query}")
+            assert compiled_query.positiontup is not None
+            values = [
+                compiled_query.params[name] for name in compiled_query.positiontup
+            ]
+            prepared_types = ", ".join(_prepared_type(value) for value in values)
+            cursor.execute(
+                f"PREPARE durable_dispatch_plan ({prepared_types}) AS {compiled_query}"
+            )
+            execute_params = ", ".join(["%s"] * len(values))
+            cursor.execute(
+                f"EXPLAIN EXECUTE durable_dispatch_plan ({execute_params})",
+                values,
+            )
             plan = "\n".join(str(row[0]) for row in cursor.fetchall())
         assert _INDEX in plan
     finally:

--- a/backend/tests/integration/migrations/test_durable_job_dispatch.py
+++ b/backend/tests/integration/migrations/test_durable_job_dispatch.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Generator
 from datetime import datetime, timezone
 from pathlib import Path
+from uuid import uuid4
 
 import psycopg2
 import pytest
@@ -117,6 +118,59 @@ def test_durable_dispatch_migration_round_trip_and_query_plan(
             )
             plan = "\n".join(str(row[0]) for row in cursor.fetchall())
         assert _INDEX in plan
+    finally:
+        connection.close()
+
+    pending_job_id = uuid4()
+    connection = psycopg2.connect(database_url.replace("+psycopg2", ""))
+    try:
+        with connection:
+            with connection.cursor() as cursor:
+                cursor.execute("ALTER TABLE jobs DISABLE TRIGGER ALL")
+                try:
+                    cursor.execute(
+                        """
+                        INSERT INTO jobs (
+                            id, user_id, task, status, dispatch_envelope
+                        )
+                        VALUES (%s::uuid, %s::uuid, %s, %s, %s::jsonb)
+                        """,
+                        (
+                            str(pending_job_id),
+                            str(uuid4()),
+                            "upload_info_blob",
+                            "queued",
+                            '{"version": 1}',
+                        ),
+                    )
+                finally:
+                    cursor.execute("ALTER TABLE jobs ENABLE TRIGGER ALL")
+    finally:
+        connection.close()
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"1.*[Dd]rain.*explicitly fail",
+    ):
+        command.downgrade(config, _PREVIOUS_REVISION)
+
+    columns, indexes = _job_schema(database_url)
+    assert "dispatch_envelope" in columns
+    assert _INDEX in indexes
+
+    connection = psycopg2.connect(database_url.replace("+psycopg2", ""))
+    try:
+        with connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT dispatch_envelope FROM jobs WHERE id = %s::uuid",
+                    (str(pending_job_id),),
+                )
+                assert cursor.fetchone() == ({"version": 1},)
+                cursor.execute(
+                    "UPDATE jobs SET status = 'failed' WHERE id = %s::uuid",
+                    (str(pending_job_id),),
+                )
     finally:
         connection.close()
 

--- a/backend/tests/integration/test_ingestion_failure_safety.py
+++ b/backend/tests/integration/test_ingestion_failure_safety.py
@@ -1,6 +1,7 @@
 import struct
 from hashlib import sha256
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
 
@@ -22,6 +23,7 @@ from eneo.database.tables.spaces_table import Spaces, SpacesTranscriptionModels
 from eneo.embedding_models.infrastructure.datastore import Datastore
 from eneo.files.chunk_embedding_list import ChunkEmbeddingList
 from eneo.jobs.job_models import Task
+from eneo.jobs.job_staging import job_staging_path
 from eneo.jobs.task_models import Transcription, UploadInfoBlob
 from eneo.main.models import Status
 from eneo.worker.upload_tasks import transcription_task, upload_info_blob_task
@@ -32,6 +34,12 @@ OLD_CHUNKS = (
     (0, "Previously published knowledge", [0.1, 0.2, 0.3]),
     (1, "that must remain searchable.", [0.4, 0.5, 0.6]),
 )
+
+
+def _stage_job_file(tmp_path: Path, job_id: UUID, content: bytes) -> None:
+    path = job_staging_path(job_id, upload_tmp_dir=tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
 
 
 def _pgvector_values(values: list[float]) -> list[float]:
@@ -162,11 +170,14 @@ def _assert_prior_knowledge(prior, blobs, chunks):
 async def test_upload_failure_preserves_committed_prior_knowledge(
     db_container, tmp_path, monkeypatch, failure
 ):
-    filepath = tmp_path / TITLE
-    filepath.write_text("replacement")
+    monkeypatch.setattr(
+        "eneo.jobs.job_staging.get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
     async with db_container() as container:
         user, space, group, job, prior = await _seed_attempt(container)
         job_id = job.id
+        _stage_job_file(tmp_path, job_id, b"replacement")
         extracted: str | Exception = "replacement knowledge"
         if failure == "extraction":
             extracted = RuntimeError("extraction failed")
@@ -191,7 +202,6 @@ async def test_upload_failure_preserves_committed_prior_knowledge(
                 user_id=user.id,
                 group_id=group.id,
                 space_id=space.id,
-                filepath=str(filepath),
                 filename=TITLE,
                 mimetype="text/plain",
             ),
@@ -209,13 +219,16 @@ async def test_upload_failure_preserves_committed_prior_knowledge(
 
 @pytest.mark.parametrize("failure", ["embedding", "blank"])
 async def test_first_upload_failure_publishes_no_knowledge(
-    db_container, tmp_path, failure
+    db_container, tmp_path, monkeypatch, failure
 ):
-    filepath = tmp_path / TITLE
-    filepath.write_text("replacement")
+    monkeypatch.setattr(
+        "eneo.jobs.job_staging.get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
     async with db_container() as container:
         user, space, group, job, _ = await _seed_attempt(container, with_existing=False)
         job_id = job.id
+        _stage_job_file(tmp_path, job_id, b"replacement")
         container.text_extractor.override(
             providers.Object(
                 StubExtractor(" \n " if failure == "blank" else "replacement knowledge")
@@ -230,7 +243,6 @@ async def test_first_upload_failure_publishes_no_knowledge(
                 user_id=user.id,
                 group_id=group.id,
                 space_id=space.id,
-                filepath=str(filepath),
                 filename=TITLE,
                 mimetype="text/plain",
             ),
@@ -247,13 +259,18 @@ async def test_first_upload_failure_publishes_no_knowledge(
     assert chunks == []
 
 
-async def test_successful_upload_commits_replacement_knowledge(db_container, tmp_path):
-    filepath = tmp_path / TITLE
-    filepath.write_text("replacement")
+async def test_successful_upload_commits_replacement_knowledge(
+    db_container, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "eneo.jobs.job_staging.get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
     replacement_text = "Committed replacement knowledge"
     async with db_container() as container:
         user, space, group, job, prior = await _seed_attempt(container)
         job_id = job.id
+        _stage_job_file(tmp_path, job_id, b"replacement")
         container.text_extractor.override(
             providers.Object(StubExtractor(replacement_text))
         )
@@ -273,7 +290,6 @@ async def test_successful_upload_commits_replacement_knowledge(db_container, tmp
                 user_id=user.id,
                 group_id=group.id,
                 space_id=space.id,
-                filepath=str(filepath),
                 filename=TITLE,
                 mimetype="text/plain",
             ),
@@ -298,13 +314,16 @@ async def test_successful_upload_commits_replacement_knowledge(db_container, tmp
 
 @pytest.mark.parametrize("failure", ["embedding", "blank"])
 async def test_transcription_failure_preserves_committed_prior_knowledge(
-    db_container, tmp_path, transcription_model_factory, failure
+    db_container, tmp_path, monkeypatch, transcription_model_factory, failure
 ):
-    filepath = tmp_path / "audio.wav"
-    filepath.write_bytes(b"not used")
+    monkeypatch.setattr(
+        "eneo.jobs.job_staging.get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
     async with db_container() as container:
         user, space, group, job, prior = await _seed_attempt(container)
         job_id = job.id
+        _stage_job_file(tmp_path, job_id, b"not used")
         transcription_model = await transcription_model_factory(
             container.session(), "ingestion-safety-transcription"
         )
@@ -329,7 +348,6 @@ async def test_transcription_failure_preserves_committed_prior_knowledge(
                 user_id=user.id,
                 group_id=group.id,
                 space_id=space.id,
-                filepath=str(filepath),
                 filename=TITLE,
                 mimetype="audio/wav",
             ),

--- a/backend/tests/unittests/jobs/test_durable_dispatch.py
+++ b/backend/tests/unittests/jobs/test_durable_dispatch.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
@@ -137,6 +138,73 @@ async def test_outer_rollback_then_unrelated_commit_never_dispatches(
     await asyncio.sleep(0)
 
     enqueue.assert_not_awaited()
+
+
+async def test_outer_rollback_removes_staged_file_and_never_dispatches(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from eneo.jobs import job_staging
+
+    monkeypatch.setattr(
+        job_staging,
+        "get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    session = Session()
+    job_id = uuid4()
+    repo = _repo(session, job_id)
+    enqueue = AsyncMock()
+    monkeypatch.setattr("eneo.jobs.job_service.job_manager.enqueue", enqueue)
+    staged_file = job_staging.job_staging_path(job_id)
+    staged_file.parent.mkdir(parents=True)
+    staged_file.write_bytes(b"pending upload")
+
+    outer = session.begin()
+    await JobService(TEST_USER, repo).queue_durable_knowledge_job(
+        Task.UPLOAD_FILE,
+        name="document.txt",
+        task_params=_params(),
+        job_id=job_id,
+    )
+    outer.rollback()
+    await asyncio.sleep(0)
+
+    assert not staged_file.exists()
+    enqueue.assert_not_awaited()
+
+
+async def test_outer_commit_keeps_staged_file_for_worker_and_dispatches_once(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from eneo.jobs import job_staging
+
+    monkeypatch.setattr(
+        job_staging,
+        "get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    session = Session()
+    job_id = uuid4()
+    repo = _repo(session, job_id)
+    enqueue = AsyncMock()
+    monkeypatch.setattr("eneo.jobs.job_service.job_manager.enqueue", enqueue)
+    staged_file = job_staging.job_staging_path(job_id)
+    staged_file.parent.mkdir(parents=True)
+    staged_file.write_bytes(b"pending upload")
+
+    with session.begin():
+        await JobService(TEST_USER, repo).queue_durable_knowledge_job(
+            Task.UPLOAD_FILE,
+            name="document.txt",
+            task_params=_params(),
+            job_id=job_id,
+        )
+    await asyncio.sleep(0)
+
+    assert staged_file.read_bytes() == b"pending upload"
+    assert enqueue.await_count == 1
 
 
 async def test_savepoint_then_outer_commit_dispatches_once(monkeypatch) -> None:

--- a/backend/tests/unittests/jobs/test_durable_dispatch.py
+++ b/backend/tests/unittests/jobs/test_durable_dispatch.py
@@ -163,6 +163,43 @@ async def test_savepoint_then_outer_commit_dispatches_once(monkeypatch) -> None:
     enqueue.assert_awaited_once_with(Task.UPLOAD_FILE, job_id, params)
 
 
+async def test_durable_queue_rejects_creation_inside_savepoint() -> None:
+    session = Session()
+    repo = _repo(session, uuid4())
+
+    with session.begin():
+        with session.begin_nested():
+            with pytest.raises(ValueError, match="nested transaction"):
+                await JobService(TEST_USER, repo).queue_durable_knowledge_job(
+                    Task.UPLOAD_FILE,
+                    name="document.txt",
+                    task_params=_params(),
+                )
+
+    repo.add_durable_knowledge_job.assert_not_awaited()
+
+
+async def test_immediate_session_reuse_dispatches_exactly_once(monkeypatch) -> None:
+    session = Session()
+    job_id = uuid4()
+    repo = _repo(session, job_id)
+    enqueue = AsyncMock()
+    monkeypatch.setattr("eneo.jobs.job_service.job_manager.enqueue", enqueue)
+
+    with session.begin():
+        await JobService(TEST_USER, repo).queue_durable_knowledge_job(
+            Task.UPLOAD_FILE,
+            name="document.txt",
+            task_params=_params(),
+            job_id=job_id,
+        )
+    with session.begin():
+        pass
+
+    await asyncio.sleep(0)
+    assert enqueue.await_count == 1
+
+
 async def test_durable_queue_rejects_mismatched_user_before_persisting() -> None:
     session = Session()
     repo = _repo(session, uuid4())

--- a/backend/tests/unittests/jobs/test_durable_dispatch.py
+++ b/backend/tests/unittests/jobs/test_durable_dispatch.py
@@ -1,15 +1,44 @@
 import asyncio
+import base64
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
+import pytest
 from arq.worker import Function
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from eneo.jobs.job_models import JobInDb, Task
+from eneo.jobs.job_serialization import deserialize_job
 from eneo.jobs.job_service import JobService
-from eneo.jobs.task_models import UploadInfoBlob, build_dispatch_envelope
+from eneo.jobs.task_models import (
+    Transcription,
+    UploadInfoBlob,
+    build_dispatch_envelope,
+)
 from eneo.main.models import Status
 from tests.fixtures import TEST_USER
+
+_FROZEN_LEGACY_UPLOAD_JOB = base64.b64decode(
+    "gASVoQEAAAAAAAB9lCiMAXSUSwGMAWaUjBRlbmVvLmpvYnMuam9iX21vZGVsc5SMBFRhc2uU"
+    "k5SMEHVwbG9hZF9pbmZvX2Jsb2KUhZRSlIwBYZSMFWVuZW8uam9icy50YXNrX21vZGVsc5SM"
+    "DlVwbG9hZEluZm9CbG9ilJOUKYGUfZQojAhfX2RpY3RfX5R9lCiMB3VzZXJfaWSUjAR1dWlk"
+    "lIwEVVVJRJSTlCmBlH2UjANpbnSUSwFzYowIZ3JvdXBfaWSUaBQpgZR9lGgXSwJzYowIc3Bh"
+    "Y2VfaWSUaBQpgZR9lGgXSwNzYowIZmlsZW5hbWWUjApsZWdhY3kudHh0lIwIbWltZXR5cGWU"
+    "jAp0ZXh0L3BsYWlulIwIZmlsZXBhdGiUjBcvdG1wL2xlZ2FjeS11cGxvYWQtcGF0aJR1jBJf"
+    "X3B5ZGFudGljX2V4dHJhX1+UTowXX19weWRhbnRpY19maWVsZHNfc2V0X1+Uj5QoaBhoEWgb"
+    "aCJoIGgekIwUX19weWRhbnRpY19wcml2YXRlX1+UTnVihZSMAWuUfZSMAmV0lEsAdS4="
+)
+
+
+class _OldUploadTaskContract(BaseModel):
+    user_id: UUID
+    group_id: UUID
+    space_id: UUID
+    filepath: str
+    filename: str
+    mimetype: str
 
 
 def _params() -> UploadInfoBlob:
@@ -22,14 +51,10 @@ def _params() -> UploadInfoBlob:
     )
 
 
-async def test_restart_safe_dispatch_is_scheduled_only_after_commit(
-    monkeypatch,
-) -> None:
-    session = Session()
+def _repo(session: Session, job_id: UUID) -> MagicMock:
     repo = MagicMock()
     repo.delegate.session.sync_session = session
-    job_id = uuid4()
-    repo.add_restart_safe_job = AsyncMock(
+    repo.add_durable_knowledge_job = AsyncMock(
         return_value=JobInDb(
             id=job_id,
             user_id=TEST_USER.id,
@@ -38,12 +63,21 @@ async def test_restart_safe_dispatch_is_scheduled_only_after_commit(
             status=Status.QUEUED,
         )
     )
+    return repo
+
+
+async def test_durable_dispatch_is_scheduled_only_after_commit(
+    monkeypatch,
+) -> None:
+    session = Session()
+    job_id = uuid4()
+    repo = _repo(session, job_id)
     enqueue = AsyncMock()
     monkeypatch.setattr("eneo.jobs.job_service.job_manager.enqueue", enqueue)
     params = _params()
 
     with session.begin():
-        await JobService(TEST_USER, repo).queue_restart_safe_job(
+        await JobService(TEST_USER, repo).queue_durable_knowledge_job(
             Task.UPLOAD_FILE,
             name="document.txt",
             task_params=params,
@@ -53,12 +87,134 @@ async def test_restart_safe_dispatch_is_scheduled_only_after_commit(
 
     await asyncio.sleep(0)
     enqueue.assert_awaited_once_with(Task.UPLOAD_FILE, job_id, params)
+    dispatched_params = enqueue.await_args.args[2]
+    assert getattr(dispatched_params, "filepath").endswith(f"/job-staging/{job_id}")
+
+
+async def test_savepoint_commit_then_outer_rollback_never_dispatches(
+    monkeypatch,
+) -> None:
+    session = Session()
+    job_id = uuid4()
+    repo = _repo(session, job_id)
+    enqueue = AsyncMock()
+    monkeypatch.setattr("eneo.jobs.job_service.job_manager.enqueue", enqueue)
+
+    outer = session.begin()
+    await JobService(TEST_USER, repo).queue_durable_knowledge_job(
+        Task.UPLOAD_FILE,
+        name="document.txt",
+        task_params=_params(),
+        job_id=job_id,
+    )
+    with session.begin_nested():
+        pass
+    await asyncio.sleep(0)
+    outer.rollback()
+
+    enqueue.assert_not_awaited()
+
+
+async def test_outer_rollback_then_unrelated_commit_never_dispatches(
+    monkeypatch,
+) -> None:
+    session = Session()
+    job_id = uuid4()
+    repo = _repo(session, job_id)
+    enqueue = AsyncMock()
+    monkeypatch.setattr("eneo.jobs.job_service.job_manager.enqueue", enqueue)
+
+    outer = session.begin()
+    await JobService(TEST_USER, repo).queue_durable_knowledge_job(
+        Task.UPLOAD_FILE,
+        name="document.txt",
+        task_params=_params(),
+        job_id=job_id,
+    )
+    outer.rollback()
+    with session.begin():
+        pass
+    await asyncio.sleep(0)
+
+    enqueue.assert_not_awaited()
+
+
+async def test_savepoint_then_outer_commit_dispatches_once(monkeypatch) -> None:
+    session = Session()
+    job_id = uuid4()
+    repo = _repo(session, job_id)
+    enqueue = AsyncMock()
+    monkeypatch.setattr("eneo.jobs.job_service.job_manager.enqueue", enqueue)
+    params = _params()
+
+    with session.begin():
+        await JobService(TEST_USER, repo).queue_durable_knowledge_job(
+            Task.UPLOAD_FILE,
+            name="document.txt",
+            task_params=params,
+            job_id=job_id,
+        )
+        with session.begin_nested():
+            pass
+        await asyncio.sleep(0)
+        enqueue.assert_not_awaited()
+
+    await asyncio.sleep(0)
+    enqueue.assert_awaited_once_with(Task.UPLOAD_FILE, job_id, params)
+
+
+async def test_durable_queue_rejects_mismatched_user_before_persisting() -> None:
+    session = Session()
+    repo = _repo(session, uuid4())
+    params = _params().model_copy(update={"user_id": uuid4()})
+
+    with pytest.raises(ValueError, match="user"):
+        await JobService(TEST_USER, repo).queue_durable_knowledge_job(
+            Task.UPLOAD_FILE,
+            name="document.txt",
+            task_params=params,
+        )
+
+    repo.add_durable_knowledge_job.assert_not_awaited()
 
 
 def test_durable_envelope_has_no_filesystem_path() -> None:
     envelope = build_dispatch_envelope(Task.UPLOAD_FILE, _params())
 
     assert "filepath" not in envelope.model_dump(mode="json")["params"]
+
+
+def test_new_worker_uses_path_from_frozen_legacy_payload() -> None:
+    from eneo.worker.upload_tasks import _job_file_path
+
+    decoded = deserialize_job(_FROZEN_LEGACY_UPLOAD_JOB)
+    args = decoded["a"]
+    assert isinstance(args, tuple)
+    params = args[0]
+    assert isinstance(params, UploadInfoBlob)
+
+    assert _job_file_path(uuid4(), params) == Path("/tmp/legacy-upload-path")
+
+
+@pytest.mark.parametrize(
+    ("task", "params_type"),
+    [
+        (Task.UPLOAD_FILE, UploadInfoBlob),
+        (Task.TRANSCRIPTION, Transcription),
+    ],
+)
+def test_new_dispatch_payload_satisfies_old_worker_contract(
+    task: Task,
+    params_type: type[UploadInfoBlob] | type[Transcription],
+) -> None:
+    from eneo.jobs.durable_dispatch import build_knowledge_dispatch_params
+
+    params = params_type(**_params().model_dump())
+    job_id = uuid4()
+    compatible = build_knowledge_dispatch_params(params, job_id)
+
+    old_payload = _OldUploadTaskContract.model_validate(compatible.__dict__)
+    assert old_payload.filepath.endswith(f"/job-staging/{job_id}")
 
 
 def test_durable_worker_functions_do_not_retain_arq_results() -> None:

--- a/backend/tests/unittests/jobs/test_durable_dispatch.py
+++ b/backend/tests/unittests/jobs/test_durable_dispatch.py
@@ -1,0 +1,78 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from arq.worker import Function
+from sqlalchemy.orm import Session
+
+from eneo.jobs.job_models import JobInDb, Task
+from eneo.jobs.job_service import JobService
+from eneo.jobs.task_models import UploadInfoBlob, build_dispatch_envelope
+from eneo.main.models import Status
+from tests.fixtures import TEST_USER
+
+
+def _params() -> UploadInfoBlob:
+    return UploadInfoBlob(
+        user_id=TEST_USER.id,
+        group_id=uuid4(),
+        space_id=uuid4(),
+        filename="document.txt",
+        mimetype="text/plain",
+    )
+
+
+async def test_restart_safe_dispatch_is_scheduled_only_after_commit(
+    monkeypatch,
+) -> None:
+    session = Session()
+    repo = MagicMock()
+    repo.delegate.session.sync_session = session
+    job_id = uuid4()
+    repo.add_restart_safe_job = AsyncMock(
+        return_value=JobInDb(
+            id=job_id,
+            user_id=TEST_USER.id,
+            task=Task.UPLOAD_FILE,
+            name="document.txt",
+            status=Status.QUEUED,
+        )
+    )
+    enqueue = AsyncMock()
+    monkeypatch.setattr("eneo.jobs.job_service.job_manager.enqueue", enqueue)
+    params = _params()
+
+    with session.begin():
+        await JobService(TEST_USER, repo).queue_restart_safe_job(
+            Task.UPLOAD_FILE,
+            name="document.txt",
+            task_params=params,
+            job_id=job_id,
+        )
+        enqueue.assert_not_awaited()
+
+    await asyncio.sleep(0)
+    enqueue.assert_awaited_once_with(Task.UPLOAD_FILE, job_id, params)
+
+
+def test_durable_envelope_has_no_filesystem_path() -> None:
+    envelope = build_dispatch_envelope(Task.UPLOAD_FILE, _params())
+
+    assert "filepath" not in envelope.model_dump(mode="json")["params"]
+
+
+def test_durable_worker_functions_do_not_retain_arq_results() -> None:
+    from eneo.worker.routes import worker
+
+    durable_functions = {
+        function.name: function
+        for function in worker.functions
+        if isinstance(function, Function)
+        and function.name in {Task.UPLOAD_FILE.value, Task.TRANSCRIPTION.value}
+    }
+
+    assert set(durable_functions) == {
+        Task.UPLOAD_FILE.value,
+        Task.TRANSCRIPTION.value,
+    }
+    assert all(function.keep_result_s == 0 for function in durable_functions.values())

--- a/backend/tests/unittests/jobs/test_job_serialization.py
+++ b/backend/tests/unittests/jobs/test_job_serialization.py
@@ -33,7 +33,6 @@ def test_job_deserializer_remaps_pre_rename_package_payloads() -> None:
         user_id=uuid4(),
         group_id=uuid4(),
         space_id=uuid4(),
-        filepath="/tmp/document.txt",
         filename="document.txt",
         mimetype="text/plain",
     )

--- a/backend/tests/unittests/jobs/test_task_service.py
+++ b/backend/tests/unittests/jobs/test_task_service.py
@@ -121,7 +121,7 @@ async def test_validate_file_size_rejects_policy_maximum_plus_one(
 async def test_queue_upload_file_cleans_up_on_queue_failure(
     task_service, job_service, tmp_upload_dir
 ):
-    job_service.queue_restart_safe_job.side_effect = RuntimeError("queue down")
+    job_service.queue_durable_knowledge_job.side_effect = RuntimeError("queue down")
 
     with pytest.raises(RuntimeError, match="queue down"):
         await task_service.queue_upload_file(
@@ -139,7 +139,7 @@ async def test_queue_upload_file_cleans_up_on_queue_failure(
 async def test_queue_upload_file_preserves_file_on_success(
     task_service, job_service, tmp_upload_dir
 ):
-    job_service.queue_restart_safe_job.return_value = MagicMock()
+    job_service.queue_durable_knowledge_job.return_value = MagicMock()
 
     await task_service.queue_upload_file(
         group_id=uuid4(),
@@ -152,7 +152,7 @@ async def test_queue_upload_file_preserves_file_on_success(
     remaining = [path for path in tmp_upload_dir.rglob("*") if path.is_file()]
     assert len(remaining) == 1
     assert remaining[0].read_bytes() == b"test data"
-    call = job_service.queue_restart_safe_job.await_args
+    call = job_service.queue_durable_knowledge_job.await_args
     assert call is not None
     params = call.kwargs["task_params"]
     assert "filepath" not in params.model_dump()

--- a/backend/tests/unittests/jobs/test_task_service.py
+++ b/backend/tests/unittests/jobs/test_task_service.py
@@ -34,9 +34,11 @@ def file_size_service(tmp_upload_dir, monkeypatch):
     from types import SimpleNamespace
 
     from eneo.files import file_size_service as fss_module
+    from eneo.jobs import job_staging
 
     settings = SimpleNamespace(upload_tmp_dir=tmp_upload_dir)
     monkeypatch.setattr(fss_module, "get_settings", lambda: settings)
+    monkeypatch.setattr(job_staging, "get_settings", lambda: settings)
     return FileSizeService()
 
 
@@ -119,7 +121,7 @@ async def test_validate_file_size_rejects_policy_maximum_plus_one(
 async def test_queue_upload_file_cleans_up_on_queue_failure(
     task_service, job_service, tmp_upload_dir
 ):
-    job_service.queue_job.side_effect = RuntimeError("queue down")
+    job_service.queue_restart_safe_job.side_effect = RuntimeError("queue down")
 
     with pytest.raises(RuntimeError, match="queue down"):
         await task_service.queue_upload_file(
@@ -130,14 +132,14 @@ async def test_queue_upload_file_cleans_up_on_queue_failure(
             filename="test.txt",
         )
 
-    remaining = list(tmp_upload_dir.iterdir())
+    remaining = [path for path in tmp_upload_dir.rglob("*") if path.is_file()]
     assert remaining == []
 
 
 async def test_queue_upload_file_preserves_file_on_success(
     task_service, job_service, tmp_upload_dir
 ):
-    job_service.queue_job.return_value = MagicMock()
+    job_service.queue_restart_safe_job.return_value = MagicMock()
 
     await task_service.queue_upload_file(
         group_id=uuid4(),
@@ -147,6 +149,11 @@ async def test_queue_upload_file_preserves_file_on_success(
         filename="test.txt",
     )
 
-    remaining = list(tmp_upload_dir.iterdir())
+    remaining = [path for path in tmp_upload_dir.rglob("*") if path.is_file()]
     assert len(remaining) == 1
     assert remaining[0].read_bytes() == b"test data"
+    call = job_service.queue_restart_safe_job.await_args
+    assert call is not None
+    params = call.kwargs["task_params"]
+    assert "filepath" not in params.model_dump()
+    assert remaining[0].name == str(call.kwargs["job_id"])


### PR DESCRIPTION
## Changes

- A new durable dispatch contract in the jobs owner for upload and transcription: a versioned typed envelope persisted with the job row, queue delivery only after the transaction commits, and a bounded cron that fairly redispatches stale queued jobs behind a concurrent partial index.
- Staged upload files now live at a path derived only from the job id (`job-staging/`), so the persisted envelope never contains filesystem paths and a corrupt envelope cannot steer file access.
- Queue result retention is disabled for exactly these two worker functions; the database row is the single completion authority. Delivery is at-least-once, processing start stays at-most-once.
- A one-release payload bridge keeps mixed old/new workers functional during rollout and rollback, with its removal conditions documented in code.
- Dispatch is outer-transaction-aware: savepoint commits, rollbacks, session reuse, and nested creation cannot produce orphaned or duplicate deliveries.

## Why

A worker crash or restart between the database commit and the queue enqueue used to strand a committed knowledge job as invisibly queued forever — the queue message was gone and the row carried nothing to rebuild it. This is the first of two slices making knowledge processing survive crashes; the follow-up adds worker-side restart safety.

## Planning

- Task: Fixes #632

## Testing

- `uv run pytest tests/integration/jobs/ tests/unittests/jobs/ -q` and the ingestion failure-safety suite — all green against real PostgreSQL 13 and real Redis (testcontainers), including held-open-producer, lost-delivery recovery with payload equality, page progress, cross-task fairness, queue key states, envelope corruption, and staging-path purity; every scenario was written red-first.
- `uv run pytest -m migration_isolation tests/integration/migrations/test_durable_job_dispatch.py -q` — migration roundtrip plus PREPARE/EXPLAIN EXECUTE proof that the prepared production query selects the partial index; the index builds concurrently.
- `uv run pyright` 0 errors; ruff clean.
- Peer commit gate: three passes, final verdict green at minimum score 8; the gate's findings (deployment-window payload compatibility, savepoint/session-reuse dispatch edges, blocking index build) were each reproduced red-first and fixed.

## Screenshots

No UI changes.
