### PR TITLE
perf(skills): keep Assistant fleet validation query-bounded

### DIFF
--- a/backend/src/eneo/assistants/assistant_repo.py
+++ b/backend/src/eneo/assistants/assistant_repo.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, cast
@@ -319,6 +319,49 @@ class AssistantRepository:
             *assistant.attachments,
             *(derived_images[metadata.id] for metadata in derived_image_metadata),
         )
+
+    async def iter_completion_files_for_validation_batches(
+        self,
+        *,
+        validation_inputs: Sequence[AssistantValidationInput],
+        tenant_id: UUID,
+        max_batch_bytes: int,
+    ) -> AsyncIterator[dict[UUID, tuple[File, ...]]]:
+        """Hydrate projected derivatives in byte-bounded validation batches."""
+        groups: list[FileAttachmentGroup] = []
+        validation_input_by_assistant_id: dict[UUID, AssistantValidationInput] = {}
+        for validation_input in validation_inputs:
+            assistant_id = validation_input.assistant.id
+            assert assistant_id is not None
+            validation_input_by_assistant_id[assistant_id] = validation_input
+            groups.append(
+                FileAttachmentGroup(
+                    owner_kind="assistant",
+                    owner_id=assistant_id,
+                    tenant_id=tenant_id,
+                    files=validation_input.derived_image_metadata,
+                )
+            )
+        async for (
+            derived_images_by_assistant_id
+        ) in self.file_content_loader.load_attachment_groups_in_payload_batches(
+            groups,
+            max_batch_bytes=max_batch_bytes,
+        ):
+            completion_files_by_assistant_id = {
+                assistant_id: (
+                    *validation_input_by_assistant_id[
+                        assistant_id
+                    ].assistant.attachments,
+                    *derived_images,
+                )
+                for (_, assistant_id), derived_images in (
+                    derived_images_by_assistant_id.items()
+                )
+            }
+            yield completion_files_by_assistant_id
+            del completion_files_by_assistant_id
+            del derived_images_by_assistant_id
 
     @staticmethod
     def _options():

--- a/backend/src/eneo/files/file_content_loader.py
+++ b/backend/src/eneo/files/file_content_loader.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -92,14 +92,27 @@ class FileContentLoader:
         if not metadata:
             return {}
 
+        unique_metadata, selections = await self._select_content(
+            metadata,
+            include_transcription=include_transcription,
+        )
+        return await self._hydrate_selected_files(unique_metadata, selections)
+
+    async def _select_content(
+        self,
+        metadata: Sequence[FileMetadata],
+        *,
+        include_transcription: bool,
+    ) -> tuple[dict[UUID, FileMetadata], dict[UUID, _FileContentSelection]]:
         unique_metadata = {file.id: file for file in metadata}
+        if not unique_metadata:
+            return {}, {}
         references = await self._repo.get_content_references(list(unique_metadata))
         by_file: defaultdict[UUID, list[FileContentReferenceRecord]] = defaultdict(list)
         for reference in references:
             by_file[reference.file_id].append(reference)
 
         selections: dict[UUID, _FileContentSelection] = {}
-        grants: list[ContentReadGrant] = []
         for file in unique_metadata.values():
             file_references = by_file[file.id]
             primary = self._primary_reference(file, file_references)
@@ -139,6 +152,16 @@ class FileContentLoader:
                 transcription_reference=transcription_reference,
             )
             selections[file.id] = selection
