### PR TITLE
fix(storage): keep reads and recovery consistent across placement changes

### DIFF
--- a/backend/src/eneo/object_content/content_repository.py
+++ b/backend/src/eneo/object_content/content_repository.py
@@ -735,6 +735,7 @@ class ObjectContentRepository:
         self,
         *,
         content_id: UUID,
+        object_key: str,
         first_chunk_index: int,
         chunk_count: int,
     ) -> tuple[bytes, ...]:
@@ -751,7 +752,10 @@ class ObjectContentRepository:
                     (first_chunk_index * _SHA256_BYTES) + 1,
                     chunk_count * _SHA256_BYTES,
                 )
-            ).where(ObjectStoreObjects.content_id == content_id)
+            ).where(
+                ObjectStoreObjects.content_id == content_id,
+                ObjectStoreObjects.object_key == object_key,
+            )
         )
         expected_bytes = chunk_count * _SHA256_BYTES
         if not isinstance(packed, bytes) or len(packed) != expected_bytes:
@@ -778,12 +782,39 @@ class ObjectContentRepository:
         *,
         content_id: UUID,
         failure_code: ContentFailureCode,
-    ) -> None:
+        observed_storage_kind: StorageKind,
+        observed_object_key: str | None = None,
+        missing_before: datetime | None = None,
+        observed_at: datetime | None = None,
+        observed_size_bytes: int | None = None,
+    ) -> bool:
         if failure_code not in {
             ContentFailureCode.BACKEND_MISSING,
             ContentFailureCode.BACKEND_CORRUPT,
         }:
             raise ValueError("mark_backend_failure requires a backend failure code")
+        if (observed_storage_kind is StorageKind.OBJECT_STORE) != (
+            observed_object_key is not None
+        ):
+            raise ValueError(
+                "A remote backend failure requires its observed object key"
+            )
+        if (observed_at is None) != (observed_size_bytes is None):
+            raise ValueError("An inventory size observation requires its timestamp")
+        if missing_before is not None and (
+            failure_code is not ContentFailureCode.BACKEND_MISSING
+            or observed_at is not None
+        ):
+            raise ValueError("Missing inventory evidence requires only its cutoff")
+        if (missing_before is not None or observed_at is not None) and (
+            observed_storage_kind is not StorageKind.OBJECT_STORE
+        ):
+            raise ValueError("Inventory evidence requires an object-store placement")
+        if (
+            observed_at is not None
+            and failure_code is not ContentFailureCode.BACKEND_CORRUPT
+        ):
+            raise ValueError("An inventory size mismatch requires a corrupt failure")
         completed_item_exists = await self._has_completed_file_icon_item(content_id)
         if not completed_item_exists:
             async with self._session.begin_nested() as savepoint:
@@ -792,12 +823,18 @@ class ObjectContentRepository:
                     content_id
                 )
                 if not completed_item_exists:
-                    if self._mark_available_content_backend_failed(
+                    changed = await self._mark_observed_backend_failed(
                         row,
                         failure_code,
-                    ):
+                        observed_storage_kind=observed_storage_kind,
+                        observed_object_key=observed_object_key,
+                        missing_before=missing_before,
+                        observed_at=observed_at,
+                        observed_size_bytes=observed_size_bytes,
+                    )
+                    if changed:
                         await self._session.flush()
-                    return
+                    return changed
                 await savepoint.rollback()
 
         admission_state = await self._session.scalar(
@@ -822,8 +859,17 @@ class ObjectContentRepository:
             )
         ).all()
         row = await self._content_for_update(content_id)
-        if self._mark_available_content_backend_failed(row, failure_code):
-            if completed_items:
+        changed = await self._mark_observed_backend_failed(
+            row,
+            failure_code,
+            observed_storage_kind=observed_storage_kind,
+            observed_object_key=observed_object_key,
+            missing_before=missing_before,
+            observed_at=observed_at,
+            observed_size_bytes=observed_size_bytes,
+        )
+        if changed:
+            if completed_items and row.state == ContentState.FAILED.value:
                 await self._reopen_failed_file_icon_items(
                     completed_items,
                     admission_state=admission_state,
@@ -831,6 +877,45 @@ class ObjectContentRepository:
                     failure_code=failure_code,
                 )
             await self._session.flush()
+        return changed
+
+    async def _mark_observed_backend_failed(
+        self,
+        row: ObjectContents,
+        failure_code: ContentFailureCode,
+        *,
+        observed_storage_kind: StorageKind,
+        observed_object_key: str | None,
+        missing_before: datetime | None,
+        observed_at: datetime | None,
+        observed_size_bytes: int | None,
+    ) -> bool:
+        if row.storage_kind != observed_storage_kind.value:
+            return False
+        if observed_storage_kind is StorageKind.OBJECT_STORE:
+            descriptor = await self._session.scalar(
+                select(ObjectStoreObjects)
+                .where(ObjectStoreObjects.content_id == row.id)
+                .with_for_update()
+            )
+            if descriptor is None or descriptor.object_key != observed_object_key:
+                return False
+            if missing_before is not None and (
+                row.available_at is None
+                or row.available_at >= missing_before
+                or descriptor.created_at >= missing_before
+                or (
+                    descriptor.remote_observed_at is not None
+                    and descriptor.remote_observed_at >= missing_before
+                )
+            ):
+                return False
+            if observed_at is not None and (
+                descriptor.remote_observed_at != observed_at
+                or row.size_bytes == observed_size_bytes
+            ):
+                return False
+        return self._mark_served_content_backend_failed(row, failure_code)
 
     async def _has_completed_file_icon_item(self, content_id: UUID) -> bool:
         return bool(
@@ -847,16 +932,20 @@ class ObjectContentRepository:
         )
 
     @staticmethod
