### PR TITLE
fix(jobs): recover pre-durable knowledge jobs

### DIFF
--- a/backend/alembic/versions/202607301200_add_job_failure_codes.py
+++ b/backend/alembic/versions/202607301200_add_job_failure_codes.py
@@ -19,8 +19,28 @@ down_revision: str | None = "202607301100"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
+_LOCK_NOT_AVAILABLE_SQLSTATE = "55P03"
+
+
+def _lock_jobs_for_schema_change() -> None:
+    try:
+        op.get_bind().exec_driver_sql("LOCK TABLE jobs IN ACCESS EXCLUSIVE MODE NOWAIT")
+    except sa.exc.DBAPIError as error:
+        sqlstate = getattr(error.orig, "sqlstate", None) or getattr(
+            error.orig,
+            "pgcode",
+            None,
+        )
+        if sqlstate != _LOCK_NOT_AVAILABLE_SQLSTATE:
+            raise
+        raise RuntimeError(
+            "Job failure-code migration could not lock jobs; stop all API "
+            "replicas and workers, then retry db-init"
+        ) from error
+
 
 def upgrade() -> None:
+    _lock_jobs_for_schema_change()
     op.add_column(
         "jobs",
         sa.Column("failure_code", sa.String(length=64), nullable=True),

--- a/backend/alembic/versions/202607311000_preserve_knowledge_original_references.py
+++ b/backend/alembic/versions/202607311000_preserve_knowledge_original_references.py
@@ -7,9 +7,12 @@ Create Date: 2026-07-31 10:00:00.000000
 The old reference shape never had a production writer. Upgrade therefore
 refuses unexpected rows instead of guessing their meaning. The coordinated
 release must also drain executable legacy knowledge jobs before this contract
-changes.
+changes. Pre-durable queued jobs left after the old worker drains have no
+durable recovery evidence; the migration records those jobs as interrupted
+instead of requiring operators to repair them by hand.
 """
 
+import logging
 from collections.abc import Sequence
 
 import sqlalchemy as sa
@@ -29,10 +32,62 @@ _ACTIVE_KNOWLEDGE_JOB = """
     task IN ('upload_info_blob', 'transcription')
     AND status IN ('queued', 'in progress')
 """
+_PRE_DURABLE_QUEUED_JOB = """
+    task IN ('upload_info_blob', 'transcription')
+    AND status = 'queued'
+    AND dispatch_envelope IS NULL
+"""
+_BLOCKING_KNOWLEDGE_JOB = f"""
+    {_ACTIVE_KNOWLEDGE_JOB}
+    AND NOT (
+        status = 'queued'
+        AND dispatch_envelope IS NULL
+    )
+"""
+_LOCK_NOT_AVAILABLE_SQLSTATE = "55P03"
+
+logger = logging.getLogger("alembic.runtime.migration")
 
 
 def _count(statement: str) -> int:
     return int(op.get_bind().execute(sa.text(statement)).scalar_one())
+
+
+def _retire_pre_durable_queued_jobs() -> int:
+    return _count(
+        f"""
+        WITH retired AS (
+            UPDATE jobs
+            SET status = 'failed',
+                result_location = NULL,
+                failure_code = 'processing_interrupted',
+                finished_at = now(),
+                updated_at = now()
+            WHERE {_PRE_DURABLE_QUEUED_JOB}
+            RETURNING 1
+        )
+        SELECT count(*) FROM retired
+        """
+    )
+
+
+def _lock_jobs_for_classification() -> None:
+    try:
+        op.get_bind().exec_driver_sql(
+            "LOCK TABLE jobs IN SHARE ROW EXCLUSIVE MODE NOWAIT"
+        )
+    except sa.exc.DBAPIError as error:
+        sqlstate = getattr(error.orig, "sqlstate", None) or getattr(
+            error.orig,
+            "pgcode",
+            None,
+        )
+        if sqlstate != _LOCK_NOT_AVAILABLE_SQLSTATE:
+            raise
+        raise RuntimeError(
+            "Knowledge-original migration could not lock jobs; stop all API "
+            "replicas and old workers, then retry db-init"
+        ) from error
 
 
 def _install_reference_identity_fence(*, include_variant: bool) -> None:
@@ -87,15 +142,21 @@ def upgrade() -> None:
             "investigate the drift before upgrading"
         )
 
-    active_job_count = _count(
-        f"SELECT count(*) FROM jobs WHERE {_ACTIVE_KNOWLEDGE_JOB}"
+    # Serialize with writers without blocking ordinary reads or waiting behind
+    # a missed old process indefinitely.
+    _lock_jobs_for_classification()
+
+    blocking_job_count = _count(
+        f"SELECT count(*) FROM jobs WHERE {_BLOCKING_KNOWLEDGE_JOB}"
     )
-    if active_job_count:
+    if blocking_job_count:
         raise RuntimeError(
             "Knowledge-original migration found "
-            f"{active_job_count} active legacy knowledge job(s); "
+            f"{blocking_job_count} active legacy knowledge job(s); "
             "stop API replicas and drain old workers before upgrading"
         )
+
+    retired_job_count = _retire_pre_durable_queued_jobs()
 
     op.drop_constraint(_PRIMARY_KEY, _TABLE, type_="primary")
     op.drop_constraint(_VARIANT_CHECK, _TABLE, type_="check")
@@ -111,6 +172,13 @@ def upgrade() -> None:
     )
     op.create_primary_key(_PRIMARY_KEY, _TABLE, ["info_blob_id"])
     _install_reference_identity_fence(include_variant=False)
+
+    if retired_job_count:
+        logger.info(
+            "Retired %d queued legacy knowledge job(s) without a durable "
+            "dispatch envelope",
+            retired_job_count,
+        )
 
 
 def downgrade() -> None:

--- a/backend/src/eneo/jobs/job_service.py
+++ b/backend/src/eneo/jobs/job_service.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 from sqlalchemy import event
 
 from eneo.jobs.job_manager import job_manager
-from eneo.jobs.job_models import Job, JobInDb, JobUpdate, Task
+from eneo.jobs.job_models import KNOWLEDGE_TASKS, Job, JobInDb, JobUpdate, Task
 from eneo.jobs.job_repo import JobRepository
 from eneo.jobs.job_staging import job_staging_path
 from eneo.jobs.task_models import (
@@ -35,6 +35,8 @@ class JobService:
     async def queue_job(
         self, task: Task, *, name: str, task_params: TaskParams, enqueue: bool = True
     ) -> JobInDb:
+        if task in KNOWLEDGE_TASKS:
+            raise ValueError(f"Knowledge task {task.value} requires durable dispatch")
         job = Job(task=task, name=name, status=Status.QUEUED, user_id=self.user.id)
         job_in_db = await self.job_repo.add_job(job=job)
 

--- a/backend/tests/integration/migrations/test_knowledge_original_references.py
+++ b/backend/tests/integration/migrations/test_knowledge_original_references.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from pathlib import Path
-from uuid import uuid4
+from typing import Literal
+from uuid import UUID, uuid4
 
 import psycopg2
 import pytest
 from sqlalchemy import create_engine, inspect
+from sqlalchemy.exc import ProgrammingError
 from testcontainers.postgres import PostgresContainer
 
 from alembic import command
@@ -14,7 +16,8 @@ from alembic.config import Config
 
 pytestmark = [pytest.mark.integration, pytest.mark.migration_isolation]
 
-_PREVIOUS_REVISION = "202607301200"
+_PREVIOUS_REVISION = "202607301100"
+_FAILURE_CODE_REVISION = "202607301200"
 _REVISION = "202607311000"
 
 
@@ -122,9 +125,12 @@ def _insert_reference_drift(
 def _insert_knowledge_job(
     database_url: str,
     *,
-    version: int,
+    task: Literal["upload_info_blob", "transcription"] = "upload_info_blob",
+    version: int | None,
     status: str,
-) -> None:
+    result_location: str | None = None,
+) -> UUID:
+    job_id = uuid4()
     with _connection(database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute("ALTER TABLE jobs DISABLE TRIGGER ALL")
@@ -132,17 +138,52 @@ def _insert_knowledge_job(
                 cursor.execute(
                     """
                     INSERT INTO jobs (
-                        id, user_id, task, name, status, dispatch_envelope
+                        id, user_id, task, name, status, result_location,
+                        dispatch_envelope
                     )
                     VALUES (
-                        %s::uuid, %s::uuid, 'upload_info_blob', 'document.txt',
-                        %s, jsonb_build_object('version', %s)
+                        %s::uuid, %s::uuid, %s, 'legacy knowledge job', %s, %s,
+                        CASE
+                            WHEN %s::integer IS NULL THEN NULL
+                            ELSE jsonb_build_object('version', %s::integer)
+                        END
                     )
                     """,
-                    (str(uuid4()), str(uuid4()), status, version),
+                    (
+                        str(job_id),
+                        str(uuid4()),
+                        task,
+                        status,
+                        result_location,
+                        version,
+                        version,
+                    ),
                 )
             finally:
                 cursor.execute("ALTER TABLE jobs ENABLE TRIGGER ALL")
+    return job_id
+
+
+def _job_recovery_state(
+    database_url: str,
+    job_id: UUID,
+) -> tuple[str, str | None, str | None, bool]:
+    with _connection(database_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT status,
+                       result_location,
+                       to_jsonb(jobs) ->> 'failure_code',
+                       finished_at IS NOT NULL
+                FROM jobs
+                WHERE id = %s::uuid
+                """,
+                (str(job_id),),
+            )
+            row = cursor.fetchone()
+    assert row is not None
+    return row
 
 
 def _clear_drift(database_url: str) -> None:
