### PR TITLE
ci: support merge queue via merge_group triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - develop
       - 'release/**'
+  # Merge queue candidates (develop + queued PRs). Every scoped job runs in
+  # full here (their conditions only scope pull_request events), and the
+  # aggregate CI job reports the required "CI" check on the candidate.
+  merge_group:
 
 permissions:
   contents: read
@@ -67,7 +71,7 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
-          BEFORE_SHA: ${{ github.event.before || '' }}
+          BEFORE_SHA: ${{ github.event.before || github.event.merge_group.base_sha || '' }}
           HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - develop
+  # Required check, so it must also report on merge queue candidates. The
+  # action itself needs a pull_request diff to review; the queue run is a
+  # no-op success (the real review already ran on the PR).
+  merge_group:
 
 permissions:
   contents: read
@@ -20,12 +24,18 @@ jobs:
 
     steps:
       - name: Checkout
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v4
 
       - name: Review dependency changes
+        if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
           show-openssf-scorecard: false
           show-patched-versions: true
+
+      - name: Merge queue no-op
+        if: github.event_name == 'merge_group'
+        run: echo "Dependency review ran on the pull request; nothing to re-check on the merge candidate."


### PR DESCRIPTION
## What this contributes

Today the develop ruleset requires branches to be **up to date before merging** (`strict_required_status_checks_policy`). That guarantee matters — it is what catches two individually-green PRs that break combined, e.g. the double Alembic head incident (#740) — but the mechanism is expensive: **every merge to develop invalidates the green checks of every other open PR**, forcing a manual *Update branch* + a full ~15 min CI re-run per PR, per merge. With N concurrent PRs that's O(N²) CI runs and a lot of waiting.

GitHub's **merge queue** provides the same guarantee without the manual churn: when you queue a PR, GitHub builds a temporary *merge candidate* (current develop + your PR + any PRs queued ahead of you), runs the required checks once on that candidate, and merges automatically on green. Cross-PR collisions are caught in the queue — e.g. two PRs each adding a migration on the same parent: the second candidate contains both, the single-head fail-fast check fails, and that PR is automatically ejected from the queue while develop stays clean. The merge queue is free for public org-owned repositories.

## How developers should use it

1. Open your PR as usual. PR CI is unchanged (still change-scoped).
2. When the PR is green and approved, click **Merge when ready** (replaces *Squash and merge*).
3. Done — no *Update branch*, no waiting for a rebase run. The queue builds the candidate, runs full CI (~15 min) on it, and squash-merges automatically.
4. If the candidate fails, your PR is kicked out of the queue and you're notified: fix, push, and queue again. This is the queue doing its job — it means your PR conflicts with something that landed after your last CI run.
5. Rebase manually only to resolve real git conflicts — never just to refresh checks.

## Changes

- **ci.yml**: trigger on `merge_group`. The scoped jobs' conditions (`github.event_name != 'pull_request' || …`) already mean non-PR events run everything, so a queue candidate gets the full suite; the aggregate `CI` job reports the required check. The change-scope diff uses `merge_group.base_sha` so candidate runs diff against the develop tip.
- **dependency-review.yml**: trigger on `merge_group` with a no-op success step. It's a required check so it must report on candidates, but the action itself needs a pull_request diff — the real review already ran on the PR. The check is kept: it's a cheap gate against known-vulnerable dependency changes (it does not create PRs — that's Dependabot, which is separate).

## Activation (admin, AFTER this PR merges — order matters)

In the **Develop branch protection** ruleset:

1. Add the **merge queue** rule (merge method: **squash**, matching current policy).
2. Turn **off** *Require branches to be up to date before merging* (the queue supersedes it).

Enabling the queue before this PR is merged would wedge it: candidates would wait forever on checks that never report on `merge_group`. This PR is inert until the ruleset is flipped.