-    def _mark_available_content_backend_failed(
+    def _mark_served_content_backend_failed(
         row: ObjectContents,
         failure_code: ContentFailureCode,
     ) -> bool:
-        if row.state != ContentState.AVAILABLE.value:
+        if row.state == ContentState.AVAILABLE.value:
+            row.state = ContentState.FAILED.value
+            row.next_attempt_at = None
+        elif (
+            row.state != ContentState.RETAINED.value
+            or row.failure_code == failure_code.value
+        ):
             return False
-        row.state = ContentState.FAILED.value
         row.failure_code = failure_code.value
         row.failure_detail = "durable object bytes are unavailable or untrusted"
-        row.next_attempt_at = None
         return True
 
     async def _reopen_failed_file_icon_items(

--- a/backend/src/eneo/object_content/content_service.py
+++ b/backend/src/eneo/object_content/content_service.py
@@ -80,6 +80,10 @@ def retry_delay_seconds(
 _READ_BATCH_MAX_ITEMS = 500
 
 
+class _ContentPlacementChanged(ObjectContentUnavailableError):
+    """The read's backend failure describes a superseded placement."""
+
+
 @dataclass(frozen=True, slots=True)
 class VerifiedObjectUpload:
     object_key: str
@@ -704,24 +708,32 @@ class ObjectContentService:
         *,
         range_header: str | None = None,
     ) -> AsyncGenerator[ContentRead]:
-        async with self._database.session() as session, session.begin():
-            sources = await ObjectContentRepository(session).get_readable_sources(
-                [grant]
+        for attempt in range(2):
+            async with self._database.session() as session, session.begin():
+                sources = await ObjectContentRepository(session).get_readable_sources(
+                    [grant]
+                )
+            source = sources[grant.content_id]
+            byte_range = (
+                None
+                if range_header is None
+                else ByteRange.parse(
+                    range_header,
+                    size_bytes=source.content.size_bytes,
+                )
             )
-        source = sources[grant.content_id]
-        byte_range = (
-            None
-            if range_header is None
-            else ByteRange.parse(
-                range_header,
-                size_bytes=source.content.size_bytes,
-            )
-        )
-        async with self._open_readable_source(
-            source,
-            byte_range=byte_range,
-        ) as opened:
-            yield opened
+            yielded = False
+            try:
+                async with self._open_readable_source(
+                    source,
+                    byte_range=byte_range,
+                ) as opened:
+                    yielded = True
+                    yield opened
+                return
+            except _ContentPlacementChanged:
+                if attempt or yielded:
+                    raise
 
     @asynccontextmanager
     async def _open_readable_source(
@@ -745,10 +757,13 @@ class ObjectContentService:
                     ) as opened:
                         yield opened
                 except ObjectContentIntegrityError:
-                    await self._mark_backend_failure(
-                        content.content_id,
+                    if not await self._mark_backend_failure(
+                        source,
                         ContentFailureCode.BACKEND_CORRUPT,
-                    )
+                    ):
+                        raise _ContentPlacementChanged(
+                            "Content placement changed during the read; try again"
+                        ) from None
                     raise
             case StorageKind.OBJECT_STORE:
                 if source.object_store_descriptor is None:
@@ -788,6 +803,7 @@ class ObjectContentService:
                         session
                     ).get_object_store_verification_chunks(
                         content_id=content.content_id,
+                        object_key=descriptor.object_key,
                         first_chunk_index=window.first_chunk_index,
                         chunk_count=window.chunk_count,
                     )
@@ -805,26 +821,38 @@ class ObjectContentService:
             ) as opened:
                 yield opened
         except (ValueError, ObjectContentStateError) as error:
-            await self._mark_backend_failure(
-                content.content_id,
+            if not await self._mark_backend_failure(
+                source,
                 ContentFailureCode.BACKEND_CORRUPT,
-            )
+                lease=lease,
+            ):
+                raise _ContentPlacementChanged(
+                    "Content placement changed during the read; try again"
+                ) from error
             raise ObjectContentIntegrityError(
                 "Durable object verification metadata is invalid"
             ) from error
         except ObjectStoreNotFoundError as error:
-            await self._mark_backend_failure(
-                content.content_id,
+            if not await self._mark_backend_failure(
+                source,
                 ContentFailureCode.BACKEND_MISSING,
-            )
+                lease=lease,
+            ):
+                raise _ContentPlacementChanged(
+                    "Content placement changed during the read; try again"
+                ) from error
             raise ObjectContentUnavailableError(
                 "Durable object content is unavailable"
             ) from error
         except ObjectStoreIntegrityError as error:
-            await self._mark_backend_failure(
-                content.content_id,
+            if not await self._mark_backend_failure(
+                source,
                 ContentFailureCode.BACKEND_CORRUPT,
-            )
+                lease=lease,
+            ):
+                raise _ContentPlacementChanged(
+                    "Content placement changed during the read; try again"
+                ) from error
             raise ObjectContentIntegrityError(
                 "Durable object verification failed"
             ) from error
@@ -972,13 +1000,25 @@ class ObjectContentService:
 
     async def _mark_backend_failure(
         self,
-        content_id: UUID,
+        source: ReadableContentSource,
         failure_code: ContentFailureCode,
-    ) -> None:
+        *,
+        lease: ObjectStoreLease | None = None,
+    ) -> bool:
         async with self._database.session() as session, session.begin():
-            await ObjectContentRepository(session).mark_backend_failure(
-                content_id=content_id,
+            if lease is not None:
+                await require_store_generation(
+                    session, slot=lease.slot, revision=lease.revision
+                )
+            return await ObjectContentRepository(session).mark_backend_failure(
+                content_id=source.content.content_id,
                 failure_code=failure_code,
+                observed_storage_kind=source.content.storage_kind,
+                observed_object_key=(
+                    source.object_store_descriptor.object_key
+                    if source.object_store_descriptor is not None
+                    else None
+                ),
             )
 
     @asynccontextmanager

--- a/backend/src/eneo/object_content/reconciliation.py
+++ b/backend/src/eneo/object_content/reconciliation.py
@@ -14,6 +14,7 @@ from eneo.object_content.content import (
     ObjectContentBusyError,
     ObjectContentStateError,
     ObjectContentUnavailableError,
+    StorageKind,
 )
 from eneo.object_content.content_repository import ObjectContentRepository
 from eneo.object_content.content_service import retry_delay_seconds
@@ -186,20 +187,9 @@ class ObjectContentReconciler:
                     "Object-store generation changed during reconciliation"
                 )
             object_cycle_completed = await self._reconcile_object_page(store_lease)
-            async with self._database.session() as session, session.begin():
-                # Missing-marking consumes a completed inventory of one
-                # destination, so like every other remote-derived transition
-                # it must not commit after that destination was switched away.
-                await require_store_generation(
-                    session,
-                    slot=store_lease.slot,
-                    revision=store_lease.revision,
-                )
-                missing_objects = await ObjectContentReconciliationRepository(
-                    session
-                ).mark_missing_from_completed_inventory(
-                    limit=settings.reconciliation_batch_size
-                )
+            missing_objects = await self._mark_missing_from_completed_inventory(
+                store_lease
+            )
             multipart_aborted = await self._reconcile_multipart_page(store_lease)
             orphan_objects_deleted = await self._delete_orphans(
                 lease_owner,
@@ -465,7 +455,7 @@ class ObjectContentReconciler:
                 slot=store_lease.slot,
                 revision=store_lease.revision,
             )
