### PR TITLE
Bump grype so the image gate stops misreading Go stdlib ranges

### DIFF
--- a/.github/workflows/build_and_push_images.yml
+++ b/.github/workflows/build_and_push_images.yml
@@ -478,7 +478,7 @@ jobs:
           only-fixed: false
           output-format: json
           output-file: seaweedfs-${{ matrix.slug }}-evidence/grype-${{ matrix.slug }}.json
-          grype-version: v0.110.0
+          grype-version: v0.117.0
 
       - name: Record exact platform digest
         env:


### PR DESCRIPTION
## Summary

After #726 merged, the `SeaweedFS linux/amd64` and `linux/arm64` jobs on develop failed at the Grype image scan with one HIGH finding: CVE-2026-46600 against `stdlib go1.25.13` in the `weed` binary.

That finding is a false positive in grype v0.110.0's vulnerability matching. CVE-2026-46600 (GO-2026-5942, an SVCB/HTTPS DNS record parsing panic) was introduced in Go 1.26.0 and fixed in 1.26.6 per the Go vulnerability database; Go 1.25.x never contained the vulnerable code, which is why there is no 1.25.x fix release and why govulncheck in the source-policy job passes. Grype v0.110.0 matches the advisory as "everything below 1.26.6" and flags 1.25.13. The x/net side of the same advisory (fixed in 0.56.0) is already cleared by the dependency patch, which carries x/net 0.57.0.

- Bump `grype-version` in the image scan step from v0.110.0 to v0.117.0, which carries the corrected ranges.

## Validation

Scanning the exact arm64 image the failed run pushed (`ghcr.io/eneo-ai/eneo-seaweedfs@sha256:6aeb8035…`):

- grype v0.110.0 reproduces the CI failure: CVE-2026-46600 High on `stdlib go1.25.13`.
- grype v0.117.0 catalogs the same 252 packages and reports 0 matches.

Control test that v0.117.0's Go module matching still works (rather than silently matching nothing): a scratch image with a binary built by the previous go1.25.12 toolchain is correctly flagged with GO-2026-6089, GO-2026-6090, and GO-2026-5972, all HIGH and fixed in 1.25.13, and a go1.25.13 binary is clean.

No image content changes, so `SEAWEEDFS_VERSION` stays 4.40-eneo.2 (never published; the publish job was skipped on the failed run).