### PR TITLE
fix(files-api): propagate deletion failures to callers

### DIFF
--- a/frontend/packages/eneo-js/src/endpoints/files.js
+++ b/frontend/packages/eneo-js/src/endpoints/files.js
@@ -78,7 +78,7 @@ export function initFiles(client) {
      * @throws {EneoError}
      * */
     delete: async ({ fileId }) => {
-      client.fetch(`/api/v1/files/{id}/`, {
+      await client.fetch(`/api/v1/files/{id}/`, {
         method: "delete",
         params: { path: { id: fileId } }
       });

--- a/frontend/packages/eneo-js/src/endpoints/files.test.js
+++ b/frontend/packages/eneo-js/src/endpoints/files.test.js
@@ -3,6 +3,52 @@ import test from "node:test";
 
 import { initFiles } from "./files.js";
 
+test("file deletion waits for the backend outcome", async () => {
+  let resolveRequest;
+  const request = new Promise((resolve) => {
+    resolveRequest = resolve;
+  });
+  const calls = [];
+  const files = initFiles({
+    baseUrl: new URL("https://eneo.example.eu"),
+    fetch: async (endpoint, options) => {
+      calls.push({ endpoint, options });
+      return request;
+    }
+  });
+
+  let settled = false;
+  const deletion = files.delete({ fileId: "file-1" }).finally(() => {
+    settled = true;
+  });
+  await Promise.resolve();
+
+  assert.equal(settled, false);
+  resolveRequest();
+  assert.equal(await deletion, undefined);
+  assert.deepEqual(calls, [
+    {
+      endpoint: "/api/v1/files/{id}/",
+      options: {
+        method: "delete",
+        params: { path: { id: "file-1" } }
+      }
+    }
+  ]);
+});
+
+test("file deletion propagates backend failures", async () => {
+  const backendError = new Error("deletion rejected");
+  const files = initFiles({
+    baseUrl: new URL("https://eneo.example.eu"),
+    fetch: async () => {
+      throw backendError;
+    }
+  });
+
+  await assert.rejects(files.delete({ fileId: "file-1" }), backendError);
+});
+
 test("processing signed URLs keep the existing route and defaults", async () => {
   const calls = [];
   const files = initFiles({


### PR DESCRIPTION
## Summary

- Make `eneo-js.files.delete()` wait for the backend deletion request.
- Propagate backend rejection to API and MCP consumers instead of creating an unhandled rejection.
- Cover pending, success, request shape, and failure behavior.

## Why

The SDK previously resolved deletion immediately even when the backend later rejected it. Consumers could continue cleanup workflows after a false success and could not reliably catch the existing typed backend error.

## What changed

`frontend/packages/eneo-js/src/endpoints/files.js` remains the canonical endpoint owner. It now awaits the existing typed client call; no second request path or abstraction was added. Focused endpoint tests protect the caller-visible promise contract.

## What was deliberately not changed

- Backend deletion authorization and lifecycle rules.
- File list, metadata, deletion-preview, signed-link, or binary streaming APIs.
- Object-content migration, placement, retention, or purge behavior.

## Deletion / consolidation

No compatibility path was added or removed. The fix reuses the existing client error contract.

## Risk and rollback

Risk is limited to callers that accidentally depended on the promise resolving before deletion completed. Reverting this commit restores the previous timing, but also restores false success and unhandled rejection behavior.

## Validation

- `bun run --cwd packages/eneo-js test`: 33 passed.
- `bun run --cwd packages/eneo-js lint`: passed.
- `git diff --check`: passed.
- Pre-commit hooks: passed.
- Pre-push check: passed.

Fixes #763