### PR TITLE
feat: keep knowledge processing safe across worker restarts

### DIFF
--- a/backend/alembic/versions/202607291000_restart_safe_knowledge_jobs.py
+++ b/backend/alembic/versions/202607291000_restart_safe_knowledge_jobs.py
@@ -1,0 +1,86 @@
+"""add restart-safe knowledge job recovery state
+
+Revision ID: 202607291000
+Revises: 202607281600
+Create Date: 2026-07-29 10:00:00.000000
+
+Both partial indexes are built concurrently so upgrades do not block job
+writes. Failed builds are safe to retry because invalid indexes are dropped
+before each build. Downgrade locks job writers so the cleanup-state guard and
+destructive DDL run atomically.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "202607291000"
+down_revision: str | None = "202607281600"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_REAPER_INDEX = "ix_jobs_knowledge_in_progress_reaper"
+_CLEANUP_INDEX = "ix_jobs_staging_cleanup"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "jobs",
+        sa.Column(
+            "staging_cleaned_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        if_not_exists=True,
+    )
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_REAPER_INDEX}")
+        op.execute(
+            f"""
+            CREATE INDEX CONCURRENTLY {_REAPER_INDEX}
+            ON jobs (updated_at ASC, id ASC)
+            WHERE status = 'in progress'
+              AND task IN ('upload_info_blob', 'transcription')
+            """
+        )
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {_CLEANUP_INDEX}")
+        op.execute(
+            f"""
+            CREATE INDEX CONCURRENTLY {_CLEANUP_INDEX}
+            ON jobs (finished_at ASC NULLS FIRST, id ASC)
+            WHERE dispatch_envelope IS NOT NULL
+              AND status IN ('complete', 'failed')
+              AND staging_cleaned_at IS NULL
+            """
+        )
+
+
+def downgrade() -> None:
+    op.execute("LOCK TABLE jobs IN ACCESS EXCLUSIVE MODE")
+    uncleaned_count = int(
+        op.get_bind()
+        .execute(
+            sa.text(
+                """
+                SELECT count(*)
+                FROM jobs
+                WHERE dispatch_envelope IS NOT NULL
+                  AND status IN ('complete', 'failed')
+                  AND staging_cleaned_at IS NULL
+                """
+            )
+        )
+        .scalar_one()
+    )
+    if uncleaned_count:
+        raise RuntimeError(
+            "Cannot downgrade restart-safe knowledge jobs while "
+            f"{uncleaned_count} terminal envelope jobs remain uncleaned. "
+            "Reconcile their staged files before retrying."
+        )
+
+    op.execute(f"DROP INDEX IF EXISTS {_CLEANUP_INDEX}")
+    op.execute(f"DROP INDEX IF EXISTS {_REAPER_INDEX}")
+    op.drop_column("jobs", "staging_cleaned_at")

--- a/backend/src/eneo/database/tables/job_table.py
+++ b/backend/src/eneo/database/tables/job_table.py
@@ -21,3 +21,6 @@ class Jobs(BasePublic):
     dispatch_attempted_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True)
     )
+    staging_cleaned_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True)
+    )

--- a/backend/src/eneo/embedding_models/infrastructure/datastore.py
+++ b/backend/src/eneo/embedding_models/infrastructure/datastore.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from typing import TYPE_CHECKING, Optional
 
@@ -128,7 +129,7 @@ class Datastore:
 
     async def add(self, info_blob: InfoBlobInDB, embedding_model: "EmbeddingModel"):
         logger.debug("Chunking text.")
-        info_blob_chunks = self._chunk_text(info_blob)
+        info_blob_chunks = await asyncio.to_thread(self._chunk_text, info_blob)
 
         if not info_blob_chunks:
             raise ValueError(

--- a/backend/src/eneo/files/transcriber.py
+++ b/backend/src/eneo/files/transcriber.py
@@ -145,7 +145,23 @@ class Transcriber:
     async def transcribe_from_filepath(
         self, *, filepath: Path, transcription_model: "TranscriptionModel"
     ):
-        adapter = await self._get_adapter(transcription_model)
+        adapter = await self.prepare_transcription(transcription_model)
+        return await self.transcribe_prepared_from_filepath(
+            filepath=filepath,
+            adapter=adapter,
+        )
 
+    async def prepare_transcription(
+        self,
+        transcription_model: "TranscriptionModel",
+    ) -> LiteLLMTranscriptionAdapter:
+        return await self._get_adapter(transcription_model)
+
+    async def transcribe_prepared_from_filepath(
+        self,
+        *,
+        filepath: Path,
+        adapter: LiteLLMTranscriptionAdapter,
+    ) -> str:
         async with audio.to_wav(str(filepath)) as wav_file:
             return await adapter.get_text_from_file(wav_file)

--- a/backend/src/eneo/jobs/job_repo.py
+++ b/backend/src/eneo/jobs/job_repo.py
@@ -11,6 +11,40 @@ from eneo.jobs.job_manager import job_manager
 from eneo.jobs.job_models import Job, JobInDb, JobUpdate
 from eneo.jobs.task_models import DispatchEnvelope
 
+KNOWLEDGE_REAPER_PAGE_SIZE = 50
+KNOWLEDGE_JOB_STALE_AFTER = timedelta(minutes=5)
+KNOWLEDGE_REAPER_FAILURE_REASON = "Knowledge processing heartbeat expired"
+_IN_PROGRESS_SQL = sa.literal_column("'in progress'", type_=sa.String())
+_KNOWLEDGE_TASKS_SQL = (
+    sa.literal_column("'upload_info_blob'", type_=sa.String()),
+    sa.literal_column("'transcription'", type_=sa.String()),
+)
+
+
+def stale_in_progress_jobs_statement(stale_before: datetime):
+    candidates = (
+        sa.select(Jobs.id)
+        .where(Jobs.status == _IN_PROGRESS_SQL)
+        .where(Jobs.task.in_(_KNOWLEDGE_TASKS_SQL))
+        .where(Jobs.updated_at < stale_before)
+        .order_by(Jobs.updated_at.asc(), Jobs.id.asc())
+        .limit(KNOWLEDGE_REAPER_PAGE_SIZE)
+        .with_for_update(skip_locked=True)
+        .cte("stale_knowledge_jobs")
+    )
+    return (
+        sa.update(Jobs)
+        .where(Jobs.id.in_(sa.select(candidates.c.id)))
+        .where(Jobs.status == _IN_PROGRESS_SQL)
+        .values(
+            status="failed",
+            result_location=KNOWLEDGE_REAPER_FAILURE_REASON,
+            finished_at=sa.func.now(),
+            updated_at=sa.func.now(),
+        )
+        .returning(Jobs.id)
+    )
+
 
 class JobRepository:
     def __init__(self, session: AsyncSession) -> None:
@@ -51,8 +85,8 @@ class JobRepository:
     async def get_job(self, id: UUID):
         return await self.delegate.get_by(conditions={Jobs.id: id})
 
-    async def touch_job(self, id: UUID) -> None:
-        """Update job's updated_at timestamp to signal 'still alive'.
+    async def touch_job(self, id: UUID) -> bool:
+        """Update an in-progress job's timestamp to signal 'still alive'.
 
         Used as a heartbeat during long-running tasks like crawls to prevent
         safe preemption from marking the job as stale.
@@ -60,8 +94,16 @@ class JobRepository:
         Args:
             id: Job UUID to touch
         """
-        stmt = sa.update(Jobs).where(Jobs.id == id).values(updated_at=sa.func.now())
-        await self.delegate.session.execute(stmt)
+        from eneo.main.models import Status
+
+        stmt = (
+            sa.update(Jobs)
+            .where(Jobs.id == id)
+            .where(Jobs.status == Status.IN_PROGRESS)
+            .values(updated_at=sa.func.now())
+        )
+        result = await self.delegate.session.execute(stmt)
+        return affected_row_count(result) > 0
 
     async def mark_job_started(self, id: UUID) -> bool:
         """Atomically transition job from QUEUED to IN_PROGRESS.
@@ -95,7 +137,28 @@ class JobRepository:
         result = await self.delegate.session.execute(stmt)
         return affected_row_count(result) > 0
 
-    async def mark_job_failed_if_running(self, id: UUID, error_message: str) -> int:
+    async def mark_job_completed(self, id: UUID, result_location: str) -> bool:
+        from eneo.main.models import Status
+
+        stmt = (
+            sa.update(Jobs)
+            .where(Jobs.id == id)
+            .where(Jobs.status == Status.IN_PROGRESS)
+            .values(
+                status=Status.COMPLETE,
+                result_location=result_location,
+                finished_at=sa.func.now(),
+                updated_at=sa.func.now(),
+            )
+        )
+        result = await self.delegate.session.execute(stmt)
+        return affected_row_count(result) > 0
+
+    async def mark_job_failed_if_running(
+        self,
+        id: UUID,
+        error_message: str | None,
+    ) -> int:
         """Atomically mark a job as FAILED only if it's currently IN_PROGRESS or QUEUED.
 
         Uses Compare-and-Swap pattern to prevent race conditions when multiple
@@ -117,6 +180,8 @@ class JobRepository:
             .where(Jobs.status.in_([Status.IN_PROGRESS, Status.QUEUED]))
             .values(
                 status=Status.FAILED,
+                result_location=error_message,
+                finished_at=sa.func.now(),
                 updated_at=sa.func.now(),
             )
         )
@@ -156,6 +221,15 @@ class JobRepository:
             .returning(Jobs.id)
         )
         result = await self.delegate.session.execute(stmt)
+        return [row[0] for row in result.all()]
+
+    async def mark_stale_in_progress_jobs_failed(
+        self,
+        stale_before: datetime,
+    ) -> list[UUID]:
+        result = await self.delegate.session.execute(
+            stale_in_progress_jobs_statement(stale_before)
+        )
         return [row[0] for row in result.all()]
 
     async def get_running_jobs(self, user_id: UUID):

--- a/backend/src/eneo/jobs/job_staging.py
+++ b/backend/src/eneo/jobs/job_staging.py
@@ -1,16 +1,148 @@
 import asyncio
 import contextlib
 import shutil
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import IO
 from uuid import UUID
 
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from eneo.database.tables.job_table import Jobs
 from eneo.main.config import get_settings
+from eneo.main.logging import get_logger
+
+STAGING_RECONCILE_PAGE_SIZE = 50
+ORPHAN_STAGING_DELETE_LIMIT = 50
+ORPHAN_STAGING_QUERY_BATCH_SIZE = 50
+ORPHAN_STAGING_GRACE_PERIOD = timedelta(hours=1)
+_TERMINAL_STATUS_SQL = (
+    sa.literal_column("'complete'", type_=sa.String()),
+    sa.literal_column("'failed'", type_=sa.String()),
+)
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class StagingReconciliationResult:
+    terminal_cleaned: int
+    orphans_deleted: int
+
+
+def _job_staging_directory(*, upload_tmp_dir: Path | None = None) -> Path:
+    root = upload_tmp_dir or get_settings().upload_tmp_dir
+    return root / "job-staging"
 
 
 def job_staging_path(job_id: UUID, *, upload_tmp_dir: Path | None = None) -> Path:
