### PR TITLE
Clear new Go advisories in the SeaweedFS supply-chain gate

### DIFF
--- a/.github/workflows/build_and_push_images.yml
+++ b/.github/workflows/build_and_push_images.yml
@@ -28,7 +28,7 @@ env:
   BACKEND_IMAGE_NAME: eneo-ai/eneo-backend
   FRONTEND_IMAGE_NAME: eneo-ai/eneo-frontend
   SEAWEEDFS_IMAGE_NAME: eneo-ai/eneo-seaweedfs
-  SEAWEEDFS_VERSION: 4.40-eneo.1
+  SEAWEEDFS_VERSION: 4.40-eneo.2
   BUILDX_VERSION: v0.33.0
   BUILDKIT_IMAGE: moby/buildkit@sha256:0168606be2315b7c807a03b3d8aa79beefdb31c98740cebdffdfeebf31190c9f
   QEMU_IMAGE: docker.io/tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0

--- a/.github/workflows/release_sbom.yml
+++ b/.github/workflows/release_sbom.yml
@@ -24,7 +24,7 @@ env:
   BACKEND_IMAGE: ghcr.io/eneo-ai/eneo-backend
   FRONTEND_IMAGE: ghcr.io/eneo-ai/eneo-frontend
   SEAWEEDFS_IMAGE: ghcr.io/eneo-ai/eneo-seaweedfs
-  SEAWEEDFS_VERSION: 4.40-eneo.1
+  SEAWEEDFS_VERSION: 4.40-eneo.2
   PLATFORM: linux/amd64
   PLATFORM_OS: linux
   PLATFORM_ARCH: amd64

--- a/docker/seaweedfs/Dockerfile
+++ b/docker/seaweedfs/Dockerfile
@@ -2,14 +2,14 @@
 
 # This image is built by Eneo from the exact upstream source archive below.
 # It is not an upstream SeaweedFS image and does not claim upstream signing.
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.25.12-bookworm@sha256:ea341baa9bd5ba6784f6d7161ace70544349a6242d54d34a0fbfd2c4d51c9d58 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.25.13-bookworm@sha256:e401dae1bf814e29204a8cb7915682e1780951e609ca0dd8865ee1937f510c48 AS builder
 
 ARG TARGETARCH
 ARG TARGETOS
 ARG SOURCE_DATE_EPOCH=1784519823
 
 WORKDIR /build
-COPY patches/0001-upgrade-grpc-to-1.82.1.patch /tmp/seaweedfs-security.patch
+COPY patches/0001-upgrade-vulnerable-dependencies.patch /tmp/seaweedfs-security.patch
 ADD --checksum=sha256:2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e \
     https://github.com/seaweedfs/seaweedfs/archive/875cd1f67ea25e8965a4f5ba1e6aaf501ba6b6fa.tar.gz \
     /tmp/seaweedfs.tar.gz
@@ -20,7 +20,7 @@ RUN mkdir source \
     && test "$(sha256sum /tmp/seaweedfs.tar.gz | cut -d ' ' -f 1)" \
         = "2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e" \
     && test "$(sha256sum /tmp/seaweedfs-security.patch | cut -d ' ' -f 1)" \
-        = "54cc9bd8b0cfadebbce56754914655526cee882075141fd64790686bd4ac409e" \
+        = "24e01bfdf3bd29bdb3e4f9b55f6567332d6e6286342ef4a9097e7803fd7e8323" \
     && git -C source apply --check /tmp/seaweedfs-security.patch \
     && git -C source apply /tmp/seaweedfs-security.patch
 
@@ -46,14 +46,14 @@ LABEL org.opencontainers.image.title="Eneo SeaweedFS object-content store" \
       org.opencontainers.image.description="Eneo-built reference S3-compatible byte store for object content" \
       org.opencontainers.image.source="https://github.com/eneo-ai/eneo" \
       org.opencontainers.image.vendor="Eneo" \
-      org.opencontainers.image.version="4.40-eneo.1" \
+      org.opencontainers.image.version="4.40-eneo.2" \
       org.opencontainers.image.licenses="Apache-2.0" \
       io.eneo.upstream.name="SeaweedFS" \
       io.eneo.upstream.version="4.40" \
       io.eneo.upstream.commit="875cd1f67ea25e8965a4f5ba1e6aaf501ba6b6fa" \
       io.eneo.upstream.tree="f6590c71c41ec414fc193b89e9d9dd586d39ad17" \
       io.eneo.upstream.archive.sha256="2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e" \
