### PR TITLE
ci: fail fast on multiple Alembic heads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --python 3.11 --frozen --all-groups
 
+      - name: Verify Alembic migration graph
+        run: uv run pytest -q tests/unit/test_alembic_migration_graph.py
+
       - name: Ruff lint
         run: uv run ruff check src/eneo --output-format github
 


### PR DESCRIPTION
## Changes

- Run the existing Alembic single-head contract test as an early `Backend quality` step after dependencies are installed.
- Keep the canonical assertion in `test_alembic_migration_graph.py` and retain its normal unit-suite coverage.

## Why

Multiple Alembic heads currently surface late in the full backend test job. Reusing the same contract in the faster quality job makes the failure visible before the longer unit and integration suites finish, without introducing a second implementation of the graph rule.

## Planning

- Task: Not linked — scoped CI feedback improvement.

## Testing

- `uv run pytest -q tests/unit/test_alembic_migration_graph.py` — 1 passed in 0.12s.
- `node .github/scripts/ci-change-scope.mjs --self-test` — passed.
- Parsed `.github/workflows/ci.yml` with PyYAML.
- `pre-commit run --files .github/workflows/ci.yml` — passed.
- Pre-push checks — passed.

## Risk and rollback

The graph test runs twice for backend changes, but the added invocation takes about 0.12 seconds after dependencies are available. Rollback is a revert of the three-line workflow step.

## Screenshots

Not applicable.