### PR TITLE
fix(model-providers): route live-listing enrichment through the shared cost-map resolver

### DIFF
--- a/backend/alembic/versions/20260501_backfill_model_costs.py
+++ b/backend/alembic/versions/20260501_backfill_model_costs.py
@@ -16,8 +16,8 @@ Notes:
     ``input_cost_per_token`` / ``output_cost_per_token`` from LiteLLM as-is.
   - Transcription gets ``cost_per_minute`` derived from
     ``input_cost_per_second × 60`` (LiteLLM's native unit).
-  - Lookup tries the bare model name first, then ``<provider>/<name>``
-    variants, mirroring `/model-defaults/`.
+  - With provider context, lookup prefers ``<provider>/<name>`` and then
+    falls back to the bare model name, mirroring `/model-defaults/`.
 
 Revision ID: 20260501_backfill_model_costs
 Revises: 20260430_add_model_costs
@@ -39,11 +39,10 @@ branch_labels = None
 depends_on = None
 
 
-# Inlined from the model defaults lookup so this
-# migration stays runnable on a fresh DB even if the app module is later
-# moved or renamed. Keep semantics in sync with that module if either
-# changes — both paths must agree on which LiteLLM row a given
-# (name, provider_type) maps to.
+# Frozen copy of the model-defaults lookup so this migration stays runnable on
+# a fresh DB even if the app module is later moved or renamed. Do not replace it
+# with a runtime import. If the application resolver changes, review explicitly
+# whether this historical migration should retain or mirror the new semantics.
 def resolve_model_defaults(
     model_cost: dict[str, dict[str, Any]],
     names: list[str | None] | str,

--- a/backend/src/eneo/model_providers/domain/model_defaults_lookup.py
+++ b/backend/src/eneo/model_providers/domain/model_defaults_lookup.py
@@ -3,10 +3,11 @@
 Single source of truth used by:
   - ``/api/v1/admin/model-providers/model-defaults/`` (interactive lookup).
   - ``20260501_backfill_model_costs.py`` (one-shot data migration).
+  - ``_enrich_with_litellm_metadata`` (live ``/v1/models`` listing enrichment).
 
-Both call paths need identical semantics so the wizard's "Lookup defaults"
-button and the bulk backfill don't disagree about which LiteLLM row a given
-``(name, provider_type)`` pair maps to.
+All call paths need identical semantics so the wizard's "Lookup defaults"
+button, the bulk backfill, and the auto-fetch model catalog don't disagree
+about which LiteLLM row a given ``(name, provider_type)`` pair maps to.
 
 Resolution order:
   1. If ``provider_type`` is known, prefer the prefixed entry

--- a/backend/src/eneo/model_providers/domain/model_defaults_lookup.py
+++ b/backend/src/eneo/model_providers/domain/model_defaults_lookup.py
@@ -1,13 +1,13 @@
 """Provider-aware resolver for LiteLLM's ``model_cost`` map.
 
-Single source of truth used by:
+Runtime single source of truth used by:
   - ``/api/v1/admin/model-providers/model-defaults/`` (interactive lookup).
-  - ``20260501_backfill_model_costs.py`` (one-shot data migration).
   - ``_enrich_with_litellm_metadata`` (live ``/v1/models`` listing enrichment).
 
-All call paths need identical semantics so the wizard's "Lookup defaults"
-button, the bulk backfill, and the auto-fetch model catalog don't disagree
-about which LiteLLM row a given ``(name, provider_type)`` pair maps to.
+The one-shot ``20260501_backfill_model_costs.py`` migration contains an
+intentionally frozen copy of these resolution semantics so it stays runnable
+without importing live application code. Runtime consumers therefore agree
+structurally; changes here must still be checked against that migration copy.
 
 Resolution order:
   1. If ``provider_type`` is known, prefer the prefixed entry

--- a/backend/src/eneo/model_providers/domain/model_provider_service.py
+++ b/backend/src/eneo/model_providers/domain/model_provider_service.py
@@ -165,8 +165,9 @@ def _enrich_with_litellm_metadata(
     This function owns presentation policy only: which models are surfaced
     (filter substrings, mode mapping) and which fields are extracted per mode.
     Which ``model_cost`` row a ``(name, provider_type)`` pair maps to is
-    delegated to ``resolve_model_defaults`` so this path can never disagree
-    with the ``/model-defaults/`` endpoint or the cost backfill.
+    delegated to ``resolve_model_defaults`` so the runtime enrichment and
+    ``/model-defaults/`` paths agree structurally. The one-shot cost backfill
+    keeps an intentionally frozen copy of the same documented semantics.
 
     Returns None when the name matches a non-text filter substring or maps to
     a litellm mode we don't surface (image, tts, moderation, etc.).

--- a/backend/src/eneo/model_providers/domain/model_provider_service.py
+++ b/backend/src/eneo/model_providers/domain/model_provider_service.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from uuid import UUID, uuid4
 
 from eneo.main.exceptions import BadRequestException, NameCollisionException
+from eneo.model_providers.domain.model_defaults_lookup import resolve_model_defaults
 from eneo.model_providers.domain.model_provider import ModelProvider
 from eneo.model_providers.infrastructure.model_provider_repository import (
     ModelProviderRepository,
@@ -158,8 +159,14 @@ def _infer_mode_from_name(name: str) -> str | None:
 def _enrich_with_litellm_metadata(
     name: str, provider_type: str, mode_hint: str | None = None
 ) -> dict[str, Any] | None:
-    """Look up `name` in litellm.model_cost (with prefix variants) and return
-    an enriched capability dict, or None if the model should be hidden.
+    """Look up `name` in litellm.model_cost and return an enriched capability
+    dict, or None if the model should be hidden.
+
+    This function owns presentation policy only: which models are surfaced
+    (filter substrings, mode mapping) and which fields are extracted per mode.
+    Which ``model_cost`` row a ``(name, provider_type)`` pair maps to is
+    delegated to ``resolve_model_defaults`` so this path can never disagree
+    with the ``/model-defaults/`` endpoint or the cost backfill.
 
     Returns None when the name matches a non-text filter substring or maps to
     a litellm mode we don't surface (image, tts, moderation, etc.).
@@ -178,13 +185,7 @@ def _enrich_with_litellm_metadata(
         return None
 
     model_cost = getattr(litellm, "model_cost", {})
-
-    candidates = [name, f"{provider_type}/{name}"]
-    info: dict[str, Any] | None = None
-    for key in candidates:
-        if key in model_cost:
-            info = model_cost[key]
-            break
+    info = resolve_model_defaults(model_cost, name, provider_type)
 
     if info is None:
         chosen = mode_hint or _infer_mode_from_name(name)

--- a/backend/tests/unittests/model_providers/test_enrich_with_litellm_metadata.py
+++ b/backend/tests/unittests/model_providers/test_enrich_with_litellm_metadata.py
@@ -66,6 +66,38 @@ def test_enriches_via_provider_prefix_lookup() -> None:
     assert result["max_input_tokens"] == 128000
 
 
+def test_prefers_provider_prefixed_entry_over_bare() -> None:
+    """When both `{provider}/{name}` and bare `{name}` exist with different
+    values, the prefixed row must win — the same rule the `/model-defaults/`
+    endpoint applies (see test_model_defaults_lookup). This used to diverge:
+    a local candidate list here tried the bare key first.
+    """
+    fake = {
+        "gpt-4o": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "max_input_tokens": 128000,
+            "input_cost_per_token": 0.000005,
+        },
+        "azure/gpt-4o": {
+            "litellm_provider": "azure",
+            "mode": "chat",
+            "max_input_tokens": 100000,
+            "input_cost_per_token": 0.000003,
+        },
+    }
+    with _patch_cost_map(fake):
+        azure = model_provider_service._enrich_with_litellm_metadata("gpt-4o", "azure")
+        openai = model_provider_service._enrich_with_litellm_metadata(
+            "gpt-4o", "openai"
+        )
+    assert azure is not None and openai is not None
+    assert azure["max_input_tokens"] == 100000
+    assert azure["input_cost_per_token"] == 0.000003
+    # No `openai/gpt-4o` entry in the map → the bare row is the right match.
+    assert openai["max_input_tokens"] == 128000
+
+
 def test_enriches_embedding_model() -> None:
     fake = {
         "text-embedding-3-large": {

--- a/backend/tests/unittests/model_providers/test_enrich_with_litellm_metadata.py
+++ b/backend/tests/unittests/model_providers/test_enrich_with_litellm_metadata.py
@@ -98,6 +98,36 @@ def test_prefers_provider_prefixed_entry_over_bare() -> None:
     assert openai["max_input_tokens"] == 128000
 
 
+def test_prefers_gateway_metadata_for_nested_model_id() -> None:
+    """Gateway providers prefix model IDs that already contain an upstream
+    provider segment. The gateway-specific row must win without changing the
+    nested model ID returned to the caller.
+    """
+    fake = {
+        "deepseek/deepseek-chat": {
+            "litellm_provider": "deepseek",
+            "mode": "chat",
+            "max_input_tokens": 131072,
+            "input_cost_per_token": 0.00000028,
+        },
+        "openrouter/deepseek/deepseek-chat": {
+            "litellm_provider": "openrouter",
+            "mode": "chat",
+            "max_input_tokens": 65536,
+            "input_cost_per_token": 0.00000014,
+        },
+    }
+    with _patch_cost_map(fake):
+        result = model_provider_service._enrich_with_litellm_metadata(
+            "deepseek/deepseek-chat", "openrouter"
+        )
+
+    assert result is not None
+    assert result["name"] == "deepseek/deepseek-chat"
+    assert result["max_input_tokens"] == 65536
+    assert result["input_cost_per_token"] == 0.00000014
+
+
 def test_enriches_embedding_model() -> None:
     fake = {
         "text-embedding-3-large": {

--- a/backend/tests/unittests/model_providers/test_model_defaults_lookup.py
+++ b/backend/tests/unittests/model_providers/test_model_defaults_lookup.py
@@ -1,8 +1,9 @@
 """Unit tests for the shared LiteLLM defaults resolver.
 
-The resolver is the single source of truth for both the interactive
-``/model-defaults/`` endpoint and the cost-backfill migration, so the test
-matrix needs to cover the cases where the two used to disagree:
+The resolver is the single source of truth for the interactive
+``/model-defaults/`` endpoint, the cost-backfill migration, and the live
+model-listing enrichment, so the test matrix needs to cover the cases
+where the call paths used to disagree:
 
   - bare-name vs. provider-prefixed entries
   - same model under multiple providers (must not silently pick one)


### PR DESCRIPTION
## Summary

`_enrich_with_litellm_metadata` (the live model catalog behind `GET /{provider_id}/models/`) previously kept a local LiteLLM `model_cost` candidate list that tried the bare model ID before `{provider}/{model}`. The shared runtime resolver `resolve_model_defaults`, used by `/model-defaults/`, deliberately does the opposite: provider-prefixed first, then bare fallback.

This PR removes the duplicate lookup policy and delegates live-listing enrichment to `resolve_model_defaults`. Runtime enrichment and the interactive defaults endpoint now share one implementation.

The historical `20260501_backfill_model_costs.py` migration intentionally keeps a frozen copy of the same documented resolution semantics so fresh-database migrations do not import live application code.

## Impact

Provider-prefixed and bare LiteLLM rows can differ in fields Eneo consumes, including token limits, prices, and capability flags. Selecting the bare row can therefore apply metadata for the upstream provider instead of the provider actually serving the model.

Azure remains a manual model/deployment flow and is still excluded from live listing. The issue is nevertheless not assumed to be purely latent: gateway or custom-endpoint providers can reach this enrichment path today. For example, LiteLLM 1.95.0 contains different metadata for `openrouter/deepseek/deepseek-chat` and the bare `deepseek/deepseek-chat` row.

The behavior change is intentionally narrow:

- when both `{provider}/{name}` and bare `{name}` exist, the provider-prefixed row wins;
- when the prefixed row is absent, the bare row remains the fallback;
- unknown models still use `mode_hint` and then name inference;
- filtering and response shapes are unchanged.

## Ownership after this change

- `model_defaults_lookup.resolve_model_defaults` owns runtime row-selection semantics.
- `_enrich_with_litellm_metadata` owns presentation policy: filtering, mode mapping, and metadata projection.
- The one-shot backfill migration owns its frozen historical copy and documents the same current precedence.

`ai_models/deprecation_lookup.py` already prefers provider-prefixed entries and only reads deprecation metadata, so it is unchanged.

## Tests

- `test_prefers_provider_prefixed_entry_over_bare` covers provider-prefixed precedence and bare fallback.
- `test_prefers_gateway_metadata_for_nested_model_id` covers a gateway prefix around a nested upstream model ID without mutating the returned model ID.
- Existing resolver tests cover ambiguous provider-less lookup, single prefixed matches, candidate priority, empty candidates, and misses.

## Verification

- `pytest tests/unittests/ -q` — 2,864 passed
- focused model-provider tests — 40 passed
- Ruff lint and format checks — clean
- Pyright on touched production modules — 0 errors, 0 warnings
- pre-commit and pre-push checks — passed

No API/schema changes. This PR does not address the separate static-catalog model-ID normalization/double-prefix work or the existing vLLM/`hosted_vllm` alias handling.
