### PR TITLE
fix(api): clarify file deletion failures

### DIFF
--- a/backend/src/eneo/files/file_models.py
+++ b/backend/src/eneo/files/file_models.py
@@ -54,7 +54,11 @@ class FileInUseError(Exception):
     def __init__(self, preview: FileDeletionPreview) -> None:
         self.preview = preview
         self.details = preview.model_dump(mode="json")
-        super().__init__("File is still used and cannot be deleted.")
+        super().__init__(
+            "File is still in use and cannot be deleted. "
+            "See details.blockers for the remaining references; "
+            "retry only after those references have been removed."
+        )
 
 
 class FileOriginalNotFoundError(Exception):

--- a/backend/src/eneo/users/user_service.py
+++ b/backend/src/eneo/users/user_service.py
@@ -1452,7 +1452,7 @@ class UserService:
                         code="insufficient_scope",
                         message=(
                             f"API key is scoped to space '{key.scope_id}'. "
-                            f"The requested resource belongs to a different scope."
+                            "The requested resource was not found or is outside this key's scope."
                         ),
                     )
                 return
@@ -1463,23 +1463,14 @@ class UserService:
                 target_space_id = await self._resolve_space_id_for_resource(
                     resource_type, resource_id
                 )
-            if target_space_id is None:
-                # Fail-closed: can't prove scope → deny
+            if target_space_id is None or key.scope_id != target_space_id:
+                # Deny without distinguishing missing resources from other scopes.
                 raise ApiKeyValidationError(
                     status_code=403,
                     code="insufficient_scope",
                     message=(
                         f"API key is scoped to space '{key.scope_id}'. "
-                        f"The requested resource belongs to a different scope."
-                    ),
-                )
-            if key.scope_id != target_space_id:
-                raise ApiKeyValidationError(
-                    status_code=403,
-                    code="insufficient_scope",
-                    message=(
-                        f"API key is scoped to space '{key.scope_id}'. "
-                        f"The requested resource belongs to a different scope."
+                        "The requested resource was not found or is outside this key's scope."
                     ),
                 )
             return

