### PR TITLE
fix(ui): stop painting the Eneo wordmark in the retired Intric indigo

### DIFF
--- a/frontend/apps/web/src/lib/features/spaces/components/MemberChip.svelte
+++ b/frontend/apps/web/src/lib/features/spaces/components/MemberChip.svelte
@@ -39,6 +39,6 @@
     @apply border-on-fill -ml-2 flex h-9 w-9 items-center justify-center rounded-full border-2 shadow hover:z-30 hover:shadow-lg;
   }
   .fallback {
-    @apply bg-brand-eneo text-on-fill text-center text-sm;
+    @apply bg-accent-default text-on-fill text-center text-sm;
   }
 </style>

--- a/frontend/packages/ui/src/styles/themes/dark.css
+++ b/frontend/packages/ui/src/styles/themes/dark.css
@@ -45,7 +45,7 @@
   --border-on-fill: var(--color-white);
 
   /* Colors */
-  --brand-eneo: var(--color-eneo-300);
+  --brand-eneo: var(--text-primary);
 
   --accent-stronger: var(--color-ui-blue-100);
   --accent-default: var(--color-ui-blue-300);

--- a/frontend/packages/ui/src/styles/themes/light.css
+++ b/frontend/packages/ui/src/styles/themes/light.css
@@ -43,7 +43,7 @@
   --border-on-fill: var(--color-white);
 
   /* Colors */
-  --brand-eneo: var(--color-eneo-500);
+  --brand-eneo: var(--text-primary);
 
   --accent-stronger: var(--color-ui-blue-700);
   --accent-default: var(--color-ui-blue-500);


### PR DESCRIPTION
## Why

The sidebar wordmark (and every other `text-brand-eneo` wordmark: login, logout, loading screen, dashboard, activate/deactivated pages) renders in the old Intric indigo.

`--brand-eneo` still resolves to the `--color-eneo-500` / `--color-eneo-300` palette entries, which are the Intric purple shades renamed. The wordmark letters had been switched to `fill="var(--text-primary)"` when the logo went black (2025-06-30), but the Intric → Eneo rename (#309) rewrote the asset with `fill="currentColor"`, so the still-present class started painting it indigo again.

## What

- `--brand-eneo` now points at `--text-primary` in both `light.css` and `dark.css`, so the wordmark follows the text colour (black in light, light grey in dark) instead of a hardcoded black that would vanish in dark mode.
- `MemberChip` initials fallback moved from `bg-brand-eneo` to `bg-accent-default`. With the token on the text colour, the old combination would have been near-white on near-white in dark mode.

## Not touched

- The create-backdrop illustrations and the deactivated page mailto link also use the token and now render in the text colour. Looks fine, but easy to move to accent if preferred.
- The indigo `--color-eneo-*` palette entries stay because `--dynamic-*` and `--chart-eneo` still reference them.