-            return await ObjectContentReconciliationRepository(
+            result = await ObjectContentReconciliationRepository(
                 session
             ).record_object_page(
                 cursor=cursor,
@@ -473,6 +463,60 @@ class ObjectContentReconciler:
                 next_token=page.next_token,
                 orphan_grace_seconds=settings.orphan_grace_seconds,
             )
+        # Page writes lock content/descriptor rows. Commit them before entering
+        # recovery, whose admission/campaign/item locks must come first.
+        for mismatch in result.size_mismatches:
+            try:
+                async with self._database.session() as session, session.begin():
+                    await require_store_generation(
+                        session, slot=store_lease.slot, revision=store_lease.revision
+                    )
+                    await ObjectContentRepository(session).mark_backend_failure(
+                        content_id=mismatch.content_id,
+                        failure_code=ContentFailureCode.BACKEND_CORRUPT,
+                        observed_storage_kind=StorageKind.OBJECT_STORE,
+                        observed_object_key=mismatch.object_key,
+                        observed_at=mismatch.observed_at,
+                        observed_size_bytes=mismatch.size_bytes,
+                    )
+            except ObjectContentUnavailableError:
+                # The page already committed; preserve its completion result.
+                break
+        return result.completed
+
+    async def _mark_missing_from_completed_inventory(
+        self, store_lease: ObjectStoreLease
+    ) -> int:
+        async with self._database.session() as session, session.begin():
+            await require_store_generation(
+                session, slot=store_lease.slot, revision=store_lease.revision
+            )
+            candidates = await ObjectContentReconciliationRepository(
+                session
+            ).missing_object_candidates(
+                limit=store_lease.settings.reconciliation_batch_size
+            )
+        changed = 0
+        for candidate in candidates:
+            try:
+                async with self._database.session() as session, session.begin():
+                    await require_store_generation(
+                        session, slot=store_lease.slot, revision=store_lease.revision
+                    )
+                    marked = await ObjectContentRepository(
+                        session
+                    ).mark_backend_failure(
+                        content_id=candidate.content_id,
+                        failure_code=ContentFailureCode.BACKEND_MISSING,
+                        observed_storage_kind=StorageKind.OBJECT_STORE,
+                        observed_object_key=candidate.object_key,
+                        missing_before=candidate.cutoff,
+                    )
+                changed += marked
+            except ObjectContentUnavailableError:
+                # Earlier item transactions remain durable after a rotation.
+                break
+        return changed
 
     async def _reconcile_multipart_page(
         self,

--- a/backend/src/eneo/object_content/reconciliation_repository.py
+++ b/backend/src/eneo/object_content/reconciliation_repository.py
@@ -68,6 +68,27 @@ class ObjectInventoryCursor:
 
 
 @dataclass(frozen=True, slots=True)
+class ObjectSizeMismatch:
+    content_id: UUID
+    object_key: str
+    size_bytes: int
+    observed_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ObjectInventoryPageResult:
+    completed: bool
+    size_mismatches: tuple[ObjectSizeMismatch, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class MissingObjectCandidate:
+    content_id: UUID
+    object_key: str
+    cutoff: datetime
+
+
+@dataclass(frozen=True, slots=True)
 class MultipartInventoryCursor:
     cycle_id: UUID
     key_marker: str | None
@@ -612,13 +633,13 @@ class ObjectContentReconciliationRepository:
         objects: Sequence[RemoteObject],
         next_token: str | None,
         orphan_grace_seconds: int,
-    ) -> bool:
+    ) -> ObjectInventoryPageResult:
         state = await self._state_for_update()
         if (
             state.object_cycle_id != cursor.cycle_id
             or state.object_continuation_token != cursor.continuation_token
         ):
-            return False
+            return ObjectInventoryPageResult(completed=False)
 
         now = await self._database_now()
         keys = tuple(item.key for item in objects)
@@ -641,17 +662,22 @@ class ObjectContentReconciliationRepository:
             }
         else:
             known_by_key = {}
+        mismatches: list[ObjectSizeMismatch] = []
         for item in objects:
             known = known_by_key.get(item.key)
             if known is None:
                 continue
             row, descriptor = known
             descriptor.remote_observed_at = now
