### PR TITLE
Expand knowledge search with adjacent chunks

### DIFF
--- a/backend/src/eneo/info_blobs/info_blob_chunk_repo.py
+++ b/backend/src/eneo/info_blobs/info_blob_chunk_repo.py
@@ -209,6 +209,43 @@ class InfoBlobChunkRepo:
             for row in rows.all()
         ]
 
+    async def get_adjacent_chunks(
+        self,
+        *,
+        info_blob_id: UUID,
+        chunk_no: int,
+        radius: int = 1,
+    ) -> list[InfoBlobChunkExcerpt]:
+        """Read the active document chunks immediately around one anchor."""
+        if radius < 1:
+            return []
+
+        stmt = (
+            sa.select(
+                InfoBlobChunks.info_blob_id,
+                InfoBlobChunks.chunk_no,
+                InfoBlobChunks.text,
+            )
+            .join(InfoBlobs, InfoBlobs.id == InfoBlobChunks.info_blob_id)
+            .where(
+                InfoBlobChunks.info_blob_id == info_blob_id,
+                InfoBlobChunks.chunk_no.between(
+                    max(0, chunk_no - radius), chunk_no + radius
+                ),
+                InfoBlobChunks.chunk_no != chunk_no,
+                active_info_blob_version(),
+            )
+            .order_by(InfoBlobChunks.chunk_no)
+        )
+
+        rows = await self.session.execute(stmt)
+        return [
+            InfoBlobChunkExcerpt(
+                info_blob_id=row.info_blob_id, chunk_no=row.chunk_no, text=row.text
+            )
+            for row in rows.all()
+        ]
+
     async def keyword_search(
         self,
         search_string: str,

--- a/backend/src/eneo/internal_mcp/knowledge.py
+++ b/backend/src/eneo/internal_mcp/knowledge.py
@@ -19,6 +19,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import EmbeddedResource, TextContent, TextResourceContents
 from pydantic import AnyUrl
 
+from eneo.info_blobs.info_blob_chunk_repo import InfoBlobChunkExcerpt
 from eneo.info_blobs.info_blob_repo import InfoBlobListing
 from eneo.internal_mcp.constants import KNOWLEDGE_SERVER_NAME
 from eneo.internal_mcp.foundation import (
@@ -112,6 +113,17 @@ class KnowledgeScope(NamedTuple):
     info_blob_ids: list[UUID]
     source_id: UUID | None = None
     name: str = ""
+
+
+class _SearchResultChunk(NamedTuple):
+    """A semantic anchor or an unscored contextual neighbor."""
+
+    info_blob_id: UUID
+    chunk_no: int
+    text: str
+    info_blob_title: str | None
+    score: float | None
+    context_for_chunk: int | None
 
 
 class _ScopeNotResolved(Exception):
@@ -288,6 +300,52 @@ def _diversify(chunks, per_doc: int, cap: int):
             if round_no < len(doc_chunks):
                 selected.append(doc_chunks[round_no])
     return selected
+
+
+def _merge_adjacent_chunks(
+    anchors: Sequence[Any], neighbors: Sequence[InfoBlobChunkExcerpt]
+) -> list[_SearchResultChunk]:
+    """Combine ranked anchors with context around the best one, without duplicates."""
+    if not anchors:
+        return []
+
+    best_anchor = anchors[0]
+    merged: list[_SearchResultChunk] = []
+    seen: set[tuple[UUID, int]] = set()
+    for anchor in anchors:
+        key = (anchor.info_blob_id, anchor.chunk_no)
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(
+            _SearchResultChunk(
+                info_blob_id=anchor.info_blob_id,
+                chunk_no=anchor.chunk_no,
+                text=anchor.text,
+                info_blob_title=anchor.info_blob_title,
+                score=anchor.score,
+                context_for_chunk=None,
+            )
+        )
+
+    for neighbor in neighbors:
+        if neighbor.info_blob_id != best_anchor.info_blob_id:
+            continue
+        key = (neighbor.info_blob_id, neighbor.chunk_no)
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(
+            _SearchResultChunk(
+                info_blob_id=neighbor.info_blob_id,
+                chunk_no=neighbor.chunk_no,
+                text=neighbor.text,
+                info_blob_title=best_anchor.info_blob_title,
+                score=None,
+                context_for_chunk=best_anchor.chunk_no,
+            )
+        )
+    return merged
 
 
 def _document_page_content(
@@ -472,13 +530,20 @@ def _search_result_content(query: str, chunks) -> list[TextContent | EmbeddedRes
         )
     ]
     for chunk in chunks:
+        meta = {}
+        score = getattr(chunk, "score", None)
+        context_for_chunk = getattr(chunk, "context_for_chunk", None)
+        if score is not None:
+            meta["score"] = score
+        if context_for_chunk is not None:
+            meta["context_for_chunk"] = context_for_chunk
         content.append(
             _chunk_resource(
                 info_blob_id=chunk.info_blob_id,
                 chunk_no=chunk.chunk_no,
                 title=chunk.info_blob_title or "Untitled source",
                 text=chunk.text,
-                meta={"score": chunk.score},
+                meta=meta,
             )
         )
     return content
@@ -644,7 +709,7 @@ async def search_knowledge(
             )
             return [TextContent(type="text", text=unresolved.message)]
 
-        chunks = await container.datastore().semantic_search(
+        semantic_chunks = await container.datastore().semantic_search(
             query,
             embedding_model=embedding_model,
             collections=scope.collections,
@@ -655,24 +720,37 @@ async def search_knowledge(
             autocut_cutoff=autocut_cutoff,
         )
 
-    fetched = len(chunks)
-    if mode == "overview" and not scope.info_blob_ids:
-        chunks = _diversify(chunks, per_doc=OVERVIEW_CHUNKS_PER_DOC, cap=cap)
-    else:
-        chunks = chunks[:cap]
-    top_score = f"{chunks[0].score:.3f}" if chunks else "n/a"
+        fetched = len(semantic_chunks)
+        if mode == "overview" and not scope.info_blob_ids:
+            chunks = _diversify(
+                semantic_chunks, per_doc=OVERVIEW_CHUNKS_PER_DOC, cap=cap
+            )
+        else:
+            chunks = semantic_chunks[:cap]
+
+        semantic_anchor_count = len(chunks)
+        top_score = f"{chunks[0].score:.3f}" if chunks else "n/a"
+        if mode == "specific" and chunks:
+            best_anchor = chunks[0]
+            neighbors = await container.info_blob_chunk_repo().get_adjacent_chunks(
+                info_blob_id=best_anchor.info_blob_id,
+                chunk_no=best_anchor.chunk_no,
+            )
+            chunks = _merge_adjacent_chunks(chunks, neighbors)
+
     if scope.info_blob_ids:
         # Within one document the model is reading, not ranking: reading order
         # carries more meaning than relevance order.
         chunks = sorted(chunks, key=lambda chunk: chunk.chunk_no)
     logger.info(
         "[RAG] search_knowledge assistant=%s mode=%s scope=%s fetch=%d fetched=%d "
-        "returned=%d top_score=%s",
+        "semantic_anchors=%d returned=%d top_score=%s",
         assistant_id,
         mode,
         scope.label,
         fetch,
         fetched,
+        semantic_anchor_count,
         len(chunks),
         top_score,
     )

--- a/backend/tests/integration/info_blobs/test_info_blob_sampling.py
+++ b/backend/tests/integration/info_blobs/test_info_blob_sampling.py
@@ -188,6 +188,56 @@ async def test_sample_evenly_without_ids_touches_no_documents(db_container) -> N
         assert excerpts == []
 
 
+async def test_adjacent_chunks_stay_in_the_exact_active_document(db_container) -> None:
+    async with db_container() as container:
+        collection, model, _space = await _seed_collection(container, name="Adjacent")
+        wanted = await _seed_document(
+            container, collection, model, title="Wanted", chunk_count=3
+        )
+        other = await _seed_document(
+            container, collection, model, title="Other", chunk_count=3
+        )
+
+        excerpts = await container.info_blob_chunk_repo().get_adjacent_chunks(
+            info_blob_id=wanted.id, chunk_no=1
+        )
+
+        assert [(excerpt.info_blob_id, excerpt.chunk_no) for excerpt in excerpts] == [
+            (wanted.id, 0),
+            (wanted.id, 2),
+        ]
+        assert all(excerpt.info_blob_id != other.id for excerpt in excerpts)
+
+
+async def test_adjacent_chunks_handle_boundaries_and_ignore_superseded_versions(
+    db_container,
+) -> None:
+    async with db_container() as container:
+        collection, model, _space = await _seed_collection(container, name="Adjacent")
+        active = await _seed_document(
+            container, collection, model, title="Active", chunk_count=3
+        )
+        superseded = await _seed_document(
+            container,
+            collection,
+            model,
+            title="Superseded",
+            chunk_count=3,
+            active=False,
+        )
+        repo = container.info_blob_chunk_repo()
+
+        first = await repo.get_adjacent_chunks(info_blob_id=active.id, chunk_no=0)
+        final = await repo.get_adjacent_chunks(info_blob_id=active.id, chunk_no=2)
+        inactive = await repo.get_adjacent_chunks(
+            info_blob_id=superseded.id, chunk_no=1
+        )
+
+        assert [excerpt.chunk_no for excerpt in first] == [1]
+        assert [excerpt.chunk_no for excerpt in final] == [1]
+        assert inactive == []
+
+
 async def test_document_scope_returns_only_that_document(db_container) -> None:
     async with db_container() as container:
         collection, model, _space = await _seed_collection(container, name="Sampling")

--- a/backend/tests/unit/test_knowledge_mcp_server.py
+++ b/backend/tests/unit/test_knowledge_mcp_server.py
@@ -30,6 +30,7 @@ from eneo.internal_mcp.knowledge import (
     _excerpts_per_document,
     _fit_titles,
     _matching_sources,
+    _merge_adjacent_chunks,
     _overview_content,
     _pick_embedding_model,
     _resolve_search_params,
@@ -273,6 +274,40 @@ class TestDiversify:
         assert len(_diversify(chunks, per_doc=2, cap=2)) == 2
 
 
+class TestMergeAdjacentChunks:
+    def test_neighbors_are_added_and_existing_anchors_are_not_duplicated(self):
+        blob_id = uuid4()
+        anchors = [
+            _chunk(info_blob_id=blob_id, chunk_no=12, score=0.95),
+            _chunk(info_blob_id=blob_id, chunk_no=13, score=0.85),
+        ]
+        neighbors = [
+            SimpleNamespace(info_blob_id=blob_id, chunk_no=11, text="Previous"),
+            SimpleNamespace(info_blob_id=blob_id, chunk_no=13, text="Next"),
+            SimpleNamespace(info_blob_id=uuid4(), chunk_no=11, text="Foreign"),
+        ]
+
+        merged = _merge_adjacent_chunks(anchors, neighbors)
+
+        assert [chunk.chunk_no for chunk in merged] == [12, 13, 11]
+        assert [chunk.score for chunk in merged] == [0.95, 0.85, None]
+        assert merged[-1].context_for_chunk == 12
+
+    def test_neighbor_resources_have_context_metadata_without_fake_scores(self):
+        blob_id = uuid4()
+        merged = _merge_adjacent_chunks(
+            [_chunk(info_blob_id=blob_id, chunk_no=5, score=0.91)],
+            [SimpleNamespace(info_blob_id=blob_id, chunk_no=4, text="Context")],
+        )
+
+        resources = _search_result_content("query", merged)[1:]
+
+        assert resources[0].resource.meta["score"] == 0.91
+        assert "context_for_chunk" not in resources[0].resource.meta
+        assert "score" not in resources[1].resource.meta
+        assert resources[1].resource.meta["context_for_chunk"] == 5
+
+
 class TestBlobInScope:
     def _assistant(self, collections=(), websites=(), integrations=()):
         return SimpleNamespace(
@@ -440,13 +475,19 @@ class TestMatchingSources:
         assert _matching_sources(assistant, "https://kommun.se")[0].source_id == wid
 
 
-def _patch_search_context(monkeypatch, assistant, *, blob=None, chunks=()):
+def _patch_search_context(
+    monkeypatch, assistant, *, blob=None, chunks=(), neighbors=()
+):
     """Patch the tool context with a datastore that records its scope kwargs."""
     calls: list[dict] = []
 
     async def semantic_search(query, **kwargs):
-        calls.append({"query": query, **kwargs})
+        calls.append({"kind": "semantic", "query": query, **kwargs})
         return list(chunks)
+
+    async def get_adjacent_chunks(**kwargs):
+        calls.append({"kind": "adjacent", **kwargs})
+        return list(neighbors)
 
     @asynccontextmanager
     async def fake_context(_ctx):
@@ -461,6 +502,9 @@ def _patch_search_context(monkeypatch, assistant, *, blob=None, chunks=()):
         container = SimpleNamespace(
             assistant_service=lambda: SimpleNamespace(get_assistant=get_assistant),
             info_blob_repo=lambda: SimpleNamespace(get=get_blob),
+            info_blob_chunk_repo=lambda: SimpleNamespace(
+                get_adjacent_chunks=get_adjacent_chunks
+            ),
             datastore=lambda: SimpleNamespace(semantic_search=semantic_search),
         )
         yield container, SimpleNamespace(), uuid4()
@@ -472,6 +516,58 @@ def _patch_search_context(monkeypatch, assistant, *, blob=None, chunks=()):
 
 
 class TestSearchScoping:
+    async def test_specific_search_expands_the_best_anchor_with_both_neighbors(
+        self, monkeypatch
+    ):
+        cid, blob_id = uuid4(), uuid4()
+        assistant = _assistant_with_sources(collections=[(cid, "Waste FAQ")])
+        anchor = _chunk(info_blob_id=blob_id, chunk_no=12, score=0.9)
+        neighbors = [
+            SimpleNamespace(info_blob_id=blob_id, chunk_no=11, text="Previous"),
+            SimpleNamespace(info_blob_id=blob_id, chunk_no=13, text="Next"),
+        ]
+        calls = _patch_search_context(
+            monkeypatch, assistant, chunks=[anchor], neighbors=neighbors
+        )
+
+        content = await search_knowledge("garden waste", ctx=None)
+
+        assert [str(item.resource.uri).rsplit("-", 1)[-1] for item in content[1:]] == [
+            "12",
+            "11",
+            "13",
+        ]
+        assert calls[1] == {
+            "kind": "adjacent",
+            "info_blob_id": blob_id,
+            "chunk_no": 12,
+        }
+
+    async def test_default_specific_search_never_returns_more_than_eight_chunks(
+        self, monkeypatch
+    ):
+        cid, best_blob_id = uuid4(), uuid4()
+        assistant = _assistant_with_sources(collections=[(cid, "Waste FAQ")])
+        anchors = [
+            _chunk(
+                info_blob_id=best_blob_id if index == 0 else uuid4(),
+                chunk_no=10 + index,
+                score=0.9 - index / 100,
+            )
+            for index in range(10)
+        ]
+        neighbors = [
+            SimpleNamespace(info_blob_id=best_blob_id, chunk_no=9, text="Previous"),
+            SimpleNamespace(info_blob_id=best_blob_id, chunk_no=11, text="Next"),
+        ]
+        _patch_search_context(
+            monkeypatch, assistant, chunks=anchors, neighbors=neighbors
+        )
+
+        content = await search_knowledge("garden waste", ctx=None)
+
+        assert len(content[1:]) == 8
+
     async def test_unscoped_search_spans_every_attached_source(self, monkeypatch):
         cid, wid = uuid4(), uuid4()
         assistant = _assistant_with_sources(
@@ -534,11 +630,26 @@ class TestSearchScoping:
             _chunk(info_blob_id=blob_id, chunk_no=7, score=0.9),
             _chunk(info_blob_id=blob_id, chunk_no=2, score=0.8),
         ]
-        _patch_search_context(monkeypatch, assistant, blob=blob, chunks=chunks)
+        neighbors = [
+            SimpleNamespace(info_blob_id=blob_id, chunk_no=6, text="Previous"),
+            SimpleNamespace(info_blob_id=blob_id, chunk_no=8, text="Next"),
+        ]
+        _patch_search_context(
+            monkeypatch, assistant, blob=blob, chunks=chunks, neighbors=neighbors
+        )
 
         content = await search_knowledge("waste", ctx=None, within=str(blob_id))
 
-        assert [c.resource.meta["score"] for c in content[1:]] == [0.8, 0.9]
+        assert [str(c.resource.uri).rsplit("-", 1)[-1] for c in content[1:]] == [
+            "2",
+            "6",
+            "7",
+            "8",
+        ]
+        assert content[1].resource.meta["score"] == 0.8
+        assert content[3].resource.meta["score"] == 0.9
+        assert "score" not in content[2].resource.meta
+        assert "score" not in content[4].resource.meta
 
     async def test_document_overview_uses_the_full_result_cap(self, monkeypatch):
         cid, blob_id = uuid4(), uuid4()
@@ -557,7 +668,7 @@ class TestSearchScoping:
             _chunk(info_blob_id=blob_id, chunk_no=1, score=0.6),
             _chunk(info_blob_id=blob_id, chunk_no=4, score=0.5),
         ]
-        _patch_search_context(monkeypatch, assistant, blob=blob, chunks=chunks)
+        calls = _patch_search_context(monkeypatch, assistant, blob=blob, chunks=chunks)
 
         content = await search_knowledge(
             "waste", ctx=None, within=str(blob_id), mode="overview", max_results=4
@@ -569,6 +680,19 @@ class TestSearchScoping:
             "5",
             "8",
         ]
+        assert [call["kind"] for call in calls] == ["semantic"]
+
+    async def test_no_results_skips_neighbor_query_and_keeps_existing_message(
+        self, monkeypatch
+    ):
+        assistant = _assistant_with_sources(collections=[(uuid4(), "Waste FAQ")])
+        calls = _patch_search_context(monkeypatch, assistant)
+
+        content = await search_knowledge("obscure query", ctx=None)
+
+        assert [call["kind"] for call in calls] == ["semantic"]
+        assert len(content) == 1
+        assert "No results" in content[0].text
 
     async def test_out_of_scope_within_is_indistinguishable_from_missing(
         self, monkeypatch


### PR DESCRIPTION
## Summary

- Expand specific knowledge searches with the previous and next chunks around the highest-ranked semantic match.
- Keep the existing six-anchor cap, bounding default output at eight chunks.
- Deduplicate results by document and chunk number.
- Preserve similarity scores for semantic anchors while marking neighbors with `context_for_chunk`.
- Keep document-scoped results in reading order.
- Leave overview searches unchanged.

## Implementation

- Add an active-version, document-isolated repository query for adjacent chunks.
- Fetch neighbors using the exact authorized `info_blob_id`.
- Avoid loading embedding vectors or performing additional vector searches.
- Add at most one SQL query per specific search.
- Defensively reject cross-document neighbors during result merging.

## Validation

- `77` knowledge MCP unit tests passed.
- `30` `info_blobs` integration tests passed.
- Ruff lint passed.
- Ruff formatting check passed.
- `git diff --check` passed.

## Notes

- No schema or migration changes.
- No ingestion, chunk-generation, or re-indexing changes.
- No changes to overview diversification.


Fixes #724
