### PR TITLE
chore(mcp): drop stale transport_type docs and harden HTTP diagnostic probe

### DIFF
--- a/backend/src/eneo/mcp_servers/infrastructure/client/mcp_client.py
+++ b/backend/src/eneo/mcp_servers/infrastructure/client/mcp_client.py
@@ -16,7 +16,11 @@ from mcp.client.streamable_http import (
 )
 from mcp.shared._httpx_utils import create_mcp_http_client
 from mcp.shared.message import SessionMessage
-from mcp.types import ServerNotification, ToolListChangedNotification
+from mcp.types import (
+    LATEST_PROTOCOL_VERSION,
+    ServerNotification,
+    ToolListChangedNotification,
+)
 
 from eneo.main.config import get_settings
 from eneo.main.exceptions import MCPAuthenticationError, MCPClientError
@@ -551,19 +555,27 @@ async def _diagnose_http(url: str, headers: dict[str, str]) -> str:
     The MCP library's anyio TaskGroups can swallow the actual HTTP error
     (e.g. 401) and replace it with a cancel scope error. This makes a
     direct HTTP request to surface the real issue.
+
+    Any HTTP status is diagnostic signal here: auth is evaluated before
+    method dispatch, so a 401/403 is trustworthy even from a server that
+    rejects the probe body itself.
     """
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(5.0)) as client:
             async with client.stream(
                 "POST",
                 url,
-                headers={**headers, "Content-Type": "application/json"},
+                headers={
+                    **headers,
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                },
                 json={
                     "jsonrpc": "2.0",
                     "method": "initialize",
                     "id": 1,
                     "params": {
-                        "protocolVersion": "2024-11-05",
+                        "protocolVersion": LATEST_PROTOCOL_VERSION,
                         "capabilities": {},
                         "clientInfo": {"name": "eneo", "version": "0.1"},
                     },
@@ -580,6 +592,10 @@ async def _diagnose_http(url: str, headers: dict[str, str]) -> str:
                     return f"Server error (HTTP {response.status_code})."
                 if response.status_code >= 400:
                     return f"Server returned HTTP {response.status_code}."
+                return (
+                    f"Server at {url} is reachable "
+                    f"(HTTP {response.status_code}) but the MCP handshake failed."
+                )
     except httpx.ConnectError:
         return f"Could not connect to {url}. Verify the URL and that the server is running."
     except httpx.TimeoutException:

--- a/frontend/packages/eneo-js/src/endpoints/mcp-servers.js
+++ b/frontend/packages/eneo-js/src/endpoints/mcp-servers.js
@@ -40,7 +40,6 @@ export function initMCPServers(client) {
      * @param {Object} params
      * @param {string} params.name Name of the MCP server
      * @param {string} params.http_url HTTP URL to the MCP server
-     * @param {"sse" | "streamable_http"} [params.transport_type] Transport type (default: sse)
      * @param {"none" | "bearer"} [params.http_auth_type] Authentication type (default: none)
      * @param {string} [params.description] Description
      * @param {{[key: string]: unknown} | null} [params.http_auth_config_schema] Authentication configuration
@@ -58,7 +57,6 @@ export function initMCPServers(client) {
     create: async ({
       name,
       http_url,
-      transport_type,
       http_auth_type,
       description,
       http_auth_config_schema,
@@ -76,7 +74,6 @@ export function initMCPServers(client) {
       const body = {
         name,
         http_url,
-        transport_type,
         http_auth_type,
         description,
         http_auth_config_schema,
@@ -105,7 +102,6 @@ export function initMCPServers(client) {
      * @param {string} params.id The MCP server ID
      * @param {string} [params.name] Name of the MCP server
      * @param {string} [params.http_url] HTTP URL to the MCP server
-     * @param {"sse" | "streamable_http"} [params.transport_type] Transport type
      * @param {"none" | "bearer"} [params.http_auth_type] Authentication type
      * @param {string} [params.description] Description
      * @param {{[key: string]: unknown} | null} [params.http_auth_config_schema] Authentication configuration
@@ -124,7 +120,6 @@ export function initMCPServers(client) {
       id,
       name,
       http_url,
-      transport_type,
       http_auth_type,
       description,
       http_auth_config_schema,
@@ -142,7 +137,6 @@ export function initMCPServers(client) {
       const body = {
         name,
         http_url,
-        transport_type,
         http_auth_type,
         description,
         http_auth_config_schema,


### PR DESCRIPTION
## Summary

Two small leftovers from the session-resume removal / Streamable-HTTP-only transition:

**eneo-js `mcp-servers` endpoints** — `transport_type: "sse" | "streamable_http"` was still documented and sent in the `create`/`update` request bodies, but the backend no longer has the field (Eneo is Streamable-HTTP only). Removed it from the JSDoc, the destructuring, and the request body in both functions; no other frontend code references it.

**`mcp_client._diagnose_http`** — the connectivity probe hardcoded an `initialize` body with `protocolVersion: "2024-11-05"`. A strict server rejecting that probe body could degrade the diagnostic from "surface the real 401" into "connection failed for unknown reasons". Now it:
- uses `LATEST_PROTOCOL_VERSION` from `mcp.types` so the version tracks SDK upgrades,
- sends the spec-required `Accept: application/json, text/event-stream` header so a strict server doesn't 406 and muddy the diagnosis,
- reports "server reachable but MCP handshake failed" on 2xx instead of the unknown-reasons fallback. Every HTTP status is now diagnostic signal; 401/403 remain trustworthy even from servers that reject the body, since auth is evaluated before method dispatch.

## Testing

- `ruff check` / `ruff format --check` pass on the backend file; pre-commit (incl. pyright) and the pre-push schema-drift check pass.
- Bun syntax check passes on the edited JS file; `grep` confirms no remaining `transport_type` references in frontend or backend.

Fixes #734