### PR TITLE
fix(models): warn six months before deprecation

### DIFF
--- a/frontend/apps/web/src/lib/features/ai-models/components/ModelStatusIcons.svelte
+++ b/frontend/apps/web/src/lib/features/ai-models/components/ModelStatusIcons.svelte
@@ -2,6 +2,7 @@
 
 <script context="module" lang="ts">
   import type { CompletionModel, EmbeddingModel, TranscriptionModel } from "@eneo/eneo-js";
+  import { getDeprecationStatus } from "$lib/features/ai-models/formatModelStats";
   import { m } from "$lib/paraglide/messages";
 
   export type StatusIcon = {
@@ -16,21 +17,21 @@
   ): StatusIcon[] {
     const icons: StatusIcon[] = [];
 
-    if ("deprecation_date" in model && model.deprecation_date) {
-      const today = new Date().toISOString().slice(0, 10);
-      if (model.deprecation_date <= today) {
+    if ("deprecation_date" in model) {
+      const deprecation = getDeprecationStatus(model);
+      if (deprecation.kind === "deprecated") {
         icons.push({
           icon: "deprecated",
-          tooltip: m.model_tooltip_deprecated({ date: model.deprecation_date }),
+          tooltip: m.model_tooltip_deprecated({ date: deprecation.date }),
           color: "text-negative-default",
           ariaLabel: m.model_label_deprecated()
         });
-      } else {
+      } else if (deprecation.kind === "retiring") {
         icons.push({
           icon: "retiring",
-          tooltip: m.model_tooltip_retiring({ date: model.deprecation_date }),
+          tooltip: m.model_tooltip_retiring({ date: deprecation.date }),
           color: "text-warning-stronger",
-          ariaLabel: m.model_label_retiring({ date: model.deprecation_date })
+          ariaLabel: m.model_label_retiring({ date: deprecation.date })
         });
       }
     }

--- a/frontend/apps/web/src/lib/features/ai-models/formatModelStats.test.ts
+++ b/frontend/apps/web/src/lib/features/ai-models/formatModelStats.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { getDeprecationStatus } from "./formatModelStats";
+
+function setToday(date: string): void {
+  vi.useFakeTimers();
+  vi.setSystemTime(`${date}T12:00:00.000Z`);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("getDeprecationStatus", () => {
+  test("keeps models active until six months before deprecation", () => {
+    setToday("2026-08-27");
+
+    expect(getDeprecationStatus({ deprecation_date: "2027-03-01" })).toEqual({
+      kind: "active",
+      date: null
+    });
+  });
+
+  test("marks a model as retiring on the six-month boundary", () => {
+    setToday("2026-08-27");
+
+    expect(getDeprecationStatus({ deprecation_date: "2027-02-27" })).toEqual({
+      kind: "retiring",
+      date: "2027-02-27"
+    });
+  });
+
+  test("keeps a model active one day outside the warning window", () => {
+    setToday("2026-08-27");
+
+    expect(getDeprecationStatus({ deprecation_date: "2027-02-28" })).toEqual({
+      kind: "active",
+      date: null
+    });
+  });
+
+  test("clamps the warning start to the end of shorter months", () => {
+    setToday("2027-02-28");
+
+    expect(getDeprecationStatus({ deprecation_date: "2027-08-31" })).toEqual({
+      kind: "retiring",
+      date: "2027-08-31"
+    });
+  });
+
+  test("marks a model as deprecated on its deprecation date", () => {
+    setToday("2026-11-27");
+
+    expect(getDeprecationStatus({ deprecation_date: "2026-11-27" })).toEqual({
+      kind: "deprecated",
+      date: "2026-11-27"
+    });
+  });
+
+  test("keeps models without a deprecation date active", () => {
+    setToday("2026-08-27");
+
+    expect(getDeprecationStatus({ deprecation_date: null })).toEqual({
+      kind: "active",
+      date: null
+    });
+  });
+});

--- a/frontend/apps/web/src/lib/features/ai-models/formatModelStats.ts
+++ b/frontend/apps/web/src/lib/features/ai-models/formatModelStats.ts
@@ -107,11 +107,35 @@ export type DeprecationStatus =
   | { kind: "retiring"; date: string }
   | { kind: "deprecated"; date: string };
 
+const DEPRECATION_WARNING_MONTHS = 6;
+
+function getWarningStartDate(deprecationDate: string): string | null {
+  const date = new Date(`${deprecationDate}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime())) return null;
+
+  const dayOfMonth = date.getUTCDate();
+  date.setUTCDate(1);
+  date.setUTCMonth(date.getUTCMonth() - DEPRECATION_WARNING_MONTHS);
+
+  const lastDayOfTargetMonth = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 0)
+  ).getUTCDate();
+  date.setUTCDate(Math.min(dayOfMonth, lastDayOfTargetMonth));
+
+  return date.toISOString().slice(0, 10);
+}
+
 export function getDeprecationStatus(model: {
   deprecation_date?: string | null;
 }): DeprecationStatus {
   const date = model.deprecation_date ?? null;
   if (!date) return { kind: "active", date: null };
+
   const today = new Date().toISOString().slice(0, 10);
-  return date <= today ? { kind: "deprecated", date } : { kind: "retiring", date };
+  if (date <= today) return { kind: "deprecated", date };
+
+  const warningStartDate = getWarningStartDate(date);
+  return warningStartDate && today >= warningStartDate
+    ? { kind: "retiring", date }
+    : { kind: "active", date: null };
 }


### PR DESCRIPTION
## Changes
- Show model deprecation warnings only during the six calendar months before the deprecation date.
- Reuse the canonical deprecation status helper in model status icons.
- Add deterministic boundary coverage, including end-of-month handling.

## Why
Models with any future deprecation date were previously shown as retiring immediately, including dates far into 2027.

## Planning
- Task: N/A

## Testing
- bunx vitest run src/lib/features/ai-models/formatModelStats.test.ts --project server
- bun run check
- Commit and pre-push hooks

## Screenshots
Not applicable; this changes when existing warnings appear.