### PR TITLE
fix: keep admin pages usable in narrow windows and on iPads

### DIFF
--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -112,6 +112,7 @@
   "governance_prompts_delete_label": "Delete {name}",
   "governance_prompts_delete_named": "Remove “{name}”? This cannot be undone. If the prompt is active in the personal assistant governance, it must be deactivated there first.",
   "admin_nav_aria": "Admin sections",
+  "admin_nav_toggle": "Open admin navigation",
   "admin_section_organisation": "Organisation",
   "admin_section_overview": "Overview",
   "admin_section_governance": "Governance",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -112,6 +112,7 @@
   "governance_prompts_delete_label": "Ta bort {name}",
   "governance_prompts_delete_named": "Ta bort ”{name}”? Detta kan inte ångras. Om prompten är aktiv i styrningen för personlig assistent måste den inaktiveras där först.",
   "admin_nav_aria": "Administrationssektioner",
+  "admin_nav_toggle": "Öppna administrationsmenyn",
   "admin_section_organisation": "Organisation",
   "admin_section_overview": "Översikt",
   "admin_section_governance": "Styrning",

--- a/frontend/apps/web/src/lib/core/detectMobile.test.ts
+++ b/frontend/apps/web/src/lib/core/detectMobile.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import { detectMobile } from "./detectMobile";
+
+// Representative UA formats from Mozilla, WebKit, Chromium, and Microsoft documentation:
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/User-Agent
+const mobileUserAgents = [
+  {
+    name: "Firefox OS with only the Mobile token",
+    userAgent: "Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0"
+  },
+  {
+    name: "iPhone Safari",
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1"
+  },
+  {
+    name: "legacy iPad Safari",
+    userAgent:
+      "Mozilla/5.0 (iPad; CPU OS 12_5_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1"
+  },
+  {
+    name: "Android Chrome",
+    userAgent:
+      "Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36"
+  },
+  {
+    name: "Firefox on Android",
+    userAgent: "Mozilla/5.0 (Android 14; Mobile; rv:126.0) Gecko/126.0 Firefox/126.0"
+  },
+  {
+    name: "Internet Explorer Mobile",
+    userAgent: "Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0)"
+  }
+] as const;
+
+const desktopUserAgents = [
+  {
+    name: "iPadOS Safari in desktop mode",
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Safari/605.1.15"
+  },
+  {
+    name: "Chrome on Windows",
+    userAgent:
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+  },
+  {
+    name: "Safari on macOS",
+    userAgent:
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15"
+  },
+  {
+    name: "Firefox on Windows",
+    userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:126.0) Gecko/20100101 Firefox/126.0"
+  },
+  {
+    name: "Edge on Windows",
+    userAgent:
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36 Edg/126.0.0.0"
+  }
+] as const;
+
+describe("detectMobile", () => {
+  test.each(mobileUserAgents)("detects $name", ({ userAgent }) => {
+    expect(detectMobile(userAgent)).toBe(true);
+  });
+
+  test.each(desktopUserAgents)("does not detect $name", ({ userAgent }) => {
+    expect(detectMobile(userAgent)).toBe(false);
+  });
+});

--- a/frontend/apps/web/src/lib/core/detectMobile.ts
+++ b/frontend/apps/web/src/lib/core/detectMobile.ts
@@ -1,4 +1,4 @@
-const mobileRegex1 = new RegExp("/Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile/");
+const mobileRegex = /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile/;
 export function detectMobile(userAgent: string): boolean {
-  return mobileRegex1.test(userAgent);
+  return mobileRegex.test(userAgent);
 }

--- a/frontend/apps/web/src/routes/(app)/admin/+layout.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/+layout.svelte
@@ -13,8 +13,18 @@
   import AdminMenu from "./AdminMenu.svelte";
   import { IconFeedback } from "@eneo/icons/feedback";
   import { m } from "$lib/paraglide/messages";
+  import { IsMobile } from "$lib/hooks/is-mobile.svelte.js";
 
   const { tenant, featureFlags, environment } = getAppContext();
