### PR TITLE
fix(alembic): stop migrations from disabling application loggers

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -14,8 +14,12 @@ from eneo.main.config import get_settings
 # Alembic Config object, which provides access to values within the .ini file
 config = context.config
 
-# Interpret the config file for logging
-fileConfig(config.config_file_name)
+# Interpret the config file for logging. Keep existing loggers alive:
+# fileConfig defaults to disable_existing_loggers=True, which sets
+# .disabled on every already-imported application logger whenever a
+# migration runs in-process (tests, programmatic upgrades) and silently
+# swallows their records from then on.
+fileConfig(config.config_file_name, disable_existing_loggers=False)
 
 target_metadata = Base.metadata
 


### PR DESCRIPTION
## TL;DR
Alembic's `env.py` called `fileConfig()` with its default `disable_existing_loggers=True`, so every in-process migration run set `.disabled` on all already-imported application loggers — silently swallowing their records for the rest of the process. One line: pass `disable_existing_loggers=False`.

## Why it surfaced
`tests/unit/test_completion_model_kwargs_capabilities.py::test_invalid_stored_capability_metadata_falls_back` asserts a warning is captured via caplog. It passed alone but failed after any integration test ran, because integration bootstrap runs migrations in-process and the module logger came out disabled — the warning was dropped at the logger, before levels or propagation. Diagnosed with a probe that attached a handler directly to the emitting logger and still captured nothing (`logger.disabled == True`).

## Impact beyond the test
Any process that runs migrations programmatically (tests, startup upgrade hooks) lost all application logging afterwards. This restores it. Alembic's own logging config is unaffected — modern Alembic templates ship exactly this flag.

## Testing
- The previously failing order now passes: `tests/integration/skills/test_skill_catalogue_repo.py` + the capability test.
- The full originally-failing battery (`tests/integration/skills tests/unittests/skills tests/unittests/assistants tests/unit`) passes: **1,801 passed, 0 failed** (previously 1 failure on pristine develop in this order).
- Standalone runs unchanged.