### PR TITLE
feat(mcp): name tools the way the UI does when talking to users

### DIFF
--- a/backend/src/eneo/completion_models/infrastructure/context_builder.py
+++ b/backend/src/eneo/completion_models/infrastructure/context_builder.py
@@ -21,6 +21,7 @@ from eneo.completion_models.infrastructure.message_payload import (
 from eneo.completion_models.infrastructure.static_prompts import (
     HALLUCINATION_GUARD,
     SHOW_REFERENCES_PROMPT,
+    TOOL_NAMING_INSTRUCTION,
     TRANSCRIPTION_PROMPT,
 )
 from eneo.files.file_models import File, FileType
@@ -198,7 +199,7 @@ class ChunkGrouping:
 
 
 class _Prompt:
-    def __init__(self, version: int = 1, model_name: str = ""):
+    def __init__(self, version: int = 1, model_name: str = "", has_tools: bool = False):
         super().__init__()
         self.prompt: str | None = None
         self.knowledge: str | None = None
@@ -208,6 +209,7 @@ class _Prompt:
         self._knowledge_tokens: int = 0
         self.version: int = version
         self.model_name: str = model_name
+        self.has_tools: bool = has_tools
 
     @override
     def __str__(self):
@@ -215,6 +217,12 @@ class _Prompt:
 
         if self.prompt:
             components.append(self.prompt)
+
+        # Tools are advertised on this request, so teach the model how to name
+        # them before it composes an answer. Grouped with the other instructions
+        # ahead of the data blocks below.
+        if self.has_tools:
+            components.append(TOOL_NAMING_INSTRUCTION)
 
         # Add references prompt if either knowledge or web search results exist
         # but only for version 2
@@ -662,7 +670,9 @@ class ContextBuilder:
 
         # Create the necessary parts of the prompt.
         # Add the tokens used.
-        _prompt = _Prompt(version=version, model_name=model_name)
+        _prompt = _Prompt(
+            version=version, model_name=model_name, has_tools=bool(tool_dicts)
+        )
         _prompt.add_prompt(
             prompt=prompt,
             transcription=bool(transcription_inputs),

--- a/backend/src/eneo/completion_models/infrastructure/static_prompts.py
+++ b/backend/src/eneo/completion_models/infrastructure/static_prompts.py
@@ -15,6 +15,22 @@ MCP_TOOL_REFERENCES_INSTRUCTION = (
     "source_id."
 )
 
+# Appended to the system prompt on every request that advertises tools. Tool
+# identifiers are sanitized `server__tool` strings (see MCPProxySession) that the
+# model must emit verbatim when calling, so they leak into prose unless the model
+# is told otherwise: asked "what tools do you have?", it answers with a list of
+# wire identifiers. Pairs with the `Display name:` line each tool description
+# opens with when its server supplies an MCP title.
+TOOL_NAMING_INSTRUCTION = (
+    "The tool identifiers you call with (for example knowledge__search_knowledge) "
+    "are internal wiring, not names for users. When you mention a tool, use the "
+    "Display name from its description when it has one, otherwise plain language "
+    "for what the tool does, in the language of the conversation. If the user "
+    "asks what you can do or which tools you have, answer with a short summary "
+    "of capabilities grouped by what the user can accomplish, not an inventory "
+    "of identifiers. Show a raw identifier only when the user asks for it."
+)
+
 SHOW_REFERENCES_PROMPT = """Use the provided sources delimited by triple quotes to answer questions.
 Only use the sources to answer questions. You MUST reference every source you use by adding an inline XML self-closing tag immediately after the information: <inref id="<source_id>"/>
 

--- a/backend/src/eneo/mcp_servers/infrastructure/proxy/mcp_proxy_session.py
+++ b/backend/src/eneo/mcp_servers/infrastructure/proxy/mcp_proxy_session.py
@@ -143,6 +143,28 @@ class MCPProxySession:
             sanitized = "t_" + sanitized
         return sanitized
 
+    @staticmethod
+    def _describe_for_llm(
+        *,
+        server_name: str,
+        name: str,
+        title: str | None,
+        description: str | None,
+    ) -> str:
+        """Model-facing description, opening with the tool's display name.
+
+        The wire name is a sanitized ``server__tool`` identifier the model must
+        emit verbatim, so it cannot double as a label; left to itself the model
+        recites that identifier when a user asks what the assistant can do. MCP's
+        optional ``title`` is the human-readable name the chat UI already prefers
+        for tool-call chips, and the description is the only channel that carries
+        it to the model: the OpenAI function schema has no title field.
+        """
+        base = description or f"Tool from {server_name}"
+        if not title or title == name:
+            return base
+        return f'Display name: "{title}".\n{base}'
+
     def _register_tool(
         self,
         server: MCPServer,
@@ -180,7 +202,12 @@ class MCPProxySession:
                 "type": "function",
                 "function": {
                     "name": prefixed_name,
-                    "description": description or f"Tool from {server.name}",
+                    "description": self._describe_for_llm(
+                        server_name=server.name,
+                        name=name,
+                        title=title,
+                        description=description,
+                    ),
                     "parameters": input_schema or {"type": "object", "properties": {}},
                 },
             }

--- a/backend/tests/unit/test_mcp_improvements.py
+++ b/backend/tests/unit/test_mcp_improvements.py
@@ -795,6 +795,7 @@ class TestMCPProxySessionToolCollision:
         for tool_def in tools:
             tool = MagicMock()
             tool.name = tool_def["name"]
+            tool.title = tool_def.get("title")
             tool.description = tool_def.get("description", "")
             tool.input_schema = tool_def.get("input_schema", {})
             tool.is_enabled_by_default = tool_def.get("is_enabled", True)
@@ -876,6 +877,44 @@ class TestMCPProxySessionToolCollision:
 
             # Warning logged
             mock_logger.warning.assert_called()
+
+
+class TestMCPProxySessionToolDisplayName:
+    """The MCP title reaches the model through the function description."""
+
+    def _proxy(self, title: str | None) -> MCPProxySession:
+        tool = MagicMock()
+        tool.name = "ingest_urls"
+        tool.title = title
+        tool.description = "Fetch files from HTTPS links."
+        tool.input_schema = {"type": "object", "properties": {}}
+        tool.is_enabled_by_default = True
+        tool.requires_approval = False
+
+        server = MagicMock()
+        server.id = uuid4()
+        server.name = "files"
+        server.http_url = "http://localhost:8080"
+        server.tools = [tool]
+        return MCPProxySession([server])
+
+    def test_title_is_prepended_to_the_description(self):
+        [tool] = self._proxy("Ladda upp filer").get_tools_for_llm()
+
+        assert tool["function"]["name"] == "files__ingest_urls"
+        assert tool["function"]["description"] == (
+            'Display name: "Ladda upp filer".\nFetch files from HTTPS links.'
+        )
+
+    def test_description_is_untouched_without_a_title(self):
+        [tool] = self._proxy(None).get_tools_for_llm()
+
+        assert tool["function"]["description"] == "Fetch files from HTTPS links."
+
+    def test_title_equal_to_the_tool_name_adds_nothing(self):
+        [tool] = self._proxy("ingest_urls").get_tools_for_llm()
+
+        assert tool["function"]["description"] == "Fetch files from HTTPS links."
 
 
 # =============================================================================

--- a/backend/tests/unittests/ai_models/test_context_builder.py
+++ b/backend/tests/unittests/ai_models/test_context_builder.py
@@ -16,6 +16,7 @@ from eneo.completion_models.infrastructure.context_builder import (
 from eneo.completion_models.infrastructure.static_prompts import (
     HALLUCINATION_GUARD,
     SHOW_REFERENCES_PROMPT,
+    TOOL_NAMING_INSTRUCTION,
 )
 from eneo.files.file_models import File, FileType
 from eneo.questions.question import ToolCallInfo
@@ -660,6 +661,41 @@ def test_message_scaffolding_overhead_is_counted(context_builder: ContextBuilder
     context = context_builder.build_context(input_str=QUESTION, max_tokens=10000)
 
     assert context.token_count > count_tokens(QUESTION)
+
+
+def test_tool_naming_instruction_is_added_when_tools_are_advertised(
+    context_builder: ContextBuilder,
+):
+    context = context_builder.build_context(
+        input_str=QUESTION,
+        max_tokens=10000,
+        prompt="You are a helpful assistant.",
+        extra_tool_dicts=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "files__ingest_urls",
+                    "description": "Fetch files from HTTPS links.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+
+    assert TOOL_NAMING_INSTRUCTION in context.prompt
+    assert context.prompt.startswith("You are a helpful assistant.")
+
+
+def test_tool_naming_instruction_is_absent_without_tools(
+    context_builder: ContextBuilder,
+):
+    context = context_builder.build_context(
+        input_str=QUESTION,
+        max_tokens=10000,
+        prompt="You are a helpful assistant.",
+    )
+
+    assert context.prompt == "You are a helpful assistant."
 
 
 def test_truncate_knowledge_if_too_many_chunks(context_builder: ContextBuilder):


### PR DESCRIPTION
## Problem

Asked "vad har du för verktyg?", the assistant answers with a list of wire identifiers:

- `ladan__filhanteraren__ingest_urls`
- `knowledge__search_knowledge`

Those strings are sanitized `server__tool` names the model has to emit verbatim to make a call, so they are the only names it knows. For a non-technical user they read as noise.

The chat UI already solves this for tool-call chips: `toolDisplayName` prefers the MCP `title` and falls back to the raw name. The inconsistency was only in model-authored prose.

## Changes

**1. The MCP `title` now reaches the model.** `MCPProxySession._describe_for_llm` prepends the display name to the function description:

```
Display name: "Search knowledge".
Semantic search across the assistant's knowledge sources...
```

The description is the only channel available, since the OpenAI function schema has no `title` field. Skipped when the server supplies no title, or when the title just repeats the tool name, so nothing gains dead tokens.

This works for both tool sources: FastMCP surfaces `title` from `@mcp.tool(title=...)` (verified), so the internal knowledge and files servers benefit immediately, and titles from third-party servers are already synced and persisted.

**2. `TOOL_NAMING_INSTRUCTION`** is appended to the system prompt whenever a request advertises tools. It does two things: use the display name or plain language rather than the identifier, and answer "what can you do?" with a capability summary grouped by what the user can accomplish rather than an inventory. Raw identifiers only on explicit request.

Wired through `_Prompt.has_tools`, set from `bool(tool_dicts)` in `build_context`. Putting it there rather than in the adapter means the instruction is counted in `_prompt.num_tokens`, so the context-window estimate in the UI stays accurate, and it sits with the other instruction blocks ahead of the knowledge data, matching how `SHOW_REFERENCES_PROMPT` is handled.

## Tests

- `test_mcp_improvements.py`: three cases for description composition (title present, absent, equal to the tool name). The existing `_create_mock_server` helper now sets `tool.title` explicitly, since `MagicMock` was auto-vivifying a truthy title that would leak into the collision tests' assertions.
- `test_context_builder.py`: instruction present with tools, and the prompt still exactly equals the user's own prompt without them.

444 passing across the affected modules (`completion_models`, `skills`, `ai_models`, MCP proxy, completion service).

## Note

For a third-party server that declares no `title`, the model still has only the wire identifier, and change 2 is what carries it by pushing toward plain language. Making `title` admin-editable would put the naming under Eneo's control rather than the upstream server author's, which is the natural follow-up if tenants want Swedish tool names.

## Tenancy / audit

No new queries, no new endpoints, no schema change. Prompt and tool-definition assembly only.