+  const isMobile = new IsMobile();
+  let navigationTrigger: HTMLButtonElement | null = null;
+
+  // Mobile open state lives in descendant context, so this layout can only close it through the trigger.
+  function closeMobileNavigation(event: MouseEvent) {
+    if (isMobile.current && event.target instanceof Element && event.target.closest("a") !== null) {
+      navigationTrigger?.click();
+    }
+  }
 </script>
 
 <div {...dynamicColour({ basedOn: "1" })} class="absolute inset-0 flex flex-grow justify-stretch">
@@ -22,7 +32,10 @@
     style="--sidebar-width: 17rem;"
     class="h-full min-h-0 w-full flex-grow justify-stretch"
   >
-    <Sidebar.Root collapsible="none" class="border-default border-r-[0.5px]">
+    <Sidebar.Root
+      collapsible={isMobile.current ? "offcanvas" : "none"}
+      class="border-default border-r-[0.5px]"
+    >
       <Sidebar.Header
         class="border-default h-[4.25rem] flex-row items-center gap-3 border-b-[0.5px] px-[1.4rem] font-medium"
       >
@@ -38,7 +51,12 @@
         </span>
       </Sidebar.Header>
 
-      <Sidebar.Content role="navigation" aria-label={m.admin_nav_aria()} class="py-1">
+      <Sidebar.Content
+        role="navigation"
+        aria-label={m.admin_nav_aria()}
+        class="py-1"
+        onclick={closeMobileNavigation}
+      >
         <AdminMenu></AdminMenu>
       </Sidebar.Content>
 
@@ -59,6 +77,12 @@
         <NavigationVersionInfo />
       </Sidebar.Footer>
     </Sidebar.Root>
+
+    <Sidebar.Trigger
+      bind:ref={navigationTrigger}
+      aria-label={m.admin_nav_toggle()}
+      class="mt-2.5 ml-2.5 size-12 self-start md:hidden"
+    />
 
     <slot />
 

