### PR TITLE
fix(chat): persist personal MCP server toggles

### DIFF
--- a/frontend/apps/web/src/lib/features/chat/components/conversation/ChatMcpServers.svelte
+++ b/frontend/apps/web/src/lib/features/chat/components/conversation/ChatMcpServers.svelte
@@ -39,6 +39,8 @@
     internalServers?: InternalMcpServer[];
     /** Server ids the user has switched off for this conversation (mutated in place). */
     disabledServerIds: SvelteSet<string>;
+    /** Called after the user changes the external server selection. */
+    onSelectionChange?: (disabledServerIds: ReadonlySet<string>) => void;
     /** When true, tool calls run without per-call approval. */
     autoAcceptTools: boolean;
   };
@@ -47,6 +49,7 @@
     servers,
     internalServers = [],
     disabledServerIds,
+    onSelectionChange,
     autoAcceptTools = $bindable()
   }: Props = $props();
 
@@ -61,13 +64,15 @@
   );
   const activeCount = $derived(total - disabledCount);
 
-  function setServer(id: string, on: boolean) {
+  function setServer(id: string, on: boolean, notify = true) {
     if (on) disabledServerIds.delete(id);
     else disabledServerIds.add(id);
+    if (notify) onSelectionChange?.(disabledServerIds);
   }
 
   function setAll(on: boolean) {
-    for (const server of servers) setServer(server.id, on);
+    for (const server of servers) setServer(server.id, on, false);
+    onSelectionChange?.(disabledServerIds);
   }
 </script>
 

--- a/frontend/apps/web/src/lib/features/chat/components/conversation/ChatMcpServers.svelte.test.ts
+++ b/frontend/apps/web/src/lib/features/chat/components/conversation/ChatMcpServers.svelte.test.ts
@@ -1,0 +1,30 @@
+import { page } from "@vitest/browser/context";
+import { render } from "vitest-browser-svelte";
+import { describe, expect, it } from "vitest";
+import { SvelteSet } from "svelte/reactivity";
+import { m } from "$lib/paraglide/messages";
+import ChatMcpServers from "./ChatMcpServers.svelte";
+
+describe("ChatMcpServers", () => {
+  it("reports the complete external server selection after a user toggle", async () => {
+    const selectionSnapshots: string[][] = [];
+    const disabledServerIds = new SvelteSet<string>();
+
+    render(ChatMcpServers, {
+      servers: [
+        { id: "server-a", name: "Server A" },
+        { id: "server-b", name: "Server B" }
+      ],
+      disabledServerIds,
+      autoAcceptTools: true,
+      onSelectionChange: (disabledIds) => selectionSnapshots.push([...disabledIds].sort())
+    });
+
+    await page
+      .getByRole("button", { name: m.mcp_servers_status_aria({ active: 2, total: 2 }) })
+      .click();
+    await page.getByRole("switch", { name: "Server A" }).click();
+
+    expect(selectionSnapshots).toEqual([["server-a"]]);
+  });
+});

--- a/frontend/apps/web/src/lib/features/chat/components/conversation/ConversationInput.svelte
+++ b/frontend/apps/web/src/lib/features/chat/components/conversation/ConversationInput.svelte
@@ -15,6 +15,12 @@
   import { getSpacesManager } from "$lib/features/spaces/SpacesManager";
   import { getChatService } from "../../ChatService.svelte";
   import { effectiveKnowledgeMode, internalMcpServerNames } from "../../internalMcpAvailability";
+  import {
+    initialDisabledMcpServerIds,
+    loadMcpServerPreferences,
+    saveMcpServerPreferences,
+    type McpServerPreferencesContext
+  } from "../../mcpServerPreferences";
   import { selectEffectiveChatModel } from "../../selectEffectiveChatModel";
   import { track } from "$lib/core/helpers/track";
   import { getAppContext } from "$lib/core/AppContext";
@@ -32,7 +38,7 @@
   };
 
   const chat = getChatService();
