### PR TITLE
fix(migrations): restore single Alembic head

### DIFF
--- a/backend/alembic/versions/202608211300_merge_migration_heads.py
+++ b/backend/alembic/versions/202608211300_merge_migration_heads.py
@@ -1,0 +1,21 @@
+"""merge migration heads
+
+Revision ID: 202608211300
+Revises: 202608041200, 202608181000
+Create Date: 2026-08-21 13:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+revision: str = "202608211300"
+down_revision: tuple[str, str] = ("202608041200", "202608181000")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

- Adds one no-op Alembic merge revision for the two parallel develop heads.
- Restores fresh database setup and deployments that target alembic upgrade head.

## Why

The current develop migration graph has two revisions descending from 202608121500. Alembic therefore rejects upgrade head, blocking a fresh devcontainer database setup.

## What changed

- Added revision 202608211300 as the single canonical migration tip.
- The revision merges 202608041200 and 202608181000 without executing schema or data operations.

## What was deliberately not changed

- The two existing migrations remain unchanged.
- No schema, model, seed, devcontainer, or CI workflow changes are included.
- A broader CI policy change can be handled separately from this recovery fix.

## Deletion / consolidation

The two parallel migration tips are consolidated into one Alembic head. No compatibility path or production logic was added.

## Risk and rollback

Risk is limited to migration ordering because the merge revision contains no DDL or data changes. Before later migrations depend on it, rollback is a revert of this commit; after that point, Alembic history should remain append-only.

## Planning

Fixes #739

## Validation

- RED: uv run pytest tests/unit/test_alembic_migration_graph.py -q failed with heads 202608041200 and 202608181000.
- GREEN: the same test passed after adding the merge revision.
- uv run alembic heads --verbose reported only 202608211300.
- uv run python init_db.py completed successfully against a new isolated PostgreSQL 13 volume and recorded 202608211300.
- Ruff check and formatting checks passed for the migration.
- Repository pre-commit and pre-push hooks passed.

## Screenshots

Not applicable.