--- a/frontend/apps/web/src/routes/(app)/admin/admin-layout.svelte.test.ts
+++ b/frontend/apps/web/src/routes/(app)/admin/admin-layout.svelte.test.ts
@@ -1,0 +1,162 @@
+import { page, userEvent } from "@vitest/browser/context";
+import { render } from "vitest-browser-svelte";
+import { readable } from "svelte/store";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import "../../../app.css";
+
+vi.mock("$app/stores", () => ({
+  page: readable({
+    url: new URL("http://localhost/admin/storage")
+  })
+}));
+
+vi.mock("$lib/core/AppContext", () => ({
+  getAppContext: () => ({
+    tenant: {
+      display_name: "Test tenant"
+    },
+    user: {
+      id: "user-1"
+    },
+    settings: {
+      using_templates: false
+    },
+    featureFlags: {
+      showHelpCenter: false
+    },
+    environment: {
+      baseUrl: "http://localhost",
+      helpCenterUrl: "https://example.com/help"
+    },
+    versions: {
+      frontend: "1.0.0",
+      backend: "1.0.0",
+      client: "1.0.0"
+    }
+  })
+}));
+
+vi.mock("$lib/paraglide/messages", () => ({
+  m: new Proxy<Record<string, () => string>>(
+    {},
+    {
+      get: (_target, key) => () => String(key)
+    }
+  )
+}));
+
+vi.mock("$lib/paraglide/runtime", () => ({
+  deLocalizeHref: (href: string) => href,
+  localizeHref: (href: string) => href
+}));
+
+import AdminLayout from "./+layout.svelte";
+
+describe("admin layout navigation", () => {
+  beforeEach(async () => {
+    await page.viewport(375, 800);
+  });
+
+  test("opens the mobile drawer and restores focus to its localized trigger", async () => {
+    render(AdminLayout);
+
+    const trigger = page.getByRole("button", { name: "admin_nav_toggle" });
+    await expect.element(trigger).toBeVisible();
+    const triggerRect = trigger.element().getBoundingClientRect();
+    const rootFontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize);
+    expect(triggerRect.left).toBeGreaterThanOrEqual(8);
+    expect(triggerRect.width).toBeGreaterThanOrEqual(44);
+    expect(triggerRect.height).toBeGreaterThanOrEqual(44);
+    expect(triggerRect.width).toBe(triggerRect.height);
+    expect(triggerRect.top + triggerRect.height / 2).toBeCloseTo((4.25 * rootFontSize) / 2);
+    expect({
+      left: triggerRect.left,
+      top: triggerRect.top,
+      width: triggerRect.width,
+      height: triggerRect.height
+    }).toEqual({ left: 9.375, top: 9.375, width: 45, height: 45 });
+
+    await trigger.click();
+
+    const drawer = page.getByRole("dialog");
+    await expect.element(drawer).toBeVisible();
+    await vi.waitFor(() => expect(drawer.element().contains(document.activeElement)).toBe(true));
+
+    const focusableCount = drawer
+      .element()
+      .querySelectorAll<HTMLElement>('a[href], button:not([disabled]), [tabindex="0"]').length;
+    for (let index = 0; index <= focusableCount; index += 1) {
+      await userEvent.keyboard("{Tab}");
+      expect(drawer.element().contains(document.activeElement)).toBe(true);
+    }
+
+    await userEvent.keyboard("{Escape}");
+
+    await expect.element(drawer).not.toBeInTheDocument();
+    await expect.element(trigger).toHaveFocus();
+    expect(trigger.element().className).toContain("focus-visible:ring-3");
+  });
+
+  test("closes the mobile drawer when an admin navigation link is activated", async () => {
+    render(AdminLayout);
+
+    await page.getByRole("button", { name: "admin_nav_toggle" }).click();
+
+    const drawer = page.getByRole("dialog");
+    await expect.element(drawer).toBeVisible();
+
+    const storageLink = page.getByRole("link", { name: "storage_settings_nav" });
+    storageLink.element().addEventListener("click", (event) => event.preventDefault(), {
+      once: true
+    });
+    await storageLink.click();
+
+    await expect.element(drawer).not.toBeInTheDocument();
+  });
+
+  test("keeps the desktop navigation permanently visible", async () => {
+    await page.viewport(1280, 800);
+    render(AdminLayout);
+
+    const navigation = page.getByRole("navigation", { name: "admin_nav_aria" });
+    const trigger = document.querySelector<HTMLElement>('[data-slot="sidebar-trigger"]');
+
+    await expect.element(navigation).toBeVisible();
+    expect(trigger).not.toBeNull();
+    expect(getComputedStyle(trigger!).display).toBe("none");
+    expect(document.querySelector('[data-slot="sidebar-gap"]')).toBeNull();
+    const sidebarRect = navigation.element().parentElement!.getBoundingClientRect();
+    const rootFontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize);
+    expect(sidebarRect.width).toBe(17 * rootFontSize);
+
+    await userEvent.keyboard("{Control>}b{/Control}");
+
+    await expect.element(navigation).toBeVisible();
+    expect(document.querySelector('[data-slot="sidebar-gap"]')).toBeNull();
+  });
+
+  test.each([375, 768, 1280, 1920, 3440])(
+    "uses the expected navigation mode without page overflow at %ipx",
+    async (width) => {
+      await page.viewport(width, 800);
+      render(AdminLayout);
+
+      const trigger = document.querySelector<HTMLElement>('[data-slot="sidebar-trigger"]');
+      expect(trigger).not.toBeNull();
+
+      if (width < 768) {
+        expect(getComputedStyle(trigger!).display).not.toBe("none");
+        await expect
+          .element(page.getByRole("navigation", { name: "admin_nav_aria" }))
+          .not.toBeInTheDocument();
+      } else {
+        expect(getComputedStyle(trigger!).display).toBe("none");
+        await expect
+          .element(page.getByRole("navigation", { name: "admin_nav_aria" }))
+          .toBeVisible();
+      }
+
+      expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(innerWidth);
+    }
+  );
+});


