### PR TITLE
fix(chat): persist tool-call metadata on non-streaming completions

### DIFF
--- a/backend/src/eneo/assistants/assistant_service.py
+++ b/backend/src/eneo/assistants/assistant_service.py
@@ -12,6 +12,7 @@ from eneo.ai_models.completion_models.completion_model import (
     ModelKwargs,
     ResponseType,
     TokenUsage,
+    ToolCallMetadata,
     function_definition_to_tool,
 )
 from eneo.assistants.api.assistant_models import AssistantResponse, KnowledgeMode
@@ -2401,6 +2402,7 @@ class AssistantService:
             generated_files: list[File] = []
 
             non_streaming_mcp_refs: list[McpToolReference] = []
+            non_streaming_tool_calls: list[ToolCallInfo] = []
             if response.completion is not None:
                 answer = response.completion
                 if isinstance(answer, str):
@@ -2411,6 +2413,24 @@ class AssistantService:
                     non_streaming_mcp_refs = (
                         getattr(answer, "mcp_tool_references", None) or []
                     )
+                    non_streaming_tool_metadata = cast(
+                        list[ToolCallMetadata],
+                        getattr(answer, "tool_calls_metadata", None) or [],
+                    )
+                    non_streaming_tool_calls = [
+                        ToolCallInfo(
+                            server_name=tc.server_name,
+                            tool_name=tc.tool_name,
+                            title=tc.title,
+                            arguments=tc.arguments,
+                            tool_call_id=tc.tool_call_id,
+                            approved=tc.approved,
+                            result_status=tc.result_status,
+                            result=tc.result,
+                            mcp_tool_name=tc.mcp_tool_name,
+                        )
+                        for tc in non_streaming_tool_metadata
+                    ]
                     final_reasoning = getattr(answer, "reasoning_content", None)
 
             non_streaming_mcp_refs = filter_mcp_tool_references(
@@ -2506,6 +2526,7 @@ class AssistantService:
                 logging_details=response.extended_logging
                 or LoggingDetails(model_kwargs={}),
                 web_search_results=list(web_search_results or []),
+                tool_calls=non_streaming_tool_calls or None,
                 mcp_tool_references=non_streaming_mcp_refs or None,
                 reasoning=final_reasoning,
                 skill_provenance=skill_provenance,

--- a/backend/src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py
+++ b/backend/src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py
@@ -1137,6 +1137,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                 tool_round = 0
                 seen_prefixes: set[str] = set()
                 captured_refs: list[McpToolReference] = []
+                collected_tool_metadata: list[ToolCallMetadata] = []
                 result_budget = _ToolResultBudget(
                     token_limit=self.model.token_limit,
                     litellm_model=self.litellm_model,
@@ -1275,6 +1276,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                         )
 
                     results: list[dict[str, Any]] = []
+                    proxy_calls: list[tuple[str, dict[str, Any]]] = []
                     if external_calls:
                         assert mcp_proxy is not None
                         allowed_tools = mcp_proxy.get_allowed_tool_names()
@@ -1298,13 +1300,18 @@ class TenantModelAdapter(CompletionModelAdapter):
                     # later persistence) and woven into the LLM-facing text via
                     # a structured MCP source context so the model can emit
                     # <inref/> markers without relying on server-specific shapes.
-                    for call, result in zip(external_calls, results):
+                    # Each call is also captured as ToolCallMetadata (buffered on
+                    # completion) so the caller can persist arguments + result
+                    # for replay on later turns, matching the streaming path.
+                    for call, (_, call_args), result in zip(
+                        external_calls, proxy_calls, results
+                    ):
                         content_list = cast(
                             list[dict[str, Any]], result.get("content") or []
                         )
                         (
                             llm_text,
-                            _display_text,
+                            display_text,
                             refs_for_call,
                         ) = _build_tool_result_with_references(
                             content_list=content_list,
@@ -1313,10 +1320,13 @@ class TenantModelAdapter(CompletionModelAdapter):
                             existing_prefixes=seen_prefixes,
                         )
                         captured_refs.extend(refs_for_call)
+                        result_status = "succeeded"
                         if result.get("is_error"):
                             llm_text = json.dumps(
                                 {"error": llm_text or "Tool execution failed"}
                             )
+                            display_text = llm_text
+                            result_status = "failed"
                         messages.append(
                             {
                                 "role": "tool",
@@ -1324,11 +1334,35 @@ class TenantModelAdapter(CompletionModelAdapter):
                                 "content": result_budget.admit(llm_text),
                             }
                         )
+                        assert mcp_proxy is not None
+                        tool_info = mcp_proxy.get_tool_info(call.name)
+                        if tool_info:
+                            server_name, tool_name, title = tool_info
+                        elif "__" in call.name:
+                            server_name, tool_name = call.name.split("__", 1)
+                            title = None
+                        else:
+                            server_name, tool_name, title = "", call.name, None
+                        collected_tool_metadata.append(
+                            ToolCallMetadata(
+                                server_name=server_name,
+                                tool_name=tool_name,
+                                title=title,
+                                arguments=call_args,
+                                tool_call_id=call.call_id,
+                                approved=True,
+                                result_status=result_status,
+                                result=display_text,
+                                mcp_tool_name=call.name,
+                            )
+                        )
                     if not await _follow_up_completion():
                         break
 
                 if captured_refs:
                     completion.mcp_tool_references = captured_refs
+                if collected_tool_metadata:
+                    completion.tool_calls_metadata = collected_tool_metadata
                 if msg.content:
                     completion.text = self._strip_thinking_content(msg.content)
                 completion.stop = choice.finish_reason == "stop"

--- a/backend/tests/unit/test_chat_stream_abort_persistence.py
+++ b/backend/tests/unit/test_chat_stream_abort_persistence.py
@@ -30,6 +30,7 @@ from eneo.ai_models.completion_models.completion_model import (
     McpToolReference,
     ResponseType,
     TokenUsage,
+    ToolCallMetadata,
 )
 from eneo.sessions import session_service as session_service_module
 from eneo.sessions.session_service import (
@@ -770,6 +771,103 @@ async def test_non_streaming_handle_response_persists_context_without_changing_c
     assert persisted["context_prompt_tokens"] == 520
     assert persisted["context_completion_tokens"] == 40
     assert persisted["skill_context_tokens"] == 37
+
+
+async def test_non_streaming_handle_response_persists_tool_calls_for_replay():
+    """Tool calls executed on the non-streaming path must be persisted on the
+    question (arguments + result text) so later turns replay them to the LLM,
+    exactly like the streaming path does."""
+
+    response = SimpleNamespace(
+        completion=Completion(
+            text="ok",
+            tool_calls_metadata=[
+                ToolCallMetadata(
+                    server_name="Server",
+                    tool_name="tool",
+                    title="Tool title",
+                    arguments={"q": "x"},
+                    tool_call_id="call_1",
+                    approved=True,
+                    result_status="succeeded",
+                    result="tool-ok",
+                    mcp_tool_name="server__tool",
+                )
+            ],
+        ),
+        total_token_count=10,
+        usage=None,
+        extended_logging=None,
+    )
+    session_service_mock = AsyncMock()
+    session_service_mock.complete_question_with_answer = AsyncMock()
+    svc = _make_assistant_service_for_streaming(session_service_mock)
+
+    from eneo.assistants.assistant_service import AssistantService
+
+    with patch("eneo.assistants.assistant_service.count_tokens", return_value=4):
+        answer = await AssistantService._handle_response(  # pyright: ignore[reportPrivateUsage]
+            svc,  # pyright: ignore[reportArgumentType]
+            response=response,
+            datastore_result=SimpleNamespace(info_blobs=[], no_duplicate_chunks=[]),
+            question="hello?",
+            files=[],
+            completion_model=SimpleNamespace(id=uuid4(), name="gpt-4"),
+            session=_make_session_in_db(),
+            stream=False,
+            assistant_id=uuid4(),
+            question_id=uuid4(),
+            **_skill_runtime_args(),
+        )
+
+    assert answer == "ok"
+    persisted = session_service_mock.complete_question_with_answer.await_args.kwargs
+    tool_calls = persisted["tool_calls"]
+    assert tool_calls is not None and len(tool_calls) == 1
+    persisted_call = tool_calls[0]
+    assert persisted_call.server_name == "Server"
+    assert persisted_call.tool_name == "tool"
+    assert persisted_call.title == "Tool title"
+    assert persisted_call.arguments == {"q": "x"}
+    assert persisted_call.tool_call_id == "call_1"
+    assert persisted_call.approved is True
+    assert persisted_call.result_status == "succeeded"
+    assert persisted_call.result == "tool-ok"
+    assert persisted_call.mcp_tool_name == "server__tool"
+
+
+async def test_non_streaming_handle_response_persists_no_tool_calls_when_none():
+    """A plain non-streaming answer without tool use persists tool_calls=None."""
+
+    response = SimpleNamespace(
+        completion=Completion(text="ok"),
+        total_token_count=10,
+        usage=None,
+        extended_logging=None,
+    )
+    session_service_mock = AsyncMock()
+    session_service_mock.complete_question_with_answer = AsyncMock()
+    svc = _make_assistant_service_for_streaming(session_service_mock)
+
+    from eneo.assistants.assistant_service import AssistantService
+
+    with patch("eneo.assistants.assistant_service.count_tokens", return_value=4):
+        await AssistantService._handle_response(  # pyright: ignore[reportPrivateUsage]
+            svc,  # pyright: ignore[reportArgumentType]
+            response=response,
+            datastore_result=SimpleNamespace(info_blobs=[], no_duplicate_chunks=[]),
+            question="hello?",
+            files=[],
+            completion_model=SimpleNamespace(id=uuid4(), name="gpt-4"),
+            session=_make_session_in_db(),
+            stream=False,
+            assistant_id=uuid4(),
+            question_id=uuid4(),
+            **_skill_runtime_args(),
+        )
+
+    persisted = session_service_mock.complete_question_with_answer.await_args.kwargs
+    assert persisted["tool_calls"] is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_tenant_model_adapter_iterate_stream.py
+++ b/backend/tests/unit/test_tenant_model_adapter_iterate_stream.py
@@ -464,6 +464,79 @@ async def test_non_streaming_supports_multiple_tool_rounds():
     }
 
 
+class _ErrorSecondRoundMCPProxy(_FakeMCPProxy):
+    async def call_tools_parallel(self, proxy_calls):
+        self.calls.append(proxy_calls)
+        is_error = len(self.calls) > 1
+        text = "boom" if is_error else "tool-ok"
+        return [
+            {"content": [{"type": "text", "text": text}], "is_error": is_error}
+            for _ in proxy_calls
+        ]
+
+
+async def test_non_streaming_populates_tool_calls_metadata_for_replay():
+    adapter = _make_completion_adapter()
+    mcp_proxy = _ErrorSecondRoundMCPProxy()
+    responses = [
+        _response(
+            tool_calls=[_response_tool_call("call_1", '{"q":"first"}')],
+            finish_reason="tool_calls",
+        ),
+        _response(
+            tool_calls=[_response_tool_call("call_2", '{"q":"second"}')],
+            finish_reason="tool_calls",
+        ),
+        _response(content="final answer"),
+    ]
+
+    with patch(
+        "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(side_effect=responses),
+    ):
+        completion = await adapter.get_response(
+            context=SimpleNamespace(),
+            model_kwargs={},
+            mcp_proxy=mcp_proxy,
+        )
+
+    assert completion.tool_calls_metadata is not None
+    assert len(completion.tool_calls_metadata) == 2
+    succeeded, failed = completion.tool_calls_metadata
+
+    assert succeeded.tool_call_id == "call_1"
+    assert succeeded.server_name == "Server"
+    assert succeeded.tool_name == "tool"
+    assert succeeded.title == "Tool title"
+    assert succeeded.mcp_tool_name == "server__tool"
+    assert succeeded.arguments == {"q": "first"}
+    assert succeeded.approved is True
+    assert succeeded.result_status == "succeeded"
+    assert succeeded.result == "tool-ok"
+
+    assert failed.tool_call_id == "call_2"
+    assert failed.arguments == {"q": "second"}
+    assert failed.result_status == "failed"
+    assert failed.result == json.dumps({"error": "boom"})
+
+
+async def test_non_streaming_without_tool_calls_has_no_tool_metadata():
+    adapter = _make_completion_adapter()
+
+    with patch(
+        "eneo.completion_models.infrastructure.adapters.tenant_model_adapter._acompletion_call",
+        AsyncMock(return_value=_response(content="plain answer")),
+    ):
+        completion = await adapter.get_response(
+            context=SimpleNamespace(),
+            model_kwargs={},
+            mcp_proxy=_FakeMCPProxy(),
+        )
+
+    assert completion.text == "plain answer"
+    assert completion.tool_calls_metadata is None
+
+
 def test_tool_result_budget_admits_until_exhausted_then_withholds():
     budget = _ToolResultBudget(token_limit=4, litellm_model="openai/test-model")
 


### PR DESCRIPTION
## Problem

Non-streaming completions never persist tool-call metadata, so tool results from those turns are lost from later turns' LLM context.

The streaming path accumulates `ToolCallMetadata` and persists it into `questions.tool_calls`, which `_replayable_tool_calls` in `context_builder.py` replays to the model on later turns. The non-streaming path had two gaps:

- `TenantModelAdapter.get_response` discarded the tool-result display text and never set `completion.tool_calls_metadata`
- the non-streaming branch of `AssistantService._handle_response` passed `mcp_tool_references` but never `tool_calls` when persisting the answer

This matters more now that cross-turn MCP state relies on server-minted handles carried in replayed tool results (protocol-session resume was removed for MCP spec 2026-07-28).

## Fix

- The adapter's non-streaming tool-round loop now records a `ToolCallMetadata` per executed external MCP call: parsed arguments, `tool_call_id`, the prefixed `mcp_tool_name` (needed so replay matches the currently registered tools), the display-text result, and `succeeded`/`failed` status. Errored calls persist the same `{"error": ...}` payload the LLM saw, mirroring the streaming path.
- The non-streaming persistence branch converts that metadata to `ToolCallInfo` rows and passes `tool_calls=` to `complete_question_with_answer`, exactly like the streaming branch.

## Tests

Extended existing unit test files:

- `tests/unit/test_tenant_model_adapter_iterate_stream.py` — adapter layer: a two-round run asserts full metadata for a succeeded call and the error payload + `failed` status for an errored one; a no-tool run asserts metadata stays `None`.
- `tests/unit/test_chat_stream_abort_persistence.py` — persistence layer: non-streaming `_handle_response` passes the converted `ToolCallInfo` rows (all fields `_replayable_tool_calls` needs) to `complete_question_with_answer`, and `tool_calls=None` when no tools ran.

Fixes #735