-      io.eneo.downstream.patch.sha256="54cc9bd8b0cfadebbce56754914655526cee882075141fd64790686bd4ac409e"
+      io.eneo.downstream.patch.sha256="24e01bfdf3bd29bdb3e4f9b55f6567332d6e6286342ef4a9097e7803fd7e8323"
 
 COPY --from=builder --chown=65532:65532 /out/weed /usr/local/bin/weed
 COPY --from=builder /out/SEAWEEDFS-LICENSE /licenses/seaweedfs/LICENSE

--- a/docker/seaweedfs/patches/0001-upgrade-vulnerable-dependencies.patch
+++ b/docker/seaweedfs/patches/0001-upgrade-vulnerable-dependencies.patch
@@ -1,13 +1,29 @@
-Subject: [PATCH] build: upgrade gRPC to 1.82.1
+Subject: [PATCH] build: upgrade gRPC to 1.82.1 and x/image to 0.45.0
 
 SeaweedFS 4.40 pins gRPC 1.81.1, which is affected by
-GHSA-hrxh-6v49-42gf. Keep this downstream patch until an upstream
-SeaweedFS release includes gRPC 1.82.1 or newer.
+GHSA-hrxh-6v49-42gf, and golang.org/x/image 0.43.0, which is affected
+by GO-2026-6222. Upgrading x/image also lifts golang.org/x/mod, net,
+text, and tools to the versions its module graph requires. Keep this
+downstream patch until an upstream SeaweedFS release includes gRPC
+1.82.1 and x/image 0.45.0 or newer.
 
 diff --git a/go.mod b/go.mod
 --- a/go.mod
 +++ b/go.mod