-    root = upload_tmp_dir or get_settings().upload_tmp_dir
-    return root / "job-staging" / str(job_id)
+    return _job_staging_directory(upload_tmp_dir=upload_tmp_dir) / str(job_id)
+
+
+def terminal_staging_jobs_statement():
+    return (
+        sa.select(Jobs)
+        .where(Jobs.dispatch_envelope.is_not(None))
+        .where(Jobs.status.in_(_TERMINAL_STATUS_SQL))
+        .where(Jobs.staging_cleaned_at.is_(None))
+        .order_by(Jobs.finished_at.asc().nullsfirst(), Jobs.id.asc())
+        .limit(STAGING_RECONCILE_PAGE_SIZE)
+        .with_for_update(skip_locked=True)
+    )
+
+
+async def _delete_orphan_staged_files(
+    session: AsyncSession,
+    *,
+    now: datetime,
+) -> int:
+    staging_directory = _job_staging_directory()
+    cutoff = now - ORPHAN_STAGING_GRACE_PERIOD
+    # The DB-driven pass keeps this directory small. A full scan ensures rare
+    # pre-commit orphans are reached even when active files sort first, so a
+    # persisted filesystem cursor is not warranted. Discovery runs off the event
+    # loop and candidates reach PostgreSQL in fixed batches to bound each query.
+    candidates = await asyncio.to_thread(
+        _discover_old_staged_files,
+        staging_directory,
+        cutoff,
+    )
+    deleted = 0
+    for offset in range(0, len(candidates), ORPHAN_STAGING_QUERY_BATCH_SIZE):
+        batch = candidates[offset : offset + ORPHAN_STAGING_QUERY_BATCH_SIZE]
+        existing_ids = set(
+            (
+                await session.scalars(
+                    sa.select(Jobs.id).where(
+                        Jobs.id.in_([job_id for job_id, _ in batch])
+                    )
+                )
+            ).all()
+        )
+        for job_id, path in batch:
+            if job_id in existing_ids:
+                continue
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning(
+                    "Orphaned job staging cleanup failed",
+                    extra={"job_id": str(job_id), "error": str(exc)},
+                )
+                continue
+            deleted += 1
+            if deleted >= ORPHAN_STAGING_DELETE_LIMIT:
+                return deleted
+    return deleted
+
+
+def _discover_old_staged_files(
+    staging_directory: Path,
+    cutoff: datetime,
+) -> list[tuple[UUID, Path]]:
+    if not staging_directory.exists():
+        return []
+
+    candidates: list[tuple[UUID, Path]] = []
+    for path in staging_directory.iterdir():
+        try:
+            job_id = UUID(path.name)
+            modified_at = datetime.fromtimestamp(path.stat().st_mtime, timezone.utc)
+        except (FileNotFoundError, OSError, ValueError):
+            continue
+        if path.is_file() and modified_at <= cutoff:
+            candidates.append((job_id, path))
+    return candidates
+
+
+async def reconcile_job_staging(
+    session: AsyncSession,
+    *,
+    now: datetime | None = None,
+) -> StagingReconciliationResult:
+    cleaned_at = now or datetime.now(timezone.utc)
+    jobs = list((await session.scalars(terminal_staging_jobs_statement())).all())
+    terminal_cleaned = 0
+    for job in jobs:
+        try:
+            job_staging_path(job.id).unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning(
+                "Terminal job staging cleanup failed",
+                extra={"job_id": str(job.id), "error": str(exc)},
+            )
+            continue
+        job.staging_cleaned_at = cleaned_at
+        terminal_cleaned += 1
+    await session.flush()
+
+    orphans_deleted = await _delete_orphan_staged_files(session, now=cleaned_at)
+    return StagingReconciliationResult(
+        terminal_cleaned=terminal_cleaned,
+        orphans_deleted=orphans_deleted,
+    )
 
 
 async def stage_job_file(file: IO[bytes], job_id: UUID) -> Path:

--- a/backend/src/eneo/worker/crawl_tasks.py
+++ b/backend/src/eneo/worker/crawl_tasks.py
@@ -637,7 +637,7 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
                         "metric_value": 1,
                     },
                 )