### PR DESCRIPTION
## Changes

- Admin navigation uses the sidebar's off-canvas drawer below 768px and keeps the permanent 17rem sidebar at 768px and above, selected by viewport in the admin layout.
- Adds a trigger below that breakpoint with a localized accessible name ("Open admin navigation" / "Öppna administrationsmenyn") and a 45px touch target inset from the edge.
- Activating a menu item closes the drawer and navigates.

## Why — and an important scoping correction

Below 768px the admin sidebar stayed expanded at 17rem, leaving about 97px of a 375px viewport for content, which wrapped to one word per line.

**Who actually hits this is worth stating precisely.** `hooks.server.ts:43-52` redirects any logged-in request whose *user agent* matches `detectMobile` to `/dashboard`, so phones and Android tablets never reach `/admin/*` — Eneo already has a separate mobile dashboard experience for them.

iPads are the interesting case: iPadOS Safari has sent a desktop (`Macintosh`) user agent by default since iPadOS 13, so it does **not** match that regex and iPads do reach the admin area. An iPad Mini in portrait, and any iPad in Split View or Slide Over, sit below 768px and hit the broken layout today.

The other real case is the narrow desktop window: a browser resized below 768px, or macOS Split View halving a 1440px display to roughly 720px. Those carry a desktop user agent, skip the redirect, and render the broken layout. Resizing an already-open window never re-triggers the server redirect either.

A 13-inch laptop at full screen is unaffected — it is already well above the breakpoint and keeps the sidebar it has today.

So this is a narrow-viewport fix for desktop sessions, not mobile support. Reviewers should weigh it on that basis.

## Implementation note

The cause was one line: the admin layout was the only place in the codebase passing `collapsible="none"`, and that branch is evaluated before the sidebar primitive's own `isMobile` branch, so the `Sheet` drawer shadcn already ships could never run.

Choosing the mode by viewport rather than switching to `offcanvas` outright is deliberate: `Sidebar.Provider` registers a global `Ctrl/Cmd+B` that toggles state regardless of whether a trigger is visible, so an `offcanvas` desktop could be collapsed by keyboard. Keeping `none` at desktop widths means that branch ignores sidebar state entirely and the desktop sidebar stays permanent, exactly as today.

No shared component, sidebar primitive, or individual admin page was modified.

## Also in this PR: the mobile-detection regex is now a real regex

`detectMobile` wrapped a regex literal in a string — `new RegExp("/Mobile|...|IEMobile/")` — so the slashes were matched as literal characters and the bare `Mobile` alternative was dead code (no real user agent contains `/Mobile`). The damage was masked because phone agents also contain `Android` or `iPhone`, but a bare-Mobile agent (Firefox OS style) slipped past the dashboard redirect. Fixed to a proper literal with 11 unit-tested user agents, red-first: the Firefox OS UA fails against the old code and passes now, and the iPadOS desktop-mode `Macintosh` UA is pinned as `false` — the deliberate behavior this PR's drawer depends on.

## Testing

- `bun run test:unit -- 'src/routes/(app)/admin'` — 65 passed across 8 files, including new layout coverage for the trigger, its localized label, its inset and target size, and close-on-navigation. `bun run check` — 0 errors, 0 warnings.
- Browser verification at 375, 768, 1280, 1920, and 3440px on `/admin/storage` and `/admin/skills` (desktop user agent, so no redirect): no horizontal overflow at any width; drawer opens at 281px with all menu links; focus enters the drawer, is trapped, and returns to the trigger on Escape; menu activation closes the drawer and navigates; at 1280px the trigger is `display: none` and content geometry matches current behavior.

## Note for the reviewer

The trigger takes layout space rather than overlaying, so content starts about 77px from the left edge at 375px (297px usable). Overlaying instead collides with the page title, and moving that title would mean changing a layout component shared with non-admin routes.
