### PR TITLE
refactor(chat-debug): gate diagnostics on assistant_debug alone

### DIFF
--- a/backend/src/eneo/conversations/conversations_router.py
+++ b/backend/src/eneo/conversations/conversations_router.py
@@ -28,7 +28,6 @@ from eneo.conversations.conversation_models import (
     PreflightResponse,
 )
 from eneo.database.database import AsyncSession
-from eneo.main.config import Settings, get_settings
 from eneo.main.container.container import Container
 from eneo.main.exceptions import NotFoundException, UnauthorizedException
 from eneo.main.logging import get_logger
@@ -381,13 +380,9 @@ async def chat(
 async def get_chat_turn_diagnostics(
     session_id: UUID,
     message_id: UUID,
-    settings: Annotated[Settings, Depends(get_settings)],
     container: Annotated[Container, Depends(get_container(with_user=True))],
 ) -> ChatTurnDiagnostics:
     """Return stored Skill decisions without loading chat or provider bodies."""
-    if not settings.show_chat_debug_panel:
-        raise NotFoundException("Chat diagnostics are not enabled.")
-
     user = container.user()
     partner = await container.session_repo().get_owned_chat_partner(
         session_id=session_id,

--- a/backend/src/eneo/main/config.py
+++ b/backend/src/eneo/main/config.py
@@ -390,7 +390,6 @@ class Settings(BaseSettings):
     using_access_management: bool = True
     using_iam: bool = False
     using_image_generation: bool = False
-    show_chat_debug_panel: bool = False
 
     # Max concurrent embedding API calls across all crawls (module-level semaphore)
     # Controls parallelism during page batch persistence to avoid overwhelming embedding APIs

--- a/backend/tests/unit/test_chat_turn_diagnostics.py
+++ b/backend/tests/unit/test_chat_turn_diagnostics.py
@@ -64,34 +64,12 @@ async def _read(
     session_id: UUID,
     message_id: UUID,
     container,
-    enabled: bool = True,
 ) -> ChatTurnDiagnostics:
     return await get_chat_turn_diagnostics(
         session_id=session_id,
         message_id=message_id,
-        settings=SimpleNamespace(show_chat_debug_panel=enabled),
         container=container,
     )
-
-
-async def test_disabled_diagnostics_do_not_resolve_the_session():
-    session_id = uuid4()
-    message_id = uuid4()
-    container, _, session_repo, question_repo, _ = _container(
-        partner=OwnedChatPartner(uuid4(), None),
-        stored=StoredSkillActivation(_evidence()),
-    )
-
-    with pytest.raises(NotFoundException):
-        await _read(
-            session_id=session_id,
-            message_id=message_id,
-            container=container,
-            enabled=False,
-        )
-
-    session_repo.get_owned_chat_partner.assert_not_awaited()
-    question_repo.get_skill_activation_evidence.assert_not_awaited()
 
 
 @pytest.mark.parametrize(

--- a/docs/deployment/env_backend.template
+++ b/docs/deployment/env_backend.template
@@ -481,10 +481,6 @@ LOGLEVEL=INFO
 # Output format. true = NDJSON (recommended for production), false = plain text
 JSON_LOGS=true
 
-# Optional per-turn diagnostics for trusted Assistant configurators and owners.
-# Set the same value in the frontend environment; both sides default to false.
-SHOW_CHAT_DEBUG_PANEL=false
-
 # OTel resource attributes. These appear in the `resource` block of every log line.
 # OTEL_SERVICE_NAME is the primary low-cardinality label most aggregators index on.
 OTEL_SERVICE_NAME=eneo

--- a/docs/deployment/env_frontend.template
+++ b/docs/deployment/env_frontend.template
@@ -88,7 +88,6 @@ FEDERATION_PER_TENANT_ENABLED=false
 # SHOW_TEMPLATES=true
 SHOW_WEB_SEARCH=true
 # SHOW_HELP_CENTER=false
-# SHOW_CHAT_DEBUG_PANEL=false
 
 # ----------------------------------------------------------------------------
 # External Services (OPTIONAL)

--- a/frontend/apps/docs-site/src/content/guides/skills.mdx
+++ b/frontend/apps/docs-site/src/content/guides/skills.mdx
@@ -389,9 +389,9 @@ configuration limit rather than a conflict, described in
 
 ## Inspect Skill activation
 
-Deployments can expose an opt-in **Debug** panel in Assistant and Personal Chat
-with `SHOW_CHAT_DEBUG_PANEL=true` in both backend and frontend configuration.
-Only owners and users with the Assistant debug permission see it. Select a
+Assistant and Personal Chat expose a **Debug** panel to users whose role carries
+the Assistant debug permission, which Owner and AI Configurator hold by default.
+Remove the permission from a role to hide the panel from it. Select a
 persisted turn to inspect which exact Skill revisions were available, entered
 the model context, were blocked, or were rejected, along with token
 measurement, activation rounds, and selection time.

--- a/frontend/apps/web/.env.example
+++ b/frontend/apps/web/.env.example
@@ -78,7 +78,6 @@ FEDERATION_PER_TENANT_ENABLED=false
 #     removed in the next release.
 # SHOW_WEB_SEARCH=False
 # SHOW_HELP_CENTER=False
-# SHOW_CHAT_DEBUG_PANEL=False
 
 # ----------------------------------------------------------------------------
 # External Services (OPTIONAL)

--- a/frontend/apps/web/src/lib/core/flags.server.ts
+++ b/frontend/apps/web/src/lib/core/flags.server.ts
@@ -127,7 +127,6 @@ export async function getFeatureFlags(fetchFn: typeof fetch = fetch) {
   // UI Features (enabled by default)
   const showWebSearch = getFlagFromEnv("SHOW_WEB_SEARCH", false);
   const showHelpCenter = getFlagFromEnv("SHOW_HELP_CENTER", false);
-  const showChatDebugPanel = getFlagFromEnv("SHOW_CHAT_DEBUG_PANEL", false);
 
   // Auth
   const zitadelConfigured =
@@ -170,7 +169,6 @@ export async function getFeatureFlags(fetchFn: typeof fetch = fetch) {
     newAuth: useNewAuth,
     showWebSearch,
     showHelpCenter,
-    showChatDebugPanel,
     federationStatus
   });
 }

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/chat/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/chat/+page.svelte
@@ -24,7 +24,6 @@
   const data = $derived.by(() => ({ ...rawData, chatPartner: rawData.chatPartner! }));
 
   const {
-    featureFlags,
     user,
     state: { userInfo }
   } = getAppContext();
@@ -36,9 +35,7 @@
   const chat = untrack(() => initChatService(data));
 
   const debugAvailable = $derived(
-    featureFlags.showChatDebugPanel &&
-      user.hasPermission("assistant_debug") &&
-      chat.partner.type !== "group-chat"
+    user.hasPermission("assistant_debug") && chat.partner.type !== "group-chat"
   );
 
   let currentTab = writable("chat");


### PR DESCRIPTION
## Changes

Removes the `SHOW_CHAT_DEBUG_PANEL` environment flag from both the backend and the frontend. The `assistant_debug` role permission is now the only gate on the chat diagnostics panel.

- Backend: dropped `show_chat_debug_panel` from `Settings` and the guard at the top of `get_chat_turn_diagnostics`, along with the now-unused `settings` dependency. `require_session_auth` + `require_permission(Permission.ASSISTANT_DEBUG)` are unchanged.
- Frontend: dropped `showChatDebugPanel` from `getFeatureFlags()` and from the `debugAvailable` check in the chat page. The `App.Locals["featureFlags"]` type is inferred from that function, so it narrowed automatically.
- Removed the entry from `.env.example` and both `docs/deployment/env_*.template` files, including the backend template's comment telling operators to keep both sides in sync.
- Updated the Skills guide to document the permission as the control instead of the env var.
- Dropped the unit test covering the removed guard; the authorization-ordering tests are untouched.

## Why

The panel was gated twice, and the two gates were not connected. The permission is enforced on the endpoint and checked in the UI. The env flag existed as two independent variables that merely shared a name: one read into backend `Settings`, one read from the SvelteKit server env.

Nothing detected drift between them, and both directions break:

- Frontend on, backend off: the Debug trigger renders and every request 404s. Because `NotFoundException` maps to a fixed `"Not found"` message in the exception handlers, "feature disabled" is indistinguishable from "message not found" or "conversation not yours", so the UI shows a permissions/deleted-message error that is not what happened. This is how the bug surfaced.
- Backend on, frontend off: a reachable endpoint with no way to use it.

The permission already expresses the intended control at the right granularity: per tenant, per role, editable by an administrator without a redeploy. It is seeded to Owner and AI Configurator (`predefined_roles.yml` plus the `202607261730` migration), so revoking it from a role is the supported way to hide the panel. The env flag only added a deployment-wide axis, strictly coarser than the permission it duplicated, and unable to express per-tenant choices on a shared deployment.

The endpoint's payload is unchanged and remains body-free: session id, message id, and typed Skill activation evidence, with no chat content or provider bodies.

## Planning

- Task: Fixes #

## Testing

- `uv run pytest tests/unit/test_chat_turn_diagnostics.py` — 11 passed
- `uv run ruff check` and `ruff format --check` on the changed Python files — clean
- `bun run check` — 0 errors, 0 warnings across `@eneo/web` and `@eneo/ui`
- Full pre-commit suite on the commit, including pyright, frontend-format, and frontend-lint — passed
- Repo-wide grep for `show_chat_debug_panel` / `SHOW_CHAT_DEBUG_PANEL` / `showChatDebugPanel` returns nothing

Not run: the wider backend suite and the browser component tests.

## Screenshots

No visual change for users who hold `assistant_debug` on a deployment that had both flags set. For a deployment where only the frontend flag was set, the panel changes from rendering-but-always-failing to working.