### PR TITLE
fix(migrations): restore original parent of 2.0.1 hotfix migration

### DIFF
--- a/backend/alembic/versions/202606041200_seed_allowed_origins_from_public_origin.py
+++ b/backend/alembic/versions/202606041200_seed_allowed_origins_from_public_origin.py
@@ -16,7 +16,7 @@ or multi-origin deployments still register additional origins via the sysadmin
 API (``POST {api_prefix}/sysadmin/allowed-origins/``).
 
 Revision ID: 202606041200
-Revises: 20260603_transcription_migrate
+Revises: 202605061100
 Create Date: 2026-06-04
 """
 
@@ -30,7 +30,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic
 revision = "202606041200"
-down_revision = "20260603_transcription_migrate"
+down_revision = "202605061100"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary

Cherry-picks 7df4cec53 from release/v2.1 onto develop. The rc.2 fix that restored `202606041200_seed_allowed_origins`'s parent to `202605061100` was applied only on the release branch, so develop still carried the broken rc.1 ordering.

## Why this matters

On develop's current graph, `202606041200` (the v2.0.1 hotfix migration, and therefore the exact revision every v2.0.1 database sits on) lists `20260603_transcription_migrate` as its parent. That places nine migrations (SCIM, model cost, model lifecycle/alignment, transcription) in its ancestry, so Alembic treats them as already applied. Any v2.0.1 deployment upgrading directly to a future release cut from develop would silently skip those nine migrations while the database is marked fully migrated. This is the same bug v2.1 fixes for the v2.0.1 to v2.1.0-rc.1 path.

## Validation

Rehearsed against real throwaway databases (per-ref `git archive` checkouts running their own Alembic):

- v2.0.1 → develop before this fix: the nine migrations are skipped (bug reproduced on develop's graph)
- v2.0.1 → develop with this fix: all nine applied, schema converges with the v2.0.0 upgrade path
- v2.0.0 → develop, fresh install at develop: clean
- Broken rc.1 database repaired per the v2.1 release notes, then upgraded to develop: schema byte-identical to a direct v2.0.1 → develop upgrade
- Graph sanity: single head (`202608121500`) before and after; the only revision referencing `202606041200` is the merge revision `92cfef80384c`, which already accommodates the restored ordering