-            if row.size_bytes != item.size_bytes:
-                if row.state == ContentState.AVAILABLE.value:
-                    row.state = ContentState.FAILED.value
-                row.failure_code = ContentFailureCode.BACKEND_CORRUPT.value
-                row.failure_detail = "object inventory length differs from PostgreSQL"
+            if row.size_bytes != item.size_bytes and row.state in {
+                ContentState.AVAILABLE.value,
+                ContentState.RETAINED.value,
+            }:
+                mismatches.append(
+                    ObjectSizeMismatch(
+                        row.id, descriptor.object_key, item.size_bytes, now
+                    )
+                )
 
         live_known_keys = tuple(
             key
@@ -699,7 +725,9 @@ class ObjectContentReconciliationRepository:
         state.object_continuation_token = next_token
         if next_token is not None:
             await self._session.flush()
-            return False
+            return ObjectInventoryPageResult(
+                completed=False, size_mismatches=tuple(mismatches)
+            )
 
         await self._session.execute(
             delete(ObjectContentOrphanCandidates).where(
@@ -728,16 +756,20 @@ class ObjectContentReconciliationRepository:
         state.object_cycle_started_at = now
         state.object_continuation_token = None
         await self._session.flush()
-        return True
+        return ObjectInventoryPageResult(
+            completed=True, size_mismatches=tuple(mismatches)
+        )
 
-    async def mark_missing_from_completed_inventory(self, *, limit: int) -> int:
+    async def missing_object_candidates(
+        self, *, limit: int
+    ) -> tuple[MissingObjectCandidate, ...]:
         state = await self._state_for_update()
         cutoff = state.last_completed_object_cycle_started_at
         if cutoff is None:
-            return 0
+            return ()
         rows = (
             await self._session.execute(
-                select(ObjectContents, ObjectStoreObjects)
+                select(ObjectContents.id, ObjectStoreObjects.object_key)
                 .join(
                     ObjectStoreObjects,
                     ObjectStoreObjects.content_id == ObjectContents.id,
@@ -764,16 +796,12 @@ class ObjectContentReconciliationRepository:
                 )
                 .order_by(ObjectContents.available_at, ObjectContents.id)
                 .limit(limit)
-                .with_for_update(skip_locked=True)
             )
         ).all()
-        for row, _descriptor in rows:
-            if row.state == ContentState.AVAILABLE.value:
-                row.state = ContentState.FAILED.value
-            row.failure_code = ContentFailureCode.BACKEND_MISSING.value
-            row.failure_detail = "complete object inventory did not observe the object"
-        await self._session.flush()
-        return len(rows)
+        return tuple(
+            MissingObjectCandidate(content_id, object_key, cutoff)
+            for content_id, object_key in rows
+        )
 
     async def claim_orphan_deletes(
         self,

--- a/backend/src/eneo/object_content/reconciliation_repository.py
+++ b/backend/src/eneo/object_content/reconciliation_repository.py
@@ -756,6 +756,7 @@ class ObjectContentReconciliationRepository:
                         ),
                     ),
                     ObjectContents.available_at < cutoff,
+                    ObjectStoreObjects.created_at < cutoff,
                     or_(
                         ObjectStoreObjects.remote_observed_at.is_(None),
                         ObjectStoreObjects.remote_observed_at < cutoff,

--- a/backend/tests/integration/object_content/test_backend_failure.py
+++ b/backend/tests/integration/object_content/test_backend_failure.py
@@ -1,0 +1,450 @@
+import asyncio
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from hashlib import sha256
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select, text
+
+from eneo.database.database import DatabaseSessionManager
+from eneo.database.tables.file_icon_backfill_table import (
+    FileIconBackfillCampaign,
+    FileIconBackfillItems,
+)
+from eneo.database.tables.object_content_table import (
+    FileContentReferences,
+    InlineContentPayloads,
+    ObjectContents,
+)
+from eneo.object_content.configuration import ObjectContentSettings
+from eneo.object_content.content import (
+    ContentAccessClass,
+    ContentReadGrant,
+    ObjectContentUnavailableError,
+    StorageKind,
+)
+from eneo.object_content.content_repository import ObjectContentRepository
+from eneo.object_content.content_service import ObjectContentService
+from eneo.object_content.file_icon_backfill import (
+    FileIconBackfill,
+    _FileIconBackfillRepository,
+)
+from eneo.object_content.move_repository import ObjectContentMoveRepository
+from eneo.object_content.object_store_provider import (
+    ObjectStoreLease,
+    ObjectStoreProvider,
+)
+from eneo.object_content.reconciliation import ObjectContentReconciler
+from eneo.object_content.reconciliation_repository import (
+    ObjectContentReconciliationRepository,
+)
+from eneo.object_content.s3_object_store import (
+    MultipartUploadPage,
+    ObjectStoreNotFoundError,
+    RemoteObject,
+    RemoteObjectPage,
+    S3ObjectStore,
+)
+from tests.integration.object_content.test_file_icon_inline_backfill import (
+    _backfill,
+    _seed_legacy_text,
+    _tenant_and_user,
+)
+from tests.integration.object_content.test_moves import (
+    _create_object_store_content,
+    _publish_object_store_move,
+    _queue_move,
+)
+from tests.integration.object_content.test_store_generation_fence import (
+    _advance_connection_revision,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+def _settings() -> ObjectContentSettings:
+    return ObjectContentSettings(
+        _env_file=None,
+        endpoint_url="http://localhost:1",
+        region="local",
+        bucket="failure-test",
+        access_key_id="test",
+        secret_access_key="test",
+        deployment_id=uuid4(),
+        allow_insecure_http=True,
+    )
+
+
+async def _adopt_remote_content(
+    database: DatabaseSessionManager, payload: bytes
+) -> tuple[UUID, UUID, str, FileIconBackfill]:
+    file_id = await _seed_legacy_text(database, payload=payload)
+    backfill = _backfill(database)
+    assert (await backfill.run_once()).state.value == "complete"
+    _, actor_id = await _tenant_and_user(database)
+    async with database.session() as session, session.begin():
+        content_id = await session.scalar(
+            select(FileContentReferences.content_id).where(
+                FileContentReferences.file_id == file_id
+            )
+        )
+    assert content_id is not None
+    object_key = await _publish_object_store_move(
+        database, content_id=content_id, actor_id=actor_id, payload=payload
+    )
+    return file_id, content_id, object_key, backfill
+
+
+def _inventory_reconciler(
+    database: DatabaseSessionManager, *, objects: tuple[RemoteObject, ...]
+) -> ObjectContentReconciler:
+    store = MagicMock(spec=S3ObjectStore)
+    store.list_object_page.return_value = RemoteObjectPage(objects, None)
+    store.list_multipart_page.return_value = MultipartUploadPage((), None, None)
+    settings = _settings()
+    return ObjectContentReconciler(
+        settings,
+        database,
+        object_store_provider=ObjectStoreProvider.fixed(settings, store),
+    )
+
+
+async def _complete_empty_inventories(database: DatabaseSessionManager) -> None:
+    for _ in range(2):
+        async with database.session() as session, session.begin():
+            repository = ObjectContentReconciliationRepository(session)
+            cursor = await repository.object_inventory_cursor()
+            result = await repository.record_object_page(
+                cursor=cursor, objects=(), next_token=None, orphan_grace_seconds=300
+            )
+            assert result.completed
+
+
+@pytest.mark.parametrize("move_back_remote", [False, True])
+async def test_ranged_read_handles_placement_changes_before_returning_bytes(
+    object_content_database: DatabaseSessionManager,
+    monkeypatch: pytest.MonkeyPatch,
+    move_back_remote: bool,
+) -> None:
+    database = object_content_database
+    payload = b"healthy bytes retained across the move"
+    content_id, actor_id = await _create_object_store_content(
+        database, payload=payload, idempotency_key=f"read-move-{uuid4().hex}"
+    )
+    await _queue_move(
+        database,
+        target_kind=StorageKind.POSTGRES_INLINE,
+        actor_id=actor_id,
+        target_maximum_bytes=len(payload),
+    )
+    async with database.session() as session, session.begin():
+        tenant_id = await session.scalar(
+            select(ObjectContents.tenant_id).where(ObjectContents.id == content_id)
+        )
+    assert tenant_id is not None
+    original = ObjectContentRepository.get_object_store_verification_chunks
+    moves_completed = 0
+
+    async def move_before_chunk_lookup(
+        repository: ObjectContentRepository,
+        *,
+        content_id: UUID,
+        object_key: str,
+        first_chunk_index: int,
+        chunk_count: int,
+    ) -> tuple[bytes, ...]:
+        nonlocal moves_completed
+        if moves_completed:
+            await _queue_move(
+                database,
+                target_kind=StorageKind.POSTGRES_INLINE,
+                actor_id=actor_id,
+                target_maximum_bytes=len(payload),
+            )
+        async with database.session() as session, session.begin():
+            moves = ObjectContentMoveRepository(session)
+            work = await moves.claim(lease_owner="read-move", lease_seconds=300)
+            assert work is not None and work.content_id == content_id
+            await moves.complete_to_inline(
+                content_id=content_id,
+                lease_owner="read-move",
+                payload=payload,
+                captured_size_bytes=len(payload),
+                captured_sha256=sha256(payload).digest(),
+                orphan_grace_seconds=300,
+            )
+        moves_completed += 1
+        if move_back_remote:
+            await _publish_object_store_move(
+                database, content_id=content_id, actor_id=actor_id, payload=payload
+            )
+        return await original(
+            repository,
+            content_id=content_id,
+            object_key=object_key,
+            first_chunk_index=first_chunk_index,
+            chunk_count=chunk_count,
+        )
+
+    monkeypatch.setattr(
+        ObjectContentRepository,
+        "get_object_store_verification_chunks",
+        move_before_chunk_lookup,
+    )
+    settings = _settings()
+    store = MagicMock(spec=S3ObjectStore)
+    provider = ObjectStoreProvider.fixed(settings, store)
+    original_acquire = provider.acquire
+    remote_lease_active = False
+
+    @asynccontextmanager
+    async def observe_lease(
+        *, refresh: bool = True, expected_revision: int | None = None
+    ) -> AsyncGenerator[ObjectStoreLease, None]:
+        nonlocal remote_lease_active
+        async with original_acquire(
+            refresh=refresh, expected_revision=expected_revision
+        ) as lease:
+            remote_lease_active = True
+            try:
+                yield lease
+            finally:
+                remote_lease_active = False
+
+    monkeypatch.setattr(provider, "acquire", observe_lease)
+    service = ObjectContentService(
+        settings,
+        database,
+        object_store_provider=provider,
+    )
+    grant = ContentReadGrant(content_id, tenant_id, ContentAccessClass.PRIVATE_RESOURCE)
+    if move_back_remote:
+        with pytest.raises(ObjectContentUnavailableError, match="placement changed"):
+            async with service.open_content(grant, range_header="bytes=0-6"):
+                pytest.fail("Repeated placement changes must not yield response bytes")
+        assert moves_completed == 2
+    else:
+        async with service.open_content(grant, range_header="bytes=0-6") as opened:
+            assert not remote_lease_active
+            assert b"".join([chunk async for chunk in opened.chunks]) == payload[:7]
+        assert moves_completed == 1
+
+    store.open_verified_read.assert_not_called()
+    async with database.session() as session, session.begin():
+        content = await session.get(ObjectContents, content_id)
+        inline = await session.get(InlineContentPayloads, content_id)
+        assert content is not None
+        assert content.state == "available"
+        if move_back_remote:
+            assert inline is None
+            assert content.storage_kind == StorageKind.OBJECT_STORE.value
+        else:
+            assert inline is not None and inline.payload == payload
+            assert content.storage_kind == StorageKind.POSTGRES_INLINE.value
+        assert content.failure_code is None
+
+
+@pytest.mark.parametrize("failure", ["missing", "length"])
+async def test_inventory_failure_reopens_adopted_content_recovery(
+    object_content_database: DatabaseSessionManager,
+    failure: str,
+) -> None:
+    database = object_content_database
+    payload = b"frozen legacy recovery source"
+    file_id, content_id, object_key, backfill = await _adopt_remote_content(
+        database, payload
+    )
+    reconciler = _inventory_reconciler(
+        database,
+        objects=(RemoteObject(object_key, len(payload) + 1),)
+        if failure == "length"
+        else (),
+    )
+    for _ in range(2):
+        await reconciler.run_once()
+
+    assert (await backfill.run_once()).state.value == "halted"
+    async with database.session() as session, session.begin():
+        content = await session.get(ObjectContents, content_id)
+        campaign = await session.scalar(select(FileIconBackfillCampaign))
+        item = await session.scalar(
+            select(FileIconBackfillItems).where(
+                FileIconBackfillItems.owner_id == file_id
+            )
+        )
+        assert content is not None and campaign is not None and item is not None
+        assert content.state == "failed"
+        assert content.failure_code == (
+            "backend_corrupt" if failure == "length" else "backend_missing"
+        )
+        assert campaign.state == "halted"
+        assert item.state == "failed"
+        assert item.content_id is None
+        assert not item.capacity_admitted
+        assert item.failure_revision == campaign.resume_revision
+
+
+async def test_read_failure_from_a_superseded_connection_keeps_content_available(
+    object_content_database: DatabaseSessionManager,
+) -> None:
+    database = object_content_database
+    content_id, _ = await _create_object_store_content(
+        database, payload=b"healthy current placement", idempotency_key=uuid4().hex
+    )
+    async with database.session() as session, session.begin():
+        tenant_id = await session.scalar(
+            select(ObjectContents.tenant_id).where(ObjectContents.id == content_id)
+        )
+    assert tenant_id is not None
+
+    async def missing_from_old_connection() -> None:
+        await _advance_connection_revision(database, revision=1)
+        raise ObjectStoreNotFoundError("The old connection no longer has these bytes")
+
+    store = MagicMock(spec=S3ObjectStore)
+    store.open_verified_read.return_value.__aenter__.side_effect = (
+        missing_from_old_connection
+    )
+    settings = _settings()
+    service = ObjectContentService(
+        settings,
+        database,
+        object_store_provider=ObjectStoreProvider.fixed(settings, store),
+    )
+    with pytest.raises(ObjectContentUnavailableError):
+        async with service.open_content(
+            ContentReadGrant(content_id, tenant_id, ContentAccessClass.PRIVATE_RESOURCE)
+        ):
+            pytest.fail("The superseded connection must not yield a response")
+    async with database.session() as session, session.begin():
+        content = await session.get(ObjectContents, content_id)
+        assert content is not None
+        assert content.state == "available"
+        assert content.failure_code is None
+
+
+@pytest.mark.parametrize("failure", ["missing", "length"])
+async def test_new_inventory_observation_supersedes_a_failure_candidate(
+    object_content_database: DatabaseSessionManager,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    database = object_content_database
+    payload = b"healthy bytes observed again"
+    _, content_id, object_key, backfill = await _adopt_remote_content(database, payload)
+    await _complete_empty_inventories(database)
+    original = ObjectContentRepository._has_completed_file_icon_item
+    observed_again = False
+
+    async def observe_before_failure_lock(
+        repository: ObjectContentRepository, checked_content_id: UUID
+    ) -> bool:
+        nonlocal observed_again
+        if checked_content_id == content_id and not observed_again:
+            async with database.session() as session, session.begin():
+                inventory = ObjectContentReconciliationRepository(session)
+                cursor = await inventory.object_inventory_cursor()
+                await inventory.record_object_page(
+                    cursor=cursor,
+                    objects=(RemoteObject(object_key, len(payload)),),
+                    next_token=None,
+                    orphan_grace_seconds=300,
+                )
+            observed_again = True
+        return await original(repository, checked_content_id)
+
+    monkeypatch.setattr(
+        ObjectContentRepository,
+        "_has_completed_file_icon_item",
+        observe_before_failure_lock,
+    )
+    result = await _inventory_reconciler(
+        database,
+        objects=(RemoteObject(object_key, len(payload) + 1),)
+        if failure == "length"
+        else (),
+    ).run_once()
+    assert observed_again
+    assert result.missing_objects == 0
+    assert (await backfill.run_once()).state.value == "complete"
+    async with database.session() as session, session.begin():
+        content = await session.get(ObjectContents, content_id)
+        assert content is not None and content.state == "available"
+        assert content.failure_code is None
+
+
+@pytest.mark.parametrize("failure", ["missing", "length"])
+async def test_inventory_recovery_waits_for_admission_without_locking_content(
+    object_content_database: DatabaseSessionManager,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: str,
+) -> None:
+    database = object_content_database
+    payload = b"adopted bytes with coordinated recovery"
+    _, content_id, object_key, backfill = await _adopt_remote_content(database, payload)
+    await _complete_empty_inventories(database)
+    admission_held = asyncio.Event()
+    release_admission = asyncio.Event()
+    admission_pid: int | None = None
+    original = _FileIconBackfillRepository.lock_admission
+
+    async def pause_admission(repository: _FileIconBackfillRepository) -> None:
+        nonlocal admission_pid
+        await original(repository)
+        if not admission_held.is_set():
+            admission_pid = await repository._session.scalar(
+                text("SELECT pg_backend_pid()")
+            )
+            admission_held.set()
+            await release_admission.wait()
+
+    monkeypatch.setattr(_FileIconBackfillRepository, "lock_admission", pause_admission)
+    admission_task = asyncio.create_task(_backfill(database).run_once())
+    inventory_task = None
+    try:
+        await asyncio.wait_for(admission_held.wait(), timeout=5)
+        assert admission_pid is not None
+        inventory_task = asyncio.create_task(
+            _inventory_reconciler(
+                database,
+                objects=(RemoteObject(object_key, len(payload) + 1),)
+                if failure == "length"
+                else (),
+            ).run_once()
+        )
+
+        async def wait_for_inventory_on_admission() -> bool:
+            async with database.session() as session, session.begin():
+                while not inventory_task.done():
+                    waiting = await session.scalar(
+                        text("""
+                        SELECT EXISTS (
+                            SELECT 1 FROM pg_stat_activity
+                            WHERE datname = current_database()
+                              AND :blocking_pid = ANY(pg_blocking_pids(pid))
+                        )
+                    """),
+                        {"blocking_pid": admission_pid},
+                    )
+                    if waiting:
+                        return True
+                    await asyncio.sleep(0.01)
+            return False
+
+        assert await asyncio.wait_for(wait_for_inventory_on_admission(), timeout=5)
+        async with database.session() as session, session.begin():
+            locked = await session.scalar(
+                select(ObjectContents.id)
+                .where(ObjectContents.id == content_id)
+                .with_for_update(nowait=True)
+            )
+            assert locked == content_id
+    finally:
+        release_admission.set()
+        pending = [admission_task]
+        if inventory_task is not None:
+            pending.append(inventory_task)
+        await asyncio.wait_for(asyncio.gather(*pending), timeout=5)
+    assert (await backfill.run_once()).state.value == "halted"

--- a/backend/tests/integration/object_content/test_destination_switch.py
+++ b/backend/tests/integration/object_content/test_destination_switch.py
@@ -2063,30 +2063,40 @@ async def test_marker_publication_serializes_concurrent_abandon(
     binding_id = await _binding_id(object_content_database)
     original_create_binding = S3ObjectStore.create_binding
     abandon_task: asyncio.Task[None] | None = None
+    initial_snapshot_taken = asyncio.Event()
 
     async def wait_for_abandon_row_lock() -> None:
-        async with object_content_database.session() as session, session.begin():
-            while not await session.scalar(
-                text(
-                    """
-                    SELECT EXISTS (
-                        SELECT 1
-                        FROM pg_stat_activity
-                        WHERE datname = current_database()
-                          AND pid <> pg_backend_pid()
-                          AND wait_event_type = 'Lock'
-                          AND query ILIKE '%object_store_connections%'
-                          AND query ILIKE '%FOR UPDATE%'
+        async with object_content_database.session() as session:
+            while True:
+                # PostgreSQL caches activity within a transaction. Each probe
+                # must see locks acquired after the initial snapshot.
+                async with session.begin():
+                    blocked = await session.scalar(
+                        text(
+                            """
+                            SELECT EXISTS (
+                                SELECT 1
+                                FROM pg_stat_activity
+                                WHERE datname = current_database()
+                                  AND pid <> pg_backend_pid()
+                                  AND wait_event_type = 'Lock'
+                                  AND query ILIKE '%object_store_connections%'
+                                  AND query ILIKE '%FOR UPDATE%'
+                            )
+                            """
+                        )
                     )
-                    """
-                )
-            ):
-                pass
+                if blocked:
+                    return
+                initial_snapshot_taken.set()
+                await asyncio.sleep(0.01)
 
     async def create_after_abandon_blocks(self, creation):  # type: ignore[no-untyped-def]
         nonlocal abandon_task
         pending = await service.get_candidate()
         assert pending is not None
+        lock_wait = asyncio.create_task(wait_for_abandon_row_lock())
+        await asyncio.wait_for(initial_snapshot_taken.wait(), timeout=5)
         abandon_task = asyncio.create_task(
             service.abandon_switch_candidate(
                 actor_user_id=actor,
@@ -2094,7 +2104,7 @@ async def test_marker_publication_serializes_concurrent_abandon(
             )
         )
         try:
-            await asyncio.wait_for(wait_for_abandon_row_lock(), timeout=10)
+            await asyncio.wait_for(lock_wait, timeout=10)
         except TimeoutError as error:
             raise AssertionError(
                 "concurrent abandon never blocked on the candidate row lock"

--- a/backend/tests/integration/object_content/test_file_icon_inline_backfill.py
+++ b/backend/tests/integration/object_content/test_file_icon_inline_backfill.py
@@ -971,6 +971,7 @@ async def test_reference_failure_before_admission_requires_inline_capacity(
         await ObjectContentRepository(session).mark_backend_failure(
             content_id=referenced_content_id,
             failure_code=ContentFailureCode.BACKEND_CORRUPT,
+            observed_storage_kind=StorageKind.POSTGRES_INLINE,
         )
 
     waiting = await backfill.run_once()
@@ -1032,6 +1033,7 @@ async def test_reference_failure_invalidates_cached_capacity_requirement(
         await ObjectContentRepository(session).mark_backend_failure(
             content_id=referenced_content_id,
             failure_code=ContentFailureCode.BACKEND_CORRUPT,
+            observed_storage_kind=StorageKind.POSTGRES_INLINE,
         )
 
     refreshed_wait = await backfill.run_once()
@@ -1093,6 +1095,7 @@ async def test_concurrent_reference_failure_precedes_campaign_capacity_snapshot(
             await failure_repository.mark_backend_failure(
                 content_id=referenced_content_id,
                 failure_code=ContentFailureCode.BACKEND_CORRUPT,
+                observed_storage_kind=StorageKind.POSTGRES_INLINE,
             )
 
     failure_task = asyncio.create_task(fail_reference())
@@ -1286,6 +1289,7 @@ async def test_reference_failure_rechecks_admission_before_lock_order_fallback(
             await ObjectContentRepository(session).mark_backend_failure(
                 content_id=content_id,
                 failure_code=ContentFailureCode.BACKEND_CORRUPT,
+                observed_storage_kind=StorageKind.POSTGRES_INLINE,
             )
 
     failure_task = asyncio.create_task(fail_reference())
@@ -1961,6 +1965,7 @@ async def test_failed_existing_reference_is_replaced_by_available_legacy_content
         await ObjectContentRepository(session).mark_backend_failure(
             content_id=failed_content_id,
             failure_code=ContentFailureCode.BACKEND_CORRUPT,
+            observed_storage_kind=StorageKind.POSTGRES_INLINE,
         )
 
     original_delete_reference = (
@@ -2107,6 +2112,7 @@ async def test_failed_icon_reference_is_replaced_by_available_legacy_content(
         await ObjectContentRepository(session).mark_backend_failure(
             content_id=failed_content_id,
             failure_code=ContentFailureCode.BACKEND_CORRUPT,
+            observed_storage_kind=StorageKind.POSTGRES_INLINE,
         )
 
     result = await _backfill(object_content_database).run_once()

--- a/backend/tests/integration/object_content/test_moves.py
+++ b/backend/tests/integration/object_content/test_moves.py
@@ -26,6 +26,7 @@ from eneo.database.tables.object_content_table import (
     ObjectContentHolds,
     ObjectContentMoves,
     ObjectContentOrphanCandidates,
+    ObjectContentReconciliationState,
     ObjectContents,
     ObjectStoreObjects,
 )
@@ -41,6 +42,7 @@ from eneo.object_content.configuration import (
 from eneo.object_content.content import (
     CapturedContent,
     ContentAccessClass,
+    ContentFailureCode,
     ContentIntent,
     ContentRead,
     ContentState,
@@ -60,7 +62,10 @@ from eneo.object_content.move_repository import (
 )
 from eneo.object_content.object_store_provider import ObjectStoreProvider
 from eneo.object_content.reconciliation import ObjectContentReconciler
-from eneo.object_content.reconciliation_repository import PublicationReservation
+from eneo.object_content.reconciliation_repository import (
+    ObjectContentReconciliationRepository,
+    PublicationReservation,
+)
 from eneo.object_content.runtime import (
     ObjectContentReadinessCode,
     ObjectContentRuntime,
@@ -234,6 +239,137 @@ async def _expire_crashed_operation(
                 .where(ObjectContentOrphanCandidates.object_key == object_key)
                 .values(lease_owner="expired-worker", lease_until=expired)
             )
+
+
+async def _publish_object_store_move(
+    database: DatabaseSessionManager,
+    *,
+    content_id: UUID,
+    actor_id: UUID,
+    payload: bytes,
+) -> str:
+    """Supply verified upload facts at the move executor's publication boundary."""
+    await _queue_move(
+        database,
+        target_kind=StorageKind.OBJECT_STORE,
+        actor_id=actor_id,
+        target_maximum_bytes=max(1, len(payload)),
+    )
+    reservation = PublicationReservation(
+        object_key=f"test/object-content/{uuid4().hex}",
+        size_bytes=len(payload),
+    )
+    async with database.session() as session, session.begin():
+        moves = ObjectContentMoveRepository(session)
+        work = await moves.claim(lease_owner="move-test", lease_seconds=300)
+        assert work is not None and work.content_id == content_id
+        await ObjectContentReconciliationRepository(
+            session
+        ).reserve_publication_objects(
+            (reservation,),
+            lease_owner="move-test",
+            lease_seconds=300,
+            orphan_grace_seconds=300,
+        )
+        await moves.record_object_target(
+            content_id=content_id,
+            lease_owner="move-test",
+            object_key=reservation.object_key,
+        )
+        await moves.record_target_verified(
+            content_id=content_id,
+            lease_owner="move-test",
+            object_key=reservation.object_key,
+            verification_chunk_size_bytes=max(1, len(payload)),
+            verification_chunk_sha256=sha256(payload).digest(),
+        )
+        await moves.complete_to_object_store(
+            content_id=content_id,
+            lease_owner="move-test",
+            reservation=reservation,
+            publication_lease_owner="move-test",
+        )
+    return reservation.object_key
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+@pytest.mark.parametrize("inventory_boundary", ["completed", "partway", "equal"])
+async def test_completed_inventory_cannot_fail_a_new_remote_placement(
+    object_content_database: DatabaseSessionManager,
+    inventory_boundary: str,
+) -> None:
+    database = object_content_database
+    payload = b"verified bytes moved after the inventory"
+    content_id, actor_id = await _create_inline_content(
+        database,
+        payload=payload,
+        idempotency_key=f"inventory-move-{uuid4().hex}",
+    )
+    # The fixture's initial cycle predates content availability. Complete a
+    # later cycle as well so the content's age cannot mask placement's age.
+    for _ in range(2):
+        async with database.session() as session, session.begin():
+            repository = ObjectContentReconciliationRepository(session)
+            cursor = await repository.object_inventory_cursor()
+            assert await repository.record_object_page(
+                cursor=cursor,
+                objects=(),
+                next_token=None,
+                orphan_grace_seconds=300,
+            )
+
+    await _publish_object_store_move(
+        database,
+        content_id=content_id,
+        actor_id=actor_id,
+        payload=payload,
+    )
+
+    async with database.session() as session, session.begin():
+        if inventory_boundary == "partway":
+            repository = ObjectContentReconciliationRepository(session)
+            cursor = await repository.object_inventory_cursor()
+            assert not await repository.record_object_page(
+                cursor=cursor,
+                objects=(),
+                next_token="next-page",
+                orphan_grace_seconds=300,
+            )
+        elif inventory_boundary == "equal":
+            descriptor = await session.get(ObjectStoreObjects, content_id)
+            state = await session.scalar(select(ObjectContentReconciliationState))
+            assert descriptor is not None and state is not None
+            state.last_completed_object_cycle_started_at = descriptor.created_at
+            await session.flush()
+        missing = await ObjectContentReconciliationRepository(
+            session
+        ).mark_missing_from_completed_inventory(limit=100)
+        content = await session.get(ObjectContents, content_id)
+        assert content is not None
+        assert missing == 0
+        assert content.state == ContentState.AVAILABLE.value
+
+    # A later complete cycle really omitting this placement must still fail it.
+    for _ in range(2):
+        async with database.session() as session, session.begin():
+            repository = ObjectContentReconciliationRepository(session)
+            cursor = await repository.object_inventory_cursor()
+            assert await repository.record_object_page(
+                cursor=cursor,
+                objects=(),
+                next_token=None,
+                orphan_grace_seconds=300,
+            )
+    async with database.session() as session, session.begin():
+        missing = await ObjectContentReconciliationRepository(
+            session
+        ).mark_missing_from_completed_inventory(limit=100)
+        content = await session.get(ObjectContents, content_id)
+        assert content is not None
+        assert missing == 1
+        assert content.state == ContentState.FAILED.value
+        assert content.failure_code == ContentFailureCode.BACKEND_MISSING.value
 
 
 @pytest.mark.integration

--- a/backend/tests/integration/object_content/test_moves.py
+++ b/backend/tests/integration/object_content/test_moves.py
@@ -297,9 +297,16 @@ async def _publish_object_store_move(
 @pytest.mark.parametrize("inventory_boundary", ["completed", "partway", "equal"])
 async def test_completed_inventory_cannot_fail_a_new_remote_placement(
     object_content_database: DatabaseSessionManager,
+    real_object_store: RealObjectStore,
     inventory_boundary: str,
 ) -> None:
     database = object_content_database
+    provider = ObjectStoreProvider.fixed(
+        real_object_store.settings, real_object_store.store
+    )
+    reconciler = ObjectContentReconciler(
+        real_object_store.settings, database, object_store_provider=provider
+    )
     payload = b"verified bytes moved after the inventory"
     content_id, actor_id = await _create_inline_content(
         database,
@@ -312,12 +319,13 @@ async def test_completed_inventory_cannot_fail_a_new_remote_placement(
         async with database.session() as session, session.begin():
             repository = ObjectContentReconciliationRepository(session)
             cursor = await repository.object_inventory_cursor()
-            assert await repository.record_object_page(
+            page = await repository.record_object_page(
                 cursor=cursor,
                 objects=(),
                 next_token=None,
                 orphan_grace_seconds=300,
             )
+            assert page.completed
 
     await _publish_object_store_move(
         database,
@@ -330,21 +338,22 @@ async def test_completed_inventory_cannot_fail_a_new_remote_placement(
         if inventory_boundary == "partway":
             repository = ObjectContentReconciliationRepository(session)
             cursor = await repository.object_inventory_cursor()
-            assert not await repository.record_object_page(
+            page = await repository.record_object_page(
                 cursor=cursor,
                 objects=(),
                 next_token="next-page",
                 orphan_grace_seconds=300,
             )
+            assert not page.completed
         elif inventory_boundary == "equal":
             descriptor = await session.get(ObjectStoreObjects, content_id)
             state = await session.scalar(select(ObjectContentReconciliationState))
             assert descriptor is not None and state is not None
             state.last_completed_object_cycle_started_at = descriptor.created_at
             await session.flush()
-        missing = await ObjectContentReconciliationRepository(
-            session
-        ).mark_missing_from_completed_inventory(limit=100)
+    async with provider.acquire(refresh=False) as lease:
+        missing = await reconciler._mark_missing_from_completed_inventory(lease)
+    async with database.session() as session, session.begin():
         content = await session.get(ObjectContents, content_id)
         assert content is not None
         assert missing == 0
@@ -355,16 +364,16 @@ async def test_completed_inventory_cannot_fail_a_new_remote_placement(
         async with database.session() as session, session.begin():
             repository = ObjectContentReconciliationRepository(session)
             cursor = await repository.object_inventory_cursor()
-            assert await repository.record_object_page(
+            page = await repository.record_object_page(
                 cursor=cursor,
                 objects=(),
                 next_token=None,
                 orphan_grace_seconds=300,
             )
+            assert page.completed
+    async with provider.acquire(refresh=False) as lease:
+        missing = await reconciler._mark_missing_from_completed_inventory(lease)
     async with database.session() as session, session.begin():
-        missing = await ObjectContentReconciliationRepository(
-            session
-        ).mark_missing_from_completed_inventory(limit=100)
         content = await session.get(ObjectContents, content_id)
         assert content is not None
         assert missing == 1

--- a/backend/tests/integration/object_content/test_reconciliation.py
+++ b/backend/tests/integration/object_content/test_reconciliation.py
@@ -1264,7 +1264,7 @@ async def test_publication_reservation_is_not_an_inventory_observation(
             reservation.object_key,
         )
 
-        assert completed is True
+        assert completed.completed is True
         assert candidate is not None
         assert candidate.completed_observations == 0
 
@@ -1326,7 +1326,7 @@ async def test_known_orphan_waits_for_a_cycle_started_after_registration(
                 next_token=None,
                 orphan_grace_seconds=1,
             )
-            assert completed is True
+            assert completed.completed is True
 
         async with object_content_database.session() as session, session.begin():
             repository = ObjectContentReconciliationRepository(session)
@@ -1337,7 +1337,7 @@ async def test_known_orphan_waits_for_a_cycle_started_after_registration(
                 next_token="after-known-former-key",
                 orphan_grace_seconds=1,
             )
-            assert completed is False
+            assert completed.completed is False
 
         allow_registration.set()
         await registration
@@ -1362,7 +1362,7 @@ async def test_known_orphan_waits_for_a_cycle_started_after_registration(
             orphan_grace_seconds=1,
         )
         candidate = await session.get(ObjectContentOrphanCandidates, object_key)
-        assert completed is True
+        assert completed.completed is True
         assert candidate is not None
         assert candidate.completed_observations == 0
 

--- a/frontend/apps/docs-site/src/content/docs/object-content-architecture.mdx
+++ b/frontend/apps/docs-site/src/content/docs/object-content-architecture.mdx
@@ -225,6 +225,24 @@ advancing cursor. An invalid or non-advancing page fails the run before Eneo
 marks unseen rows missing. A complete scan can mark absent available content as
 failed; retained content stays retained while health reports missing bytes.
 
+A missing-object scan only applies to remote descriptors created before that
+scan began. Moving older inline content to object storage does not inherit the
+inline placement's inventory age. Before recording a backend failure, the
+content repository rechecks the observed storage kind and object key; remote
+evidence also has to match the leased connection revision. A newer inventory
+observation supersedes an older missing or length-mismatch candidate. Reads may
+resolve a changed placement once more after releasing the old store lease and
+before returning any response bytes.
+
+Backend failures use the same legacy recovery owner as reads. For adopted
+content, it locks admission state, campaign, ordered ledger items, content, and
+then the remote descriptor. Inventory pages commit their content and descriptor
+updates before applying failure candidates in separate transactions, so they
+never enter that recovery sequence while holding page locks. A genuine failure
+reopens the affected ledger items and halts the campaign; its next run observes
+that durable state even when completion was cached. Recovery still requires
+the existing capacity acknowledgement and a higher resume revision.
+
 Unknown remote objects become orphan candidates. Eneo waits through repeated
 complete inventories and the configured grace period before deletion. This
 protects bytes that are newer than a restored PostgreSQL snapshot.


### PR DESCRIPTION
## TL;DR

Fixes three storage bugs affecting Files and Icons:

- An older inventory can no longer mark a newly moved object as missing.
- A download can retry once when its storage location changes, without marking healthy replacement bytes as corrupt.
- Genuine missing or corrupt bytes reopen adopted-content recovery instead of leaving its migration campaign incorrectly marked complete.

## Changes

Keep healthy File and Icon content available when reads or object inventories overlap a storage move. Missing detection now excludes remote placements created after the inventory began. Read failures recheck the observed placement and connection revision; a read may resolve a moved placement once more before returning bytes.

Inventory failures now use the existing content recovery owner after committing page observations. Current-placement missing or wrong-length bytes reopen adopted-content recovery and halt its campaign, while newer placement or inventory evidence prevents stale failures. Retained content keeps its lifecycle and cleanup schedule.

## Why

An older completed inventory could mark a newly moved object missing, and a ranged read could mistake a removed old descriptor for corruption of its replacement. Inventory failures also bypassed legacy recovery bookkeeping, leaving unavailable content behind a cached complete campaign. The shared transition fixes these cases while preserving admission, campaign, ledger, content and descriptor lock ordering.

## Planning

- Fixes #786
- Fixes #787

Both tasks belong to epic #549. Migration controls, preflight, full-scale PostgreSQL 13 qualification and later legacy contraction remain separate work. The direct legacy-to-S3 adapter is excluded; PostgreSQL remains the complete default and S3 remains optional.

## Testing

- Reproduced the three original defects against the unchanged base and retained failing-before/passing-after evidence.
- 100 affected PostgreSQL and S3 integration tests passed, including inventory cutoff boundaries, ranged move races, stale evidence and connection revisions, recovery cache invalidation, retained-content behavior, and coordinated backfill/inventory locking.
- CI passes all 4,868 backend unit tests and the full integration suite: 1,516 passed, 105 skipped and 1 expected failure.
- Ruff lint and format, Pyright, lockfile consistency, Alembic graph, whitespace validation, and the documentation production build passed.
- The final combined review of #788 and #790 by Fable 5.1 at high effort is green with no blockers, including pause/recovery interactions and the current schema chain.
- Required CI passes, including backend quality/tests, frontend E2E, schema drift and Docker builds. The docs production build also passes.

No schema or public API changes are required. This PR does not claim production capacity, provider conformance, or full-scale migration qualification.

The destination-switch concurrency test now uses a fresh transaction for each activity probe and deliberately observes the database before abandonment starts. This preserves the lock assertion while avoiding a cached PostgreSQL activity snapshot. The deterministic reproduction failed before the test fix and passes afterward (28.11 s).