@@ -167,6 +208,29 @@ def _clear_drift(database_url: str) -> None:
                 cursor.execute("ALTER TABLE jobs ENABLE TRIGGER ALL")
 
 
+def _drop_variant_check(database_url: str) -> None:
+    with _connection(database_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                ALTER TABLE info_blob_content_references
+                DROP CONSTRAINT ck_info_blob_content_references_variant
+                """
+            )
+
+
+def _restore_variant_check(database_url: str) -> None:
+    with _connection(database_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                ALTER TABLE info_blob_content_references
+                ADD CONSTRAINT ck_info_blob_content_references_variant
+                CHECK (variant = 'extracted_text')
+                """
+            )
+
+
 def test_knowledge_original_reference_migration_guards_and_round_trip(
     migration_database: tuple[str, Config],
 ) -> None:
@@ -178,12 +242,132 @@ def test_knowledge_original_reference_migration_guards_and_round_trip(
         command.upgrade(config, _REVISION)
     _clear_drift(database_url)
 
-    _insert_knowledge_job(database_url, version=1, status="queued")
-    with pytest.raises(RuntimeError, match="active legacy knowledge job"):
-        command.upgrade(config, _REVISION)
+    failure_code_lock_job_id = _insert_knowledge_job(
+        database_url,
+        version=None,
+        status="queued",
+        result_location="preserve pre-column result",
+    )
+    writer = _connection(database_url)
+    try:
+        with writer.cursor() as cursor:
+            cursor.execute(
+                "UPDATE jobs SET updated_at = updated_at WHERE id = %s::uuid",
+                (str(failure_code_lock_job_id),),
+            )
+        with pytest.raises(RuntimeError, match="failure-code migration could not lock"):
+            command.upgrade(config, _FAILURE_CODE_REVISION)
+    finally:
+        writer.rollback()
+        writer.close()
+    assert _job_recovery_state(database_url, failure_code_lock_job_id) == (
+        "queued",
+        "preserve pre-column result",
+        None,
+        False,
+    )
     _clear_drift(database_url)
 
+    command.upgrade(config, _FAILURE_CODE_REVISION)
+
+    durable_job_id = _insert_knowledge_job(
+        database_url,
+        version=1,
+        status="queued",
+        result_location="preserve durable result",
+    )
+    with pytest.raises(RuntimeError, match="active legacy knowledge job"):
+        command.upgrade(config, _REVISION)
+    assert _job_recovery_state(database_url, durable_job_id) == (
+        "queued",
+        "preserve durable result",
+        None,
+        False,
+    )
+    _clear_drift(database_url)
+
+    active_job_id = _insert_knowledge_job(
+        database_url,
+        version=None,
+        status="in progress",
+        result_location="preserve active result",
+    )
+    with pytest.raises(RuntimeError, match="active legacy knowledge job"):
+        command.upgrade(config, _REVISION)
+    assert _job_recovery_state(database_url, active_job_id) == (
+        "in progress",
+        "preserve active result",
+        None,
+        False,
+    )
+    _clear_drift(database_url)
+
+    locked_job_id = _insert_knowledge_job(
+        database_url,
+        version=None,
+        status="queued",
+        result_location="preserve locked result",
+    )
+    writer = _connection(database_url)
+    try:
+        with writer.cursor() as cursor:
+            cursor.execute(
+                "UPDATE jobs SET updated_at = updated_at WHERE id = %s::uuid",
+                (str(locked_job_id),),
+            )
+        with pytest.raises(RuntimeError, match="could not lock jobs"):
+            command.upgrade(config, _REVISION)
+    finally:
+        writer.rollback()
+        writer.close()
+    assert _job_recovery_state(database_url, locked_job_id) == (
+        "queued",
+        "preserve locked result",
+        None,
+        False,
+    )
+    _clear_drift(database_url)
+
+    pre_durable_job_ids = (
+        _insert_knowledge_job(
+            database_url,
+            task="upload_info_blob",
+            version=None,
+            status="queued",
+            result_location="clear upload result",
+        ),
+        _insert_knowledge_job(
+            database_url,
+            task="transcription",
+            version=None,
+            status="queued",
+            result_location="clear transcription result",
+        ),
+    )
+    _drop_variant_check(database_url)
+    with pytest.raises(ProgrammingError, match="does not exist"):
+        command.upgrade(config, _REVISION)
+    for job_id, result_location in zip(
+        pre_durable_job_ids,
+        ("clear upload result", "clear transcription result"),
+        strict=True,
+    ):
+        assert _job_recovery_state(database_url, job_id) == (
+            "queued",
+            result_location,
+            None,
+            False,
+        )
+
+    _restore_variant_check(database_url)
     command.upgrade(config, _REVISION)
+    for job_id in pre_durable_job_ids:
+        assert _job_recovery_state(database_url, job_id) == (
+            "failed",
+            None,
+            "processing_interrupted",
+            True,
+        )
     columns, primary_key = _reference_schema(database_url)
     assert columns == {
         "info_blob_id",
@@ -216,3 +400,4 @@ def test_knowledge_original_reference_migration_guards_and_round_trip(
     assert primary_key == ("info_blob_id", "variant")
 
     command.upgrade(config, _REVISION)
+    command.upgrade(config, "head")

--- a/backend/tests/unittests/jobs/test_durable_dispatch.py
+++ b/backend/tests/unittests/jobs/test_durable_dispatch.py
@@ -8,7 +8,7 @@ import pytest
 from arq.worker import Function
 from sqlalchemy.orm import Session
 
-from eneo.jobs.job_models import JobInDb, Task
+from eneo.jobs.job_models import KNOWLEDGE_TASKS, JobInDb, Task
 from eneo.jobs.job_service import JobService
 from eneo.jobs.task_models import (
     KnowledgeOriginalAdmission,
@@ -38,6 +38,7 @@ def _params() -> UploadInfoBlob:
 def _repo(session: Session, job_id: UUID) -> MagicMock:
     repo = MagicMock()
     repo.delegate.session.sync_session = session
+    repo.add_job = AsyncMock()
     repo.add_durable_knowledge_job = AsyncMock(
         return_value=JobInDb(
             id=job_id,
@@ -48,6 +49,21 @@ def _repo(session: Session, job_id: UUID) -> MagicMock:
         )
     )
     return repo
+
+
+@pytest.mark.parametrize("task", KNOWLEDGE_TASKS)
+async def test_generic_queue_rejects_knowledge_tasks(task: Task) -> None:
+    session = Session()
+    repo = _repo(session, uuid4())
+
+    with pytest.raises(ValueError, match="requires durable dispatch"):
+        await JobService(TEST_USER, repo).queue_job(
+            task,
+            name="document.txt",
+            task_params=_params(),
+        )
+
+    repo.add_job.assert_not_awaited()
 
 
 async def test_durable_dispatch_is_scheduled_only_after_commit(

--- a/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
+++ b/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
@@ -621,25 +621,51 @@ payload columns:
 1. Stop all `backend` API replicas so no new writes or knowledge jobs can be
    accepted. In the reference Compose deployment, `docker compose stop backend`
    leaves `worker`, `db`, `redis`, and optional `object-content` running.
-2. Keep the old worker running until both queued and in-progress
-   `upload_info_blob` and `transcription` jobs are zero:
+2. Keep the old worker running and read its live ARQ health value plus TTL from
+   Redis:
+
+   ```bash
+   docker compose exec -T redis redis-cli --raw GET arq:queue:health-check
+   docker compose exec -T redis redis-cli --raw TTL arq:queue:health-check
+   ```
+
+   The health value must contain `queued=0`, and the TTL must be greater than
+   zero. In the single-worker reference deployment, also require
+   `j_ongoing=0`. If the old release has multiple worker replicas, keep all of
+   them running until the shared Redis value first reports `queued=0` with a
+   positive TTL. Then use the deployment orchestrator to verify that every
+   replica has zero active jobs, scale down to one idle old worker, and repeat
+   both Redis commands. Proceed only when the repeated value contains both
+   `queued=0` and `j_ongoing=0` and its TTL is positive. Then inspect the
+   matching database jobs:
 
    ```bash
    docker compose exec -T db sh -lc \
      'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 \
-     -c "SELECT task, status, count(*) FROM jobs
+     -c "SELECT task, status,
+                to_jsonb(jobs) ->> 'dispatch_envelope' IS NULL AS pre_durable,
+                count(*)
+         FROM jobs
          WHERE task IN ('\''upload_info_blob'\'', '\''transcription'\'')
            AND status IN ('\''queued'\'', '\''in progress'\'')
-         GROUP BY task, status;"'
+         GROUP BY task, status, pre_durable;"'
    ```
 
-   No rows is the required result.
+   No rows is the normal result. Once the live Redis health value reports an
+   empty queue and its TTL is positive, a deployment may still contain
+   historical `queued` rows with
+   `pre_durable = true` that have no executable queue entry. `db-init` records
+   only those rows as failed and continues; no manual SQL repair is needed. An
+   `in progress` row or any row with `pre_durable = false` still blocks the
+   migration.
    An old worker marks an in-progress knowledge job failed after five minutes
    without a heartbeat. If a worker process stopped mid-job, keep one old worker
    running until that automatic recovery has completed; do not edit the job row
    by hand.
 
-3. Stop every old worker. Verify the zero-job condition again.
+3. Stop every old worker. Run the database query again and proceed only when it
+   shows no `in progress` row and no row with `pre_durable = false`. Historical
+   `queued` rows with `pre_durable = true` are the only permitted exception.
 4. Take one recovery point containing PostgreSQL and, when configured, the
    object store. Preserve Redis and the shared staging volume until the release
    has been verified.

--- a/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
+++ b/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
@@ -643,7 +643,7 @@ payload columns:
    docker compose exec -T db sh -lc \
      'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -v ON_ERROR_STOP=1 \
      -c "SELECT task, status,
-                to_jsonb(jobs) ->> 'dispatch_envelope' IS NULL AS pre_durable,
+                to_jsonb(jobs) ->> '\''dispatch_envelope'\'' IS NULL AS pre_durable,
                 count(*)
          FROM jobs
          WHERE task IN ('\''upload_info_blob'\'', '\''transcription'\'')


### PR DESCRIPTION
## Summary

- Recover upgrades automatically when historical knowledge jobs are still
  `queued` but have no durable dispatch envelope.
- Keep active and recoverable jobs as hard blockers, with immediate actionable
  lock errors instead of an apparently stuck `db-init`.
- Prevent new knowledge jobs from using the non-durable queue path.
- Document the worker drain, live Redis/DB checks, backup, retry, and scaled
  worker sequence.

## Why

Older databases can contain queued upload or transcription jobs that no current
worker can redispatch because the rows predate durable dispatch. The first
knowledge-original schema transition treated every such row as active, so
`db-init` stopped and operators had to edit PostgreSQL manually. This change
separates unrecoverable historical rows from real work and makes durable
dispatch the enforced runtime owner for future knowledge jobs.

## What changed

- The blocking knowledge-original revision marks only queued
  `upload_info_blob`/`transcription` rows with no dispatch envelope as failed
  with `processing_interrupted`, in the same transaction as the schema change.
- Both `jobs` migration lock points use `NOWAIT` and return a retryable message
  when an API or worker is still writing.
- `JobService.queue_job` rejects knowledge tasks; those tasks must use
  `queue_durable_knowledge_job`.
- The PostgreSQL migration test covers both task types, lock contention,
  preserved blockers, rollback after a forced later DDL failure, retry, and
  upgrade through `head`.

## What was deliberately not changed

- Alembic does not inspect Redis and no generic migration-repair framework was
  added.
- In-progress jobs and queued jobs with a durable envelope are not failed or
  bypassed.
- There is no release, date, deployment, or database-size special case.

## Planning

- Post-mortem follow-up to #680. This PR does not reopen or close #658.

## Risk and rollback

The intentional data transition is limited to historical queued knowledge jobs
that have no durable recovery evidence, after the documented old-worker drain.
All other active knowledge jobs still stop the upgrade. PostgreSQL rolls the job
update back if the schema revision fails, and rerunning `db-init` is safe.

Before deployment, retain the coordinated pre-upgrade PostgreSQL/object-store
recovery point. If post-upgrade verification fails, keep traffic closed and
recover forward or restore that complete recovery point. Reverting this commit
before release restores the previous manual-blocker behavior.

## Validation

- `uv run ruff format <touched Python files>` - passed.
- `uv run ruff check <touched Python files>` - passed.
- `uv run pyright` - 0 errors, 0 warnings.
- `uv run pytest tests/unittests/jobs/test_durable_dispatch.py -q` - 13 passed.
- `POSTGRES_HOST=localhost uv run pytest -m migration_isolation tests/integration/migrations/test_knowledge_original_references.py -q` - 1 passed against PostgreSQL 16 and upgraded through `head`.
- `bunx prettier --write src/content/guides/object-content-storage.mdx` - passed.
- `bun run build` in `frontend/apps/docs-site` - passed; 31 pages indexed.
- Live ARQ health `GET`/`TTL` commands exercised against Redis 7.
- Pre-push repository check - passed.

## Screenshots

Not applicable; no UI changed.
