### PR TITLE
Make storage usage colors easy to understand

### DIFF
--- a/frontend/apps/web/src/routes/(app)/admin/storage/StorageOverviewSection.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/storage/StorageOverviewSection.svelte
@@ -210,29 +210,56 @@
         {#if inventory}
           <p class="text-lg font-semibold tabular-nums">{storageBytes(managedTotalBytes, 2)}</p>
           {#if managedTotalBytes > 0}
-            <div
-              class="bg-secondary flex h-1.5 overflow-hidden rounded-full"
+            <span
+              class="bg-secondary flex h-1.5 gap-px overflow-hidden rounded-full"
               role="img"
               aria-label={m.storage_overview_distribution_label({
                 postgresql: storageBytes(managedPostgresqlBytes, 2),
                 objectStore: storageBytes(managedObjectStoreBytes, 2)
               })}
             >
-              <div class="bg-accent-default h-full" style={`flex-basis: ${postgresqlShare}%`}></div>
-              <div
-                class="bg-positive-default h-full"
-                style={`flex-basis: ${objectStoreShare}%`}
-              ></div>
-            </div>
+              {#if managedPostgresqlBytes > 0}
+                <span
+                  data-storage-segment="postgresql"
+                  class="bg-accent-default block h-full min-w-[4px] shrink-0"
+                  style={`flex-grow: ${postgresqlShare}; flex-basis: 0`}
+                ></span>
+              {/if}
+              {#if managedObjectStoreBytes > 0}
+                <span
+                  data-storage-segment="object-store"
+                  class="bg-positive-default block h-full min-w-[4px] shrink-0"
+                  style={`flex-grow: ${objectStoreShare}; flex-basis: 0`}
+                ></span>
+              {/if}
+            </span>
           {/if}
           <dl class="text-muted grid gap-1 text-xs">
             <div class="flex justify-between gap-3">
-              <dt>{m.storage_target_postgres_inline()}</dt>
-              <dd class="tabular-nums">{storageBytes(managedPostgresqlBytes, 2)}</dd>
+              <dt class="flex min-w-0 items-center gap-2">
+                <span
+                  data-storage-swatch="postgresql"
+                  class="bg-accent-default size-2 shrink-0 rounded-[2px]"
+                  aria-hidden="true"
+                ></span>
+                <span>{m.storage_target_postgres_inline()}</span>
+              </dt>
+              <dd class="shrink-0 tabular-nums">
+                {storageBytes(managedPostgresqlBytes, 2)}
+              </dd>
             </div>
             <div class="flex justify-between gap-3">
-              <dt>{m.storage_target_object_store()}</dt>
-              <dd class="tabular-nums">{storageBytes(managedObjectStoreBytes, 2)}</dd>
+              <dt class="flex min-w-0 items-center gap-2">
+                <span
+                  data-storage-swatch="object-store"
+                  class="bg-positive-default size-2 shrink-0 rounded-[2px]"
+                  aria-hidden="true"
+                ></span>
+                <span>{m.storage_target_object_store()}</span>
+              </dt>
+              <dd class="shrink-0 tabular-nums">
+                {storageBytes(managedObjectStoreBytes, 2)}
+              </dd>
             </div>
           </dl>
         {:else if inventoryStatus === "loading"}

--- a/frontend/apps/web/src/routes/(app)/admin/storage/StorageOverviewSection.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/storage/StorageOverviewSection.svelte
@@ -221,15 +221,15 @@
               {#if managedPostgresqlBytes > 0}
                 <span
                   data-storage-segment="postgresql"
-                  class="bg-accent-default block h-full min-w-[4px] shrink-0"
-                  style={`flex-grow: ${postgresqlShare}; flex-basis: 0`}
+                  class="bg-accent-default block h-full shrink-0"
+                  style={`min-width: 4px; flex-grow: ${postgresqlShare}; flex-basis: 0`}
                 ></span>
               {/if}
               {#if managedObjectStoreBytes > 0}
                 <span
                   data-storage-segment="object-store"
-                  class="bg-positive-default block h-full min-w-[4px] shrink-0"
-                  style={`flex-grow: ${objectStoreShare}; flex-basis: 0`}
+                  class="bg-positive-default block h-full shrink-0"
+                  style={`min-width: 4px; flex-grow: ${objectStoreShare}; flex-basis: 0`}
                 ></span>
               {/if}
             </span>

--- a/frontend/apps/web/src/routes/(app)/admin/storage/storage-page.svelte.test.ts
+++ b/frontend/apps/web/src/routes/(app)/admin/storage/storage-page.svelte.test.ts
@@ -1,9 +1,7 @@
 import { page, userEvent } from "@vitest/browser/context";
 import { EneoError } from "@eneo/eneo-js";
 import { render } from "vitest-browser-svelte";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-
-import "../../../../app.css";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const getPolicy = vi.hoisted(() => vi.fn());
 const getInventory = vi.hoisted(() => vi.fn());
@@ -97,13 +95,6 @@ vi.mock("$lib/paraglide/runtime", () => ({
 }));
 
 import StoragePage from "./+page.svelte";
-
-const originalTheme = document.documentElement.dataset.theme;
-
-afterEach(() => {
-  if (originalTheme === undefined) delete document.documentElement.dataset.theme;
-  else document.documentElement.dataset.theme = originalTheme;
-});
 
 function policy(overrides: Record<string, unknown> = {}) {
   return {
@@ -2719,7 +2710,6 @@ describe("admin storage settings page", () => {
   });
 
   test("labels both storage locations when one share is very small", async () => {
-    document.documentElement.dataset.theme = "light";
     testUser.canAdministerStorage = true;
     getPolicy.mockResolvedValue(policy());
     getInventory.mockResolvedValue({
@@ -2751,8 +2741,12 @@ describe("admin storage settings page", () => {
     const distribution = overview
       .getByRole("img", { name: /storage_overview_distribution_label/ })
       .element();
-    const postgresqlSegment = distribution.querySelector("[data-storage-segment='postgresql']")!;
-    const objectStoreSegment = distribution.querySelector("[data-storage-segment='object-store']")!;
+    const postgresqlSegment = distribution.querySelector<HTMLElement>(
+      "[data-storage-segment='postgresql']"
+    )!;
+    const objectStoreSegment = distribution.querySelector<HTMLElement>(
+      "[data-storage-segment='object-store']"
+    )!;
     const postgresqlSwatch = overview
       .element()
       .querySelector("[data-storage-swatch='postgresql']")!;
@@ -2760,15 +2754,10 @@ describe("admin storage settings page", () => {
       .element()
       .querySelector("[data-storage-swatch='object-store']")!;
 
-    expect(objectStoreSegment.getBoundingClientRect().width).toBeGreaterThanOrEqual(4);
-    expect(getComputedStyle(postgresqlSwatch).backgroundColor).toBe(
-      getComputedStyle(postgresqlSegment).backgroundColor
-    );
-    expect(getComputedStyle(objectStoreSwatch).backgroundColor).toBe(
-      getComputedStyle(objectStoreSegment).backgroundColor
-    );
-    expect(getComputedStyle(postgresqlSwatch).backgroundColor).not.toBe(
-      getComputedStyle(objectStoreSwatch).backgroundColor
-    );
+    expect(objectStoreSegment.style.minWidth).toBe("4px");
+    expect(postgresqlSwatch.classList).toContain("bg-accent-default");
+    expect(postgresqlSegment.classList).toContain("bg-accent-default");
+    expect(objectStoreSwatch.classList).toContain("bg-positive-default");
+    expect(objectStoreSegment.classList).toContain("bg-positive-default");
   });
 });

--- a/frontend/apps/web/src/routes/(app)/admin/storage/storage-page.svelte.test.ts
+++ b/frontend/apps/web/src/routes/(app)/admin/storage/storage-page.svelte.test.ts
@@ -1,7 +1,9 @@
 import { page, userEvent } from "@vitest/browser/context";
 import { EneoError } from "@eneo/eneo-js";
 import { render } from "vitest-browser-svelte";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import "../../../../app.css";
 
 const getPolicy = vi.hoisted(() => vi.fn());
 const getInventory = vi.hoisted(() => vi.fn());
@@ -95,6 +97,13 @@ vi.mock("$lib/paraglide/runtime", () => ({
 }));
 
 import StoragePage from "./+page.svelte";
+
+const originalTheme = document.documentElement.dataset.theme;
+
+afterEach(() => {
+  if (originalTheme === undefined) delete document.documentElement.dataset.theme;
+  else document.documentElement.dataset.theme = originalTheme;
+});
 
 function policy(overrides: Record<string, unknown> = {}) {
   return {
@@ -2707,5 +2716,59 @@ describe("admin storage settings page", () => {
     await expect
       .element(overview.getByText("30 storage_unit_kb", { exact: true }))
       .not.toBeInTheDocument();
+  });
+
+  test("labels both storage locations when one share is very small", async () => {
+    document.documentElement.dataset.theme = "light";
+    testUser.canAdministerStorage = true;
+    getPolicy.mockResolvedValue(policy());
+    getInventory.mockResolvedValue({
+      ...inventory(),
+      inventory: [
+        {
+          owner: "file_content",
+          target: "postgres_inline",
+          state: "available",
+          count: 100,
+          bytes: 100 * 1024 * 1024 * 1024,
+          oldest_created_at: "2026-07-20T10:00:00Z"
+        },
+        {
+          owner: "knowledge_file",
+          target: "object_store",
+          state: "available",
+          count: 1,
+          bytes: 1024 * 1024,
+          oldest_created_at: "2026-07-19T10:00:00Z"
+        }
+      ]
+    });
+
+    render(StoragePage);
+
+    const overview = page.getByRole("region", { name: "storage_overview_title" });
+    await expect.element(overview).toBeVisible();
+    const distribution = overview
+      .getByRole("img", { name: /storage_overview_distribution_label/ })
+      .element();
+    const postgresqlSegment = distribution.querySelector("[data-storage-segment='postgresql']")!;
+    const objectStoreSegment = distribution.querySelector("[data-storage-segment='object-store']")!;
+    const postgresqlSwatch = overview
+      .element()
+      .querySelector("[data-storage-swatch='postgresql']")!;
+    const objectStoreSwatch = overview
+      .element()
+      .querySelector("[data-storage-swatch='object-store']")!;
+
+    expect(objectStoreSegment.getBoundingClientRect().width).toBeGreaterThanOrEqual(4);
+    expect(getComputedStyle(postgresqlSwatch).backgroundColor).toBe(
+      getComputedStyle(postgresqlSegment).backgroundColor
+    );
+    expect(getComputedStyle(objectStoreSwatch).backgroundColor).toBe(
+      getComputedStyle(objectStoreSegment).backgroundColor
+    );
+    expect(getComputedStyle(postgresqlSwatch).backgroundColor).not.toBe(
+      getComputedStyle(objectStoreSwatch).backgroundColor
+    );
   });
 });


### PR DESCRIPTION
## TL;DR

The Admin Storage overview now shows which distribution color belongs to PostgreSQL and which belongs to object storage. A non-empty storage location also keeps a small visible segment at extreme ratios; the displayed sizes remain the exact source of truth.

Fixes #714

## Problem and outcome

The blue/green distribution bar did not identify its colors, and a very small non-zero share could disappear visually. Administrators had to infer the mapping from the numbers below.

This change keeps the existing summary and adds a matching color key beside each storage location. Each non-zero share receives a 4 px minimum visual segment without changing the underlying byte totals or accessible summary.

## Implementation

- Deepens the existing `StorageOverviewSection`; no new component or data owner.
- Reuses Eneo's existing accent and positive theme tokens.
- Keeps proportional sizing and exact formatted byte values.
- Adds one focused browser test covering a 100 GB versus 1 MB ratio, the rendered minimum, and color correspondence.

## Validation

- `bun run --cwd apps/web check` — passed, 0 errors and 0 warnings.
- Focused browser test — passed.
- Full Admin Storage browser suite — 63 passed.
- Pre-commit frontend format/lint hooks — passed.
- Pre-push check — passed.
- Manual light-theme review at `/admin/storage` in the Oderland storage devcontainer — approved.

## Screenshots / UI states

Manually verified in the existing Admin Storage page in light mode. The card retains the current responsive layout; only the distribution key and minimum non-zero segment change.

<img width="804" height="402" alt="image" src="https://github.com/user-attachments/assets/b195ec6b-e219-48fe-a146-f6b9767f3fea" />

## Risk and recovery

Low-risk presentation-only change. Reverting the commit restores the previous unlabeled proportional bar. No backend, persisted data, authorization, or storage behavior changes.

## Out of scope

- Percentages, tooltips, quotas, capacity monitoring, or new storage metrics.
- Changes to the storage detail table or PostgreSQL allocation calculations.
- Broader Admin Storage redesign.