### PR TITLE
chore: clear the dead-code report findings

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "greenlet>=3.2.2,<4",
     "litellm==1.90.2",
     "mcp>=1.2.0,<2", # Model Context Protocol SDK for MCP server integration
+    "anyio>=4.5,<5",  # memory-stream types the MCP client annotates against; floor matches mcp's
     "cryptography>=48.0.1,<49", # For Fernet encryption of HTTP auth passwords
     "httpx~=0.28.0",
     "pandas>=2.2.3,<3",

--- a/backend/src/eneo/jobs/job_service.py
+++ b/backend/src/eneo/jobs/job_service.py
@@ -94,7 +94,7 @@ class JobService:
         outer_committed = False
         active = True
 
-        def after_commit(committed_session: object) -> None:
+        def after_commit(_session: object) -> None:
             nonlocal outer_committed
             if active and not session.in_nested_transaction():
                 outer_committed = True

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -604,6 +604,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "alembic" },
+    { name = "anyio" },
     { name = "arq" },
     { name = "asyncpg" },
     { name = "audioread" },
@@ -689,6 +690,7 @@ dev = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=23.0,<24" },
     { name = "alembic", specifier = ">=1.10.2,<2" },
+    { name = "anyio", specifier = ">=4.5,<5" },
     { name = "arq", specifier = ">=0.26,<1" },
     { name = "asyncpg", specifier = ">=0.27.0,<0.28" },
     { name = "audioread", specifier = ">=3.0.1,<4" },


### PR DESCRIPTION
Clears both findings the dead-code workflow currently reports on every PR. Report-only, so nothing was failing — but the list is only useful while it is empty.

## vulture — unused variable `committed_session`

`backend/src/eneo/jobs/job_service.py:97`. The durable-dispatch `after_commit` listener only needs its closure over `outer_committed`; SQLAlchemy passes the session positionally and we never read it. The parameter has to stay for the callback signature, so it takes the underscore prefix that the sibling `after_transaction_end` listener in the same function already uses — which is why that one was never flagged.

## deptry DEP003 — `anyio` imported but transitive

`backend/src/eneo/mcp_servers/infrastructure/client/mcp_client.py:11` annotates against `anyio.streams.memory.MemoryObjectReceiveStream` / `MemoryObjectSendStream`, which so far only resolved through `mcp`, `httpx` and `starlette`.

Declared `anyio` as a direct dependency rather than extending `[tool.deptry.per_rule_ignores]`. The `>=4.5` floor matches what `mcp` already requires, and it means an upstream dropping anyio can't silently break us. `uv.lock` gains only the two edges — anyio stays at 4.14.1, no version moved.

## Verification

- `uv run vulture` → clean, exit 0
- `uv run deptry src` → "No dependency issues found", exit 0
- `uv lock --check` passes; full backend unit suite green (2803 passed)
- `ruff check` / `ruff format --check` clean on the edited file