-                setattr(task_manager, "_job_already_handled", True)
+                task_manager.mark_job_handled()
                 return {
                     "status": "duplicate_skipped",
                     "job_id": str(job_id),
@@ -1613,7 +1613,7 @@ async def crawl_task(*, job_id: UUID, params: CrawlTask, container: Container):
             # Signal task_manager to skip its complete_job() call
             # Why: We've already completed the job with a fresh session above,
             # task_manager's job_service has stale session references
-            setattr(task_manager, "_job_already_handled", True)
+            task_manager.mark_job_handled()
 
         return task_manager.successful()
     finally:

--- a/backend/src/eneo/worker/routes.py
+++ b/backend/src/eneo/worker/routes.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from typing import cast
 from uuid import UUID
 
@@ -12,6 +13,8 @@ from eneo.audit.application.export_worker_task import export_audit_logs_task
 from eneo.database.database import AsyncSession
 from eneo.jobs.durable_dispatch import redispatch_stale_jobs
 from eneo.jobs.job_manager import job_manager
+from eneo.jobs.job_repo import KNOWLEDGE_JOB_STALE_AFTER, JobRepository
+from eneo.jobs.job_staging import reconcile_job_staging
 from eneo.jobs.task_models import (
     AnalyzeConversationInsightsTask,
     Transcription,
@@ -80,14 +83,14 @@ class AuditPurgeResult(TypedDict):
     success: bool
 
 
-@worker.function(keep_result=0)
+@worker.long_running_function(keep_result=0)
 async def upload_info_blob(job_id: UUID, params: UploadInfoBlob, container: Container):
     return await upload_info_blob_task(
         job_id=job_id, params=params, container=container
     )
 
 
-@worker.function(keep_result=0)
+@worker.long_running_function(keep_result=0)
 async def transcription(job_id: UUID, params: Transcription, container: Container):
     return await transcription_task(job_id=job_id, params=params, container=container)
 
@@ -97,6 +100,24 @@ async def redispatch_durable_knowledge_jobs(container: Container) -> None:
     session = cast(AsyncSession, container.session())
     async with session.begin():
         await redispatch_stale_jobs(session, enqueue=job_manager.enqueue)
+
+
+@worker.cron_job(manages_own_session=True)
+async def reap_stale_knowledge_jobs(container: Container) -> None:
+    session = cast(AsyncSession, container.session())
+    async with session.begin():
+        await JobRepository(session).mark_stale_in_progress_jobs_failed(
+            datetime.now(timezone.utc) - KNOWLEDGE_JOB_STALE_AFTER
+        )
+
+
+@worker.cron_job(manages_own_session=True)
+async def reconcile_knowledge_job_staging(
+    container: Container,
+) -> None:
+    session = cast(AsyncSession, container.session())
+    async with session.begin():
+        await reconcile_job_staging(session)
 
 
 @worker.long_running_function()

--- a/backend/src/eneo/worker/task_manager.py
+++ b/backend/src/eneo/worker/task_manager.py
@@ -67,7 +67,7 @@ class TaskManager:
     def _log_status(self, status: Status):
         logger.info(f"Status for {self.job_id}: {status}")
 
-    async def _publish_status(self, status: Status):
+    async def publish_status(self, status: Status):
         if self.channel_type is not None:
             user_id = self.user.id
             channel = Channel(
@@ -130,16 +130,19 @@ class TaskManager:
     def successful(self) -> bool | None:
         return self.success
 
+    def mark_job_handled(self) -> None:
+        self._job_already_handled = True
+
     async def set_status(self, status: Status):
         self._log_status(status)
-        await self._publish_status(status=status)
+        await self.publish_status(status=status)
         if self.job_service is not None:
             await self.job_service.set_status(self.job_id, status)
 
     async def complete_job(self):
         if self._job_already_handled:
             return
-        await self._publish_status(status=Status.COMPLETE)
+        await self.publish_status(status=Status.COMPLETE)
         if self.job_service is not None:
             try:
                 await self.job_service.complete_job(self.job_id, self._result_location)
@@ -152,7 +155,7 @@ class TaskManager:
     async def fail_job(self, message: str | None = None):
         if self._job_already_handled:
             return
-        await self._publish_status(status=Status.FAILED)
+        await self.publish_status(status=Status.FAILED)
 
         if message:
             logger.warning(

--- a/backend/src/eneo/worker/upload_tasks.py
+++ b/backend/src/eneo/worker/upload_tasks.py
@@ -1,16 +1,22 @@
+import asyncio
 import contextlib
 import os
+from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import cast
 from uuid import UUID
-
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from eneo.files.text import NoExtractableTextError
 from eneo.jobs.job_staging import job_staging_path
 from eneo.jobs.task_models import Transcription, UploadInfoBlob
 from eneo.main.container.container import Container
 from eneo.main.exceptions import BadRequestException
+from eneo.main.logging import get_logger
+from eneo.main.models import Status
+from eneo.worker.task_manager import TaskManager
+
+KNOWLEDGE_HEARTBEAT_INTERVAL_SECONDS = 30
+
+logger = get_logger(__name__)
 
 
 def _remove_file(filepath: Path):
@@ -27,56 +33,167 @@ def _job_file_path(job_id: UUID, params: UploadInfoBlob | Transcription) -> Path
     return job_staging_path(job_id)
 
 
+async def _run_knowledge_heartbeat(
+    container: Container,
+    job_id: UUID,
+    owner_task: asyncio.Task[object],
+) -> None:
+    while True:
+        await asyncio.sleep(KNOWLEDGE_HEARTBEAT_INTERVAL_SECONDS)
+        try:
+            async with Container.session_scope():
+                lease_live = await container.job_repo().touch_job(job_id)
+        except Exception as exc:
+            logger.warning(
+                "Knowledge job heartbeat failed",
+                extra={"job_id": str(job_id), "error": str(exc)},
+            )
+            continue
+        if not lease_live:
+            owner_task.cancel()
+            return
+
+
+@asynccontextmanager
+async def _knowledge_heartbeat(container: Container, job_id: UUID):
+    owner_task = asyncio.current_task()
+    assert owner_task is not None
+    heartbeat = asyncio.create_task(
+        _run_knowledge_heartbeat(container, job_id, owner_task)
+    )
+    try:
+        yield
+    finally:
+        heartbeat.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await heartbeat
+
+
+class _KnowledgeJobLifecycle:
+    def __init__(
+        self,
+        *,
+        container: Container,
+        job_id: UUID,
+        task_manager: TaskManager,
+    ) -> None:
+        self.container = container
+        self.job_id = job_id
+        self.task_manager = task_manager
+
+    @classmethod
+    async def start(
+        cls,
+        *,
+        container: Container,
+        job_id: UUID,
+    ) -> "_KnowledgeJobLifecycle | None":
+        async with Container.session_scope():
+            if not await container.job_repo().mark_job_started(job_id):
+                return None
+
+        return cls(
+            container=container,
+            job_id=job_id,
+            task_manager=container.task_manager(
+                job_id=job_id,
+            ),
+        )
+
+    async def finalize(self, result_location: str) -> None:
+        if not await self.container.job_repo().mark_job_completed(
+            self.job_id,
+            result_location,
+        ):
+            raise RuntimeError("Knowledge job is no longer in progress")
+        self.task_manager.result_location = result_location
+
+    async def _fail_if_running(self, exc: BaseException) -> None:
+        if isinstance(exc, asyncio.CancelledError):
+            message = "Job cancelled"
+        else:
+            error = str(exc).strip()
+            message = error[:512] if error else None
+
+        self.task_manager.mark_job_handled()
+        async with Container.session_scope():
+            failed = await self.container.job_repo().mark_job_failed_if_running(
+                self.job_id,
+                message,
+            )
+        if failed:
+            await self.task_manager.publish_status(Status.FAILED)
+
+    @asynccontextmanager
+    async def process(self):
+        async with self.task_manager.set_status_on_exception(status_already_set=True):
+            try:
+                await self.task_manager.publish_status(Status.IN_PROGRESS)
+                async with _knowledge_heartbeat(self.container, self.job_id):
+                    yield
+            except (Exception, asyncio.CancelledError) as exc:
+                await self._fail_if_running(exc)
+                raise
+            else:
+                self.task_manager.mark_job_handled()
+                await self.task_manager.publish_status(Status.COMPLETE)
+
+
 async def transcription_task(
     *,
     job_id: UUID,
     params: Transcription,
     container: Container,
 ):
-    task_manager = container.task_manager(job_id=job_id)
-    async with task_manager.set_status_on_exception():
-        filepath = _job_file_path(job_id, params)
+    lifecycle = await _KnowledgeJobLifecycle.start(
+        container=container,
+        job_id=job_id,
+    )
+    if lifecycle is None:
+        return None
 
-        # Define cleanup function
-        task_manager.cleanup_func = lambda: _remove_file(filepath)
+    filepath = _job_file_path(job_id, params)
+    lifecycle.task_manager.cleanup_func = lambda: _remove_file(filepath)
+    async with lifecycle.process():
+        async with Container.session_scope():
+            space_service = container.space_service()
+            space = await space_service.get_space(params.space_id)
 
-        # Get the space
-        space_service = container.space_service()
-        space = await space_service.get_space(params.space_id)
+            transcription_model = space.get_default_transcription_model()
 
-        # Get the transcription model from the space
-        transcription_model = space.get_default_transcription_model()
+            if transcription_model is None:
+                raise BadRequestException(
+                    "No transcription model enabled in the space."
+                )
 
-        # If the space doesn't have any transcription models, fail the job
-        if transcription_model is None:
-            raise BadRequestException("No transcription model enabled in the space.")
+            transcriber = container.transcriber()
+            group_service = container.group_service()
+            group = await group_service.get_group(params.group_id)
+            embedding_model = group.embedding_model
 
-        transcriber = container.transcriber()
-        uploader = container.text_processor()
-        group_service = container.group_service()
-        group = await group_service.get_group(params.group_id)
-        embedding_model = group.embedding_model
-
-        text = await transcriber.transcribe_from_filepath(
-            filepath=filepath, transcription_model=transcription_model
+            prepared_transcription = await transcriber.prepare_transcription(
+                transcription_model
+            )
+        text = await transcriber.transcribe_prepared_from_filepath(
+            filepath=filepath,
+            adapter=prepared_transcription,
         )
         if not text.strip():
             raise NoExtractableTextError(params.filename)
 
-        # Keep knowledge publication atomic while job status uses the ambient transaction.
-        session = cast(AsyncSession, container.session())
-        async with session.begin_nested():
+        async with Container.session_scope():
+            uploader = container.text_processor()
             info_blob = await uploader.process_text(
                 text=text,
                 embedding_model=embedding_model,
                 title=params.filename,
                 group_id=params.group_id,
             )
+            result_location = f"/api/v1/info-blobs/{info_blob.id}/"
+            await lifecycle.finalize(result_location)
         assert info_blob is not None
 
-        task_manager.result_location = f"/api/v1/info-blobs/{info_blob.id}/"
-
-    return task_manager.successful()
+    return lifecycle.task_manager.successful()
 
 
 async def upload_info_blob_task(
@@ -85,34 +202,40 @@ async def upload_info_blob_task(
     params: UploadInfoBlob,
     container: Container,
 ):
-    task_manager = container.task_manager(job_id=job_id)
-    async with task_manager.set_status_on_exception():
-        filepath = _job_file_path(job_id, params)
+    lifecycle = await _KnowledgeJobLifecycle.start(
+        container=container,
+        job_id=job_id,
+    )
+    if lifecycle is None:
+        return None
 
-        # Define cleanup function
-        task_manager.cleanup_func = lambda: _remove_file(filepath)
+    filepath = _job_file_path(job_id, params)
+    lifecycle.task_manager.cleanup_func = lambda: _remove_file(filepath)
+    async with lifecycle.process():
+        async with Container.session_scope():
+            group_service = container.group_service()
+            group = await group_service.get_group(params.group_id)
+            embedding_model = group.embedding_model
 
-        uploader = container.text_processor()
-        group_service = container.group_service()
-        group = await group_service.get_group(params.group_id)
-        embedding_model = group.embedding_model
-
-        text = container.text_extractor().extract(
-            filepath, params.mimetype, params.filename
+        text = await asyncio.to_thread(
+            container.text_extractor().extract,
+            filepath,
+            params.mimetype,
+            params.filename,
         )
         if not text.strip():
             raise NoExtractableTextError(params.filename)
 
-        session = cast(AsyncSession, container.session())
-        async with session.begin_nested():
+        async with Container.session_scope():
+            uploader = container.text_processor()
             info_blob = await uploader.process_text(
                 text=text,
                 embedding_model=embedding_model,
                 title=params.filename,
                 group_id=params.group_id,
             )
+            result_location = f"/api/v1/info-blobs/{info_blob.id}/"
+            await lifecycle.finalize(result_location)
         assert info_blob is not None
 
-        task_manager.result_location = f"/api/v1/info-blobs/{info_blob.id}/"
-
-    return task_manager.successful()
+    return lifecycle.task_manager.successful()

--- a/backend/src/eneo/worker/worker.py
+++ b/backend/src/eneo/worker/worker.py
@@ -359,7 +359,9 @@ class Worker:
 
         return decorator
 
-    def long_running_function(self, with_user: bool = True):
+    def long_running_function(
+        self, with_user: bool = True, *, keep_result: int | None = None
+    ):
         """Decorator for long-running tasks (crawls, batch jobs).
 
         Unlike function(), this does NOT hold a database session for the entire
@@ -453,7 +455,12 @@ class Worker:
                 assert job_id is not None
                 return await func(job_id, params, container=container)
 
-            self.functions.append(_traced_job("job", wrapper))
+            traced = _traced_job("job", wrapper)
+            self.functions.append(
+                arq_func(traced, keep_result=keep_result)
+                if keep_result is not None
+                else traced
+            )
             return wrapper
 
         return decorator

--- a/backend/tests/integration/jobs/test_restart_safe_knowledge_processing.py
+++ b/backend/tests/integration/jobs/test_restart_safe_knowledge_processing.py
@@ -1,0 +1,1091 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+from dependency_injector import providers
+
+from eneo.database.database import sessionmanager
+from eneo.database.tables.job_table import Jobs
+from eneo.embedding_models.infrastructure.datastore import Datastore
+from eneo.files.chunk_embedding_list import ChunkEmbeddingList
+from eneo.info_blobs.info_blob import InfoBlobInDB
+from eneo.jobs.job_models import Task
+from eneo.jobs.job_repo import JobRepository
+from eneo.jobs.job_staging import job_staging_path
+from eneo.jobs.task_models import Transcription, UploadInfoBlob
+from eneo.main.container.container import Container, SessionProxy
+from eneo.main.models import ChannelType, RedisMessage, Status
+from eneo.worker import task_manager as task_manager_module
+from eneo.worker import upload_tasks
+from eneo.worker.task_manager import TaskManager
+from eneo.worker.upload_tasks import transcription_task, upload_info_blob_task
+
+pytestmark = pytest.mark.integration
+
+
+class StubExtractor:
+    def extract(
+        self, filepath: Path, mimetype: str, filename: str | None = None
+    ) -> str:
+        return "replacement knowledge"
+
+
+async def _job_updated_at(job_id: UUID) -> datetime:
+    async with sessionmanager.session() as session, session.begin():
+        updated_at = await session.scalar(
+            sa.select(Jobs.updated_at).where(Jobs.id == job_id)
+        )
+    assert updated_at is not None
+    return updated_at
+
+
+async def test_concurrent_deliveries_start_compute_at_most_once_and_preserve_staging(
+    db_container, tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "eneo.jobs.job_staging.get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    job_id = uuid4()
+    async with db_container() as setup:
+        user = setup.user()
+        tenant = setup.tenant()
+        setup.session().add(
+            Jobs(
+                id=job_id,
+                user_id=user.id,
+                task=Task.UPLOAD_FILE.value,
+                status=Status.QUEUED.value,
+            )
+        )
+
+    filepath = job_staging_path(job_id)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    filepath.write_bytes(b"replacement")
+
+    compute_started = asyncio.Event()
+    allow_compute_to_finish = asyncio.Event()
+    compute_entries = 0
+
+    async def process_text(**_kwargs: object) -> SimpleNamespace:
+        nonlocal compute_entries
+        compute_entries += 1
+        compute_started.set()
+        await allow_compute_to_finish.wait()
+        return SimpleNamespace(id=uuid4())
+
+    async def deliver() -> bool | None:
+        container = Container(
+            session=providers.Object(SessionProxy()),
+            user=providers.Object(user),
+            tenant=providers.Object(tenant),
+        )
+        container.text_extractor.override(providers.Object(StubExtractor()))
+        container.group_service.override(
+            providers.Object(
+                SimpleNamespace(
+                    get_group=AsyncMock(
+                        return_value=SimpleNamespace(embedding_model=object())
+                    )
+                )
+            )
+        )
+        container.text_processor.override(
+            providers.Object(SimpleNamespace(process_text=process_text))
+        )
+        return await upload_info_blob_task(
+            job_id=job_id,
+            params=UploadInfoBlob(
+                user_id=user.id,
+                group_id=uuid4(),
+                space_id=uuid4(),
+                filename="replacement.txt",
+                mimetype="text/plain",
+            ),
+            container=container,
+        )
+
+    deliveries = [asyncio.create_task(deliver()) for _ in range(2)]
+    try:
+        await asyncio.wait_for(compute_started.wait(), timeout=5)
+        for _ in range(100):
+            if any(delivery.done() for delivery in deliveries):
+                break
+            await asyncio.sleep(0.01)
+
+        assert compute_entries == 1
+        assert any(delivery.done() for delivery in deliveries)
+        assert filepath.exists()
+    finally:
+        allow_compute_to_finish.set()
+        await asyncio.gather(*deliveries)
+
+
+async def test_successful_upload_publishes_cas_statuses_without_generic_db_writes(
+    db_container, tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "eneo.jobs.job_staging.get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    job_id = uuid4()
+    async with db_container() as setup:
+        user = setup.user()
+        tenant = setup.tenant()
+        setup.session().add(
+            Jobs(
+                id=job_id,
+                user_id=user.id,
+                task=Task.UPLOAD_FILE.value,
+                status=Status.QUEUED.value,
+            )
+        )
+
+    filepath = job_staging_path(job_id)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    filepath.write_bytes(b"replacement")
+    redis_publish = AsyncMock()
+    monkeypatch.setattr(
+        task_manager_module,
+        "r",
+        SimpleNamespace(publish=redis_publish),
+    )
+
+    container = Container(
+        session=providers.Object(SessionProxy()),
+        user=providers.Object(user),
+        tenant=providers.Object(tenant),
+    )
+    job_service = container.job_service()
+    set_status = AsyncMock()
+    complete_job = AsyncMock()
+    monkeypatch.setattr(job_service, "set_status", set_status)
+    monkeypatch.setattr(job_service, "complete_job", complete_job)
+    container.task_manager.override(
+        providers.Factory(
+            TaskManager,
+            user=user,
+            job_service=job_service,
+            channel_type=ChannelType.APP_RUN_UPDATES,
+        )
+    )
+    container.text_extractor.override(providers.Object(StubExtractor()))
+    container.group_service.override(
+        providers.Object(
+            SimpleNamespace(
+                get_group=AsyncMock(
+                    return_value=SimpleNamespace(embedding_model=object())
+                )
+            )
+        )
+    )
+    container.text_processor.override(
+        providers.Object(
+            SimpleNamespace(
+                process_text=AsyncMock(return_value=SimpleNamespace(id=uuid4()))
+            )
+        )
+    )
+
+    result = await upload_info_blob_task(
+        job_id=job_id,
+        params=UploadInfoBlob(
+            user_id=user.id,
+            group_id=uuid4(),
+            space_id=uuid4(),
+            filename="replacement.txt",
+            mimetype="text/plain",
+        ),
+        container=container,
+    )
+
+    published_statuses = [
+        RedisMessage.model_validate_json(call.args[1]).status
+        for call in redis_publish.await_args_list
+    ]
+    assert result is True
+    assert published_statuses == [Status.IN_PROGRESS, Status.COMPLETE]
+    set_status.assert_not_awaited()
+    complete_job.assert_not_awaited()
+
+
+async def test_transcription_releases_its_session_before_remote_work(
+    db_container, tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "eneo.jobs.job_staging.get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    job_id = uuid4()
+    async with db_container() as setup:
+        user = setup.user()
+        tenant = setup.tenant()
+        setup.session().add(
+            Jobs(
+                id=job_id,
+                user_id=user.id,
+                task=Task.TRANSCRIPTION.value,
+                status=Status.QUEUED.value,
+            )
+        )
+
+    filepath = job_staging_path(job_id)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    filepath.write_bytes(b"audio")
+    container = Container(
+        session=providers.Object(SessionProxy()),
+        user=providers.Object(user),
+        tenant=providers.Object(tenant),
+    )
+
+    class ScopeObservingTranscriber:
+        session_released = False
+
+        async def prepare_transcription(self, _model: object) -> object:
+            return object()
+
+        async def _remote_transcription(self) -> str:
+            try:
+                await container.session().execute(sa.select(1))
+            except RuntimeError:
+                self.session_released = True
+            async with sessionmanager.session() as session, session.begin():
+                assert await session.scalar(sa.select(1)) == 1
+            return "replacement transcript"
+
+        async def transcribe_from_filepath(self, **_kwargs: object) -> str:
+            return await self._remote_transcription()
+
+        async def transcribe_prepared_from_filepath(self, **_kwargs: object) -> str:
+            return await self._remote_transcription()
+
+    transcriber = ScopeObservingTranscriber()
+    container.transcriber.override(providers.Object(transcriber))
+    container.space_service.override(
+        providers.Object(
+            SimpleNamespace(
+                get_space=AsyncMock(
+                    return_value=SimpleNamespace(
+                        get_default_transcription_model=lambda: object()
+                    )
+                )
+            )
+        )
+    )
+    container.group_service.override(
+        providers.Object(
+            SimpleNamespace(
+                get_group=AsyncMock(
+                    return_value=SimpleNamespace(embedding_model=object())
+                )
+            )
+        )
+    )
+    container.text_processor.override(
+        providers.Object(
+            SimpleNamespace(
+                process_text=AsyncMock(return_value=SimpleNamespace(id=uuid4()))
+            )
+        )
+    )
+
+    result = await transcription_task(
+        job_id=job_id,
+        params=Transcription(
+            user_id=user.id,
+            group_id=uuid4(),
+            space_id=uuid4(),
+            filename="replacement.wav",
+            mimetype="audio/wav",
+        ),
+        container=container,
+    )
+
+    assert result is True
+    assert transcriber.session_released is True
+
+
+@pytest.mark.parametrize("stalled_phase", ["extraction", "chunking", "embedding"])
+async def test_heartbeat_advances_updated_at_during_each_compute_phase(
+    db_container, tmp_path, monkeypatch, stalled_phase: str
+) -> None:
+    monkeypatch.setattr(
+        "eneo.jobs.job_staging.get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    monkeypatch.setattr(
+        upload_tasks,
+        "KNOWLEDGE_HEARTBEAT_INTERVAL_SECONDS",
+        0.05,
+        raising=False,
+    )
+    job_id = uuid4()
+    async with db_container() as setup:
+        user = setup.user()
+        tenant = setup.tenant()
+        setup.session().add(
+            Jobs(
+                id=job_id,
+                user_id=user.id,
+                task=Task.UPLOAD_FILE.value,
+                status=Status.QUEUED.value,
+            )
+        )
+
+    filepath = job_staging_path(job_id)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    filepath.write_bytes(b"replacement")
+
+    phase_started_at: datetime | None = None
+    phase_finished = asyncio.Event()
+    allow_task_to_finish = asyncio.Event()
+    allow_embedding_to_finish = asyncio.Event()
+
+    def stall_sync_phase() -> None:
+        nonlocal phase_started_at
+        phase_started_at = datetime.now(timezone.utc)
+        release = threading.Event()
+        threading.Timer(0.25, release.set).start()
+        assert release.wait(timeout=2)
+
+    class PhaseExtractor:
+        def extract(
+            self, filepath: Path, mimetype: str, filename: str | None = None
+        ) -> str:
+            if stalled_phase == "extraction":
+                stall_sync_phase()
+            return "replacement knowledge"
+
+    original_chunk_text = Datastore._chunk_text
+
+    def chunk_text(datastore: Datastore, info_blob: InfoBlobInDB):
+        if stalled_phase == "chunking":
+            stall_sync_phase()
+        return original_chunk_text(datastore, info_blob)
+
+    monkeypatch.setattr(Datastore, "_chunk_text", chunk_text)
+
+    class Embeddings:
+        async def get_embeddings(self, *, model, chunks):
+            nonlocal phase_started_at
+            if stalled_phase == "embedding":
+                phase_started_at = datetime.now(timezone.utc)
+                phase_finished.set()
+                await allow_embedding_to_finish.wait()
+            result = ChunkEmbeddingList()
+            result.add(chunks, [[0.1, 0.2, 0.3] for _ in chunks])
+            return result
+
+    chunk_repo = SimpleNamespace(add=AsyncMock())
+    datastore = Datastore(
+        user=user,
+        info_blob_chunk_repo=chunk_repo,
+        create_embeddings_service=Embeddings(),
+    )
+
+    async def process_text(**_kwargs: object) -> SimpleNamespace:
+        await datastore.add(
+            InfoBlobInDB(
+                id=uuid4(),
+                embedding_model_id=uuid4(),
+                user_id=user.id,
+                tenant_id=user.tenant_id,
+                size=0,
+                source_id=uuid4(),
+                version_state="active",
+                text="replacement knowledge",
+                group_id=uuid4(),
+            ),
+            embedding_model=object(),
+        )
+        phase_finished.set()
+        await allow_task_to_finish.wait()
+        return SimpleNamespace(id=uuid4())
+
+    container = Container(
+        session=providers.Object(SessionProxy()),
+        user=providers.Object(user),
+        tenant=providers.Object(tenant),
+    )
+    container.text_extractor.override(providers.Object(PhaseExtractor()))
+    container.group_service.override(
+        providers.Object(
+            SimpleNamespace(
+                get_group=AsyncMock(
+                    return_value=SimpleNamespace(embedding_model=object())
+                )
+            )
+        )
+    )
+    container.text_processor.override(
+        providers.Object(SimpleNamespace(process_text=process_text))
+    )
+
+    task = asyncio.create_task(
+        upload_info_blob_task(
+            job_id=job_id,
+            params=UploadInfoBlob(
+                user_id=user.id,
+                group_id=uuid4(),
+                space_id=uuid4(),
+                filename="replacement.txt",
+                mimetype="text/plain",
+            ),
+            container=container,
+        )
+    )
+    try:
+        await asyncio.wait_for(phase_finished.wait(), timeout=5)
+        assert phase_started_at is not None
+        if stalled_phase == "embedding":
+            await asyncio.sleep(0.15)
+        assert await _job_updated_at(job_id) > phase_started_at
+    finally:
+        allow_embedding_to_finish.set()
+        allow_task_to_finish.set()
+        await task
+
+
+async def test_heartbeat_recovers_after_one_failed_database_update(
+    db_container, tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "eneo.jobs.job_staging.get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    monkeypatch.setattr(
+        upload_tasks,
+        "KNOWLEDGE_HEARTBEAT_INTERVAL_SECONDS",
+        0.05,
+        raising=False,
+    )
+    job_id = uuid4()
+    async with db_container() as setup:
+        user = setup.user()
+        tenant = setup.tenant()
+        setup.session().add(
+            Jobs(
+                id=job_id,
+                user_id=user.id,
+                task=Task.UPLOAD_FILE.value,
+                status=Status.QUEUED.value,
+            )
+        )
+
+    filepath = job_staging_path(job_id)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    filepath.write_bytes(b"replacement")
+    phase_started_at = datetime.now(timezone.utc)
+    allow_task_to_finish = asyncio.Event()
+    original_touch_job = JobRepository.touch_job
+    beat_attempts = 0
+
+    async def fail_first_beat(self: JobRepository, touched_job_id: UUID) -> bool:
+        nonlocal beat_attempts
+        beat_attempts += 1
+        if beat_attempts == 1:
+            raise RuntimeError("transient heartbeat failure")
+        return await original_touch_job(self, touched_job_id)
+
+    monkeypatch.setattr(JobRepository, "touch_job", fail_first_beat)
+
+    async def process_text(**_kwargs: object) -> SimpleNamespace:
+        await allow_task_to_finish.wait()
+        return SimpleNamespace(id=uuid4())
+
+    container = Container(
+        session=providers.Object(SessionProxy()),
+        user=providers.Object(user),
+        tenant=providers.Object(tenant),
+    )
+    container.text_extractor.override(providers.Object(StubExtractor()))
+    container.group_service.override(
+        providers.Object(
+            SimpleNamespace(
+                get_group=AsyncMock(
+                    return_value=SimpleNamespace(embedding_model=object())
+                )
+            )
+        )
+    )
+    container.text_processor.override(
+        providers.Object(SimpleNamespace(process_text=process_text))
+    )
+
+    task = asyncio.create_task(
+        upload_info_blob_task(
+            job_id=job_id,
+            params=UploadInfoBlob(
+                user_id=user.id,
+                group_id=uuid4(),
+                space_id=uuid4(),
+                filename="replacement.txt",
+                mimetype="text/plain",
+            ),
+            container=container,
+        )
+    )
+    try:
+        for _ in range(100):
+            await asyncio.sleep(0.02)
+            if beat_attempts >= 2 and await _job_updated_at(job_id) > phase_started_at:
+                break
+        assert beat_attempts >= 2
+        assert await _job_updated_at(job_id) > phase_started_at
+    finally:
+        allow_task_to_finish.set()
+        await task
+
+
+async def test_heartbeat_does_not_touch_failed_job(db_container, monkeypatch) -> None:
+    monkeypatch.setattr(
+        upload_tasks,
+        "KNOWLEDGE_HEARTBEAT_INTERVAL_SECONDS",
+        0.01,
+        raising=False,
+    )
+    job_id = uuid4()
+    failed_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+    async with db_container() as setup:
+        setup.session().add(
+            Jobs(
+                id=job_id,
+                user_id=setup.user().id,
+                task=Task.UPLOAD_FILE.value,
+                status=Status.FAILED.value,
+                updated_at=failed_at,
+            )
+        )
+
+    owner_task = asyncio.create_task(asyncio.Event().wait())
+    heartbeat = asyncio.create_task(
+        upload_tasks._run_knowledge_heartbeat(
+            Container(session=providers.Object(SessionProxy())),
+            job_id,
+            owner_task,
+        )
+    )
+    await asyncio.wait_for(heartbeat, timeout=1)
+    with pytest.raises(asyncio.CancelledError):
+        await owner_task
+
+    assert await _job_updated_at(job_id) == failed_at
+
+
+@pytest.mark.parametrize("reaped_before_cancel", [False, True])
+async def test_cancelled_upload_uses_guarded_failure_and_reraises(
+    db_container,
+    tmp_path,
+    monkeypatch,
+    reaped_before_cancel: bool,
+) -> None:
+    monkeypatch.setattr(
+        "eneo.jobs.job_staging.get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    monkeypatch.setattr(
+        upload_tasks,
+        "KNOWLEDGE_HEARTBEAT_INTERVAL_SECONDS",
+        0.01,
+    )
+    job_id = uuid4()
+    async with db_container() as setup:
+        user = setup.user()
+        tenant = setup.tenant()
+        setup.session().add(
+            Jobs(
+                id=job_id,
+                user_id=user.id,
+                task=Task.UPLOAD_FILE.value,
+                status=Status.QUEUED.value,
+            )
+        )
+
+    filepath = job_staging_path(job_id)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    filepath.write_bytes(b"replacement")
+    redis_publish = AsyncMock()
+    monkeypatch.setattr(
+        task_manager_module,
+        "r",
+        SimpleNamespace(publish=redis_publish),
+    )
+    compute_started = asyncio.Event()
+    compute_cancelled = asyncio.Event()
+
+    async def process_text(**_kwargs: object) -> SimpleNamespace:
+        compute_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            compute_cancelled.set()
+            raise
+        raise AssertionError("unreachable")
+
+    container = Container(
+        session=providers.Object(SessionProxy()),
+        user=providers.Object(user),
+        tenant=providers.Object(tenant),
+    )
+
+    def create_task_manager(*, job_id: UUID) -> TaskManager:
+        return TaskManager(
+            user=user,
+            job_id=job_id,
+            channel_type=ChannelType.APP_RUN_UPDATES,
+        )
+
+    container.task_manager.override(providers.Callable(create_task_manager))
+    container.text_extractor.override(providers.Object(StubExtractor()))
+    container.group_service.override(
+        providers.Object(
+            SimpleNamespace(
+                get_group=AsyncMock(
+                    return_value=SimpleNamespace(embedding_model=object())
+                )
+            )
+        )
+    )
+    container.text_processor.override(
+        providers.Object(SimpleNamespace(process_text=process_text))
+    )
+    task = asyncio.create_task(
+        upload_info_blob_task(
+            job_id=job_id,
+            params=UploadInfoBlob(
+                user_id=user.id,
+                group_id=uuid4(),
+                space_id=uuid4(),
+                filename="replacement.txt",
+                mimetype="text/plain",
+            ),
+            container=container,
+        )
+    )
+    compute_waiter = asyncio.create_task(compute_started.wait())
+    done, _ = await asyncio.wait(
+        {task, compute_waiter},
+        timeout=5,
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+    assert done
+    if task in done:
+        await task
+    assert compute_waiter in done
+
+    reaped_finished_at = datetime.now(timezone.utc)
+    if reaped_before_cancel:
+        async with sessionmanager.session() as session, session.begin():
+            await session.execute(
+                sa.update(Jobs)
+                .where(Jobs.id == job_id)
+                .values(
+                    status=Status.FAILED.value,
+                    result_location="Reaped before cancellation",
+                    finished_at=reaped_finished_at,
+                    updated_at=reaped_finished_at,
+                )
+            )
+
+    if reaped_before_cancel:
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=1)
+    else:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    assert compute_cancelled.is_set()
+
+    async with sessionmanager.session() as session, session.begin():
+        status, reason, finished_at = (
+            await session.execute(
+                sa.select(
+                    Jobs.status,
+                    Jobs.result_location,
+                    Jobs.finished_at,
+                ).where(Jobs.id == job_id)
+            )
+        ).one()
+    published_statuses = [
+        RedisMessage.model_validate_json(call.args[1]).status
+        for call in redis_publish.await_args_list
+    ]
+    if reaped_before_cancel:
+        assert (status, reason, finished_at) == (
+            Status.FAILED.value,
+            "Reaped before cancellation",
+            reaped_finished_at,
+        )
+        assert published_statuses == [Status.IN_PROGRESS]
+    else:
+        assert status == Status.FAILED.value
+        assert reason == "Job cancelled"
+        assert finished_at is not None
+        assert published_statuses == [Status.IN_PROGRESS, Status.FAILED]
+
+
+async def test_reaper_only_fails_a_bounded_page_of_stale_in_progress_jobs(
+    db_container,
+) -> None:
+    from eneo.jobs import job_repo
+
+    now = datetime.now(timezone.utc)
+    stale_at = now - timedelta(minutes=10)
+    fresh_id = uuid4()
+    queued_id = uuid4()
+    stale_ids = [uuid4() for _ in range(job_repo.KNOWLEDGE_REAPER_PAGE_SIZE + 2)]
+
+    async with db_container() as setup:
+        user = setup.user()
+        setup.session().add_all(
+            [
+                Jobs(
+                    id=job_id,
+                    user_id=user.id,
+                    task=(
+                        Task.UPLOAD_FILE.value
+                        if offset % 2 == 0
+                        else Task.TRANSCRIPTION.value
+                    ),
+                    status=Status.IN_PROGRESS.value,
+                    updated_at=stale_at,
+                )
+                for offset, job_id in enumerate(stale_ids)
+            ]
+            + [
+                Jobs(
+                    id=fresh_id,
+                    user_id=user.id,
+                    task=Task.UPLOAD_FILE.value,
+                    status=Status.IN_PROGRESS.value,
+                    updated_at=now,
+                ),
+                Jobs(
+                    id=queued_id,
+                    user_id=user.id,
+                    task=Task.TRANSCRIPTION.value,
+                    status=Status.QUEUED.value,
+                    dispatch_envelope={"version": 1},
+                    updated_at=stale_at,
+                ),
+            ]
+        )
+
+    async with sessionmanager.session() as session, session.begin():
+        first = await JobRepository(session).mark_stale_in_progress_jobs_failed(
+            now - job_repo.KNOWLEDGE_JOB_STALE_AFTER
+        )
+    async with sessionmanager.session() as session, session.begin():
+        second = await JobRepository(session).mark_stale_in_progress_jobs_failed(
+            now - job_repo.KNOWLEDGE_JOB_STALE_AFTER
+        )
+
+    assert len(first) == job_repo.KNOWLEDGE_REAPER_PAGE_SIZE
+    assert len(second) == 2
+    assert set(first + second) == set(stale_ids)
+    async with sessionmanager.session() as session, session.begin():
+        rows = {
+            row.id: (row.status, row.result_location)
+            for row in (
+                await session.execute(
+                    sa.select(Jobs.id, Jobs.status, Jobs.result_location).where(
+                        Jobs.id.in_([*stale_ids, fresh_id, queued_id])
+                    )
+                )
+            ).all()
+        }
+    assert rows[fresh_id][0] == Status.IN_PROGRESS.value
+    assert rows[queued_id][0] == Status.QUEUED.value
+    assert all(
+        rows[job_id] == (Status.FAILED.value, job_repo.KNOWLEDGE_REAPER_FAILURE_REASON)
+        for job_id in stale_ids
+    )
+
+
+def _write_old_staging_file(path: Path, *, now: datetime) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"staged")
+    old_timestamp = (now - timedelta(hours=2)).timestamp()
+    os.utime(path, (old_timestamp, old_timestamp))
+
+
+async def test_staging_reconciler_recovers_terminal_files_and_reaches_orphans(
+    db_container, tmp_path, monkeypatch
+) -> None:
+    from eneo.jobs import job_staging
+
+    monkeypatch.setattr(
+        job_staging,
+        "get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    now = datetime.now(timezone.utc)
+    complete_id = uuid4()
+    failed_id = uuid4()
+    active_ids = [uuid4() for _ in range(job_staging.STAGING_RECONCILE_PAGE_SIZE)]
+    orphan_id = uuid4()
+    async with db_container() as setup:
+        user = setup.user()
+        setup.session().add_all(
+            [
+                Jobs(
+                    id=complete_id,
+                    user_id=user.id,
+                    task=Task.UPLOAD_FILE.value,
+                    status=Status.COMPLETE.value,
+                    dispatch_envelope={"version": 1},
+                    finished_at=now,
+                ),
+                Jobs(
+                    id=failed_id,
+                    user_id=user.id,
+                    task=Task.TRANSCRIPTION.value,
+                    status=Status.FAILED.value,
+                    dispatch_envelope={"version": 1},
+                    finished_at=now,
+                ),
+                *[
+                    Jobs(
+                        id=job_id,
+                        user_id=user.id,
+                        task=Task.UPLOAD_FILE.value,
+                        status=Status.IN_PROGRESS.value,
+                        dispatch_envelope={"version": 1},
+                    )
+                    for job_id in active_ids
+                ],
+            ]
+        )
+
+    paths = {
+        job_id: job_staging.job_staging_path(job_id)
+        for job_id in [complete_id, failed_id, *active_ids, orphan_id]
+    }
+    for path in paths.values():
+        _write_old_staging_file(path, now=now)
+
+    async with sessionmanager.session() as session, session.begin():
+        result = await job_staging.reconcile_job_staging(session, now=now)
+
+    assert result.terminal_cleaned == 2
+    assert result.orphans_deleted == 1
+    assert not paths[complete_id].exists()
+    assert not paths[failed_id].exists()
+    assert not paths[orphan_id].exists()
+    assert all(paths[job_id].exists() for job_id in active_ids)
+    async with sessionmanager.session() as session, session.begin():
+        cleaned = dict(
+            (
+                await session.execute(
+                    sa.select(Jobs.id, Jobs.staging_cleaned_at).where(
+                        Jobs.id.in_([complete_id, failed_id, *active_ids])
+                    )
+                )
+            ).all()
+        )
+    assert cleaned[complete_id] is not None
+    assert cleaned[failed_id] is not None
+    assert all(cleaned[job_id] is None for job_id in active_ids)
+
+
+async def test_orphan_sweep_offloads_discovery_and_batches_database_queries(
+    db_container, tmp_path, monkeypatch
+) -> None:
+    from eneo.jobs import job_staging
+
+    query_batch_size = 4
+    delete_limit = 3
+    monkeypatch.setattr(
+        job_staging,
+        "get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    monkeypatch.setattr(
+        job_staging,
+        "ORPHAN_STAGING_QUERY_BATCH_SIZE",
+        query_batch_size,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        job_staging,
+        "ORPHAN_STAGING_DELETE_LIMIT",
+        delete_limit,
+    )
+    now = datetime.now(timezone.utc)
+    existing_ids = [uuid4() for _ in range(query_batch_size * 2 + 1)]
+    orphan_ids = [uuid4() for _ in range(delete_limit + 1)]
+    async with db_container() as setup:
+        user = setup.user()
+        setup.session().add_all(
+            [
+                Jobs(
+                    id=job_id,
+                    user_id=user.id,
+                    task=Task.UPLOAD_FILE.value,
+                    status=Status.IN_PROGRESS.value,
+                )
+                for job_id in existing_ids
+            ]
+        )
+
+    paths = [
+        job_staging.job_staging_path(job_id) for job_id in [*existing_ids, *orphan_ids]
+    ]
+    for path in paths:
+        _write_old_staging_file(path, now=now)
+
+    staging_directory = paths[0].parent
+    original_iterdir = Path.iterdir
+    discovery_started = threading.Event()
+    allow_discovery = threading.Event()
+    event_loop_progressed = asyncio.Event()
+
+    def ordered_iterdir(self: Path):
+        if self != staging_directory:
+            return original_iterdir(self)
+        discovery_started.set()
+        assert allow_discovery.wait(timeout=1)
+        return iter(paths)
+
+    async def release_discovery() -> None:
+        while not discovery_started.is_set():
+            await asyncio.sleep(0)
+        event_loop_progressed.set()
+        allow_discovery.set()
+
+    monkeypatch.setattr(Path, "iterdir", ordered_iterdir)
+    release_task = asyncio.create_task(release_discovery())
+    query_sizes: list[int] = []
+    async with sessionmanager.session() as session, session.begin():
+        assert session.bind is not None
+        sync_engine = session.bind.sync_engine
+
+        def capture_query_size(
+            _connection,
+            _cursor,
+            statement,
+            parameters,
+            _context,
+            _executemany,
+        ) -> None:
+            if "WHERE jobs.id IN" in statement:
+                query_sizes.append(len(parameters))
+
+        sa.event.listen(sync_engine, "before_cursor_execute", capture_query_size)
+        try:
+            result = await job_staging.reconcile_job_staging(session, now=now)
+        finally:
+            sa.event.remove(
+                sync_engine,
+                "before_cursor_execute",
+                capture_query_size,
+            )
+            await release_task
+
+    assert event_loop_progressed.is_set()
+    assert query_sizes
+    assert max(query_sizes) <= query_batch_size
+    assert result.orphans_deleted == delete_limit
+    assert not job_staging.job_staging_path(orphan_ids[0]).exists()
+    assert job_staging.job_staging_path(orphan_ids[-1]).exists()
+    assert all(job_staging.job_staging_path(job_id).exists() for job_id in existing_ids)
+
+
+async def test_staging_reconciler_retries_failed_unlink(
+    db_container, tmp_path, monkeypatch
+) -> None:
+    from eneo.jobs import job_staging
+
+    monkeypatch.setattr(
+        job_staging,
+        "get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    now = datetime.now(timezone.utc)
+    job_id = uuid4()
+    async with db_container() as setup:
+        user = setup.user()
+        setup.session().add(
+            Jobs(
+                id=job_id,
+                user_id=user.id,
+                task=Task.UPLOAD_FILE.value,
+                status=Status.FAILED.value,
+                dispatch_envelope={"version": 1},
+                finished_at=now,
+            )
+        )
+    path = job_staging.job_staging_path(job_id)
+    _write_old_staging_file(path, now=now)
+    original_unlink = Path.unlink
+
+    def fail_target_unlink(self: Path, *args, **kwargs):
+        if self == path:
+            raise OSError("volume unavailable")
+        return original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_target_unlink)
+    async with sessionmanager.session() as session, session.begin():
+        result = await job_staging.reconcile_job_staging(session, now=now)
+
+    assert result.terminal_cleaned == 0
+    assert path.exists()
+    async with sessionmanager.session() as session, session.begin():
+        assert (
+            await session.scalar(
+                sa.select(Jobs.staging_cleaned_at).where(Jobs.id == job_id)
+            )
+            is None
+        )
+
+
+async def test_staging_reconciler_limits_terminal_database_page(
+    db_container, tmp_path, monkeypatch
+) -> None:
+    from eneo.jobs import job_staging
+
+    monkeypatch.setattr(
+        job_staging,
+        "get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    now = datetime.now(timezone.utc)
+    job_ids = [uuid4() for _ in range(job_staging.STAGING_RECONCILE_PAGE_SIZE + 1)]
+    async with db_container() as setup:
+        user = setup.user()
+        setup.session().add_all(
+            [
+                Jobs(
+                    id=job_id,
+                    user_id=user.id,
+                    task=Task.UPLOAD_FILE.value,
+                    status=Status.COMPLETE.value,
+                    dispatch_envelope={"version": 1},
+                    finished_at=now,
+                )
+                for job_id in job_ids
+            ]
+        )
+    for job_id in job_ids:
+        _write_old_staging_file(job_staging.job_staging_path(job_id), now=now)
+
+    async with sessionmanager.session() as session, session.begin():
+        result = await job_staging.reconcile_job_staging(session, now=now)
+
+    assert result.terminal_cleaned == job_staging.STAGING_RECONCILE_PAGE_SIZE
+    async with sessionmanager.session() as session, session.begin():
+        cleaned_count = await session.scalar(
+            sa.select(sa.func.count())
+            .select_from(Jobs)
+            .where(Jobs.id.in_(job_ids), Jobs.staging_cleaned_at.is_not(None))
+        )
+    assert cleaned_count == job_staging.STAGING_RECONCILE_PAGE_SIZE

--- a/backend/tests/integration/migrations/test_durable_job_dispatch.py
+++ b/backend/tests/integration/migrations/test_durable_job_dispatch.py
@@ -191,7 +191,11 @@ def test_durable_dispatch_migration_round_trip_and_query_plan(
                 )
                 assert cursor.fetchone() == ({"version": 1},)
                 cursor.execute(
-                    "UPDATE jobs SET status = 'failed' WHERE id = %s::uuid",
+                    """
+                    UPDATE jobs
+                    SET status = 'failed', staging_cleaned_at = now()
+                    WHERE id = %s::uuid
+                    """,
                     (str(pending_job_id),),
                 )
     finally:
@@ -222,6 +226,15 @@ def test_downgrade_excludes_a_concurrent_durable_insert(
     barrier.autocommit = True
     try:
         with barrier.cursor() as cursor:
+            cursor.execute(
+                """
+                UPDATE jobs
+                SET staging_cleaned_at = now()
+                WHERE dispatch_envelope IS NOT NULL
+                  AND status IN ('complete', 'failed')
+                  AND staging_cleaned_at IS NULL
+                """
+            )
             cursor.execute("ALTER TABLE jobs DISABLE TRIGGER ALL")
             cursor.execute("SELECT pg_advisory_lock(%s)", (barrier_key,))
             cursor.execute(
@@ -231,7 +244,8 @@ def test_downgrade_excludes_a_concurrent_durable_insert(
                 LANGUAGE plpgsql
                 AS $$
                 BEGIN
-                    IF tg_tag = 'DROP INDEX' THEN
+                    IF tg_tag = 'DROP INDEX'
+                       AND current_query() LIKE '%ix_jobs_durable_dispatch%' THEN
                         PERFORM pg_advisory_lock({barrier_key});
                         PERFORM pg_advisory_unlock({barrier_key});
                     END IF;

--- a/backend/tests/integration/migrations/test_restart_safe_knowledge_jobs.py
+++ b/backend/tests/integration/migrations/test_restart_safe_knowledge_jobs.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import psycopg2
+import pytest
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import ClauseElement
+from testcontainers.postgres import PostgresContainer
+
+from alembic import command
+from alembic.config import Config
+from eneo.jobs.job_repo import stale_in_progress_jobs_statement
+from eneo.jobs.job_staging import terminal_staging_jobs_statement
+
+pytestmark = [pytest.mark.integration, pytest.mark.migration_isolation]
+
+_PREVIOUS_REVISION = "202607281600"
+_REAPER_INDEX = "ix_jobs_knowledge_in_progress_reaper"
+_CLEANUP_INDEX = "ix_jobs_staging_cleanup"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def override_settings_for_session() -> Generator[None, None, None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def cleanup_database() -> Generator[None, None, None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def seed_default_models() -> Generator[None, None, None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def encryption_service() -> Generator[None, None, None]:
+    yield
+
+
+def _alembic_config(database_url: str) -> Config:
+    backend_dir = Path(__file__).resolve().parents[3]
+    config = Config(str(backend_dir / "alembic.ini"))
+    config.set_main_option("script_location", str(backend_dir / "alembic"))
+    config.set_main_option("sqlalchemy.url", database_url)
+    return config
+
+
+@pytest.fixture(scope="module")
+def migration_database() -> Generator[tuple[str, Config], None, None]:
+    postgres = PostgresContainer(
+        image="pgvector/pgvector:pg16",
+        username="restart_safe_jobs",
+        password="restart_safe_jobs_password",
+        dbname="restart_safe_jobs",
+    )
+    with postgres:
+        database_url = postgres.get_connection_url()
+        yield database_url, _alembic_config(database_url)
+
+
+def _job_schema(database_url: str) -> tuple[set[str], set[str]]:
+    engine = create_engine(database_url)
+    try:
+        inspector = inspect(engine)
+        columns = {str(column["name"]) for column in inspector.get_columns("jobs")}
+        indexes = {str(index["name"]) for index in inspector.get_indexes("jobs")}
+        return columns, indexes
+    finally:
+        engine.dispose()
+
+
+def _prepared_type(value: object) -> str:
+    if isinstance(value, datetime):
+        return "timestamptz"
+    if isinstance(value, str):
+        return "text"
+    if isinstance(value, int):
+        return "integer"
+    raise TypeError(f"Unsupported prepared query value: {type(value).__name__}")
+
+
+def _prepared_plan(
+    connection: psycopg2.extensions.connection,
+    *,
+    name: str,
+    statement: ClauseElement,
+) -> str:
+    compiled_query = statement.compile(
+        dialect=postgresql.dialect(paramstyle="numeric_dollar"),
+        compile_kwargs={"render_postcompile": True},
+    )
+    assert compiled_query.positiontup is not None
+    values = [compiled_query.params[key] for key in compiled_query.positiontup]
+    prepared_types = ", ".join(_prepared_type(value) for value in values)
+    execute_params = ", ".join(["%s"] * len(values))
+    with connection.cursor() as cursor:
+        cursor.execute(f"PREPARE {name} ({prepared_types}) AS {compiled_query}")
+        cursor.execute(f"EXPLAIN EXECUTE {name} ({execute_params})", values)
+        return "\n".join(str(row[0]) for row in cursor.fetchall())
+
+
+def test_restart_safe_knowledge_migration_round_trip_and_query_plans(
+    migration_database: tuple[str, Config],
+) -> None:
+    database_url, config = migration_database
+    command.upgrade(config, "head")
+
+    columns, indexes = _job_schema(database_url)
+    assert "staging_cleaned_at" in columns
+    assert {_REAPER_INDEX, _CLEANUP_INDEX} <= indexes
+
+    connection = psycopg2.connect(database_url.replace("+psycopg2", ""))
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SET enable_seqscan = off")
+            cursor.execute("SET plan_cache_mode = force_generic_plan")
+        reaper_plan = _prepared_plan(
+            connection,
+            name="restart_safe_reaper_plan",
+            statement=stale_in_progress_jobs_statement(datetime.now(timezone.utc)),
+        )
+        cleanup_plan = _prepared_plan(
+            connection,
+            name="restart_safe_cleanup_plan",
+            statement=terminal_staging_jobs_statement(),
+        )
+        assert _REAPER_INDEX in reaper_plan
+        assert _CLEANUP_INDEX in cleanup_plan
+    finally:
+        connection.close()
+
+    terminal_job_id = uuid4()
+    connection = psycopg2.connect(database_url.replace("+psycopg2", ""))
+    try:
+        with connection:
+            with connection.cursor() as cursor:
+                cursor.execute("ALTER TABLE jobs DISABLE TRIGGER ALL")
+                try:
+                    cursor.execute(
+                        """
+                        INSERT INTO jobs (
+                            id, user_id, task, status, dispatch_envelope,
+                            finished_at
+                        )
+                        VALUES (%s::uuid, %s::uuid, %s, %s, %s::jsonb, now())
+                        """,
+                        (
+                            str(terminal_job_id),
+                            str(uuid4()),
+                            "upload_info_blob",
+                            "complete",
+                            '{"version": 1}',
+                        ),
+                    )
+                finally:
+                    cursor.execute("ALTER TABLE jobs ENABLE TRIGGER ALL")
+    finally:
+        connection.close()
+
+    with pytest.raises(RuntimeError, match=r"1 terminal envelope jobs"):
+        command.downgrade(config, _PREVIOUS_REVISION)
+
+    columns, indexes = _job_schema(database_url)
+    assert "staging_cleaned_at" in columns
+    assert {_REAPER_INDEX, _CLEANUP_INDEX} <= indexes
+
+    connection = psycopg2.connect(database_url.replace("+psycopg2", ""))
+    try:
+        with connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    UPDATE jobs
+                    SET staging_cleaned_at = now()
+                    WHERE id = %s::uuid
+                    """,
+                    (str(terminal_job_id),),
+                )
+    finally:
+        connection.close()
+
+    command.downgrade(config, _PREVIOUS_REVISION)
+    columns, indexes = _job_schema(database_url)
+    assert "staging_cleaned_at" not in columns
+    assert _REAPER_INDEX not in indexes
+    assert _CLEANUP_INDEX not in indexes
+
+    command.upgrade(config, "head")
+    columns, indexes = _job_schema(database_url)
+    assert "staging_cleaned_at" in columns
+    assert {_REAPER_INDEX, _CLEANUP_INDEX} <= indexes

--- a/backend/tests/integration/test_ingestion_failure_safety.py
+++ b/backend/tests/integration/test_ingestion_failure_safety.py
@@ -22,10 +22,13 @@ from eneo.database.tables.job_table import Jobs
 from eneo.database.tables.spaces_table import Spaces, SpacesTranscriptionModels
 from eneo.embedding_models.infrastructure.datastore import Datastore
 from eneo.files.chunk_embedding_list import ChunkEmbeddingList
+from eneo.info_blobs.info_blob_service import InfoBlobService
 from eneo.jobs.job_models import Task
 from eneo.jobs.job_staging import job_staging_path
 from eneo.jobs.task_models import Transcription, UploadInfoBlob
+from eneo.main.container.container import Container, SessionProxy
 from eneo.main.models import Status
+from eneo.worker.task_manager import TaskManager
 from eneo.worker.upload_tasks import transcription_task, upload_info_blob_task
 
 TITLE = "stable-knowledge.txt"
@@ -166,6 +169,14 @@ def _assert_prior_knowledge(prior, blobs, chunks):
     assert chunks == expected_chunks
 
 
+def _sessionless_container(*, user, tenant) -> Container:
+    return Container(
+        session=providers.Object(SessionProxy()),
+        user=providers.Object(user),
+        tenant=providers.Object(tenant),
+    )
+
+
 @pytest.mark.parametrize("failure", ["extraction", "chunking", "embedding", "blank"])
 async def test_upload_failure_preserves_committed_prior_knowledge(
     db_container, tmp_path, monkeypatch, failure
@@ -177,37 +188,43 @@ async def test_upload_failure_preserves_committed_prior_knowledge(
     async with db_container() as container:
         user, space, group, job, prior = await _seed_attempt(container)
         job_id = job.id
-        _stage_job_file(tmp_path, job_id, b"replacement")
-        extracted: str | Exception = "replacement knowledge"
-        if failure == "extraction":
-            extracted = RuntimeError("extraction failed")
-        elif failure == "blank":
-            extracted = " \n\t "
-        container.text_extractor.override(providers.Object(StubExtractor(extracted)))
-        if failure in {"embedding", "blank"}:
-            embeddings = AsyncMock()
-            embeddings.get_embeddings.side_effect = RuntimeError("embedding failed")
-            container.create_embeddings_service.override(providers.Object(embeddings))
-        if failure == "chunking":
-            monkeypatch.setattr(
-                Datastore,
-                "_chunk_text",
-                lambda self, info_blob: (_ for _ in ()).throw(
-                    RuntimeError("chunking failed")
-                ),
-            )
+        group_id = group.id
+        space_id = space.id
+        tenant = container.tenant()
+
+    _stage_job_file(tmp_path, job_id, b"replacement")
+    extracted: str | Exception = "replacement knowledge"
+    if failure == "extraction":
+        extracted = RuntimeError("extraction failed")
+    elif failure == "blank":
+        extracted = " \n\t "
+    task_container = _sessionless_container(user=user, tenant=tenant)
+    task_container.text_extractor.override(providers.Object(StubExtractor(extracted)))
+    if failure in {"embedding", "blank"}:
+        embeddings = AsyncMock()
+        embeddings.get_embeddings.side_effect = RuntimeError("embedding failed")
+        task_container.create_embeddings_service.override(providers.Object(embeddings))
+    if failure == "chunking":
+        monkeypatch.setattr(
+            Datastore,
+            "_chunk_text",
+            lambda self, info_blob: (_ for _ in ()).throw(
+                RuntimeError("chunking failed")
+            ),
+        )
+    async with db_container():
         result = await upload_info_blob_task(
-            job_id=job.id,
+            job_id=job_id,
             params=UploadInfoBlob(
                 user_id=user.id,
-                group_id=group.id,
-                space_id=space.id,
+                group_id=group_id,
+                space_id=space_id,
                 filename=TITLE,
                 mimetype="text/plain",
             ),
-            container=container,
+            container=task_container,
         )
-        assert result is False
+    assert result is False
 
     (status, error), blobs, chunks = await _committed_state(job_id)
     assert status == Status.FAILED.value
@@ -228,27 +245,33 @@ async def test_first_upload_failure_publishes_no_knowledge(
     async with db_container() as container:
         user, space, group, job, _ = await _seed_attempt(container, with_existing=False)
         job_id = job.id
-        _stage_job_file(tmp_path, job_id, b"replacement")
-        container.text_extractor.override(
-            providers.Object(
-                StubExtractor(" \n " if failure == "blank" else "replacement knowledge")
-            )
+        group_id = group.id
+        space_id = space.id
+        tenant = container.tenant()
+
+    _stage_job_file(tmp_path, job_id, b"replacement")
+    task_container = _sessionless_container(user=user, tenant=tenant)
+    task_container.text_extractor.override(
+        providers.Object(
+            StubExtractor(" \n " if failure == "blank" else "replacement knowledge")
         )
-        embeddings = AsyncMock()
-        embeddings.get_embeddings.side_effect = RuntimeError("embedding failed")
-        container.create_embeddings_service.override(providers.Object(embeddings))
+    )
+    embeddings = AsyncMock()
+    embeddings.get_embeddings.side_effect = RuntimeError("embedding failed")
+    task_container.create_embeddings_service.override(providers.Object(embeddings))
+    async with db_container():
         result = await upload_info_blob_task(
-            job_id=job.id,
+            job_id=job_id,
             params=UploadInfoBlob(
                 user_id=user.id,
-                group_id=group.id,
-                space_id=space.id,
+                group_id=group_id,
+                space_id=space_id,
                 filename=TITLE,
                 mimetype="text/plain",
             ),
-            container=container,
+            container=task_container,
         )
-        assert result is False
+    assert result is False
 
     (status, error), blobs, chunks = await _committed_state(job_id)
     assert status == Status.FAILED.value
@@ -270,32 +293,38 @@ async def test_successful_upload_commits_replacement_knowledge(
     async with db_container() as container:
         user, space, group, job, prior = await _seed_attempt(container)
         job_id = job.id
-        _stage_job_file(tmp_path, job_id, b"replacement")
-        container.text_extractor.override(
-            providers.Object(StubExtractor(replacement_text))
-        )
-        embeddings = AsyncMock()
+        group_id = group.id
+        space_id = space.id
+        tenant = container.tenant()
 
-        def embed(*, model, chunks):
-            result = ChunkEmbeddingList()
-            result.add(chunks, [[0.7, 0.8, 0.9] for _ in chunks])
-            return result
+    _stage_job_file(tmp_path, job_id, b"replacement")
+    task_container = _sessionless_container(user=user, tenant=tenant)
+    task_container.text_extractor.override(
+        providers.Object(StubExtractor(replacement_text))
+    )
+    embeddings = AsyncMock()
 
-        embeddings.get_embeddings.side_effect = embed
-        container.create_embeddings_service.override(providers.Object(embeddings))
+    def embed(*, model, chunks):
+        result = ChunkEmbeddingList()
+        result.add(chunks, [[0.7, 0.8, 0.9] for _ in chunks])
+        return result
 
+    embeddings.get_embeddings.side_effect = embed
+    task_container.create_embeddings_service.override(providers.Object(embeddings))
+
+    async with db_container():
         result = await upload_info_blob_task(
-            job_id=job.id,
+            job_id=job_id,
             params=UploadInfoBlob(
                 user_id=user.id,
-                group_id=group.id,
-                space_id=space.id,
+                group_id=group_id,
+                space_id=space_id,
                 filename=TITLE,
                 mimetype="text/plain",
             ),
-            container=container,
+            container=task_container,
         )
-        assert result is True
+    assert result is True
 
     (status, result_location), blobs, chunks = await _committed_state(job_id)
     old_blob_id, _ = prior
@@ -312,6 +341,156 @@ async def test_successful_upload_commits_replacement_knowledge(
     assert chunks[0][3] == _pgvector_values([0.7, 0.8, 0.9])
 
 
+async def test_reaped_job_cannot_publish_or_report_success(
+    db_container, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "eneo.jobs.job_staging.get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    replacement_text = "Replacement that must roll back"
+    async with db_container() as container:
+        user, space, group, job, prior = await _seed_attempt(container)
+        job_id = job.id
+        group_id = group.id
+        space_id = space.id
+        tenant = container.tenant()
+
+    original_publish = InfoBlobService.publish_info_blob_without_validation
+    reaped_finished_at = None
+
+    async def publish_then_reap(self, info_blob, *, embedding_model):
+        nonlocal reaped_finished_at
+        published = await original_publish(
+            self,
+            info_blob,
+            embedding_model=embedding_model,
+        )
+        async with sessionmanager.session() as session, session.begin():
+            reaped_finished_at = (
+                await session.execute(
+                    sa.update(Jobs)
+                    .where(Jobs.id == job_id)
+                    .values(
+                        status=Status.FAILED.value,
+                        finished_at=sa.func.now(),
+                        result_location="Reaped while processing",
+                    )
+                    .returning(Jobs.finished_at)
+                )
+            ).scalar_one()
+        return published
+
+    monkeypatch.setattr(
+        InfoBlobService,
+        "publish_info_blob_without_validation",
+        publish_then_reap,
+    )
+    _stage_job_file(tmp_path, job_id, b"replacement")
+    task_container = _sessionless_container(user=user, tenant=tenant)
+    task_container.text_extractor.override(
+        providers.Object(StubExtractor(replacement_text))
+    )
+    embeddings = AsyncMock()
+
+    def embed(*, model, chunks):
+        result = ChunkEmbeddingList()
+        result.add(chunks, [[0.7, 0.8, 0.9] for _ in chunks])
+        return result
+
+    embeddings.get_embeddings.side_effect = embed
+    task_container.create_embeddings_service.override(providers.Object(embeddings))
+
+    async with db_container():
+        result = await upload_info_blob_task(
+            job_id=job_id,
+            params=UploadInfoBlob(
+                user_id=user.id,
+                group_id=group_id,
+                space_id=space_id,
+                filename=TITLE,
+                mimetype="text/plain",
+            ),
+            container=task_container,
+        )
+
+    assert result is False
+    (status, reason), blobs, chunks = await _committed_state(job_id)
+    assert status == Status.FAILED.value
+    assert reason == "Reaped while processing"
+    async with sessionmanager.session() as session, session.begin():
+        finished_at = await session.scalar(
+            sa.select(Jobs.finished_at).where(Jobs.id == job_id)
+        )
+    assert finished_at == reaped_finished_at
+    _assert_prior_knowledge(prior, blobs, chunks)
+
+
+async def test_complete_status_publication_failure_preserves_committed_knowledge(
+    db_container, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(
+        "eneo.jobs.job_staging.get_settings",
+        lambda: SimpleNamespace(upload_tmp_dir=tmp_path),
+    )
+    replacement_text = "Committed replacement knowledge"
+    async with db_container() as container:
+        user, space, group, job, prior = await _seed_attempt(container)
+        job_id = job.id
+        group_id = group.id
+        space_id = space.id
+        tenant = container.tenant()
+
+    original_publish_status = TaskManager.publish_status
+
+    async def fail_complete_status(self, status):
+        if status == Status.COMPLETE:
+            raise RuntimeError("status publication failed")
+        await original_publish_status(self, status)
+
+    monkeypatch.setattr(TaskManager, "publish_status", fail_complete_status)
+    _stage_job_file(tmp_path, job_id, b"replacement")
+    task_container = _sessionless_container(user=user, tenant=tenant)
+    task_container.text_extractor.override(
+        providers.Object(StubExtractor(replacement_text))
+    )
+    embeddings = AsyncMock()
+
+    def embed(*, model, chunks):
+        result = ChunkEmbeddingList()
+        result.add(chunks, [[0.7, 0.8, 0.9] for _ in chunks])
+        return result
+
+    embeddings.get_embeddings.side_effect = embed
+    task_container.create_embeddings_service.override(providers.Object(embeddings))
+
+    async with db_container():
+        result = await upload_info_blob_task(
+            job_id=job_id,
+            params=UploadInfoBlob(
+                user_id=user.id,
+                group_id=group_id,
+                space_id=space_id,
+                filename=TITLE,
+                mimetype="text/plain",
+            ),
+            container=task_container,
+        )
+
+    assert result is False
+    (status, result_location), blobs, chunks = await _committed_state(job_id)
+    old_blob_id, _ = prior
+    assert status == Status.COMPLETE.value
+    assert len(blobs) == 1
+    blob_id, text, _ = blobs[0]
+    assert blob_id != old_blob_id
+    assert text == replacement_text
+    assert result_location == f"/api/v1/info-blobs/{blob_id}/"
+    assert [(chunk_no, text) for _, chunk_no, text, _ in chunks] == [
+        (0, replacement_text)
+    ]
+
+
 @pytest.mark.parametrize("failure", ["embedding", "blank"])
 async def test_transcription_failure_preserves_committed_prior_knowledge(
     db_container, tmp_path, monkeypatch, transcription_model_factory, failure
@@ -323,7 +502,9 @@ async def test_transcription_failure_preserves_committed_prior_knowledge(
     async with db_container() as container:
         user, space, group, job, prior = await _seed_attempt(container)
         job_id = job.id
-        _stage_job_file(tmp_path, job_id, b"not used")
+        group_id = group.id
+        space_id = space.id
+        tenant = container.tenant()
         transcription_model = await transcription_model_factory(
             container.session(), "ingestion-safety-transcription"
         )
@@ -333,27 +514,32 @@ async def test_transcription_failure_preserves_committed_prior_knowledge(
             )
         )
         await container.session().flush()
-        transcriber = AsyncMock()
-        transcriber.transcribe_from_filepath.return_value = (
-            " \n " if failure == "blank" else "replacement transcript"
-        )
-        container.transcriber.override(providers.Object(transcriber))
-        embeddings = AsyncMock()
-        embeddings.get_embeddings.side_effect = RuntimeError("embedding failed")
-        container.create_embeddings_service.override(providers.Object(embeddings))
 
+    _stage_job_file(tmp_path, job_id, b"not used")
+    task_container = _sessionless_container(user=user, tenant=tenant)
+    transcriber = AsyncMock()
+    transcriber.prepare_transcription.return_value = object()
+    transcriber.transcribe_prepared_from_filepath.return_value = (
+        " \n " if failure == "blank" else "replacement transcript"
+    )
+    task_container.transcriber.override(providers.Object(transcriber))
+    embeddings = AsyncMock()
+    embeddings.get_embeddings.side_effect = RuntimeError("embedding failed")
+    task_container.create_embeddings_service.override(providers.Object(embeddings))
+
+    async with db_container():
         result = await transcription_task(
-            job_id=job.id,
+            job_id=job_id,
             params=Transcription(
                 user_id=user.id,
-                group_id=group.id,
-                space_id=space.id,
+                group_id=group_id,
+                space_id=space_id,
                 filename=TITLE,
                 mimetype="audio/wav",
             ),
-            container=container,
+            container=task_container,
         )
-        assert result is False
+    assert result is False
 
     (status, error), blobs, chunks = await _committed_state(job_id)
     assert status == Status.FAILED.value


### PR DESCRIPTION
## Changes

- Starting a knowledge job (file upload or transcription) is now a durable compare-and-set on the existing `mark_job_started` owner, so two workers can never process the same job and a duplicate delivery exits harmlessly without touching the winner's staged file.
- Both tasks moved onto the sessionless long-running worker pattern (deepened to preserve `keep_result`), with their shared start/heartbeat/finalize sequence consolidated in one small lifecycle owner. Extraction, token-aware chunking, and remote transcription now run off the event loop and outside any held database connection — `Transcriber` separates provider resolution from the remote call.
- A scoped heartbeat keeps a running job visibly alive; it touches only in-progress rows and logs-and-continues on transient database failures.
- Publication and completion commit in one transaction whose completion step is a CAS, and terminal states are monotonic: failure is an in-progress-only guarded transition, the reaper's verdict is never overwritten, a committed completion can never be demoted by a later publication failure, and worker shutdown (cancellation) takes the same guarded path.
- A dedicated bounded reaper fails stale in-progress knowledge jobs behind a new partial index, leaving queued jobs to redispatch and SharePoint semantics untouched.
- Staged files gain jobs-owned reconciliation: a cleanup-state column driven in indexed pages, retryable on unlink failure, plus a capped grace-period sweep for files whose job row never committed.

## Why

Since #633 a committed job always reaches a worker, but processing itself was fragile: a worker killed mid-extraction left the job silently stuck with no sign of life, staged files leaked onto the persistent volume, and a slow worker could still mark a job successful after the system had given up on it. Administrators saw jobs that hang forever or change state in ways they could not trust. Active knowledge remains intact when processing fails (the #609 contract is preserved; the redundant task-level savepoints are removed only after the failure-safety suite was rewritten to drive the real production path).

## Planning

- Task: Fixes #636

## Testing

- `POSTGRES_HOST=localhost uv run pytest tests/integration/jobs/ tests/integration/test_ingestion_failure_safety.py -q` — 31 passed. Red-first coverage per contract: concurrent-delivery race, heartbeat across extraction/chunking/embedding plus one failed beat, reaper-wins-before-finalize rollback, terminal-state monotonicity, cancellation, connection release during remote transcription, all three staging crash boundaries.
- `POSTGRES_HOST=localhost uv run pytest -m migration_isolation` for both migration suites — 3 passed (concurrent index creation, query plans, guarded downgrade, round trip).
- `uv run pyright` — 0 errors. Ruff clean on every touched file.
- Three-pass independent review gate: two P1 defects (connection held through remote work; terminal state overwritable) and follow-ups fixed test-first; pass 3 green.

## Screenshots

Backend only.
