### PR TITLE
Keep object storage reliable across S3-compatible services

### DIFF
--- a/backend/src/eneo/object_content/s3_object_store.py
+++ b/backend/src/eneo/object_content/s3_object_store.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import io
 from collections.abc import AsyncGenerator, Awaitable, Callable, Sequence
 from contextlib import asynccontextmanager
@@ -70,15 +69,12 @@ class ObjectStoreBindingError(ObjectStoreError):
 class StoreBindingCreation:
     binding_id: UUID
     body: bytes
-    checksum_sha256: str
 
 
 @dataclass(frozen=True, slots=True)
 class ObjectHead:
     size_bytes: int
     media_type: str
-    checksum_sha256: str | None
-    checksum_type: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -182,20 +178,6 @@ def new_object_key(settings: ObjectContentSettings) -> str:
     return f"{settings.object_key_prefix}{token_hex(16)}"
 
 
-def composite_sha256(part_sha256: Sequence[bytes]) -> str:
-    """Return the S3 SHA-256 composite checksum; never a content digest."""
-    if not part_sha256 or any(len(digest) != _SHA256_BYTES for digest in part_sha256):
-        raise ValueError("part SHA-256 values must be non-empty 32-byte digests")
-    digest = sha256(b"".join(part_sha256)).digest()
-    return f"{base64.b64encode(digest).decode()}-{len(part_sha256)}"
-
-
-def _base64_sha256(digest: bytes) -> str:
-    if len(digest) != _SHA256_BYTES:
-        raise ValueError("canonical SHA-256 must be a 32-byte digest")
-    return base64.b64encode(digest).decode()
-
-
 def _client_error_code(error: ClientError) -> str:
     response = cast(Mapping[str, object], error.response)
     detail = response.get("Error")
@@ -231,6 +213,8 @@ def _create_client(
                     "total_max_attempts": max_attempts,
                 },
                 s3={"addressing_style": settings.addressing_style},
+                request_checksum_calculation="when_required",
+                response_checksum_validation="when_required",
             ),
         ),
     )
@@ -302,11 +286,9 @@ class S3ObjectStore:
 
         await self._require_empty_content_namespace()
         expected = _BINDING_PREAMBLE + binding_id.bytes
-        checksum = base64.b64encode(sha256(expected).digest()).decode()
         return StoreBindingCreation(
             binding_id=binding_id,
             body=expected,
-            checksum_sha256=checksum,
         )
 
     async def create_binding(self, creation: StoreBindingCreation) -> None:
@@ -319,7 +301,6 @@ class S3ObjectStore:
                 Body=creation.body,
                 ContentLength=len(creation.body),
                 ContentType=_BINDING_MEDIA_TYPE,
-                ChecksumSHA256=creation.checksum_sha256,
                 IfNoneMatch="*",
             )
         except ClientError as error:
@@ -346,19 +327,24 @@ class S3ObjectStore:
         operation_checkpoint: OperationCheckpoint | None = None,
     ) -> ObjectHead:
         self._require_owned_key(key)
-        if content.size_bytes >= self._settings.multipart_threshold_bytes:
-            head = await self._upload_multipart(
-                key,
-                content,
-                multipart_started=multipart_started,
-                operation_checkpoint=operation_checkpoint,
-            )
-        else:
-            head = await self._upload_single(
-                key,
-                content,
-                operation_checkpoint=operation_checkpoint,
-            )
+        try:
+            if content.size_bytes >= self._settings.multipart_threshold_bytes:
+                head = await self._upload_multipart(
+                    key,
+                    content,
+                    multipart_started=multipart_started,
+                    operation_checkpoint=operation_checkpoint,
+                )
+            else:
+                head = await self._upload_single(
+                    key,
+                    content,
+                    operation_checkpoint=operation_checkpoint,
+                )
+        except ObjectStoreNotFoundError as error:
+            raise ObjectStoreUnavailableError(
+                "Stored object disappeared before verification"
+            ) from error
         if head.size_bytes != content.size_bytes:
             raise ObjectStoreIntegrityError(
                 "Stored object length does not match intent"
@@ -376,10 +362,9 @@ class S3ObjectStore:
         *,
         operation_checkpoint: OperationCheckpoint | None,
     ) -> ObjectHead:
-        expected_checksum = _base64_sha256(content.sha256)
         content.file.seek(0)
         try:
-            result = await _run_mutation(
+            await _run_mutation(
                 operation_checkpoint,
                 lambda: asyncio.to_thread(
                     self._client.put_object,
@@ -388,28 +373,19 @@ class S3ObjectStore:
                     Body=content.file,
                     ContentLength=content.size_bytes,
                     ContentType=content.verified_media_type,
-                    ChecksumSHA256=expected_checksum,
                 ),
             )
         except (BotoCoreError, ClientError) as error:
             raise ObjectStoreUnavailableError("Object upload failed") from error
 
-        if result.get("ChecksumSHA256") != expected_checksum:
-            raise ObjectStoreIntegrityError(
-                "Object store did not confirm the full-object SHA-256"
-            )
-
         if operation_checkpoint is not None:
             await operation_checkpoint()
         head = await self.head(key)
-        if head.checksum_sha256 != expected_checksum:
-            raise ObjectStoreIntegrityError(
-                "Object store HEAD checksum does not match the upload"
-            )
-        if head.checksum_type not in {None, "FULL_OBJECT"}:
-            raise ObjectStoreIntegrityError(
-                "Unexpected checksum type for single upload"
-            )
+        await self._verify_stored_bytes(
+            key,
+            content,
+            operation_checkpoint=operation_checkpoint,
+        )
         return head
 
     async def _upload_multipart(
@@ -433,8 +409,6 @@ class S3ObjectStore:
                     Bucket=self._settings.bucket,
                     Key=key,
                     ContentType=content.verified_media_type,
-                    ChecksumAlgorithm="SHA256",
-                    ChecksumType="COMPOSITE",
                 ),
             )
             upload_id = created.get("UploadId")
@@ -451,8 +425,7 @@ class S3ObjectStore:
                 content,
                 operation_checkpoint=operation_checkpoint,
             )
-            expected_composite = composite_sha256(content.part_sha256)
-            completed = await _run_mutation(
+            await _run_mutation(
                 operation_checkpoint,
                 lambda: asyncio.to_thread(
                     self._client.complete_multipart_upload,
@@ -460,7 +433,6 @@ class S3ObjectStore:
                     Key=key,
                     UploadId=upload_id,
                     MultipartUpload={"Parts": completed_parts},
-                    ChecksumType="COMPOSITE",
                 ),
             )
         except ObjectStoreError:
@@ -470,25 +442,14 @@ class S3ObjectStore:
                 "Multipart object upload failed"
             ) from error
 
-        if (
-            "ChecksumSHA256" in completed
-            and completed["ChecksumSHA256"] != expected_composite
-        ):
-            raise ObjectStoreIntegrityError(
-                "Object store returned the wrong multipart composite SHA-256"
-            )
-        if completed.get("ChecksumType") not in {None, "COMPOSITE"}:
-            raise ObjectStoreIntegrityError("Unexpected multipart checksum type")
-
         if operation_checkpoint is not None:
             await operation_checkpoint()
         head = await self.head(key)
-        if head.checksum_sha256 != expected_composite:
-            raise ObjectStoreIntegrityError(
-                "Object store HEAD composite checksum does not match the parts"
-            )
-        if head.checksum_type not in {None, "COMPOSITE"}:
-            raise ObjectStoreIntegrityError("Unexpected multipart HEAD checksum type")
+        await self._verify_stored_bytes(
+            key,
+            content,
+            operation_checkpoint=operation_checkpoint,
+        )
         return head
 
     async def _upload_parts(
@@ -501,22 +462,17 @@ class S3ObjectStore:
     ) -> list[CompletedPartTypeDef]:
         completed_parts: list[CompletedPartTypeDef] = []
         transferred = 0
-        expected_part_count = (
+        part_count = (
             content.size_bytes + self._settings.multipart_part_bytes - 1
         ) // self._settings.multipart_part_bytes
-        if len(content.part_sha256) != expected_part_count:
-            raise ObjectStoreIntegrityError(
-                "Multipart part inventory has the wrong part count"
-            )
 
-        for index, part_digest in enumerate(content.part_sha256, start=1):
+        for index in range(1, part_count + 1):
             part_length = min(
                 self._settings.multipart_part_bytes,
                 content.size_bytes - transferred,
             )
             if part_length <= 0:
                 raise ObjectStoreIntegrityError("Multipart intent has an extra part")
-            expected_checksum = _base64_sha256(part_digest)
             part = _FileSlice(
                 content.file,
                 start=transferred,
@@ -534,13 +490,8 @@ class S3ObjectStore:
                     PartNumber=index,
                     Body=cast(BinaryIO, part),
                     ContentLength=part_length,
-                    ChecksumSHA256=expected_checksum,
                 ),
             )
