### PR TITLE
fix: converge parallel Alembic migrations

### DIFF
--- a/backend/alembic/versions/202607301100_merge_context_usage_and_restart_safe_jobs.py
+++ b/backend/alembic/versions/202607301100_merge_context_usage_and_restart_safe_jobs.py
@@ -1,0 +1,21 @@
+"""merge context usage and restart-safe knowledge job heads
+
+Revision ID: 202607301100
+Revises: 202607291000, 202607301000
+Create Date: 2026-07-30 11:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+revision: str = "202607301100"
+down_revision: tuple[str, str] = ("202607291000", "202607301000")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/tests/unit/test_alembic_migration_graph.py
+++ b/backend/tests/unit/test_alembic_migration_graph.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def test_migration_graph_has_one_head() -> None:
+    backend_dir = Path(__file__).resolve().parents[2]
+    config = Config(str(backend_dir / "alembic.ini"))
+    config.set_main_option("script_location", str(backend_dir / "alembic"))
+
+    heads = ScriptDirectory.from_config(config).get_heads()
+
+    assert len(heads) == 1, f"Expected one Alembic head, found: {', '.join(heads)}"


### PR DESCRIPTION
## Changes

- Merge the restart-safe knowledge job and question context usage revisions into
  one Alembic head without rewriting either shipped migration.
- Add a fast backend test that rejects multiple migration heads before the
  integration and E2E jobs start.

## Why

The latest `develop` push could not run `alembic upgrade head` because PR #641
and PR #648 added sibling revisions from the same parent. Backend integration
setup failed 1,346 times, and the E2E backend exited during startup. The merge
revision lets databases at either sibling apply the missing migration and
converge.

## Planning

This is a post-merge repair for PR #641 and PR #648. It does not start or close
a storage-roadmap task.

## Testing

- Red proof: `uv run pytest -q tests/unit/test_alembic_migration_graph.py`
  failed with both head IDs.
- `uv run alembic heads --verbose` — one merge head.
- `uv run pytest -q tests/unit/test_alembic_migration_graph.py` — 1 passed.
- Touched-file Ruff and Pyright — passed.
- `POSTGRES_HOST=localhost uv run pytest -q -m migration_isolation tests/integration/migrations/test_restart_safe_knowledge_jobs.py`
  — 1 passed, including downgrade and re-upgrade.
- Full non-integration backend suite — 4,137 passed.
- Full integration backend suite — 1,340 passed, 92 skipped, 1 expected xfail.
- Fresh `docker-compose.e2e.ci.yml` startup — all services healthy; database at
  revision `202607301100`.
- CI-mode Playwright — 12 passed.
- Pre-commit and pre-push hooks — passed.
- Independent commit gate — green, score 9/10, no findings.

## Screenshots

Not applicable.
