### PR TITLE
ci: stop the post-merge image publish from running out of memory

### DIFF
--- a/.github/workflows/build_and_push_images.yml
+++ b/.github/workflows/build_and_push_images.yml
@@ -34,8 +34,12 @@ env:
   QEMU_IMAGE: docker.io/tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
 
 jobs:
-  build-and-push:
+  build-and-push-backend:
     runs-on: ubuntu-latest
+    outputs:
+      backend_tag: ${{ steps.backend-version.outputs.version }}
+      is_latest: ${{ steps.check-latest.outputs.is-latest }}
+      is_release: ${{ steps.build-context.outputs.is-release }}
     permissions:
       contents: read
       packages: write
@@ -55,14 +59,6 @@ jobs:
         with:
           version: ${{ env.BUILDX_VERSION }}
           driver-opts: image=${{ env.BUILDKIT_IMAGE }}
-
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq curl
-
-      - name: Install bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
-        with:
-          bun-version: 1.3.14
 
       - name: Log in to the Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -178,10 +174,47 @@ jobs:
           subject-digest: ${{ steps.build-backend.outputs.digest }}
           push-to-registry: true
 
-      # Frontend build and push
+  build-and-push-frontend:
+    needs: build-and-push-backend
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      artifact-metadata: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0  # Fetch full history for tags
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          version: ${{ env.BUILDX_VERSION }}
+          driver-opts: image=${{ env.BUILDKIT_IMAGE }}
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq curl
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Add swap for frontend image build
         run: |
-          sudo fallocate --length 4G /mnt/eneo-frontend.swap
+          sudo fallocate --length 6G /mnt/eneo-frontend.swap
           sudo chmod 600 /mnt/eneo-frontend.swap
           sudo mkswap /mnt/eneo-frontend.swap
           sudo swapon /mnt/eneo-frontend.swap
@@ -197,23 +230,18 @@ jobs:
             type=ref,event=branch,enable=${{ github.ref != 'refs/heads/develop' }}
 
             # Version tags (only for releases)
-            type=semver,pattern={{version}},enable=${{ steps.build-context.outputs.is-release == 'true' }}
+            type=semver,pattern={{version}},enable=${{ needs['build-and-push-backend'].outputs.is_release == 'true' }}
 
-            type=raw,value=latest,enable=${{ steps.check-latest.outputs.is-latest == 'true' }}
+            type=raw,value=latest,enable=${{ needs['build-and-push-backend'].outputs.is_latest == 'true' }}
 
             # Git SHA for traceability (always included)
             type=sha,prefix={{branch}}-,format=short,enable=${{ github.ref_type == 'branch' }}
             type=sha,format=short,enable=${{ github.ref_type == 'tag' }}
 
       - name: Synchronize frontend with backend
-        run: |
-          # For branches, use the SHA-suffixed tag (second tag), for tags use first tag
-          if [[ "${{ github.ref_type }}" == "branch" ]]; then
-            BACKEND_TAG=$(echo "${{ steps.meta-backend.outputs.tags }}" | sed -n '2p' | cut -d':' -f2)
-          else
-            BACKEND_TAG=$(echo "${{ steps.meta-backend.outputs.tags }}" | head -n1 | cut -d':' -f2)
-          fi
-          ./scripts/sync-frontend-with-backend.sh "${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:$BACKEND_TAG"
+        env:
+          BACKEND_TAG: ${{ needs['build-and-push-backend'].outputs.backend_tag }}
+        run: ./scripts/sync-frontend-with-backend.sh "${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE_NAME }}:$BACKEND_TAG"
 
       - name: Build and push frontend Docker image
         id: build-frontend
@@ -234,7 +262,16 @@ jobs:
           subject-digest: ${{ steps.build-frontend.outputs.digest }}
           push-to-registry: true
 
-      # Summary of what was built
+  build-summary:
+    name: Application image build summary
+    needs:
+      - build-and-push-backend
+      - build-and-push-frontend
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
       - name: Build Summary
         run: |
           echo "## 🐳 Docker Images Built and Pushed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/rerun-image-publish.yml
+++ b/.github/workflows/rerun-image-publish.yml
@@ -1,0 +1,25 @@
+name: Rerun Failed Image Publish
+
+on:
+  workflow_run:
+    workflows: ["Build and Push Docker Images"]
+    types: [completed]
+
+permissions:
+  actions: write
+
+# Hosted-runner deaths are nondeterministic. One automatic retry keeps merges
+# reliable without masking real breakage, which still fails on attempt 2.
+jobs:
+  rerun-failed-jobs:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 2
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Rerun failed image publish jobs
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: gh run rerun "${{ github.event.workflow_run.id }}" --failed


### PR DESCRIPTION
## Changes

- The application image publish splits into two jobs, one per image, so the backend and frontend builds no longer share one runner's memory; the frontend job's swap grows to 6 GB.
- The frontend job consumes the backend's tag/release decisions through declared job outputs instead of re-parsing tag lists with shell.
- A new `rerun-image-publish.yml` workflow reruns failed publish jobs exactly once (`run_attempt < 2`), so a nondeterministic hosted-runner death self-heals while real breakage still fails on attempt two.
- Published refs and attestations are unchanged for every trigger (develop, manual branch, release, prerelease); the SeaweedFS section is untouched.

## Why

"Build and Push Docker Images" is the one workflow that keeps failing after merges while PR checks stay green: the publish path builds both large images on a single 7 GB runner. On 2026-07-27 the frontend build failed with `ResourceExhausted: cannot allocate memory`; after the 4 GB swap (#617), the same job on 2026-07-28 killed its runner ("The hosted runner lost communication with the server"). PR-side checks build native-arch without publishing, so this cliff only ever appears post-merge. Splitting removes the shared-memory coupling; the bounded retry covers genuine runner deaths, which no pre-merge gate can prevent.

## Planning

CI chore following the precedent of #617; no development task exists for this class of change.

## Testing

- Both workflows YAML-parse cleanly; structural review verified exactly two application jobs, the frontend's `needs` on the backend, and a summary job that depends on both and reads only `github`/`env` context.
- Side-by-side tag-rule comparison against the previous file: all tag generators, cache settings, attestation subjects, triggers, and the SeaweedFS section are identical.
- The real publish behavior is proven by the next push to develop; this PR's own merge exercises it.

## Screenshots

Not applicable.