-            if result.get("ChecksumSHA256") != expected_checksum:
-                raise ObjectStoreIntegrityError(
-                    "Object store did not confirm a part SHA-256"
-                )
             etag = result.get("ETag")
             if not etag:
                 raise ObjectStoreIntegrityError(
@@ -549,7 +500,6 @@ class S3ObjectStore:
             completed_parts.append(
                 {
                     "ETag": etag,
-                    "ChecksumSHA256": expected_checksum,
                     "PartNumber": index,
                 }
             )
@@ -561,6 +511,24 @@ class S3ObjectStore:
             )
         return completed_parts
 
+    async def _verify_stored_bytes(
+        self,
+        key: str,
+        content: CapturedContent,
+        *,
+        operation_checkpoint: OperationCheckpoint | None,
+    ) -> None:
+        persisted_sha256 = await self.recompute_sha256(
+            key,
+            expected_size_bytes=content.size_bytes,
+            expected_media_type=content.verified_media_type,
+            operation_checkpoint=operation_checkpoint,
+        )
+        if persisted_sha256 != content.sha256:
+            raise ObjectStoreIntegrityError(
+                "Stored object bytes do not match the upload"
+            )
+
     async def head(self, key: str) -> ObjectHead:
         self._require_owned_key(key)
         try:
@@ -568,7 +536,6 @@ class S3ObjectStore:
                 self._client.head_object,
                 Bucket=self._settings.bucket,
                 Key=key,
-                ChecksumMode="ENABLED",
             )
         except ClientError as error:
             if _client_error_code(error) in {"404", "NoSuchKey", "NotFound"}:
@@ -582,8 +549,6 @@ class S3ObjectStore:
         return ObjectHead(
             size_bytes=result.get("ContentLength", -1),
             media_type=result.get("ContentType", ""),
-            checksum_sha256=result.get("ChecksumSHA256"),
-            checksum_type=result.get("ChecksumType"),
         )
 
     @asynccontextmanager
@@ -600,7 +565,6 @@ class S3ObjectStore:
                 self._client.get_object,
                 Bucket=self._settings.bucket,
                 Key=key,
-                ChecksumMode="ENABLED",
             )
         except ClientError as error:
             if _client_error_code(error) in {"404", "NoSuchKey", "NotFound"}:

--- a/backend/tests/integration/object_content/test_content_service.py
+++ b/backend/tests/integration/object_content/test_content_service.py
@@ -52,6 +52,8 @@ if TYPE_CHECKING:
         CompleteMultipartUploadRequestTypeDef,
         CreateMultipartUploadOutputTypeDef,
         CreateMultipartUploadRequestTypeDef,
+        GetObjectOutputTypeDef,
+        GetObjectRequestTypeDef,
         HeadObjectOutputTypeDef,
         HeadObjectRequestTypeDef,
         PutObjectOutputTypeDef,
@@ -122,6 +124,9 @@ class _DelayedSingleUploadClient:
             raise TimeoutError("test did not release the verification HEAD")
         return self._delegate.head_object(**cast("HeadObjectRequestTypeDef", request))
 
+    def get_object(self, **request: object) -> "GetObjectOutputTypeDef":
+        return self._delegate.get_object(**cast("GetObjectRequestTypeDef", request))
+
 
 class _DelayedMultipartUploadClient:
     def __init__(self, delegate: "S3Client") -> None:
@@ -155,6 +160,9 @@ class _DelayedMultipartUploadClient:
 
     def head_object(self, **request: object) -> "HeadObjectOutputTypeDef":
         return self._delegate.head_object(**cast("HeadObjectRequestTypeDef", request))
+
+    def get_object(self, **request: object) -> "GetObjectOutputTypeDef":
+        return self._delegate.get_object(**cast("GetObjectRequestTypeDef", request))
 
 
 async def _wait_for(event: Event) -> None:

--- a/backend/tests/integration/object_content/test_s3_conformance.py
+++ b/backend/tests/integration/object_content/test_s3_conformance.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 from collections.abc import AsyncIterator
 from hashlib import sha256
 from typing import TYPE_CHECKING, cast