-  const { featureFlags } = getAppContext();
+  const { featureFlags, tenant, user } = getAppContext();
 
   const {
     state: { attachments, isUploading, uploadError },
@@ -66,6 +72,29 @@
   // the backend narrows the effective server set accordingly. Mutated in place
   // by ChatMcpServers.
   const disabledMcpServerIds = new SvelteSet<string>();
+
+  function mcpServerPreferencesContext(): McpServerPreferencesContext | null {
+    const partner = chat.partner;
+    if (!partner || partner.type !== "default-assistant") return null;
+
+    return {
+      tenantId: tenant.id,
+      userId: user.id,
+      assistantId: partner.id
+    };
+  }
+
+  function persistMcpServerSelection(disabledServerIds: ReadonlySet<string>) {
+    if (!browser) return;
+    const context = mcpServerPreferencesContext();
+    if (!context) return;
+
+    saveMcpServerPreferences(
+      context,
+      mcpServers.map((server) => server.id),
+      disabledServerIds
+    );
+  }
 
   onMount(() => {
     if (!browser) {
@@ -252,9 +281,14 @@
 
   $effect(() => {
     const validIds = new Set(mcpServers.map((server) => server.id));
+    let selectionChanged = false;
     for (const id of Array.from(disabledMcpServerIds)) {
-      if (!validIds.has(id)) disabledMcpServerIds.delete(id);
+      if (!validIds.has(id)) {
+        disabledMcpServerIds.delete(id);
+        selectionChanged = true;
+      }
     }
+    if (selectionChanged) persistMcpServerSelection(disabledMcpServerIds);
   });
 
   // Seed the toggles from the governance policy's per-server chat defaults.
@@ -268,11 +302,28 @@
     if (conversation === seededConversation) return;
     seededConversation = conversation;
     untrack(() => {
+      const availableServerIds = mcpServers.map((server) => server.id);
+      const defaultDisabledServerIds =
+        partner && "effective_config" in partner
+          ? (partner.effective_config?.default_disabled_mcp_server_ids ?? [])
+          : [];
+      const preferencesContext = mcpServerPreferencesContext();
+      const preferences =
+        browser && preferencesContext ? loadMcpServerPreferences(preferencesContext) : null;
+      const initialDisabledServerIds = initialDisabledMcpServerIds({
+        availableServerIds,
+        defaultDisabledServerIds,
+        preferences
+      });
+
       disabledMcpServerIds.clear();
-      if (partner && "effective_config" in partner) {
-        for (const id of partner.effective_config?.default_disabled_mcp_server_ids ?? []) {
-          disabledMcpServerIds.add(id);
-        }
+      for (const id of initialDisabledServerIds) disabledMcpServerIds.add(id);
+
+      // Normalize an existing preference to the currently available server set.
+      // A missing preference remains missing until the user changes a toggle, so
+      // future governance defaults can still take effect.
+      if (preferences && preferencesContext) {
+        saveMcpServerPreferences(preferencesContext, availableServerIds, disabledMcpServerIds);
       }
     });
   });
@@ -483,6 +534,7 @@
           servers={mcpServers}
           internalServers={internalMcpServers}
           disabledServerIds={disabledMcpServerIds}
+          onSelectionChange={persistMcpServerSelection}
           bind:autoAcceptTools
         />
       {/if}

--- a/frontend/apps/web/src/lib/features/chat/mcpServerPreferences.test.ts
+++ b/frontend/apps/web/src/lib/features/chat/mcpServerPreferences.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  initialDisabledMcpServerIds,
+  loadMcpServerPreferences,
+  saveMcpServerPreferences,
+  type McpServerPreferencesContext
+} from "./mcpServerPreferences";
+
+class MemoryStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+const context: McpServerPreferencesContext = {
+  tenantId: "tenant-1",
+  userId: "user-1",
+  assistantId: "assistant-1"
+};
+
+describe("MCP server preferences", () => {
+  it("round-trips enabled and disabled server states", () => {
+    const storage = new MemoryStorage();
+
+    saveMcpServerPreferences(context, ["server-a", "server-b"], new Set(["server-b"]), storage);
+
+    expect(loadMcpServerPreferences(context, storage)).toEqual({
+      serverStates: { "server-a": true, "server-b": false }
+    });
+  });
+
+  it("isolates preferences by tenant, user, and assistant", () => {
+    const storage = new MemoryStorage();
+    saveMcpServerPreferences(context, ["server-a"], new Set(["server-a"]), storage);
+
+    for (const differentContext of [
+      { ...context, tenantId: "tenant-2" },
+      { ...context, userId: "user-2" },
+      { ...context, assistantId: "assistant-2" }
+    ]) {
+      expect(loadMcpServerPreferences(differentContext, storage)).toBeNull();
+    }
+  });
+
+  it("uses governance defaults for new servers without overriding explicit choices", () => {
+    expect(
+      initialDisabledMcpServerIds({
+        availableServerIds: ["explicitly-on", "explicitly-off", "new-default-off"],
+        defaultDisabledServerIds: ["explicitly-on", "new-default-off"],
+        preferences: {
+          serverStates: { "explicitly-on": true, "explicitly-off": false }
+        }
+      })
+    ).toEqual(["explicitly-off", "new-default-off"]);
+  });
+
+  it("ignores unavailable saved servers", () => {
+    expect(
+      initialDisabledMcpServerIds({
+        availableServerIds: ["available"],
+        defaultDisabledServerIds: [],
+        preferences: { serverStates: { stale: false } }
+      })
+    ).toEqual([]);
+  });
+
+  it("discards malformed storage instead of breaking chat", () => {
+    const storage = new MemoryStorage();
+    storage.values.set("eneo:chat-mcp:v1:tenant-1:user-1:assistant-1", "not-json");
+
+    expect(loadMcpServerPreferences(context, storage)).toBeNull();
+  });
+
+  it("keeps chat usable when browser storage is unavailable", () => {
+    const unavailableStorage = {
+      getItem: () => {
+        throw new Error("storage blocked");
+      },
+      setItem: () => {
+        throw new Error("storage blocked");
+      },
+      removeItem: () => {
+        throw new Error("storage blocked");
+      }
+    };
+
+    expect(loadMcpServerPreferences(context, unavailableStorage)).toBeNull();
+    expect(() =>
+      saveMcpServerPreferences(context, ["server-a"], new Set(), unavailableStorage)
+    ).not.toThrow();
+  });
+});

--- a/frontend/apps/web/src/lib/features/chat/mcpServerPreferences.ts
+++ b/frontend/apps/web/src/lib/features/chat/mcpServerPreferences.ts
@@ -1,0 +1,92 @@
+const STORAGE_PREFIX = "eneo:chat-mcp:v1:";
+
+export interface McpServerPreferencesContext {
+  tenantId: string;
+  userId: string;
+  assistantId: string;
+}
+
+export interface McpServerPreferences {
+  serverStates: Record<string, boolean>;
+}
+
+interface PreferencesStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+function storageKey(context: McpServerPreferencesContext): string {
+  return `${STORAGE_PREFIX}${context.tenantId}:${context.userId}:${context.assistantId}`;
+}
+
+function resolveStorage(storage?: PreferencesStorage): PreferencesStorage {
+  return storage ?? globalThis.localStorage;
+}
+
+export function loadMcpServerPreferences(
+  context: McpServerPreferencesContext,
+  storage?: PreferencesStorage
+): McpServerPreferences | null {
+  try {
+    const resolvedStorage = resolveStorage(storage);
+    const raw = resolvedStorage.getItem(storageKey(context));
+    if (raw === null) return null;
+
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !("serverStates" in parsed) ||
+      typeof parsed.serverStates !== "object" ||
+      parsed.serverStates === null ||
+      Array.isArray(parsed.serverStates)
+    ) {
+      resolvedStorage.removeItem(storageKey(context));
+      return null;
+    }
+
+    const serverStates: Record<string, boolean> = {};
+    for (const [serverId, enabled] of Object.entries(parsed.serverStates)) {
+      if (typeof enabled === "boolean") serverStates[serverId] = enabled;
+    }
+
+    return { serverStates };
+  } catch {
+    return null;
+  }
+}
+
+export function saveMcpServerPreferences(
+  context: McpServerPreferencesContext,
+  availableServerIds: readonly string[],
+  disabledServerIds: ReadonlySet<string>,
+  storage?: PreferencesStorage
+): void {
+  const serverStates = Object.fromEntries(
+    availableServerIds.map((serverId) => [serverId, !disabledServerIds.has(serverId)])
+  );
+
+  try {
+    resolveStorage(storage).setItem(storageKey(context), JSON.stringify({ serverStates }));
+  } catch {
+    // A blocked or full localStorage must not prevent the user from chatting.
+  }
+}
+
+export function initialDisabledMcpServerIds({
+  availableServerIds,
+  defaultDisabledServerIds,
+  preferences
+}: {
+  availableServerIds: readonly string[];
+  defaultDisabledServerIds: readonly string[];
+  preferences: McpServerPreferences | null;
+}): string[] {
+  const defaultDisabled = new Set(defaultDisabledServerIds);
+
+  return availableServerIds.filter((serverId) => {
+    const persistedState = preferences?.serverStates[serverId];
+    return persistedState === undefined ? defaultDisabled.has(serverId) : !persistedState;
+  });
+}


### PR DESCRIPTION
## Changes
- persist personal-chat MCP server toggle states in localStorage
- scope preferences by tenant, user, and personal assistant
- keep governance defaults for users without preferences and for newly available servers
- ignore unavailable server IDs and degrade safely when browser storage is blocked or full
- add unit and browser component coverage for persistence and toggle notifications

## Why
MCP server selections previously lived only in the composer component. Refreshing or reloading a conversation reset them to governance defaults, while the adjacent automatic-tool setting already persisted. This keeps the selected state stable on the same device without adding backend state or a database migration.

## Planning
- Task: N/A

## Testing
- bunx vitest run --reporter=dot: 88 files, 622 tests passed
- bun run check: 0 errors and 0 warnings
- ESLint and Prettier on changed files
- git diff --check
- repository commit and pre-push hooks

## Screenshots
Not applicable; behavior-only change.