### PR TITLE
chore(devcontainer): make the bundled object-content endpoint connectable

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,8 +18,12 @@ services:
       - OBJECT_CONTENT_ACCESS_KEY_ID
       - OBJECT_CONTENT_SECRET_ACCESS_KEY
       - OBJECT_CONTENT_DEPLOYMENT_ID
-      - OBJECT_CONTENT_ALLOW_INSECURE_HTTP
-      - OBJECT_CONTENT_ADMIN_ALLOWED_ENDPOINT_ORIGINS
+      # Guardrail defaults for the bundled `object-content` profile below. They
+      # are inert while that profile is off, because nothing resolves the
+      # allowlisted host. Development only; production keeps the secure
+      # defaults (plain HTTP refused, empty allowlist).
+      - OBJECT_CONTENT_ALLOW_INSECURE_HTTP=${OBJECT_CONTENT_ALLOW_INSECURE_HTTP:-true}
+      - 'OBJECT_CONTENT_ADMIN_ALLOWED_ENDPOINT_ORIGINS=${OBJECT_CONTENT_ADMIN_ALLOWED_ENDPOINT_ORIGINS:-["http://object-content:8333"]}'
     volumes:
       - ../:/workspace
       # Isolate .venv from host to prevent host-side uv/python from corrupting it

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -44,6 +44,59 @@ cd frontend && bun run dev                 # Terminal 2
 cd backend && uv run worker             # Terminal 3
 ```
 
+**Optional: object storage locally**
+
+Eneo stores file bytes in PostgreSQL by default, which is all most work needs.
+To exercise the S3-compatible path instead, start the bundled SeaweedFS service
+from the `object-content` Compose profile. It is off by default because the
+image is built from upstream source, so the first start takes a few minutes.
+
+```bash
+docker compose -p eneo_devcontainer -f .devcontainer/docker-compose.yml \
+  --profile object-content up -d object-content
+```
+
+To have VS Code bring it up together with the rest of the devcontainer, create
+`.devcontainer/.env` (gitignored, so it stays a per-developer choice) with:
+
+```
+COMPOSE_PROFILES=object-content
+```
+
+Compose loads that file automatically because the devcontainer's project
+directory is `.devcontainer/`. Rebuild or reopen the container to apply it.
+
+Then connect it on the admin **File storage** page (`/admin/storage`). That page
+is read-only unless your user holds platform-administrator authority, which is
+granted only through the sysadmin API:
+
+```bash
+curl -X PUT "$ENEO_URL/api/v1/sysadmin/users/$USER_ID/platform-admin" \
+  -H "X-API-Key: $ENEO_SUPER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"enabled": true}'
+```
+
+Use these values in the connection dialog. They match the Compose defaults, and
+the devcontainer already allowlists this endpoint and permits plain HTTP for it:
+
+| Field | Value |
+| --- | --- |
+| S3 endpoint | `http://object-content:8333` |
+| Bucket | `eneo-object-content-dev` |
+| Region for signing | `local` |
+| Access key ID | `eneo-dev-object-content` |
+| Secret access key | `local-development-only-secret` |
+| Bucket addressing | `Bucket in the URL path` (the default) |
+
+Leave `OBJECT_CONTENT_ENDPOINT_URL`, `OBJECT_CONTENT_REGION`,
+`OBJECT_CONTENT_BUCKET`, `OBJECT_CONTENT_ACCESS_KEY_ID`,
+`OBJECT_CONTENT_SECRET_ACCESS_KEY`, `OBJECT_CONTENT_DEPLOYMENT_ID`, and
+`OBJECT_CONTENT_ADDRESSING_STYLE` unset. Setting any one of them switches Eneo
+to the operator-managed connection instead, and the admin dialog stops being the
+authority. See [docs/deployment/OBJECT_CONTENT.md](deployment/OBJECT_CONTENT.md)
+for the operator-managed path and for connecting an external endpoint.
+
 ### 2. Make Your First Contribution
 
 ```bash


### PR DESCRIPTION
## Why

The `object-content` Compose profile already ships a SeaweedFS endpoint on the private devcontainer network, but you could not actually connect it from the admin **File storage** page. Two operator guardrails, both correctly secure-by-default, blocked it:

- `admin_allowed_endpoint_origins` defaults to empty, so `permits_admin_endpoint()` rejected `http://object-content:8333` with `object_store_endpoint_not_permitted`.
- `allow_insecure_http` defaults to false, so the plain-HTTP endpoint failed `validate_transport`.

So the bundled profile was unreachable through the surface that is meant to configure it.

## What

Give both guardrails a devcontainer-local default scoped to exactly the bundled endpoint, and document the local setup path in CONTRIBUTING.

## Why this is safe

- Neither variable is in the `connection_fields` set that `load_object_content_settings()` scans, so this does **not** put Eneo into an operator-managed connection. The admin dialog stays the authority and the default inline-PostgreSQL path is unchanged.
- The allowlist names one origin. Any other endpoint an admin types is still refused.
- Both defaults use `${VAR:-default}`, so an existing value wins.
- `.devcontainer/docker-compose.yml` is devcontainer-only. The deployment Compose files are untouched, so production keeps the secure defaults.

## Verification

Confirmed inside the running devcontainer that the values land and parse:

```
allow_insecure_http = True
admin_allowed_endpoint_origins = ('http://object-content:8333',)
```

`docker compose config` renders the interpolation correctly, and the pass-through connection variables stay absent from the container environment, which is what keeps the admin-managed mode active.

## Docs

CONTRIBUTING gains an optional section covering: starting the profile, opting in for VS Code via a gitignored `.devcontainer/.env`, granting platform-admin through the sysadmin API, the connection values (matching the Compose defaults and the actual dialog labels), and which variables to leave unset so the admin dialog remains the authority.