@@ -180,7 +179,6 @@ async def test_real_store_single_multipart_range_list_and_delete(
     ) as captured:
         head = await store.upload(multipart_key, captured)
         assert head.size_bytes == len(multipart_payload)
-        assert head.checksum_type == "COMPOSITE"
         assert (
             await _read_all(
                 store,
@@ -201,7 +199,7 @@ async def test_real_store_single_multipart_range_list_and_delete(
 
 
 @pytest.mark.asyncio
-async def test_real_store_rejects_wrong_checksum_and_bucket_escape(
+async def test_real_store_rejects_bucket_escape_and_wrong_credentials(
     real_object_store: RealObjectStore,
 ) -> None:
     client = _raw_client(real_object_store)
@@ -212,20 +210,6 @@ async def test_real_store_rejects_wrong_checksum_and_bucket_escape(
         secret_access_key="wrong-object-content-secret",
     )
     try:
-        with pytest.raises(ClientError) as checksum_error:
-            client.put_object(
-                Bucket=settings.bucket,
-                Key=new_object_key(settings),
-                Body=b"trusted bytes",
-                ContentLength=13,
-                ContentType="application/octet-stream",
-                ChecksumSHA256=base64.b64encode(bytes(32)).decode(),
-            )
-        assert checksum_error.value.response["Error"]["Code"] in {
-            "BadDigest",
-            "InvalidRequest",
-        }
-
         with pytest.raises(ClientError) as bucket_error:
             client.list_objects_v2(Bucket="outside-object-content-test")
         assert bucket_error.value.response["Error"]["Code"] in {
@@ -258,15 +242,12 @@ async def test_real_store_lists_and_aborts_multipart_and_rejects_part_reordering
             Bucket=settings.bucket,
             Key=key,
             ContentType="application/octet-stream",
-            ChecksumAlgorithm="SHA256",
-            ChecksumType="COMPOSITE",
         )
         upload_id = created["UploadId"]
         first = b"a" * (5 * _MEBIBYTE)
         second = b"b" * _MEBIBYTE
         uploaded_parts: list[dict[str, object]] = []
         for number, payload in enumerate((first, second), start=1):
-            checksum = base64.b64encode(sha256(payload).digest()).decode()
             result = client.upload_part(
                 Bucket=settings.bucket,
                 Key=key,
@@ -274,12 +255,10 @@ async def test_real_store_lists_and_aborts_multipart_and_rejects_part_reordering
                 PartNumber=number,
                 Body=payload,
                 ContentLength=len(payload),
-                ChecksumSHA256=checksum,
             )
             uploaded_parts.append(
                 {
                     "ETag": result["ETag"],
-                    "ChecksumSHA256": checksum,
                     "PartNumber": number,
                 }
             )
@@ -302,7 +281,6 @@ async def test_real_store_lists_and_aborts_multipart_and_rejects_part_reordering
                 Key=key,
                 UploadId=upload_id,
                 MultipartUpload={"Parts": list(reversed(uploaded_parts))},
-                ChecksumType="COMPOSITE",
             )
         assert order_error.value.response["Error"]["Code"] in {
             "InvalidPartOrder",

--- a/backend/tests/unittests/object_content/test_runtime.py
+++ b/backend/tests/unittests/object_content/test_runtime.py
@@ -128,7 +128,6 @@ class _ReadinessStore:
         return StoreBindingCreation(
             binding_id=binding_id,
             body=b"test binding",
-            checksum_sha256="test checksum",
         )
 
     async def create_binding(self, _creation: StoreBindingCreation) -> None:

--- a/backend/tests/unittests/object_content/test_s3_integrity.py
+++ b/backend/tests/unittests/object_content/test_s3_integrity.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 import re
 from collections.abc import Awaitable, Callable
 from hashlib import sha256
@@ -23,8 +22,8 @@ from eneo.object_content.s3_object_store import (
     ObjectStoreIntegrityError,
     ObjectStoreUnavailableError,
     S3ObjectStore,
+    _create_client,
     _FileSlice,
-    composite_sha256,
     new_object_key,
 )
 
@@ -57,16 +56,19 @@ def test_object_keys_are_opaque_and_deployment_scoped() -> None:
     assert "filename" not in first
 
 
-def test_multipart_sha256_is_composite_and_not_the_canonical_digest() -> None:
-    parts = (sha256(b"first").digest(), sha256(b"second").digest())
-
-    composite = composite_sha256(parts)
-    canonical = sha256(b"firstsecond").digest()
-
-    assert (
-        composite == f"{base64.b64encode(sha256(b''.join(parts)).digest()).decode()}-2"
+def test_s3_client_uses_only_explicitly_requested_checksums() -> None:
+    client = _create_client(
+        _settings(),
+        connect_timeout_seconds=1,
+        read_timeout_seconds=1,
+        max_attempts=1,
     )
-    assert base64.b64decode(composite.removesuffix("-2")) != canonical
+    try:
+        config = client.meta.config
+        assert config.request_checksum_calculation == "when_required"
+        assert config.response_checksum_validation == "when_required"
+    finally:
+        client.close()
 
 
 def test_file_slice_bounds_unbounded_reader_requests() -> None:
@@ -85,26 +87,62 @@ def test_file_slice_bounds_unbounded_reader_requests() -> None:
 
 
 class _SingleUploadClient:
-    def __init__(self, expected_checksum: str, events: list[str] | None = None) -> None:
-        self.expected_checksum = expected_checksum
+    def __init__(
+        self,
+        *,
+        readback_payload: bytes | None = None,
+        missing_on_readback: bool = False,
+        events: list[str] | None = None,
+    ) -> None:
+        self._payload: bytes | None = None
+        self._readback_payload = readback_payload
+        self._missing_on_readback = missing_on_readback
         self.events = events
         self.head_calls = 0
+        self.get_calls = 0
 
-    def put_object(self, **request: object) -> dict[str, str]:
+    def put_object(self, **request: object) -> dict[str, object]:
         if self.events is not None:
             self.events.append("put")
-        assert request["ChecksumSHA256"] == self.expected_checksum
-        return {"ChecksumSHA256": self.expected_checksum}
+        assert not any(key.startswith("Checksum") for key in request)
+        body = cast(BinaryIO, request["Body"])
+        self._payload = body.read()
+        return {}
 
     def head_object(self, **request: object) -> dict[str, object]:
         if self.events is not None:
             self.events.append("head")
         self.head_calls += 1
+        assert "ChecksumMode" not in request
+        assert self._payload is not None
         return {
-            "ContentLength": 7,
+            "ContentLength": len(self._payload),
             "ContentType": "text/plain",
-            "ChecksumSHA256": self.expected_checksum,
-            "ChecksumType": "FULL_OBJECT",
+        }
+
+    def get_object(self, **request: object) -> dict[str, object]:
+        if self.events is not None:
+            self.events.append("get")
+        assert self._payload is not None
+        self.get_calls += 1
+        assert "ChecksumMode" not in request
+        if self._missing_on_readback:
+            raise ClientError(
+                {
+                    "Error": {"Code": "NoSuchKey"},
+                    "ResponseMetadata": {"HTTPStatusCode": 404},
+                },
+                "GetObject",
+            )
+        payload = (
+            self._readback_payload
+            if self._readback_payload is not None
+            else self._payload
+        )
+        return {
+            "Body": StreamingBody(BytesIO(payload), len(payload)),
+            "ContentLength": len(payload),
+            "ContentType": "text/plain",
         }
 
 
@@ -136,46 +174,63 @@ class _MultipartUploadClient:
     def __init__(
         self,
         *,
-        size_bytes: int,
-        composite_checksum: str,
+        payload: bytes,
+        readback_payload: bytes | None = None,
         events: list[str] | None = None,
     ) -> None:
-        self._size_bytes = size_bytes
-        self._composite_checksum = composite_checksum
+        self._payload = payload
+        self._readback_payload = readback_payload
         self.events = events
+        self.get_calls = 0
 
-    def create_multipart_upload(self, **_request: object) -> dict[str, str]:
+    def create_multipart_upload(self, **request: object) -> dict[str, str]:
         if self.events is not None:
             self.events.append("create")
+        assert not any(key.startswith("Checksum") for key in request)
         return {"UploadId": "bounded-upload"}
 
     def upload_part(self, **request: object) -> dict[str, str]:
         if self.events is not None:
             self.events.append(f"part:{request['PartNumber']}")
+        assert not any(key.startswith("Checksum") for key in request)
         body = cast(BinaryIO, request["Body"])
         while body.read(1024 * 1024):
             pass
-        return {
-            "ChecksumSHA256": cast(str, request["ChecksumSHA256"]),
-            "ETag": f'"part-{request["PartNumber"]}"',
-        }
+        part_number = cast(int, request["PartNumber"])
+        return {"ETag": f'"part-{part_number}"'}
 
-    def complete_multipart_upload(self, **_request: object) -> dict[str, str]:
+    def complete_multipart_upload(self, **request: object) -> dict[str, str]:
         if self.events is not None:
             self.events.append("complete")
-        return {
-            "ChecksumSHA256": self._composite_checksum,
-            "ChecksumType": "COMPOSITE",
-        }
+        assert not any(key.startswith("Checksum") for key in request)
+        manifest = cast(dict[str, object], request["MultipartUpload"])
+        parts = cast(list[dict[str, object]], manifest["Parts"])
+        assert all(set(part) == {"ETag", "PartNumber"} for part in parts)
+        return {}
 
-    def head_object(self, **_request: object) -> dict[str, object]:
+    def head_object(self, **request: object) -> dict[str, object]:
         if self.events is not None:
             self.events.append("head")
+        assert "ChecksumMode" not in request
         return {
-            "ContentLength": self._size_bytes,
+            "ContentLength": len(self._payload),
             "ContentType": "application/octet-stream",
-            "ChecksumSHA256": self._composite_checksum,
-            "ChecksumType": "COMPOSITE",
+        }
+
+    def get_object(self, **request: object) -> dict[str, object]:
+        if self.events is not None:
+            self.events.append("get")
+        self.get_calls += 1
+        assert "ChecksumMode" not in request
+        payload = (
+            self._readback_payload
+            if self._readback_payload is not None
+            else self._payload
+        )
+        return {
+            "Body": StreamingBody(BytesIO(payload), len(payload)),
+            "ContentLength": len(payload),
+            "ContentType": "application/octet-stream",
         }
 
 
@@ -293,6 +348,7 @@ class _BindingClient:
 
     def put_object(self, **request: object) -> dict[str, str]:
         assert request["IfNoneMatch"] == "*"
+        assert "ChecksumSHA256" not in request
         payload = cast(bytes, request["Body"])
         with self._lock:
             self.put_calls += 1
@@ -307,7 +363,7 @@ class _BindingClient:
                     "PutObject",
                 )
             self._payload = payload
-        return {"ChecksumSHA256": cast(str, request["ChecksumSHA256"])}
+        return {}
 
     def get_object(self, **_request: object) -> dict[str, object]:
         with self._lock:
@@ -351,12 +407,79 @@ class _RecordingCheckpoint:
 
 
 @pytest.mark.asyncio
+async def test_single_upload_verifies_stored_bytes() -> None:
+    payload = b"portable s3 content"
+    digest = sha256(payload).digest()
+    client = _SingleUploadClient()
+    store = S3ObjectStore(_settings(), client=cast("S3Client", client))
+    captured = CapturedContent(
+        file=BytesIO(payload),
+        sha256=digest,
+        size_bytes=len(payload),
+        declared_media_type="text/plain",
+        verified_media_type="text/plain",
+        part_sha256=(digest,),
+        part_size_bytes=len(payload),
+    )
+
+    head = await store.upload(new_object_key(_settings()), captured)
+
+    assert head.size_bytes == len(payload)
+    assert client.get_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_single_upload_rejects_corrupted_readback() -> None:
+    payload = b"portable s3 content"
+    replacement = b"corrupted s3 bytes!"
+    assert len(replacement) == len(payload)
+    digest = sha256(payload).digest()
+    client = _SingleUploadClient(readback_payload=replacement)
+    store = S3ObjectStore(_settings(), client=cast("S3Client", client))
+    captured = CapturedContent(
+        file=BytesIO(payload),
+        sha256=digest,
+        size_bytes=len(payload),
+        declared_media_type="text/plain",
+        verified_media_type="text/plain",
+        part_sha256=(digest,),
+        part_size_bytes=len(payload),
+    )
+
+    with pytest.raises(ObjectStoreIntegrityError, match="Stored object bytes"):
+        await store.upload(new_object_key(_settings()), captured)
+
+    assert client.get_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_single_upload_retries_when_object_disappears_before_readback() -> None:
+    payload = b"portable s3 content"
+    digest = sha256(payload).digest()
+    client = _SingleUploadClient(missing_on_readback=True)
+    store = S3ObjectStore(_settings(), client=cast("S3Client", client))
+    captured = CapturedContent(
+        file=BytesIO(payload),
+        sha256=digest,
+        size_bytes=len(payload),
+        declared_media_type="text/plain",
+        verified_media_type="text/plain",
+        part_sha256=(digest,),
+        part_size_bytes=len(payload),
+    )
+
+    with pytest.raises(ObjectStoreUnavailableError, match="disappeared"):
+        await store.upload(new_object_key(_settings()), captured)
+
+    assert client.get_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_single_upload_checkpoints_before_each_sdk_request() -> None:
     payload = b"content"
     digest = sha256(payload).digest()
-    checksum = base64.b64encode(digest).decode()
     events: list[str] = []
-    client = _SingleUploadClient(checksum, events)
+    client = _SingleUploadClient(events=events)
     store = S3ObjectStore(_settings(), client=cast("S3Client", client))
     captured = CapturedContent(
         file=BytesIO(payload),
@@ -378,13 +501,17 @@ async def test_single_upload_checkpoints_before_each_sdk_request() -> None:
 
     assert head.size_bytes == len(payload)
     assert client.head_calls == 1
-    assert events == [
-        "checkpoint",
+    sdk_events = {"put", "head", "get"}
+    assert [event for event in events if event in sdk_events] == [
         "put",
-        "checkpoint",
-        "checkpoint",
         "head",
+        "get",
     ]
+    assert all(
+        index > 0 and events[index - 1] == "checkpoint"
+        for index, event in enumerate(events)
+        if event in sdk_events
+    )
 
 
 @pytest.mark.asyncio
@@ -475,8 +602,7 @@ async def test_multipart_upload_emits_bounded_lease_checkpoints() -> None:
     )
     events: list[str] = []
     client = _MultipartUploadClient(
-        size_bytes=len(payload),
-        composite_checksum=composite_sha256(part_digests),
+        payload=payload,
         events=events,
     )
     settings = ObjectContentSettings(
@@ -510,22 +636,58 @@ async def test_multipart_upload_emits_bounded_lease_checkpoints() -> None:
         operation_checkpoint=checkpoint,
     )
 
-    assert events == [
-        "checkpoint",
+    sdk_events = {"create", "part:1", "part:2", "complete", "head", "get"}
+    assert [event for event in events if event in sdk_events] == [
         "create",
-        "checkpoint",
-        "checkpoint",
         "part:1",
-        "checkpoint",
-        "checkpoint",
         "part:2",
-        "checkpoint",
-        "checkpoint",
         "complete",
-        "checkpoint",
-        "checkpoint",
         "head",
+        "get",
     ]
+    assert all(
+        index > 0 and events[index - 1] == "checkpoint"
+        for index, event in enumerate(events)
+        if event in sdk_events
+    )
+    assert client.get_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_multipart_upload_rejects_corrupted_readback() -> None:
+    mebibyte = 1024 * 1024
+    part_bytes = 5 * mebibyte
+    payload = b"a" * part_bytes + b"b"
+    replacement = b"x" * len(payload)
+    part_digests = (
+        sha256(payload[:part_bytes]).digest(),
+        sha256(payload[part_bytes:]).digest(),
+    )
+    settings = _settings().model_copy(
+        update={
+            "multipart_part_bytes": part_bytes,
+            "multipart_threshold_bytes": part_bytes,
+        }
+    )
+    client = _MultipartUploadClient(
+        payload=payload,
+        readback_payload=replacement,
+    )
+    store = S3ObjectStore(settings, client=cast("S3Client", client))
+    captured = CapturedContent(
+        file=BytesIO(payload),
+        sha256=sha256(payload).digest(),
+        size_bytes=len(payload),
+        declared_media_type="application/octet-stream",
+        verified_media_type="application/octet-stream",
+        part_sha256=part_digests,
+        part_size_bytes=part_bytes,
+    )
+
+    with pytest.raises(ObjectStoreIntegrityError, match="Stored object bytes"):
+        await store.upload(new_object_key(settings), captured)
+
+    assert client.get_calls == 1
 
 
 @pytest.mark.asyncio

--- a/docs/deployment/OBJECT_CONTENT.md
+++ b/docs/deployment/OBJECT_CONTENT.md
@@ -83,8 +83,11 @@ must pass the same tested subset:
 - bucket-scoped paginated object and multipart listing;
 - single-part `PUT`, `HEAD`, streaming `GET`, and one byte range;
 - multipart create, ordered part upload, complete, abort, and list;
-- object deletion with observable not-found convergence;
-- SHA-256 part/composite semantics for multipart where requested.
+- object deletion with observable not-found convergence.
+
+Eneo does not require AWS additional-checksum extensions from an external
+endpoint. Some compatible services implement them fully, some omit them, and
+some accept only the core multipart fields.
 
 Native range support is an endpoint conformance gate. Eneo fetches and verifies
 only the persisted upload chunks covering the requested interval before sending
@@ -92,10 +95,11 @@ response headers. Content migrated as one whole-object chunk retains its
 full-verification cost for range reads.
 
 Eneo computes the canonical full-byte SHA-256 incrementally over its own upload
-stream. S3 ETags, multipart composite checksums, CRCs, and user metadata never
-replace that digest. A bypassing upload, migration, restore, or ambiguous
-reconciliation must be fully streamed back and rehashed before it becomes
-available.
+stream and stores it in PostgreSQL. Every new remote write is streamed back and
+rehashed before it becomes available. S3 ETags, multipart composite checksums,
+CRCs, and user metadata never replace that digest. The same read-back contract
+also applies to a bypassing upload, migration, restore, or ambiguous
+reconciliation.
 
 For an external endpoint, set `OBJECT_CONTENT_ENDPOINT_URL`, TLS, addressing,
 signing region, bucket, credentials, and the stable deployment ID in `.env`,
@@ -442,10 +446,12 @@ bounded (1-32) and should be raised only after measuring PostgreSQL and endpoint
 capacity. Size the backend/worker temporary volume for concurrent in-flight
 upload and verified-read spools: memory use stops at the configured threshold,
 while the remainder uses temporary disk until each upload or verified response
-finishes. Full reads verify and spool the full object. Range reads fetch and
-verify only the persisted upload chunks covering the requested interval before
-response headers are sent. Their transfer and temporary-disk cost is the
-requested interval plus at most two chunk edges; existing rows migrated as one
+finishes. Account for one full remote read after each new remote write; this is
+the provider-neutral integrity check before publication. Full user reads verify
+and spool the full object. Range reads fetch and verify only the persisted upload
+chunks covering the requested interval before response headers are sent. Their
+transfer and temporary-disk cost is the requested interval plus at most two
+chunk edges; existing rows migrated as one
 whole-object chunk retain their previous full-verification cost. The chunk size
 is captured per object, so later multipart tuning cannot invalidate existing
 content. A range proves the chunks it covers; a full read still checks the


### PR DESCRIPTION
## Changes

- use the portable S3-compatible write contract instead of requiring optional
  AWS checksum fields;
- keep PostgreSQL's SHA-256 as the integrity authority and stream every new
  remote object back for verification before publication;
- classify objects that disappear during verification as retryable and keep
  corrupted bytes on the typed integrity path;
- align the SeaweedFS conformance suite and deployment guidance with the same
  provider-neutral contract, including the full-read capacity cost.

## Why

An object-storage endpoint could pass readiness checks but still reject valid
knowledge uploads. SeaweedFS supported the additional checksum fields Eneo
required, while the tested Oderland S3-compatible endpoint did not support the
same multipart extension. Storage therefore appeared ready to administrators
but failed during durable publication.

This keeps the integrity guarantee inside Eneo without adding provider-specific
branches, fallback storage, or an S3 requirement for PostgreSQL-only installs.

## Planning

- Task: Fixes #689

## Testing

- `uv run pytest tests/unittests/object_content/test_s3_integrity.py -q` — 28 passed
- `POSTGRES_HOST=localhost uv run pytest tests/integration/object_content/test_s3_conformance.py -q` — 7 passed against SeaweedFS
- object-content integration suite — 140 passed; two delayed-client contract
  tests passed after typed readback delegation
- touched-file Ruff and Pyright — passed
- live Oderland single-part and multipart write/read/SHA-256/delete — passed
- live Eneo knowledge PDF upload through Oderland and fresh digest comparison — passed

## Screenshots

Not applicable; this changes backend storage verification and deployment guidance.