+        return unique_metadata, selections
+
+    async def _hydrate_selected_files(
+        self,
+        metadata: dict[UUID, FileMetadata],
+        selections: dict[UUID, _FileContentSelection],
+    ) -> dict[UUID, File]:
+        grants: list[ContentReadGrant] = []
+        for file in metadata.values():
+            selection = selections[file.id]
             grants.extend(
                 ContentReadGrant(
                     content_id=reference.content_id,
@@ -150,7 +173,7 @@ class FileContentLoader:
 
         payloads = await self._object_content.read_content_bytes(grants)
         hydrated: dict[UUID, File] = {}
-        for file in unique_metadata.values():
+        for file in metadata.values():
             selection = selections[file.id]
             text = (
                 None
@@ -197,6 +220,90 @@ class FileContentLoader:
         include_transcription: bool = True,
     ) -> dict[tuple[str, UUID], list[File]]:
         """Validate, deduplicate, hydrate, and regroup concrete attachments."""
+        metadata_by_id, ids_by_group = self._index_attachment_groups(groups)
+        loaded = await self.load(
+            list(metadata_by_id.values()),
+            include_transcription=include_transcription,
+        )
+        return {
+            key: [loaded[file_id] for file_id in file_ids]
+            for key, file_ids in ids_by_group.items()
+        }
+
+    async def load_attachment_groups_in_payload_batches(
+        self,
+        groups: Sequence[FileAttachmentGroup],
+        *,
+        max_batch_bytes: int,
+        include_transcription: bool = True,
+    ) -> AsyncIterator[dict[tuple[str, UUID], list[File]]]:
+        """Hydrate groups incrementally after one content-reference lookup.
+
+        A group is never split, so one unusually large owner has the same peak
+        payload as the single-owner loader. Shared content counts once within a
+        batch and may keep several groups below the byte limit.
+        """
+        if max_batch_bytes <= 0:
+            raise ValueError("max_batch_bytes must be positive")
+
+        metadata_by_id, ids_by_group = self._index_attachment_groups(groups)
+        _, selections = await self._select_content(
+            list(metadata_by_id.values()),
+            include_transcription=include_transcription,
+        )
+        batch_keys: list[tuple[str, UUID]] = []
+        batch_file_ids: dict[UUID, None] = {}
+        batch_content_ids: set[UUID] = set()
+        batch_bytes = 0
+
+        for key, file_ids in ids_by_group.items():
+            group_content_sizes: dict[UUID, int] = {}
+            for file_id in file_ids:
+                for reference in selections[file_id].readable_references:
+                    group_content_sizes[reference.content_id] = reference.size_bytes
+            additional_bytes = sum(
+                size
+                for content_id, size in group_content_sizes.items()
+                if content_id not in batch_content_ids
+            )
+            if batch_keys and batch_bytes + additional_bytes > max_batch_bytes:
+                loaded_groups = await self._hydrate_attachment_group_batch(
+                    keys=batch_keys,
+                    ids_by_group=ids_by_group,
+                    metadata_by_id=metadata_by_id,
+                    selections=selections,
+                    file_ids=batch_file_ids,
+                )
+                yield loaded_groups
+                del loaded_groups
+                batch_keys = []
+                batch_file_ids = {}
+                batch_content_ids = set()
+                batch_bytes = 0
+
+            batch_keys.append(key)
+            batch_file_ids.update((file_id, None) for file_id in file_ids)
+            for content_id, size in group_content_sizes.items():
+                if content_id not in batch_content_ids:
+                    batch_content_ids.add(content_id)
+                    batch_bytes += size
+
+        if batch_keys:
+            yield await self._hydrate_attachment_group_batch(
+                keys=batch_keys,
+                ids_by_group=ids_by_group,
+                metadata_by_id=metadata_by_id,
+                selections=selections,
+                file_ids=batch_file_ids,
+            )
+
+    @staticmethod
+    def _index_attachment_groups(
+        groups: Sequence[FileAttachmentGroup],
+    ) -> tuple[
+        dict[UUID, FileMetadata],
+        dict[tuple[str, UUID], list[UUID]],
+    ]:
         metadata_by_id: dict[UUID, FileMetadata] = {}
         ids_by_group: dict[tuple[str, UUID], list[UUID]] = {}
         for group in groups:
@@ -210,15 +317,22 @@ class FileContentLoader:
                 metadata_by_id[metadata.id] = metadata
                 file_ids.append(metadata.id)
             ids_by_group[group.key] = file_ids
+        return metadata_by_id, ids_by_group
 
-        loaded = await self.load(
-            list(metadata_by_id.values()),
-            include_transcription=include_transcription,
+    async def _hydrate_attachment_group_batch(
+        self,
+        *,
+        keys: Sequence[tuple[str, UUID]],
+        ids_by_group: dict[tuple[str, UUID], list[UUID]],
+        metadata_by_id: dict[UUID, FileMetadata],
+        selections: dict[UUID, _FileContentSelection],
+        file_ids: dict[UUID, None],
+    ) -> dict[tuple[str, UUID], list[File]]:
+        loaded = await self._hydrate_selected_files(
+            {file_id: metadata_by_id[file_id] for file_id in file_ids},
+            selections,
         )
-        return {
-            key: [loaded[file_id] for file_id in file_ids]
-            for key, file_ids in ids_by_group.items()
-        }
+        return {key: [loaded[file_id] for file_id in ids_by_group[key]] for key in keys}
 
     @staticmethod
     def _first_reference(

--- a/backend/src/eneo/skills/application/organization_skill_service.py
+++ b/backend/src/eneo/skills/application/organization_skill_service.py
@@ -4,6 +4,7 @@ from uuid import UUID, uuid4
 from eneo.audit.application.audit_metadata import AuditMetadata
 from eneo.audit.domain.action_types import ActionType
 from eneo.audit.domain.entity_types import EntityType
+from eneo.main.config import get_settings
 from eneo.main.exceptions import (
     BadRequestException,
     NotFoundException,
@@ -613,9 +614,20 @@ class OrganizationSkillService:
             allow_inactive_providers=True,
         )
         preflight_adapters = adapter_load.adapters
+        file_validation_inputs = [
+            validation_input
+            for assistant_id, validation_input in validation_inputs.items()
+            if assistant_id in validation_resolutions
+            and (
+                validation_input.assistant.completion_model is None
+                or validation_input.assistant.completion_model.id
+                not in adapter_load.unavailable_model_ids
+            )
+        ]
 
         validation_results: list[AssistantPinAdvanceTargetResult] = []
         write_targets: list[AssistantPinAdvanceTarget] = []
+        target_by_assistant_id = {target.assistant_id: target for target in targets}
         for target in targets:
             validation_input = validation_inputs.get(target.assistant_id)
             resolution = validation_resolutions.get(target.assistant_id)
@@ -637,35 +649,49 @@ class OrganizationSkillService:
                     )
                 )
                 continue
-            incompatible_reason = await self.assistant_service.assert_assistant_fits_candidate_pin(
-                assistant=validation_input.assistant,
-                space_is_personal=validation_input.space_is_personal,
-                candidate=PersonalChatPinOverride(
-                    skill_id=skill_id,
-                    from_revision_id=target.from_revision_id,
-                    to_revision_id=expected_published_revision_id,
-                ),
-                candidate_binding=candidate_binding,
-                resolution=resolution,
-                runtime_policy=runtime_policy_snapshot.policy,
-                preflight_adapters=preflight_adapters,
-                completion_prompt_files=(
-                    await self.assistant_service.repo.hydrate_completion_files_for_validation(
+
+        async for (
+            completion_files_by_assistant_id
+        ) in self.assistant_service.repo.iter_completion_files_for_validation_batches(
+            validation_inputs=file_validation_inputs,
+            tenant_id=self.user.tenant_id,
+            max_batch_bytes=get_settings().attachment_max_size_bytes,
+        ):
+            for (
+                assistant_id,
+                completion_files,
+            ) in completion_files_by_assistant_id.items():
+                validation_input = validation_inputs[assistant_id]
+                resolution = validation_resolutions[assistant_id]
+                target = target_by_assistant_id[assistant_id]
+                incompatible_reason = (
+                    await self.assistant_service.assert_assistant_fits_candidate_pin(
                         assistant=validation_input.assistant,
-                        derived_image_metadata=validation_input.derived_image_metadata,
-                    )
-                ),
-            )
-            if incompatible_reason is not None:
-                validation_results.append(
-                    AssistantPinAdvanceTargetResult(
-                        assistant_id=target.assistant_id,
-                        outcome=AssistantPinAdvanceOutcome.INCOMPATIBLE,
-                        reason=incompatible_reason,
+                        space_is_personal=validation_input.space_is_personal,
+                        candidate=PersonalChatPinOverride(
+                            skill_id=skill_id,
+                            from_revision_id=target.from_revision_id,
+                            to_revision_id=expected_published_revision_id,
+                        ),
+                        candidate_binding=candidate_binding,
+                        resolution=resolution,
+                        runtime_policy=runtime_policy_snapshot.policy,
+                        preflight_adapters=preflight_adapters,
+                        completion_prompt_files=completion_files,
                     )
                 )
-                continue
-            write_targets.append(target)
+                if incompatible_reason is not None:
+                    validation_results.append(
+                        AssistantPinAdvanceTargetResult(
+                            assistant_id=assistant_id,
+                            outcome=AssistantPinAdvanceOutcome.INCOMPATIBLE,
+                            reason=incompatible_reason,
+                        )
+                    )
+                else:
+                    write_targets.append(target)
+                del completion_files
+            del completion_files_by_assistant_id
 
         try:
             write_results = await self.repo.advance_assistant_skill_pins(

--- a/backend/tests/integration/skills/test_assistant_fleet_advance_http_contract.py
+++ b/backend/tests/integration/skills/test_assistant_fleet_advance_http_contract.py
@@ -41,6 +41,7 @@ from eneo.database.tables.skill_table import (
 from eneo.database.tables.spaces_table import Spaces, SpacesUsers
 from eneo.files.file_models import FileContentVariant, FileType
 from eneo.files.file_repo import FileRepository
+from eneo.main.config import get_settings
 from eneo.main.exceptions import BadRequestException
 from eneo.object_content.content import ContentFailureCode, ContentState, StorageKind
 from eneo.object_content.content_service import ObjectContentService
@@ -1329,9 +1330,11 @@ class _OwnerAttachmentFleetSeed:
     old_revision_id: UUID
     candidate_revision_id: UUID
     assistant_id: UUID
+    assistant_ids: tuple[UUID, ...]
     owner_user_id: UUID
     root_file_id: UUID
     derived_content_id: UUID
+    derived_content_ids: tuple[UUID, ...]
     derived_payload: bytes
 
 
@@ -1344,7 +1347,10 @@ async def _seed_owner_attachment_fleet(
     space_factory,
     derived_state: ContentState,
     vision: bool = True,
+    assistant_count: int = 1,
 ) -> _OwnerAttachmentFleetSeed:
+    if assistant_count < 1:
+        raise ValueError("assistant_count must be positive")
     async with db_container() as container:
         session = container.session()
         owner = await user_factory(session, tenant_id=admin_user.tenant_id)
@@ -1360,46 +1366,22 @@ async def _seed_owner_attachment_fleet(
             [model.id],
             user_id=owner.id,
         )
-        assistant = Assistants(
-            name="Owner vision Assistant",
-            user_id=owner.id,
-            completion_model_id=model.id,
-            completion_model_kwargs={},
-            logging_enabled=True,
-            is_default=False,
-            published=False,
-            space_id=personal_space.id,
-        )
-        session.add(assistant)
+        assistants = [
+            Assistants(
+                name=f"Owner vision Assistant {index + 1}",
+                user_id=owner.id,
+                completion_model_id=model.id,
+                completion_model_kwargs={},
+                logging_enabled=True,
+                is_default=False,
+                published=False,
+                space_id=personal_space.id,
+            )
+            for index in range(assistant_count)
+        ]
+        session.add_all(assistants)
         await session.flush()
 
-        root = Files(
-            name="owner-document.txt",
-            mimetype="text/plain",
-            file_type=FileType.TEXT.value,
-            tenant_id=admin_user.tenant_id,
-            user_id=owner.id,
-        )
-        session.add(root)
-        await session.flush()
-        derived = Files(
-            name="owner-page.png",
-            mimetype="image/png",
-            file_type=FileType.IMAGE.value,
-            tenant_id=admin_user.tenant_id,
-            user_id=owner.id,
-            parent_file_id=root.id,
-        )
-        session.add(derived)
-        await session.flush()
-        await _add_inline_file_content(
-            session,
-            file=root,
-            user_id=owner.id,
-            payload=b"short root attachment",
-            variant=FileContentVariant.ORIGINAL,
-            media_type="text/plain",
-        )
         derived_image = BytesIO()
         Image.new("RGB", (2_048, 1_024), color=(24, 95, 180)).save(
             derived_image,
@@ -1411,30 +1393,65 @@ async def _seed_owner_attachment_fleet(
             if derived_state is ContentState.AVAILABLE
             else _add_pending_file_content
         )
-        derived_content_id = await add_derived_content(
-            session,
-            file=derived,
-            user_id=owner.id,
-            payload=derived_payload,
-            variant=FileContentVariant.DERIVED_PAGE,
-            media_type="image/png",
-        )
+        roots: list[Files] = []
+        derived_content_ids: list[UUID] = []
+        for index, assistant in enumerate(assistants):
+            root = Files(
+                name=f"owner-document-{index + 1}.txt",
+                mimetype="text/plain",
+                file_type=FileType.TEXT.value,
+                tenant_id=admin_user.tenant_id,
+                user_id=owner.id,
+            )
+            session.add(root)
+            await session.flush()
+            roots.append(root)
+            derived = Files(
+                name=f"owner-page-{index + 1}.png",
+                mimetype="image/png",
+                file_type=FileType.IMAGE.value,
+                tenant_id=admin_user.tenant_id,
+                user_id=owner.id,
+                parent_file_id=root.id,
+            )
+            session.add(derived)
+            await session.flush()
+            await _add_inline_file_content(
+                session,
+                file=root,
+                user_id=owner.id,
+                payload=b"short root attachment",
+                variant=FileContentVariant.ORIGINAL,
+                media_type="text/plain",
+            )
+            derived_content_ids.append(
+                await add_derived_content(
+                    session,
+                    file=derived,
+                    user_id=owner.id,
+                    payload=derived_payload,
+                    variant=FileContentVariant.DERIVED_PAGE,
+                    media_type="image/png",
+                )
+            )
+            session.add(AssistantsFiles(assistant_id=assistant.id, file_id=root.id))
         if derived_state is ContentState.FAILED:
             await session.execute(
                 sa.update(ObjectContents)
-                .where(ObjectContents.id == derived_content_id)
+                .where(ObjectContents.id.in_(derived_content_ids))
                 .values(
                     state=ContentState.FAILED.value,
                     failure_code=ContentFailureCode.VERIFICATION_MISMATCH.value,
                     failure_detail="Terminal derivative failure for fleet validation",
                 )
             )
-        session.add(AssistantsFiles(assistant_id=assistant.id, file_id=root.id))
         await session.flush()
         personal_space_id = personal_space.id
-        assistant_id = assistant.id
+        assistant_ids = tuple(assistant.id for assistant in assistants)
+        assistant_id = assistant_ids[0]
         owner_user_id = owner.id
-        root_file_id = root.id
+        root_file_id = roots[0].id
+        derived_content_id = derived_content_ids[0]
 
     async with db_container() as container:
         session = container.session()
@@ -1462,7 +1479,7 @@ async def _seed_owner_attachment_fleet(
             skill_id=skill.id,
             expected_revision_id=old_revision.id,
         )
-        session.add(
+        session.add_all(
             AssistantSkillBindings(
                 assistant_id=assistant_id,
                 tenant_id=admin_user.tenant_id,
@@ -1473,6 +1490,7 @@ async def _seed_owner_attachment_fleet(
                 position=0,
                 activation_mode=SkillActivationMode.ALWAYS.value,
             )
+            for assistant_id in assistant_ids
         )
         change = await repo.create_revision(
             skill_id=skill.id,
@@ -1497,14 +1515,16 @@ async def _seed_owner_attachment_fleet(
         old_revision_id=old_revision_id,
         candidate_revision_id=candidate_revision_id,
         assistant_id=assistant_id,
+        assistant_ids=assistant_ids,
         owner_user_id=owner_user_id,
         root_file_id=root_file_id,
         derived_content_id=derived_content_id,
+        derived_content_ids=tuple(derived_content_ids),
         derived_payload=derived_payload,
     )
 
 
-async def _advance_owner_attachment_fleet_with_derived_query_count(
+async def _advance_owner_attachment_fleet_with_query_counts(
     *,
     client,
     admin_token: str,
@@ -1515,6 +1535,7 @@ async def _advance_owner_attachment_fleet_with_derived_query_count(
         bind = container.session().get_bind()
         engine = getattr(bind, "engine", bind)
         derived_selects = 0
+        content_reference_selects = 0
 
         def record_statement(
             _connection: object,
@@ -1524,8 +1545,13 @@ async def _advance_owner_attachment_fleet_with_derived_query_count(
             _context: object,
             _executemany: bool,
         ) -> None:
-            nonlocal derived_selects
+            nonlocal content_reference_selects, derived_selects
             normalized = statement.lower()
+            if (
+                normalized.lstrip().startswith("select")
+                and "from file_content_references" in normalized
+            ):
+                content_reference_selects += 1
             if (
                 normalized.lstrip().startswith("select")
                 and "left outer join files as" in normalized
@@ -1546,7 +1572,7 @@ async def _advance_owner_attachment_fleet_with_derived_query_count(
             )
         finally:
             sa.event.remove(engine, "before_cursor_execute", record_statement)
-    return response, derived_selects
+    return response, derived_selects, content_reference_selects
 
 
 @pytest.mark.integration
@@ -1572,7 +1598,8 @@ async def test_owner_derived_images_are_included_in_admin_fleet_validation(
     (
         response,
         derived_selects,
-    ) = await _advance_owner_attachment_fleet_with_derived_query_count(
+        _content_reference_selects,
+    ) = await _advance_owner_attachment_fleet_with_query_counts(
         client=client,
         admin_token=admin_token,
         db_container=db_container,
@@ -1605,6 +1632,102 @@ async def test_owner_derived_images_are_included_in_admin_fleet_validation(
 
 @pytest.mark.integration
 @pytest.mark.asyncio
+async def test_owner_derived_image_hydration_query_count_is_chunk_bounded(
+    monkeypatch,
+    client,
+    admin_token,
+    db_container,
+    admin_user,
+    user_factory,
+    completion_model_factory,
+    space_factory,
+):
+    seed = await _seed_owner_attachment_fleet(
+        db_container,
+        admin_user=admin_user,
+        user_factory=user_factory,
+        completion_model_factory=completion_model_factory,
+        space_factory=space_factory,
+        derived_state=ContentState.AVAILABLE,
+        assistant_count=25,
+    )
+    derived_batch_limit = len(seed.derived_payload) * 4
+    settings = get_settings().model_copy(
+        update={"attachment_max_size_bytes": derived_batch_limit}
+    )
+    monkeypatch.setattr(
+        "eneo.skills.application.organization_skill_service.get_settings",
+        lambda: settings,
+    )
+    original_read_content_bytes = ObjectContentService.read_content_bytes
+    derived_content_ids = frozenset(seed.derived_content_ids)
+    derived_payload_batch_sizes: list[int] = []
+    live_derived_payload_bytes = [0]
+    peak_live_derived_payload_bytes = [0]
+
+    class TrackedDerivedPayload(bytes):
+        def __del__(self):
+            live_derived_payload_bytes[0] -= len(self)
+
+    async def record_derived_payload_batch(service, grants):
+        derived_grant_ids = {
+            grant.content_id
+            for grant in grants
+            if grant.content_id in derived_content_ids
+        }
+        if derived_grant_ids:
+            assert live_derived_payload_bytes[0] == 0
+        payloads = await original_read_content_bytes(service, grants)
+        batch_size = 0
+        for content_id in derived_grant_ids:
+            tracked_payload = TrackedDerivedPayload(payloads[content_id])
+            payloads[content_id] = tracked_payload
+            batch_size += len(tracked_payload)
+        live_derived_payload_bytes[0] += batch_size
+        peak_live_derived_payload_bytes[0] = max(
+            peak_live_derived_payload_bytes[0],
+            live_derived_payload_bytes[0],
+        )
+        if batch_size:
+            derived_payload_batch_sizes.append(batch_size)
+        return payloads
+
+    monkeypatch.setattr(
+        ObjectContentService,
+        "read_content_bytes",
+        record_derived_payload_batch,
+    )
+
+    (
+        response,
+        derived_selects,
+        content_reference_selects,
+    ) = await _advance_owner_attachment_fleet_with_query_counts(
+        client=client,
+        admin_token=admin_token,
+        db_container=db_container,
+        seed=seed,
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["counts"] == {
+        "advanced": 0,
+        "concurrent_change": 0,
+        "incompatible": 25,
+    }
+    assert derived_selects == 1
+    assert content_reference_selects == 3
+    assert len(derived_payload_batch_sizes) == 7
+    assert max(derived_payload_batch_sizes) <= derived_batch_limit
+    assert sum(derived_payload_batch_sizes) == (
+        len(seed.derived_payload) * len(seed.derived_content_ids)
+    )
+    assert peak_live_derived_payload_bytes[0] <= derived_batch_limit
+    assert live_derived_payload_bytes[0] == 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_non_vision_fleet_skips_derived_image_projection(
     client,
     admin_token,
@@ -1627,7 +1750,8 @@ async def test_non_vision_fleet_skips_derived_image_projection(
     (
         response,
         derived_selects,
-    ) = await _advance_owner_attachment_fleet_with_derived_query_count(
+        _content_reference_selects,
+    ) = await _advance_owner_attachment_fleet_with_query_counts(
         client=client,
         admin_token=admin_token,
         db_container=db_container,


### PR DESCRIPTION
## TL;DR

Updating a published Skill across many vision-capable Assistants no longer reloads derived-file references once per Assistant. References are selected once per 100-target fleet chunk, while image payloads are materialized and released in byte-bounded groups. The public endpoint, validation outcomes, stop/resume behavior, authorization, and concurrency contract are unchanged.

## Changes

- Deepen `FileContentLoader` with an incremental attachment-group reader that selects durable references once and limits live payload bytes to the configured attachment budget.
- Keep each Assistant's attachment family together; a single oversized family runs alone, so peak memory is no worse than the previous per-Assistant path.
- Let the fleet service validate and release one payload group before loading the next, while preserving stored-file-before-derived-file order.
- Add an HTTP performance contract with 25 Assistants and distinct derived images. It proves constant reference queries, bounded payload batches, and no retained bytes between batches.

## Why

The fleet endpoint was already keyset-paged and batch-wrote pins, but vision validation hydrated derived images inside the Assistant loop. A warm 100-target run grew from 38 SQL statements for one target to 236 statements, and the focused red test observed 27 content-reference reads for 25 targets. A naive whole-chunk preload removed those reads but could retain every image payload at once; this version keeps the query improvement without introducing that memory risk.

## Planning

- Follow-up to #638.

## Testing

- Red proof: the 25-target query contract expected 3 content-reference SELECTs and observed 27 before the fix.
- Final focused fleet, pin-advance, aggregate-hydration, and attachment-budget suites: 97 passed.
- Required combined Skills/Assistants/unit/governance suite: 1,854 passed; its final 8 governance setups lost the shared test Redis connection. Fresh isolated governance run: 8 passed.
- Pyright on Skills, Assistants, and the changed file loader: 0 errors and 0 warnings.
- Ruff check, Ruff format check, `git diff --check`, commit hooks, and pre-push schema drift: passed.
- Skeptical pre-commit gate: green, 8/10, no findings.

## Screenshots

Not applicable; this PR changes backend fleet validation performance only.