--- a/backend/tests/integration/object_content/test_file_public_routes.py
+++ b/backend/tests/integration/object_content/test_file_public_routes.py
@@ -191,6 +191,11 @@ async def test_used_file_delete_returns_the_typed_preview_before_mutation(
     assert deletion.status_code == 409, deletion.text
     assert deletion.json()["code"] == "file_in_use"
     assert deletion.json()["eneo_error_code"] == 9044
+    assert deletion.json()["message"] == (
+        "File is still in use and cannot be deleted. "
+        "See details.blockers for the remaining references; "
+        "retry only after those references have been removed."
+    )
     assert deletion.json()["details"] == expected_preview
 
     async with db_container() as container:

--- a/backend/tests/integration/test_api_key_scope_integration.py
+++ b/backend/tests/integration/test_api_key_scope_integration.py
@@ -587,6 +587,61 @@ async def test_space_scoped_key_denied_prompt_from_other_space(
     assert detail["code"] == "insufficient_scope"
 
 
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_missing_and_out_of_scope_knowledge_deletes_have_same_error(
+    api_client, bearer_token, db_container, default_user
+):
+    space_a = await _create_space(api_client, token=bearer_token)
+    space_b = await _create_space(api_client, token=bearer_token)
+    group_b = await _create_group(api_client, token=bearer_token, space_id=space_b)
+    blob_b = await _seed_info_blob(
+        db_container,
+        user_id=default_user.id,
+        tenant_id=default_user.tenant_id,
+        group_id=group_b,
+        text="Knowledge outside the key's space",
+    )
+    space_key = await _create_api_key(
+        api_client,
+        token=bearer_token,
+        scope_type="space",
+        scope_id=space_a,
+        permission="admin",
+    )
+    headers = {"X-API-Key": space_key, "X-Request-ID": "knowledge-scope-denial"}
+    expected_error = {
+        "code": "insufficient_scope",
+        "message": (
+            f"API key is scoped to space '{space_a}'. "
+            "The requested resource was not found or is outside this key's scope."
+        ),
+        "context": {"auth_layer": "api_key_scope"},
+        "request_id": "knowledge-scope-denial",
+    }
+    for blob_id in (str(uuid4()), blob_b):
+        response = await api_client.delete(
+            f"/api/v1/info-blobs/{blob_id}/", headers=headers
+        )
+        assert response.status_code == 403, response.text
+        assert response.json() == expected_error
+
+    # The denied deletion must leave the document available to an authorized key.
+    tenant_key = await _create_api_key(
+        api_client, token=bearer_token, permission="admin"
+    )
+    response = await api_client.delete(
+        f"/api/v1/info-blobs/{blob_b}/", headers={"X-API-Key": tenant_key}
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["id"] == blob_b
+
+    response = await api_client.delete(
+        f"/api/v1/info-blobs/{blob_b}/", headers={"X-API-Key": tenant_key}
+    )
+    assert response.status_code == 404, response.text
+
+
 # ---------------------------------------------------------------------------
 # 2C: Create-Body Scope Mismatch
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_api_key_scope_enforcement.py
+++ b/backend/tests/unit/test_api_key_scope_enforcement.py
@@ -174,7 +174,7 @@ class TestScopeEnforcementUnit:
         with pytest.raises(ApiKeyValidationError) as exc_info:
             await svc._enforce_api_key_scope(request, key, scope_config)
         assert exc_info.value.code == "insufficient_scope"
-        assert "different scope" in exc_info.value.message
+        assert "outside this key's scope" in exc_info.value.message
 
     @pytest.mark.asyncio
     async def test_space_key_space_resource_exact_match(self):
@@ -1396,20 +1396,31 @@ class TestScopeErrorMessages:
         assert "admin" in msg.lower()
 
     @pytest.mark.asyncio
-    async def test_space_denial_mentions_different_scope(self):
-        """Space scope denial should mention the resource belongs to a different scope."""
+    @pytest.mark.parametrize("resource_type", ["assistant", "info_blob", "prompt"])
+    @pytest.mark.parametrize("resource_exists", [False, True])
+    async def test_space_denial_covers_missing_and_out_of_scope_resources(
+        self, resource_type: str, resource_exists: bool
+    ):
         key_space = uuid4()
         other_space = uuid4()
-        svc = _make_user_service(session_scalar_return=other_space)
+        svc = _make_user_service(
+            session_scalar_return=other_space if resource_exists else None
+        )
         key = _make_key(scope_type=ApiKeyScopeType.SPACE, scope_id=key_space)
         request = _scope_request(path_params={"id": str(uuid4())})
-        scope_config = {"resource_type": "assistant", "path_param": "id"}
+        scope_config = {
+            "resource_type": resource_type,
+            "path_param": None if resource_type == "info_blob" else "id",
+        }
 
         with pytest.raises(ApiKeyValidationError) as exc_info:
             await svc._enforce_api_key_scope(request, key, scope_config)
-        msg = exc_info.value.message
-        assert str(key_space) in msg
-        assert "different scope" in msg.lower()
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.code == "insufficient_scope"
+        assert exc_info.value.message == (
+            f"API key is scoped to space '{key_space}'. "
+            "The requested resource was not found or is outside this key's scope."
+        )
 
     @pytest.mark.asyncio
     async def test_assistant_denial_explains_scope_limit(self):
@@ -1481,7 +1492,7 @@ class TestPromptScopeResolver:
         with pytest.raises(ApiKeyValidationError) as exc_info:
             await svc._enforce_api_key_scope(request, key, scope_config)
         assert exc_info.value.code == "insufficient_scope"
-        assert "different scope" in exc_info.value.message
+        assert "outside this key's scope" in exc_info.value.message
 
     @pytest.mark.asyncio
     async def test_prompt_with_no_associated_spaces_fails_closed(self):

--- a/frontend/apps/docs-site/src/content/docs/api-key-management.mdx
+++ b/frontend/apps/docs-site/src/content/docs/api-key-management.mdx
@@ -327,6 +327,32 @@ Scope limits where the key can operate:
 
 Tenant-scoped admin user keys require the owner to remain a tenant administrator. Tenant-scoped read/write user keys inherit the owner's live role permissions through endpoint-level guards. Space-, assistant-, and app-scoped user keys require the owner to remain a member of the target space.
 
+### Why does deletion fail even with admin permission?
+
+Check the response's `code` before changing permissions or retrying:
+
+| Response | Meaning | Next step |
+|----------|---------|-----------|
+| `403 insufficient_permission` or `insufficient_resource_permission` | The key does not allow this action or resource type. | Check the key's method and resource permissions. |
+| `403 insufficient_scope` | The requested resource is outside the key's scope, or Eneo cannot establish that it exists within that scope. | Check the environment, actual key, resource ID, and owning space. |
+| `409 file_in_use` | The File still has attachment or input references. | Inspect `details.blockers`; resolve those references before retrying. |
+
+Admin permission does not expand a space-scoped key's boundary. An
+organisation-scoped (`tenant`) key passes that scope check, but user-owned keys
+still depend on their owner's access. Compare the request's environment and
+masked key suffix with the key shown in the admin UI; matching display names
+across test and production do not identify the same credential.
+
+Knowledge documents under `/info-blobs/` use `knowledge` permission. Uploaded
+runtime files under `/files/` use `files` permission. Missing and inaccessible
+resources deliberately share the scope-denial response, so it does not prove
+that a document exists in another space. Use the stable error code and request
+ID for handling and diagnostics, rather than parsing the English message.
+
+For `file_in_use`, see the [file cleanup workflow](/guides/object-content-storage#why-can-i-not-delete-an-uploaded-file).
+Chat attachments currently remain referenced until their conversation is
+deleted; there is no standalone detach endpoint.
+
 ### Can API keys create or manage other API keys?
 
 No. API-key management endpoints require a session login. API-key callers, including tenant-admin service keys, are rejected for API-key mutations.

--- a/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
+++ b/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
@@ -821,9 +821,40 @@ Storage**. Changing the target for new writes never starts a fleet migration.
 
 ### Why can I not delete an uploaded File?
 
-The File is still used by a chat, Assistant, App, or App run. Check its deletion
-preview, remove those uses deliberately, and try again. Eneo blocks the delete
-instead of silently breaking those resources.
+`DELETE /api/v1/files/{file_id}/` returns `409` with `code: "file_in_use"`
+while a chat, Assistant, App, or App run still references the File or one of
+its generated files. This is a usage conflict; granting more permissions or
+retrying the same request does not resolve it.
+
+The response's `details.blockers` lists the remaining uses and their counts.
+For example, `{"kind": "chat_attachment", "count": 1}` means one chat-message
+attachment reference remains. The read-only
+`GET /api/v1/files/{file_id}/deletion-preview/` endpoint returns the same usage
+information before deletion. It reports counts, not the conversation IDs.
+
+There is currently no API endpoint to detach an individual file from an
+existing chat message while preserving the conversation. Leaving the file out
+of a later chat request does not remove its earlier reference.
+
+For a disposable automation conversation:
+
+1. Retain the conversation ID and uploaded file IDs when creating them.
+2. Finish processing and save the result the integration needs.
+3. Delete the conversation with `DELETE /api/v1/conversations/{session_id}/`.
+   This removes the whole conversation and its attachment references.
+4. Delete each uploaded file with `DELETE /api/v1/files/{file_id}/`. A successful
+   deletion returns `204`. If another reference remains, it still returns `409`.
+
+Use credentials for the owning user/principal, with the required scope and
+permissions. Conversation deletion checks `assistants` and `conversations`
+admin permission; file deletion requires a user-owned key with `files` admin
+permission. Adapt the `/api/v1` prefix to your gateway's environment and version.
+
+If the conversation must be retained, retain its attached files too. Do not
+delete conversation history merely to make file cleanup succeed. For other
+blocker kinds, remove the reference through the owning resource's supported
+workflow before retrying. The final DELETE always rechecks usage, even if a
+previous preview allowed deletion.
 
 ### What happens when an endpoint is down?
 


### PR DESCRIPTION
API consumers can receive two different deletion failures: a missing or inaccessible knowledge document returns `403 insufficient_scope`, while an attached runtime file returns `409 file_in_use`. This change makes the explanations and recovery steps clearer while preserving both protections.

## Summary

- Explain missing and inaccessible resources without claiming they exist in another space.
- Direct file-in-use callers to `details.blockers` and explain when retrying can work.
- Document the supported cleanup sequence for disposable conversations and the absence of a standalone chat-attachment detach endpoint.

## Why

Admin permission does not expand a key's scope or override active file references. Operators need to distinguish credential/environment problems from files still used by conversation history.

## What changed

- `UserService._enforce_api_key_scope` owns the revised scope message.
- `FileInUseError` owns the revised usage-conflict message.
- Existing API-key and storage guides explain error codes, preview limitations, ownership, and conversation-then-file cleanup.
- Real HTTP/database regressions protect error payloads, denied-delete safety, and authorised deletion.

## What was deliberately not changed

No new fields, endpoints, queries, permissions, UI, force-delete option, detach operation, or retention behavior. Status codes, machine-readable error codes, request IDs, and blocker details are preserved.

## Deletion / consolidation

Merged duplicate unresolved-space and mismatched-space denial branches. No new helper.

## Risk and rollback

Only English error messages and guidance change. Consumers should handle stable error codes rather than parse message text. Revert the implementation PR to restore the previous wording; no data migration.

## Planning

Task: Fixes #778. The task belongs to the file storage and retention epic #549.

## Validation

Run from `backend/` unless stated otherwise:
- Both HTTP regressions failed on their original misleading/incomplete messages, then passed with the new explanations.
- `POSTGRES_HOST=localhost LITELLM_LOCAL_MODEL_COST_MAP=True uv run --no-sync pytest -q tests/integration/test_api_key_scope_integration.py tests/integration/object_content/test_file_public_routes.py::test_used_file_delete_returns_the_typed_preview_before_mutation` — 28 passed, 4 skipped.
- `POSTGRES_HOST=localhost LITELLM_LOCAL_MODEL_COST_MAP=True uv run --no-sync pytest -q tests/integration/object_content/test_file_public_routes.py::test_used_file_delete_returns_the_typed_preview_before_mutation tests/integration/test_api_key_scope_integration.py::test_missing_and_out_of_scope_knowledge_deletes_have_same_error` — 2 passed after the final message change.
- `LITELLM_LOCAL_MODEL_COST_MAP=True uv run --no-sync pytest -q tests/unit/test_api_key_scope_enforcement.py tests/unit/test_api_key_contract_matrix.py tests/unit/test_api_key_auth_guards.py tests/unit/test_api_key_openapi_contract.py tests/unittests/info_blobs/test_info_blobs_service.py tests/unittests/actors/test_space_actor.py` — 347 passed.
- `uv run --no-sync pyright` — 0 errors or warnings.
- `uv run --no-sync ruff check src/eneo/users/user_service.py src/eneo/files/file_models.py tests/unit/test_api_key_scope_enforcement.py tests/integration/test_api_key_scope_integration.py tests/integration/object_content/test_file_public_routes.py` — passed. Touched files formatted with Ruff.
- Repository OpenAPI schema-drift check — generated client schema unchanged.
- `bun run build` in `frontend/apps/docs-site` — passed; both updated explanations verified in exported HTML.
- `git diff --check` — passed.
- Separate final review — green, minimum score 8/10, no blockers.