-@@ -102,7 +102,7 @@ require (
+@@ -93,16 +93,16 @@ require (
+ 	gocloud.dev/pubsub/rabbitpubsub v0.46.0
+ 	golang.org/x/crypto v0.54.0
+ 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
+-	golang.org/x/image v0.43.0
+-	golang.org/x/net v0.56.0
++	golang.org/x/image v0.45.0
++	golang.org/x/net v0.57.0
+ 	golang.org/x/oauth2 v0.36.0
+ 	golang.org/x/sys v0.47.0
+-	golang.org/x/text v0.40.0 // indirect
+-	golang.org/x/tools v0.47.0 // indirect
++	golang.org/x/text v0.41.0 // indirect
++	golang.org/x/tools v0.48.0 // indirect
  	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
  	google.golang.org/api v0.287.0
  	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
@@ -16,6 +32,15 @@ diff --git a/go.mod b/go.mod
  	google.golang.org/protobuf v1.36.11
  	gopkg.in/inf.v0 v0.9.1 // indirect
  	modernc.org/b v1.0.0 // indirect
+@@ -280,7 +280,7 @@ require (
+ 	go.uber.org/mock v0.5.2 // indirect
+ 	go.yaml.in/yaml/v2 v2.4.3 // indirect
+ 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+-	golang.org/x/mod v0.37.0 // indirect
++	golang.org/x/mod v0.38.0 // indirect
+ 	gonum.org/v1/gonum v0.17.0 // indirect
+ )
+ 
 @@ -300,7 +300,7 @@ require (
  	github.com/Azure/go-ntlmssp v0.1.1 // indirect
  	github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 // indirect
@@ -46,7 +71,7 @@ diff --git a/go.mod b/go.mod
 diff --git a/go.sum b/go.sum
 --- a/go.sum
 +++ b/go.sum
-@@ -595,6 +595,8 @@
+@@ -595,6 +595,8 @@ github.com/Files-com/files-sdk-go/v3 v3.3.82 h1:2RfP0d2QgkFH64BjZSWd59aMsc28IyWs
  github.com/Files-com/files-sdk-go/v3 v3.3.82/go.mod h1:IPk80dOmc7VFC0DJ85xMTPmre+8xoXX6kGHAkf5jRRw=
  github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 h1:DHa2U07rk8syqvCge0QIGMCE1WxGj9njT44GH7zNJLQ=
  github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
@@ -55,7 +80,7 @@ diff --git a/go.sum b/go.sum
  github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 h1:UnDZ/zFfG1JhH/DqxIZYU/1CUAlTUScoXD/LcM2Ykk8=
  github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0/go.mod h1:IA1C1U7jO/ENqm/vhi7V9YYpBsp+IMyqNrEN94N7tVc=
  github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/cloudmock v0.55.0 h1:7t/qx5Ost0s0wbA/VDrByOooURhp+ikYwv20i9Y07TQ=
-@@ -2090,6 +2092,8 @@
+@@ -2090,6 +2092,8 @@ go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ
  go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
  go.opentelemetry.io/contrib/detectors/gcp v1.42.0 h1:kpt2PEJuOuqYkPcktfJqWWDjTEd/FNgrxcniL7kQrXQ=
  go.opentelemetry.io/contrib/detectors/gcp v1.42.0/go.mod h1:W9zQ439utxymRrXsUOzZbFX4JhLxXU4+ZnCt8GG7yA8=
@@ -64,7 +89,52 @@ diff --git a/go.sum b/go.sum
  go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 h1:yI1/OhfEPy7J9eoa6Sj051C7n5dvpj0QX8g4sRchg04=
  go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0/go.mod h1:NoUCKYWK+3ecatC4HjkRktREheMeEtrXoQxrqYFeHSc=
  go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.63.0 h1:2pn7OzMewmYRiNtv1doZnLo3gONcnMHlFnmOR8Vgt+8=
-@@ -2811,6 +2815,8 @@
+@@ -2213,6 +2217,8 @@ golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeap
+ golang.org/x/image v0.0.0-20220302094943-723b81ca9867/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
+ golang.org/x/image v0.43.0 h1:FLxcP4ec2350nTfOC8ysKtqYSIFbk/QGjw1ZHNP4tsY=
+ golang.org/x/image v0.43.0/go.mod h1:rrpelvGFt+kLPAjPM4HeWPgrl0FtafueU//e5N0qk/Q=
++golang.org/x/image v0.45.0 h1:FMb1nTbH5H9vF55SriQHgFw5GnNL9Jg6L25BwXKzhB0=
++golang.org/x/image v0.45.0/go.mod h1:n62x/7RqlwXDvGsSU4u6IUTUf6KghUZ9Bt7cG/T9Fx4=
+ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
+ golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
+ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
+@@ -2248,6 +2254,8 @@ golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+ golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+ golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+ golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
++golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=
++golang.org/x/mod v0.38.0/go.mod h1:V6Xz0pq8TQ3dGqVQ1FVHuelZpAL0uNhSkk9ogYP3c40=
+ golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+@@ -2317,6 +2325,8 @@ golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
+ golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+ golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+ golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
++golang.org/x/net v0.57.0 h1:K5+3DljvIuDG9/Jv9rvyMywYNFCQ9RSUY6OOTTkT+tE=
++golang.org/x/net v0.57.0/go.mod h1:KpXc8iv+r3XplLAG/f7Jsf9RPszJzdR0f58q9vGOuEU=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+@@ -2516,6 +2526,8 @@ golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+ golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+ golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
+ golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
++golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=
++golang.org/x/text v0.41.0/go.mod h1:jvf1O8ajNzZqhSrQBPbutR/EB83Cc0CFrezNQIwbb5M=
+ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+ golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+@@ -2595,6 +2607,8 @@ golang.org/x/tools v0.14.0/go.mod h1:uYBEerGOWcJyEORxN+Ek8+TT266gXkNlHdJBwexUsBg
+ golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
+ golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
+ golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
++golang.org/x/tools v0.48.0 h1:3+hClM1aLL5mjMKm5ovokw9epgRXPuu2tILgismM6RE=
++golang.org/x/tools v0.48.0/go.mod h1:08xX0orndb/F7jJxGDicx061tyd5pcMto75YMAXr6lk=
+ golang.org/x/tools/godoc v0.1.0-deprecated h1:o+aZ1BOj6Hsx/GBdJO/s815sqftjSnrZZwyYTHODvtk=
+ golang.org/x/tools/godoc v0.1.0-deprecated/go.mod h1:qM63CriJ961IHWmnWa9CjZnBndniPt4a3CK0PVB9bIg=
+ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+@@ -2811,6 +2825,8 @@ google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 h1:XzmzkmB14QhVhgn
  google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:L43LFes82YgSonw6iTXTxXUX1OlULt4AQtkik4ULL/I=
  google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 h1:VPWxll4HlMw1Vs/qXtN7BvhZqsS9cdAittCNvVENElA=
  google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9/go.mod h1:7QBABkRtR8z+TEnmXTqIqwJLlzrZKVfAUm7tY3yGv0M=
@@ -73,7 +143,7 @@ diff --git a/go.sum b/go.sum
  google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d h1:mpAgMyM9vQHxycBlDq50y1VHpfSfVwzXvrQKtYbXuUY=
  google.golang.org/genproto/googleapis/rpc v0.0.0-20260622175928-b703f567277d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
  google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
-@@ -2855,6 +2861,8 @@
+@@ -2855,6 +2871,8 @@ google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwS
  google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGONTY8=
  google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
  google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=

--- a/docker/seaweedfs/verify-supply-chain.sh
+++ b/docker/seaweedfs/verify-supply-chain.sh
@@ -6,11 +6,11 @@ readonly SOURCE_COMMIT="875cd1f67ea25e8965a4f5ba1e6aaf501ba6b6fa"
 readonly SOURCE_TREE="f6590c71c41ec414fc193b89e9d9dd586d39ad17"
 readonly SOURCE_ARCHIVE_SHA256="2e37f5d8980256e490324e3759d38437ecfee734f60aa3e75528b05f7d19460e"
 readonly SOURCE_LICENSE_SHA256="d789d433cc11da163273d1e39be2e8fa67642f9a58ef220d3f258fa9c14ef613"
-readonly DOWNSTREAM_PATCH_NAME="0001-upgrade-grpc-to-1.82.1.patch"
-readonly DOWNSTREAM_PATCH_SHA256="54cc9bd8b0cfadebbce56754914655526cee882075141fd64790686bd4ac409e"
+readonly DOWNSTREAM_PATCH_NAME="0001-upgrade-vulnerable-dependencies.patch"
+readonly DOWNSTREAM_PATCH_SHA256="24e01bfdf3bd29bdb3e4f9b55f6567332d6e6286342ef4a9097e7803fd7e8323"
 readonly SCRIPT_DIRECTORY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly DOWNSTREAM_PATCH="$SCRIPT_DIRECTORY/patches/$DOWNSTREAM_PATCH_NAME"
-readonly GO_IMAGE="docker.io/library/golang:1.25.12-bookworm@sha256:ea341baa9bd5ba6784f6d7161ace70544349a6242d54d34a0fbfd2c4d51c9d58"
+readonly GO_IMAGE="docker.io/library/golang:1.25.13-bookworm@sha256:e401dae1bf814e29204a8cb7915682e1780951e609ca0dd8865ee1937f510c48"
 readonly GO_LICENSES_REVISION="3e084b0caf710f7bfead967567539214f598c0a2"
 readonly GOVULNCHECK_VERSION="v1.6.0"
 
@@ -128,6 +128,8 @@ audit_source() {
             and .Replace.Version == "v0.23.1-0.20260429145742-d2acd3c49e58")
         and any(.[]; .Path == "google.golang.org/grpc"
             and .Version == "v1.82.1")
+        and any(.[]; .Path == "golang.org/x/image"
+            and .Version == "v0.45.0")
         ' "$output_directory/modules.json" >/dev/null
 
     cut -d, -f3 "$output_directory/licenses.csv" | LC_ALL=C sort -u \


### PR DESCRIPTION
## Summary

The `SeaweedFS source policy` job started failing on every push to `develop` (first seen on the run for #719) after new Go vulnerability advisories were published. Nothing in the failing commits caused it; the pinned toolchain and dependencies did.

- Bump the pinned Go builder image from `golang:1.25.12-bookworm` to `golang:1.25.13-bookworm` (by digest), clearing the seven stdlib advisories fixed in Go 1.25.13 (GO-2026-6218, GO-2026-6091, GO-2026-6090, GO-2026-6089, GO-2026-6088, GO-2026-5972, GO-2026-5026).
- Extend the downstream dependency patch (renamed to `0001-upgrade-vulnerable-dependencies.patch`) to also lift `golang.org/x/image` from 0.43.0 to 0.45.0, clearing GO-2026-6222 (excessive memory allocation in VP8L decoding, reachable through SeaweedFS image resizing). The gRPC 1.82.1 upgrade is unchanged; x/mod, x/net, x/text, and x/tools move to the versions the new x/image module graph requires.
- Assert `golang.org/x/image v0.45.0` in the modules.json policy check alongside the existing pins.
- Bump `SEAWEEDFS_VERSION` to `4.40-eneo.2` in both workflows and the image label, since the published artifact changes.

The go.mod/go.sum hunks were regenerated by applying the existing patch to the pinned upstream archive (`875cd1f`, checksum-verified) and running `go get golang.org/x/image@v0.45.0` in the new builder image.

## Validation

- `docker/seaweedfs/verify-supply-chain.sh source` (the exact failing CI step) passes locally: archive and license checksums OK, license policy OK, module pins OK, and govulncheck reports `Your code is affected by 0 vulnerabilities.`
- The regenerated patch applies cleanly to the pristine pinned source with `git apply --check`.