### PR TITLE
feat(storage): inspect and pause legacy File and Icon migration

### DIFF
--- a/backend/alembic/versions/202609071000_add_file_icon_migration_pause.py
+++ b/backend/alembic/versions/202609071000_add_file_icon_migration_pause.py
@@ -1,0 +1,27 @@
+"""Keep the temporary File/Icon migration pause across worker restarts.
+
+Revision ID: 202609071000
+Revises: 202609041000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "202609071000"
+down_revision: str | None = "202609041000"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "file_icon_backfill_admission_state",
+        sa.Column("paused", sa.Boolean(), server_default=sa.false(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("file_icon_backfill_admission_state", "paused")

--- a/backend/src/eneo/database/tables/file_icon_backfill_table.py
+++ b/backend/src/eneo/database/tables/file_icon_backfill_table.py
@@ -124,6 +124,11 @@ class FileIconBackfillAdmissionState(BaseWithTableName):
         server_default=text("0"),
         nullable=False,
     )
+    paused: Mapped[bool] = mapped_column(
+        Boolean,
+        server_default=text("false"),
+        nullable=False,
+    )
 
     __table_args__ = (
         CheckConstraint(

--- a/backend/src/eneo/object_content/file_icon_backfill.py
+++ b/backend/src/eneo/object_content/file_icon_backfill.py
@@ -79,6 +79,8 @@ class FileIconBackfillSettings(BaseSettings):
 
 
 class FileIconBackfillState(StrEnum):
+    PREPARING = "preparing"
+    PAUSED = "paused"
     WAITING_FOR_CAPACITY = "waiting_for_capacity"
     WAITING_FOR_OBJECT_STORE = "waiting_for_object_store"
     ACTIVE = "active"
@@ -96,6 +98,20 @@ class FileIconBackfillResult:
     cancelled_count: int
     failed_count: int
     detail: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class FileIconBackfillStatus:
+    state: FileIconBackfillState
+    paused: bool
+    target_kind: StorageKind | None
+    detail: str | None
+    capacity_required_bytes: int | None
+    capacity_admitted_bytes: int
+    configured_auto_inline_max_bytes: int
+    configured_capacity_ack_bytes: int
+    configured_resume_revision: int
+    campaign_resume_revision: int | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -159,6 +175,76 @@ class _AdmissionContended(Exception):
     pass
 
 
+async def set_file_icon_backfill_paused(session: AsyncSession, *, paused: bool) -> None:
+    """Change only the temporary pause, within the caller's transaction."""
+    changed = await session.execute(
+        sa.update(FileIconBackfillAdmissionState)
+        .where(FileIconBackfillAdmissionState.singleton.is_(True))
+        .values(paused=paused)
+    )
+    if affected_row_count(changed) != 1:
+        raise ObjectContentStateError("File/Icon backfill admission state is missing")
+
+
+async def read_file_icon_backfill_status(
+    session: AsyncSession, settings: FileIconBackfillSettings
+) -> FileIconBackfillStatus:
+    """Read migration facts; callers use a read-only, consistent snapshot.
+
+    Pre-campaign capacity sums ledger metadata on demand. It neither reads
+    payloads nor persists a second copy of the worker's capacity decision.
+    """
+    repository = _FileIconBackfillRepository(session)
+    paused = await repository.is_paused()
+    campaign = await session.scalar(sa.select(FileIconBackfillCampaign))
+    required_bytes = None
+    if campaign is not None:
+        state = FileIconBackfillState(campaign.state)
+        target_kind = StorageKind(campaign.target_kind)
+        detail = campaign.halt_reason
+    else:
+        state = FileIconBackfillState.PREPARING
+        target_kind = None
+        pending = await session.scalar(
+            sa.select(sa.exists().where(FileIconBackfillItems.state == "pending"))
+        )
+        detail = "The worker is finalizing legacy metadata before the capacity decision"
+        if not pending:
+            target_kind = await repository.policy_target()
+            if (
+                await repository.has_source_items()
+                and target_kind is StorageKind.OBJECT_STORE
+            ):
+                state = FileIconBackfillState.WAITING_FOR_OBJECT_STORE
+                detail = (
+                    "Select PostgreSQL inline for legacy adoption; optional object "
+                    "storage moves can follow after the migration completes"
+                )
+            else:
+                required_bytes = await repository.capacity_required_bytes()
+                if not repository.capacity_granted(settings, required_bytes):
+                    state = FileIconBackfillState.WAITING_FOR_CAPACITY
+                    detail = repository.capacity_detail(required_bytes)
+                else:
+                    detail = "Admission is ready for the next migration worker run"
+    return FileIconBackfillStatus(
+        state=state,
+        paused=paused,
+        target_kind=target_kind,
+        detail=detail,
+        capacity_required_bytes=required_bytes,
+        capacity_admitted_bytes=(
+            0 if campaign is None else campaign.capacity_admitted_bytes
+        ),
+        configured_auto_inline_max_bytes=settings.auto_inline_max_bytes,
+        configured_capacity_ack_bytes=settings.inline_capacity_ack,
+        configured_resume_revision=settings.resume_revision,
+        campaign_resume_revision=(
+            None if campaign is None else campaign.resume_revision
+        ),
+    )
+
+
 class _FileIconBackfillRepository:
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
@@ -199,11 +285,11 @@ class _FileIconBackfillRepository:
                         settings.resume_revision,
                     )
                     required_bytes = campaign.capacity_admitted_bytes + additional_bytes
-                    if additional_bytes > 0 and not self._capacity_granted(
+                    if additional_bytes > 0 and not self.capacity_granted(
                         settings,
                         required_bytes,
                     ):
-                        campaign.halt_reason = self._capacity_detail(required_bytes)
+                        campaign.halt_reason = self.capacity_detail(required_bytes)
                     else:
                         campaign.state = FileIconBackfillState.ACTIVE.value
                         campaign.halt_reason = None
@@ -240,12 +326,12 @@ class _FileIconBackfillRepository:
 
         admission_generation = await self.admission_generation()
         required_bytes = await self.capacity_required_bytes()
-        capacity_granted = self._capacity_granted(settings, required_bytes)
+        capacity_granted = self.capacity_granted(settings, required_bytes)
         if not capacity_granted:
             return _Campaign(
                 state=FileIconBackfillState.WAITING_FOR_CAPACITY,
                 target_kind=StorageKind.POSTGRES_INLINE,
-                detail=self._capacity_detail(required_bytes),
+                detail=self.capacity_detail(required_bytes),
                 admission_generation=admission_generation,
             )
         return await self._insert_campaign(
@@ -262,6 +348,18 @@ class _FileIconBackfillRepository:
             raise ObjectContentStateError(
                 "File/Icon backfill admission state is missing"
             )
+
+    async def is_paused(self) -> bool:
+        paused = await self._session.scalar(
+            sa.select(FileIconBackfillAdmissionState.paused).where(
+                FileIconBackfillAdmissionState.singleton.is_(True)
+            )
+        )
+        if paused is None:
+            raise ObjectContentStateError(
+                "File/Icon backfill admission state is missing"
+            )
+        return paused
 
     async def _insert_campaign(
         self,
@@ -295,7 +393,7 @@ class _FileIconBackfillRepository:
         )
 
     @staticmethod
-    def _capacity_granted(
+    def capacity_granted(
         settings: FileIconBackfillSettings,
         required_bytes: int,
     ) -> bool:
@@ -305,7 +403,7 @@ class _FileIconBackfillRepository:
         )
 
     @staticmethod
-    def _capacity_detail(required_bytes: int) -> str:
+    def capacity_detail(required_bytes: int) -> str:
         return (
             "The upgrade is complete and existing File/Icon content remains "
             "readable, but legacy adoption is waiting for an inline capacity "
@@ -1126,6 +1224,9 @@ class FileIconBackfill:
         self._waiting_capacity_result: tuple[FileIconBackfillResult, int] | None = None
 
     async def run_once(self) -> FileIconBackfillResult:
+        async with self._database.session() as session, session.begin():
+            if await _FileIconBackfillRepository(session).is_paused():
+                return self._paused_result()
         if self._completed_result is not None:
             async with self._database.session() as session, session.begin():
                 state = await _FileIconBackfillRepository(session).campaign_state()
@@ -1195,6 +1296,10 @@ class FileIconBackfill:
             async with self._database.session() as session, session.begin():
                 repository = _FileIconBackfillRepository(session)
                 await repository.lock_admission()
+                # Serialize the pause with admission/claims on every replica.
+                # Already claimed work may finish after the pause commits.
+                if await repository.is_paused():
+                    return self._paused_result(), None
                 if not await repository.has_campaign():
                     admission = await repository.admit(self._settings)
                     if not admission.terminal:
@@ -1321,6 +1426,15 @@ class FileIconBackfill:
                 failed_count=failed_count,
             ),
             None,
+        )
+
+    def _paused_result(self) -> FileIconBackfillResult:
+        return self._result(
+            _Campaign(
+                state=FileIconBackfillState.PAUSED,
+                target_kind=None,
+                detail="File/Icon legacy adoption is paused by the operator",
+            )
         )
 
     async def _contended_result(self) -> FileIconBackfillResult:

--- a/backend/src/eneo/object_content/file_icon_migration.py
+++ b/backend/src/eneo/object_content/file_icon_migration.py
@@ -1,0 +1,76 @@
+"""Operator controls for the temporary File/Icon migration.
+
+Run inside the maintenance worker environment:
+    python -m eneo.object_content.file_icon_migration status|pause|resume
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+from contextlib import redirect_stdout
+from dataclasses import asdict
+
+import sqlalchemy as sa
+
+
+async def _run(command: str) -> str:
+    from eneo.database.database import DatabaseSessionManager
+    from eneo.main.config import get_settings
+    from eneo.main.logging import get_logger
+    from eneo.object_content.file_icon_backfill import (
+        FileIconBackfillSettings,
+        read_file_icon_backfill_status,
+        set_file_icon_backfill_paused,
+    )
+
+    logger = get_logger(__name__)
+    database = DatabaseSessionManager()
+    database.init(get_settings().database_url)
+    try:
+        if command == "status":
+            settings = FileIconBackfillSettings()
+            async with database.session() as session, session.begin():
+                await session.execute(
+                    sa.text(
+                        "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY"
+                    )
+                )
+                status = await read_file_icon_backfill_status(session, settings)
+            return json.dumps(asdict(status), indent=2)
+        else:
+            paused = command == "pause"
+            async with database.session() as session, session.begin():
+                await set_file_icon_backfill_paused(session, paused=paused)
+            logger.info(
+                "object_content.file_icon_migration_pause_changed",
+                extra={"paused": paused},
+            )
+            return json.dumps(
+                {
+                    "paused": paused,
+                    "detail": (
+                        "New migration claims are paused; an already claimed batch may finish"
+                        if paused
+                        else "Migration claims may resume; capacity and failure recovery checks still apply"
+                    ),
+                },
+                indent=2,
+            )
+    finally:
+        await database.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("status", "pause", "resume"))
+    arguments = parser.parse_args()
+    # App loggers bind their console stream on import. Keep diagnostics on
+    # stderr and reserve stdout for one complete JSON result.
+    with redirect_stdout(sys.stderr):
+        result = asyncio.run(_run(arguments.command))
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -175,9 +175,8 @@ def postgres_container() -> Generator[PostgresContainer, None, None]:
     """
     Start a PostgreSQL container with pgvector extension for the test session.
     """
-    # Use postgres:16 with pgvector pre-installed
     postgres = PostgresContainer(
-        image="pgvector/pgvector:pg16",
+        image=os.environ.get("ENEO_TEST_POSTGRES_IMAGE", "pgvector/pgvector:pg16"),
         username="integration_test_user",
         password="integration_test_password",
         dbname="integration_test_db",

--- a/backend/tests/integration/object_content/test_file_icon_inline_backfill.py
+++ b/backend/tests/integration/object_content/test_file_icon_inline_backfill.py
@@ -61,12 +61,14 @@ from tests.integration.object_content.conftest import RealObjectStore
 
 async def _tenant_and_user(
     database: DatabaseSessionManager,
+    *,
+    user_email: str = "object-content@example.test",
 ) -> tuple[UUID, UUID]:
     async with database.session() as session, session.begin():
         return (
             await session.execute(
                 sa.select(Users.tenant_id, Users.id).where(
-                    Users.email == "object-content@example.test"
+                    Users.email == user_email
                 )
             )
         ).one()
@@ -79,8 +81,9 @@ async def _seed_legacy_text(
     estimate: int | None = None,
     file_id: UUID | None = None,
     parent_file_id: UUID | None = None,
+    user_email: str = "object-content@example.test",
 ) -> UUID:
-    tenant_id, user_id = await _tenant_and_user(database)
+    tenant_id, user_id = await _tenant_and_user(database, user_email=user_email)
     file_id = file_id or uuid4()
     async with database.session() as session, session.begin():
         await session.execute(sa.text("SET LOCAL session_replication_role = replica"))

--- a/backend/tests/integration/object_content/test_file_icon_migration_controls.py
+++ b/backend/tests/integration/object_content/test_file_icon_migration_controls.py
@@ -1,0 +1,313 @@
+import asyncio
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+import sqlalchemy as sa
+
+from eneo.database.tables.file_icon_backfill_table import (
+    FileIconBackfillCampaign,
+    FileIconBackfillItems,
+)
+from eneo.object_content import file_icon_backfill as migration
+from tests.integration.object_content.test_file_icon_inline_backfill import (
+    _backfill,
+    _seed_legacy_text,
+    _set_policy_target,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+async def restore_storage_target(object_content_database):
+    async with object_content_database.session() as session, session.begin():
+        target = await session.scalar(
+            sa.text(
+                "SELECT new_write_storage_target FROM object_content_deployment_policy WHERE id = 1"
+            )
+        )
+    try:
+        yield
+    finally:
+        await _set_policy_target(object_content_database, target)
+
+
+async def test_pause_survives_worker_restart_and_preserves_pending_admission(
+    object_content_database,
+):
+    database = object_content_database
+    await _seed_legacy_text(database, payload=b"legacy payload")
+    async with database.session() as session, session.begin():
+        await migration.set_file_icon_backfill_paused(session, paused=True)
+
+    for worker in (_backfill(database), _backfill(database)):
+        result = await worker.run_once()
+        assert result.state.value == "paused"
+        assert result.admitted_count == result.claimed_count == 0
+    async with database.session() as session, session.begin():
+        assert await session.scalar(sa.select(FileIconBackfillItems.state)) == "pending"
+        assert await session.scalar(sa.select(FileIconBackfillCampaign.id)) is None
+        await migration.set_file_icon_backfill_paused(session, paused=False)
+
+    result = await _backfill(database).run_once()
+    assert result.state is migration.FileIconBackfillState.COMPLETE
+    assert result.completed_count == 1
+
+
+async def test_status_reports_preparation_capacity_wait_and_complete_without_writes(
+    object_content_database,
+):
+    database = object_content_database
+    payload = b"legacy payload"
+    await _seed_legacy_text(database, payload=payload)
+    settings = migration.FileIconBackfillSettings(auto_inline_max_bytes=0)
+
+    async def status():
+        async with database.session() as session, session.begin():
+            await session.execute(
+                sa.text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY")
+            )
+            return await migration.read_file_icon_backfill_status(session, settings)
+
+    preparing = await status()
+    assert preparing.state.value == "preparing"
+    assert preparing.capacity_required_bytes is None
+    assert preparing.paused is False
+    await _backfill(database, auto_inline_max_bytes=0).run_once()
+    waiting = await status()
+    assert waiting.state is migration.FileIconBackfillState.WAITING_FOR_CAPACITY
+    assert waiting.capacity_required_bytes == len(payload)
+    async with database.session() as session, session.begin():
+        assert await session.scalar(sa.select(FileIconBackfillCampaign.id)) is None
+        await migration.set_file_icon_backfill_paused(session, paused=True)
+    paused = await status()
+    assert paused.paused is True
+    assert paused.state is migration.FileIconBackfillState.WAITING_FOR_CAPACITY
+    async with database.session() as session, session.begin():
+        await migration.set_file_icon_backfill_paused(session, paused=False)
+    await _backfill(database, inline_capacity_ack=len(payload)).run_once()
+    complete = await status()
+    assert complete.state is migration.FileIconBackfillState.COMPLETE
+    assert complete.capacity_admitted_bytes == len(payload)
+
+
+async def test_committed_pause_wins_before_a_waiting_worker_claims(
+    object_content_database,
+):
+    database = object_content_database
+    await _seed_legacy_text(database, payload=b"legacy payload")
+    worker_task = None
+    try:
+        async with database.session() as pause_session:
+            async with pause_session.begin():
+                pause_pid = await pause_session.scalar(
+                    sa.text("SELECT pg_backend_pid()")
+                )
+                await migration.set_file_icon_backfill_paused(
+                    pause_session, paused=True
+                )
+                worker_task = asyncio.create_task(_backfill(database).run_once())
+                async with asyncio.timeout(5):
+                    while True:
+                        assert not worker_task.done()
+                        async with database.session() as session, session.begin():
+                            blocked = await session.scalar(
+                                sa.text(
+                                    "SELECT EXISTS (SELECT 1 FROM pg_stat_activity "
+                                    "WHERE datname = current_database() "
+                                    "AND :pause_pid = ANY(pg_blocking_pids(pid)))"
+                                ),
+                                {"pause_pid": pause_pid},
+                            )
+                        if blocked:
+                            break
+                        await asyncio.sleep(0.01)
+            result = await asyncio.wait_for(worker_task, timeout=5)
+        assert result.state is migration.FileIconBackfillState.PAUSED
+        assert result.claimed_count == result.admitted_count == 0
+        async with database.session() as session, session.begin():
+            assert (
+                await session.scalar(sa.select(FileIconBackfillItems.state))
+                == "pending"
+            )
+    finally:
+        if worker_task is not None:
+            if not worker_task.done():
+                worker_task.cancel()
+            await asyncio.gather(worker_task, return_exceptions=True)
+
+
+async def test_resume_does_not_bypass_a_cached_capacity_wait(object_content_database):
+    database = object_content_database
+    await _seed_legacy_text(database, payload=b"legacy payload")
+    worker = _backfill(database, auto_inline_max_bytes=0)
+    waiting = await worker.run_once()
+    assert waiting.state is migration.FileIconBackfillState.WAITING_FOR_CAPACITY
+    async with database.session() as session, session.begin():
+        await migration.set_file_icon_backfill_paused(session, paused=True)
+    assert (await worker.run_once()).state is migration.FileIconBackfillState.PAUSED
+    async with database.session() as session, session.begin():
+        await migration.set_file_icon_backfill_paused(session, paused=False)
+    resumed = await worker.run_once()
+    assert resumed.state is migration.FileIconBackfillState.WAITING_FOR_CAPACITY
+    assert resumed.claimed_count == resumed.completed_count == 0
+
+
+async def test_active_pause_allows_claimed_batch_to_finish_then_resumes_remaining_work(
+    object_content_database, monkeypatch
+):
+    database = object_content_database
+    for payload in (b"first", b"second", b"third"):
+        await _seed_legacy_text(database, payload=payload)
+    worker = _backfill(database, batch_rows=2)
+    assert (await worker.run_once()).claimed_count == 0
+    claimed = asyncio.Event()
+    continue_copy = asyncio.Event()
+    original = migration._FileIconBackfillRepository.complete_inline
+
+    async def complete_after_pause(repository, item, object_content):
+        claimed.set()
+        await continue_copy.wait()
+        return await original(repository, item, object_content)
+
+    monkeypatch.setattr(
+        migration._FileIconBackfillRepository, "complete_inline", complete_after_pause
+    )
+    active_batch = asyncio.create_task(worker.run_once())
+    try:
+        await asyncio.wait_for(claimed.wait(), timeout=5)
+        async with database.session() as session, session.begin():
+            await migration.set_file_icon_backfill_paused(session, paused=True)
+        continue_copy.set()
+        result = await asyncio.wait_for(active_batch, timeout=5)
+        assert result.claimed_count == result.completed_count == 2
+        assert result.state is migration.FileIconBackfillState.ACTIVE
+        paused = await worker.run_once()
+        assert paused.state is migration.FileIconBackfillState.PAUSED
+        assert paused.claimed_count == 0
+        async with database.session() as session, session.begin():
+            assert (
+                await session.scalar(
+                    sa.select(sa.func.count())
+                    .select_from(FileIconBackfillItems)
+                    .where(FileIconBackfillItems.state == "ready")
+                )
+                == 1
+            )
+            await migration.set_file_icon_backfill_paused(session, paused=False)
+        resumed = await worker.run_once()
+        assert resumed.completed_count == 1
+        assert resumed.state is migration.FileIconBackfillState.COMPLETE
+    finally:
+        continue_copy.set()
+        if not active_batch.done():
+            active_batch.cancel()
+        await asyncio.gather(active_batch, return_exceptions=True)
+
+
+async def test_resume_preserves_a_halt_and_its_required_recovery_revision(
+    object_content_database,
+):
+    database = object_content_database
+    for payload in (b"first", b"second"):
+        await _seed_legacy_text(database, payload=payload)
+    worker = _backfill(database, batch_rows=1)
+    for _ in range(4):
+        if (await worker.run_once()).claimed_count == 1:
+            break
+    else:
+        pytest.fail("The first migration item was not claimed")
+    await _set_policy_target(database, migration.StorageKind.OBJECT_STORE.value)
+    assert (await worker.run_once()).state is migration.FileIconBackfillState.HALTED
+    async with database.session() as session, session.begin():
+        before = await migration.read_file_icon_backfill_status(
+            session, migration.FileIconBackfillSettings()
+        )
+        await migration.set_file_icon_backfill_paused(session, paused=True)
+    await _set_policy_target(database, migration.StorageKind.POSTGRES_INLINE.value)
+    async with database.session() as session, session.begin():
+        await migration.set_file_icon_backfill_paused(session, paused=False)
+        after = await migration.read_file_icon_backfill_status(
+            session, migration.FileIconBackfillSettings()
+        )
+    assert after == before
+    assert (await worker.run_once()).state is migration.FileIconBackfillState.HALTED
+    recovery_worker = _backfill(database, resume_revision=1)
+    recovered = await recovery_worker.run_once()
+    assert recovered.completed_count == 1
+    assert (
+        await recovery_worker.run_once()
+    ).state is migration.FileIconBackfillState.COMPLETE
+
+
+async def test_status_explains_a_remote_target_wait_without_starting_a_campaign(
+    object_content_database,
+):
+    database = object_content_database
+    await _seed_legacy_text(database, payload=b"legacy payload")
+    await _set_policy_target(database, migration.StorageKind.OBJECT_STORE.value)
+    assert (
+        await _backfill(database).run_once()
+    ).state is migration.FileIconBackfillState.WAITING_FOR_OBJECT_STORE
+    async with database.session() as session, session.begin():
+        status = await migration.read_file_icon_backfill_status(
+            session, migration.FileIconBackfillSettings()
+        )
+        assert await session.scalar(sa.select(FileIconBackfillCampaign.id)) is None
+    assert status.state is migration.FileIconBackfillState.WAITING_FOR_OBJECT_STORE
+    assert status.target_kind is migration.StorageKind.OBJECT_STORE
+    assert "PostgreSQL inline" in status.detail
+
+
+async def test_operator_command_uses_worker_settings_and_persists_only_pause(
+    object_content_database, object_content_postgres_13, test_settings, tmp_path
+):
+    await _seed_legacy_text(object_content_database, payload=b"legacy payload")
+    environment = os.environ.copy()
+    environment.update(
+        {
+            name.upper(): str(getattr(test_settings, name))
+            for name, field in type(test_settings).model_fields.items()
+            if field.is_required()
+        }
+    )
+    environment.update(
+        POSTGRES_HOST=object_content_postgres_13.get_container_host_ip(),
+        POSTGRES_PORT=str(object_content_postgres_13.get_exposed_port(5432)),
+        POSTGRES_USER="object_content_test",
+        POSTGRES_PASSWORD="object_content_test_password",
+        POSTGRES_DB="object_content_test",
+        FILE_ICON_BACKFILL_AUTO_INLINE_MAX_BYTES="0",
+        FILE_ICON_BACKFILL_INLINE_CAPACITY_ACK="123",
+        FILE_ICON_BACKFILL_RESUME_REVISION="4",
+        TESTING="true",
+    )
+
+    async def command(action):
+        result = await asyncio.to_thread(
+            subprocess.run,
+            [sys.executable, "-m", "eneo.object_content.file_icon_migration", action],
+            cwd=tmp_path,
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        return json.loads(result.stdout)
+
+    assert (await command("pause"))["paused"] is True
+    status = await command("status")
+    assert status["paused"] is True
+    assert status["state"] == "preparing"
+    assert status["configured_capacity_ack_bytes"] == 123
+    assert status["configured_resume_revision"] == 4
+    assert status["campaign_resume_revision"] is None
+    assert (await command("resume"))["paused"] is False
+    async with object_content_database.session() as session, session.begin():
+        assert await session.scalar(sa.select(FileIconBackfillItems.state)) == "pending"
+        assert await session.scalar(sa.select(FileIconBackfillCampaign.id)) is None

--- a/backend/tests/integration/object_content/test_file_icon_migration_traffic.py
+++ b/backend/tests/integration/object_content/test_file_icon_migration_traffic.py
@@ -1,0 +1,139 @@
+"""Authenticated ASGI requests during adoption; not a production load benchmark."""
+
+import asyncio
+import json
+from time import perf_counter
+from uuid import UUID
+
+import pytest
+import sqlalchemy as sa
+
+from eneo.database.database import sessionmanager
+from eneo.database.tables.file_icon_backfill_table import FileIconBackfillItems
+from eneo.object_content.file_icon_backfill import FileIconBackfillState
+from tests.integration.object_content.test_file_icon_inline_backfill import (
+    _backfill,
+    _seed_legacy_text,
+)
+from tests.integration.object_content.test_file_original_download import (
+    _signed_download,
+)
+
+pytestmark = pytest.mark.integration
+
+
+async def test_authenticated_uploads_and_downloads_continue_during_legacy_adoption(
+    client, db_container, admin_user, admin_user_api_key, capsys
+):
+    # Keep the production runtime alive across overlapping requests and batches.
+    async with db_container():
+        async with sessionmanager.session() as session, session.begin():
+            server_version = await session.scalar(sa.text("SHOW server_version"))
+        legacy_payload = b"legacy text\n" * 4096
+        legacy_files = [
+            await _seed_legacy_text(
+                sessionmanager, payload=legacy_payload, user_email=admin_user.email
+            )
+            for _ in range(20)
+        ]
+        worker = _backfill(
+            sessionmanager,
+            batch_rows=2,
+            batch_bytes=1024 * 1024,
+            inline_maximum_bytes=1024 * 1024,
+            inline_capacity_ack=20 * len(legacy_payload),
+        )
+        headers = {"X-API-Key": admin_user_api_key.key}
+        request_seconds = []
+        uploads = []
+
+        async def foreground(round_number):
+            started = perf_counter()
+            legacy = await _signed_download(
+                client,
+                headers,
+                legacy_files[round_number % len(legacy_files)],
+                original=False,
+            )
+            assert legacy.status_code == 200, legacy.text
+            assert legacy.content == legacy_payload
+            payload = f"new upload {round_number}\n".encode() * 1024
+            upload = await client.post(
+                "/api/v1/files/",
+                files={
+                    "upload_file": (f"new-{round_number}.txt", payload, "text/plain")
+                },
+                headers=headers,
+            )
+            assert upload.status_code == 200, upload.text
+            file_id = UUID(upload.json()["id"])
+            original = await _signed_download(client, headers, file_id, original=True)
+            assert original.status_code == 200, original.text
+            assert original.content == payload
+            uploads.append((file_id, payload))
+            request_seconds.append(perf_counter() - started)
+
+        started = perf_counter()
+        active_copy_rounds = 0
+        async with asyncio.timeout(60):
+            for round_number in range(30):
+                result, _ = await asyncio.gather(
+                    worker.run_once(), foreground(round_number)
+                )
+                active_copy_rounds += int(result.completed_count > 0)
+                if result.state is FileIconBackfillState.COMPLETE:
+                    break
+            else:
+                pytest.fail(
+                    "Migration did not finish within its bounded fixture workload"
+                )
+        elapsed_seconds = perf_counter() - started
+        assert active_copy_rounds == 10
+        for file_id in legacy_files:
+            response = await _signed_download(client, headers, file_id, original=False)
+            assert response.status_code == 200, response.text
+            assert response.content == legacy_payload
+        for file_id, payload in uploads:
+            response = await _signed_download(client, headers, file_id, original=True)
+            assert response.status_code == 200, response.text
+            assert response.content == payload
+        async with sessionmanager.session() as session, session.begin():
+            assert (
+                await session.scalar(
+                    sa.select(sa.func.count())
+                    .select_from(FileIconBackfillItems)
+                    .where(FileIconBackfillItems.state == "done")
+                )
+                == 20
+            )
+            assert (
+                await session.scalar(
+                    sa.select(sa.func.count())
+                    .select_from(FileIconBackfillItems)
+                    .where(
+                        FileIconBackfillItems.owner_id.in_(
+                            [file_id for file_id, _ in uploads]
+                        )
+                    )
+                )
+                == 0
+            )
+
+    with capsys.disabled():
+        print(
+            "FILE_ICON_MIGRATION_TRAFFIC_RESULT "
+            + json.dumps(
+                {
+                    "transport": "in-process ASGI; real authenticated production routes",
+                    "postgres_version": server_version,
+                    "legacy_items": len(legacy_files),
+                    "legacy_bytes": len(legacy_files) * len(legacy_payload),
+                    "foreground_rounds": len(request_seconds),
+                    "active_copy_rounds": active_copy_rounds,
+                    "elapsed_seconds": elapsed_seconds,
+                    "max_foreground_round_seconds": max(request_seconds),
+                    "failed_requests_or_byte_mismatches": 0,
+                },
+                sort_keys=True,
+            )
+        )

--- a/backend/tests/integration/object_content/test_file_icon_pause_migration.py
+++ b/backend/tests/integration/object_content/test_file_icon_pause_migration.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import psycopg2
+import pytest
+
+from alembic import command
+from alembic.config import Config
+
+pytestmark = [pytest.mark.integration, pytest.mark.migration_isolation]
+
+
+def test_pause_revision_preserves_admission_generation(
+    object_content_database, object_content_postgres_13
+):
+    backend = Path(__file__).resolve().parents[3]
+    config = Config(str(backend / "alembic.ini"))
+    url = object_content_postgres_13.get_connection_url()
+    config.set_main_option("sqlalchemy.url", url)
+    connection = psycopg2.connect(url.replace("postgresql+psycopg2", "postgresql"))
+    connection.autocommit = True
+    try:
+        command.downgrade(config, "202609041000")
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "UPDATE file_icon_backfill_admission_state SET generation = 42"
+            )
+        command.upgrade(config, "202609071000")
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT generation, paused FROM file_icon_backfill_admission_state"
+            )
+            assert cursor.fetchone() == (42, False)
+            cursor.execute(
+                "UPDATE file_icon_backfill_admission_state SET paused = true"
+            )
+        command.upgrade(config, "202609071000")
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT generation, paused FROM file_icon_backfill_admission_state"
+            )
+            assert cursor.fetchone() == (42, True)
+        command.downgrade(config, "202609041000")
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT generation FROM file_icon_backfill_admission_state")
+            assert cursor.fetchone() == (42,)
+    finally:
+        command.upgrade(config, "head")
+        connection.close()

--- a/docs/deployment/OBJECT_CONTENT.md
+++ b/docs/deployment/OBJECT_CONTENT.md
@@ -641,6 +641,24 @@ guide](https://docs.eneo.ai/guides/file-icon-storage-upgrade) for its operator
 checklist, disk and duration estimates, pause/rollback decisions, and cleanup.
 This section is the detailed SQL and recovery reference.
 
+The File/Icon upgrade consolidates durable bytes, integrity, storage policy and
+cleanup in the shared object-content module. It is a one-time migration for all
+installations with legacy content, including PostgreSQL-only installations.
+S3-compatible storage is optional and is not the reason the migration is required.
+
+The organizational sequence is:
+
+1. Restore and test the intended release with representative data. Measure legacy
+   payload size, reserve PostgreSQL/WAL headroom, and keep PostgreSQL inline selected.
+2. Drain old jobs, stop all old backend/worker processes, take the coordinated
+   recovery point, and run `db-init` with the API closed.
+3. Start the new release. Let bounded online adoption run, or acknowledge the
+   reported cumulative capacity above the default 5 GiB threshold.
+4. Monitor status, disk, WAL and request latency. Verify old/new content and a
+   restore of the new release after adoption completes.
+5. Optionally select S3-compatible storage and queue verified moves. Preserve the
+   old columns until the separate contract release; space reclamation is separate.
+
 Before an Eneo or object-store upgrade, take a paired backup and retain the old
 image digests. Upgrade the byte plane without changing endpoint semantics,
 credentials, bucket, or deployment ID. Verify liveness, readiness, single and
@@ -738,9 +756,8 @@ reported exact logical-byte requirement and recreate the worker. The
 acknowledgement does not reserve disk and the requirement is not peak
 allocation; it records that the operator has accepted the capacity plan. When the current
 Admin storage policy selects object storage, this inline worker does not start
-or silently redirect the campaign. Remote adoption requires the verified
-object-store adapter and changes the coordinated backup contract. Selecting
-PostgreSQL inline instead changes the deployment-wide target for eligible new
+or silently redirect the campaign. This release adopts legacy bytes into
+PostgreSQL inline. Selecting inline changes the deployment-wide target for eligible new
 writes; keep it selected until the campaign is complete, then reselect object
 storage and queue verified moves if required.
 Set `FILE_ICON_BACKFILL_AUTO_INLINE_MAX_BYTES=0` in `env_backend.env` when every
@@ -749,6 +766,48 @@ Waiting for capacity is non-fatal: the upgrade is complete, the application
 continues serving frozen legacy File/Icon content, and the worker emits a
 structured warning with the requirement and required acknowledgement on startup
 and every scheduled tick.
+
+### Inspect or pause the one-time File/Icon migration
+
+Run these commands inside the maintenance worker, using the deployment's Compose
+files, profiles and service name (`worker` in the reference deployment):
+
+```bash
+docker compose exec worker python -m eneo.object_content.file_icon_migration status
+docker compose exec worker python -m eneo.object_content.file_icon_migration pause
+docker compose exec worker python -m eneo.object_content.file_icon_migration resume
+```
+
+`status` reads a consistent, read-only snapshot of the temporary ledger/campaign
+and the command's environment settings. It never admits work, creates a campaign,
+or reads legacy payload bytes. Before campaign creation it checks for pending
+admission and, once admission has finished, may sum ready ledger metadata for
+`capacity_required_bytes`. This is an on-demand metadata scan, not a polling API.
+After creation, `capacity_required_bytes` is null and `capacity_admitted_bytes`
+reports the accepted cumulative exposure. The configured acknowledgement is not
+a measurement of free disk.
+
+`state` reports `preparing`, `waiting_for_capacity`, `waiting_for_object_store`,
+`active`, `halted` or `complete`; `detail` explains a wait or halt. `paused` is
+separate so a pause does not hide the underlying condition. Preparation and waits
+can exist without a campaign row. Run status in the worker container so its
+`configured_*` fields match the worker's environment; changing the env file alone
+does not update a running container.
+
+Pause updates one flag in `file_icon_backfill_admission_state` and serializes
+with new admission/claims through the existing admission lock. Once it commits,
+all replicas stop claiming migration work. A previously claimed bounded batch
+may finish, so retain headroom for that batch. The flag survives restarts and
+does not affect ordinary moves or other worker jobs. `resume` clears only that
+flag: it never changes the storage target, acknowledges capacity, clears a halt,
+increments the recovery revision, or rewrites ledger state. Use the recovery
+procedure below for a halted campaign. Stop the worker as well if its ongoing
+work must be interrupted.
+
+The command and pause field are temporary upgrade tooling and leave with the
+File/Icon ledger in the later contract release.
+
+### Bound throughput and recover a halted campaign
 
 Large installations can tune bounded throughput without changing application
 or tenant policy:
@@ -800,6 +859,36 @@ throughput. Before changing the batch limits, run a canary under representative
 traffic and monitor foreground p95/p99 latency, errors, database CPU and I/O,
 WAL/checkpoints, and batch duration. Restore the defaults if that traffic
 regresses.
+
+A repeatable PostgreSQL 13 check on 2026-09-07 copied about 1 GiB in 1,639 items
+with the default bounds: 36.49 seconds active time, 28.07 MiB/s, 17 runs
+(16.01 minutes at the normal cadence), 140 MiB worker peak RSS, 1.08 GiB
+generated WAL, 1.04 GiB additional database allocation, no temporary files,
+no failed items or digest mismatches, and all legacy rows preserved. The
+concurrent metadata SQL probe recorded p95 4.58 ms and p99 13.33 ms. This was
+a shared local Docker host with six CPUs and about 16 GiB assigned to Docker.
+It is a measurement of this workload, not a claimed speedup or production SLA.
+
+A separate authenticated ASGI test used the production upload, signed-download,
+and original-download routes against PostgreSQL 13 during bounded adoption.
+It passed 19 foreground rounds while adopting 20 legacy text items (983,040
+bytes) in ten copy batches, then verified every old and new payload again. It
+completed the concurrent phase in 4.71 seconds with no request or byte-check
+failure. This is API correctness evidence with a small fixture, not a latency
+benchmark for real users. It does not qualify ingestion, model providers,
+offline expansion, replicas, backup retention, or full restore behavior.
+
+The [raw results and frozen profile](benchmarks/file-icon-migration-pg13-20260907.json)
+record image, PostgreSQL settings, workload and source hashes. Reproduce the
+resource check with `ENEO_RUN_FILE_ICON_BACKFILL_BENCHMARK=1`,
+`ENEO_FILE_ICON_BENCHMARK_TOTAL_MIB=1024`, and
+`ENEO_FILE_ICON_BENCHMARK_FOREGROUND_PROBE=1` when running
+`tests/integration/object_content/test_file_icon_backfill_benchmark.py`.
+The API check is `test_file_icon_migration_traffic.py` in the same directory;
+set `ENEO_TEST_POSTGRES_IMAGE` to the profile's pinned PostgreSQL 13 image when
+running it. This optional test-fixture override leaves deployment images and
+the broader integration fixture's existing default unchanged.
+
 Only one worker replica may run a batch at a time. A PostgreSQL advisory lock
 prevents minute jobs from overlapping and multiplying the configured byte and
 memory bounds. Memory is bounded by one item rather than the campaign or batch

--- a/docs/deployment/benchmarks/file-icon-migration-pg13-20260907.json
+++ b/docs/deployment/benchmarks/file-icon-migration-pg13-20260907.json
@@ -1,0 +1,152 @@
+{
+  "measured_at": "2026-09-07",
+  "scope": "Local PostgreSQL 13 copy/resource measurement and a separate authenticated in-process ASGI correctness check. Not production-load or full-upgrade qualification.",
+  "profile": {
+    "base_head": "e42ad3b4d582beaa1049a7a4eaf8f4fe56f56432",
+    "files_sha256": {
+      "src/eneo/object_content/file_icon_backfill.py": "ef43d8f55cc956db3221fc60914b604e3f4631d62009f7da50d6eec8bd39ed19",
+      "src/eneo/database/tables/file_icon_backfill_table.py": "705481df43d5a14504219c7f31ca99556ed53660018fc2730e3eeddf669beebd",
+      "tests/integration/object_content/test_file_icon_backfill_benchmark.py": "f286f7730b5ade2844e07627136bef6260d84a2a86214660fa0a7a9d12289596"
+    },
+    "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+    "postgres_image": "pgvector/pgvector:pg13@sha256:751a89c96f7c32cb8133472f711c274853378fb5f8b55dd9fa0e9d3f1471bfc3",
+    "target_mib": 1024,
+    "item_kib": 640,
+    "batch_rows": 200,
+    "batch_mib": 128,
+    "foreground": "metadata SELECT every 50ms; separate authenticated ASGI correctness test",
+    "acceptance": "all seeded items done, zero failures/digest mismatches, legacy rows preserved; report measured wall time/resources without asserting production throughput",
+    "environment": "local Docker, shared developer host; no production traffic, replicas, backups or offline upgrade timing",
+    "docker_resources": "6 CPUs; 16820240384 memory bytes"
+  },
+  "copy_resource_measurement": {
+    "backfill": {
+      "active_mib_per_second": 28.072946351806486,
+      "active_seconds": 36.48975733300904,
+      "admitted_count": 1639,
+      "batch_count": 17,
+      "batch_current_rss_bytes": [
+        145571840,
+        145670144,
+        145735680,
+        145784832,
+        145801216,
+        145850368,
+        145850368,
+        145850368,
+        146554880,
+        140476416,
+        133840896,
+        133971968,
+        134037504,
+        134152192,
+        134168576,
+        134316032,
+        134332416
+      ],
+      "batch_max_rss_bytes": [
+        145588224,
+        145686528,
+        145752064,
+        145801216,
+        145817600,
+        145866752,
+        145866752,
+        145866752,
+        146571264,
+        146833408,
+        146833408,
+        146833408,
+        146833408,
+        146833408,
+        146833408,
+        146833408,
+        146833408
+      ],
+      "batch_seconds_max": 6.385331208992284,
+      "batch_seconds_mean": 2.1390208187684254,
+      "batch_seconds_p50": 0.8729033750132658,
+      "batch_seconds_p95": 5.169783791992813,
+      "claimed_count": 1639,
+      "completed_count": 1639,
+      "projected_minute_cron_seconds": 960.8729033750133
+    },
+    "config": {
+      "batch_mib": 128,
+      "batch_rows": 200,
+      "item_kib": 640,
+      "seed_rows_per_transaction": 64,
+      "total_mib": 1024
+    },
+    "environment": {
+      "object_content_inline_io_chunk_bytes": 262144,
+      "object_content_inline_maximum_bytes": 209715200,
+      "platform": "macOS-26.5.2-arm64-arm-64bit",
+      "postgres": {
+        "checkpoint_completion_target": "0.5",
+        "max_wal_size": "1GB",
+        "server_version": "13.23 (Debian 13.23-1.pgdg12+1)",
+        "shared_buffers": "128MB",
+        "synchronous_commit": "on",
+        "wal_compression": "off",
+        "work_mem": "4MB"
+      },
+      "python": "3.11.14"
+    },
+    "foreground_latency": {
+      "sample_count": 728,
+      "seconds_max": 0.023749458021484315,
+      "seconds_p50": 0.0016789170040283352,
+      "seconds_p95": 0.004584375012200326,
+      "seconds_p99": 0.013333667011465877
+    },
+    "resources": {
+      "database_bytes_after": 2253967919,
+      "database_bytes_before": 1133384239,
+      "files_bytes_after": 1115824128,
+      "files_bytes_before": 1115824128,
+      "inline_bytes_after": 1115471872,
+      "inline_bytes_before": 16384,
+      "postgres_blocks_hit": 2315497,
+      "postgres_blocks_read": 277760,
+      "postgres_temp_bytes": 0,
+      "process_cpu_seconds": 10.654034999999999,
+      "process_cpu_utilization_percent": 29.197330370740065,
+      "process_system_seconds": 1.424748,
+      "process_user_seconds": 9.229287,
+      "wal_bytes": 1162983200,
+      "worker_current_rss_bytes_after": 134348800,
+      "worker_current_rss_bytes_before": 133578752,
+      "worker_max_rss_bytes_after": 146833408,
+      "worker_max_rss_bytes_before": 133775360,
+      "worker_rss_growth_limit_bytes": 67108864
+    },
+    "seed": {
+      "item_count": 1639,
+      "mib_per_second": 172.70735428441537,
+      "seconds": 5.931276084011188,
+      "seeded_bytes": 1074135040
+    },
+    "verification": {
+      "campaign_state": "complete",
+      "content_bytes": 1074135040,
+      "digest_mismatch_count": 0,
+      "done_count": 1639,
+      "failed_count": 0,
+      "inline_count": 1639,
+      "preserved_legacy_count": 1639,
+      "reference_count": 1639
+    }
+  },
+  "authenticated_api_check": {
+    "active_copy_rounds": 10,
+    "elapsed_seconds": 4.7075112919847015,
+    "failed_requests_or_byte_mismatches": 0,
+    "foreground_rounds": 19,
+    "legacy_bytes": 983040,
+    "legacy_items": 20,
+    "max_foreground_round_seconds": 0.9553203750110697,
+    "postgres_version": "13.23 (Debian 13.23-1.pgdg12+1)",
+    "transport": "in-process ASGI; real authenticated production routes"
+  }
+}

--- a/frontend/apps/docs-site/src/content/guides/file-icon-storage-upgrade.mdx
+++ b/frontend/apps/docs-site/src/content/guides/file-icon-storage-upgrade.mdx
@@ -4,43 +4,37 @@ import { Callout, Steps, Tabs } from "nextra/components";
 
 ## TL;DR
 
-This is a **one-time adoption** of File and Icon bytes written by older Eneo
-releases.
+This upgrade consolidates File and Icon bytes, integrity checks, storage rules,
+and cleanup in the shared object-content module. It removes the need to maintain
+separate storage paths as Eneo grows. **Every installation with legacy File or
+Icon content needs this one-time migration, including PostgreSQL-only
+installations. S3-compatible storage is optional.**
 
-<Callout type="info">
-  **Normal availability:** `db-init` keeps the API closed while Eneo expands the
-  schema, installs the legacy write fence, and inventories row metadata. After
-  it succeeds, Eneo starts normally. The maintenance worker then copies and
-  verifies bounded batches while old files remain readable.
-</Callout>
+For an organization upgrading an existing installation:
 
-New uploads use object content as soon as the new release starts. They do not
-wait for the legacy adoption or write bytes back to the old columns.
-
-The default capacity path depends on the **combined logical size of affected
-legacy payloads**, not the size of the whole database or the largest file:
-
-- **At or below 5 GiB:** no action. The online worker starts automatically.
-- **Above 5 GiB:** check disk and WAL headroom, set the reported capacity
-  acknowledgement, and recreate the worker.
-
-During the verification period, affected payloads exist in both layouts. For
-example, 10 GiB of existing legacy payload becomes roughly 20.4 GiB in total:
-the original 10 GiB already on disk plus about 10.4 GiB for the new verified
-copy. The host therefore needs about 10.4 GiB of **additional** database space,
-not another 20.4 GiB, plus temporary WAL growth and its normal free-space floor.
-
-PostgreSQL inline remains a complete byte backend, so this adoption is required
-even when the deployment does not use S3-compatible storage. Run large
-deployments at a quiet time and verify representative files and a current
-restore before closing the recovery window. Do not delete the old columns when
-the worker finishes; a later contract release owns their removal. PostgreSQL
-does not return that filesystem space automatically. Run a planned `pg_repack`
-or `VACUUM FULL` after the contract release only when the host needs it back.
-
-This release adopts legacy payloads into PostgreSQL inline. If object storage is
-selected before the campaign starts, the worker waits rather than silently
-changing the destination; follow [Run and monitor](#run-and-monitor).
+1. **Prepare and test.** Restore a recent backup in a test environment and follow
+   this guide with the intended release. Measure the affected legacy bytes,
+   reserve additional PostgreSQL and WAL space, and test representative uploads
+   and downloads during adoption. Keep **PostgreSQL inline** selected for the
+   migration.
+2. **Take the recovery point and upgrade.** Drain jobs, stop all old backend and
+   worker processes, and take the coordinated backup. Deploy the new release and
+   let `db-init` finish while the API remains closed. This phase needs a
+   maintenance window; use the [deployment commands](/guides/deployment#updating-eneo).
+3. **Start Eneo and let the worker adopt old content.** New uploads use the shared
+   model immediately; existing files remain readable during the background copy.
+   Ready legacy payloads up to 5 GiB start automatically. Above that default,
+   [acknowledge the required capacity](#read-migration-status) after checking
+   disk and WAL headroom.
+4. **Monitor and verify.** Check [migration status](#read-migration-status), disk,
+   WAL, and API latency.
+   Pause adoption if needed. After completion, verify representative old and new
+   content and restore a backup of the new release before closing the recovery
+   window.
+5. **Choose optional storage changes later.** Once adoption is complete, you may
+   select S3-compatible storage and explicitly move existing content. Retain the
+   legacy columns until the separate contract release removes them; completion
+   alone does not reclaim filesystem space.
 
 ## What this changes
 
@@ -299,7 +293,7 @@ copy runs      = max(ceil(payload MiB / 128), ceil(items / 200))
 scheduled runs = admission runs + copy runs - 1
 ```
 
-- **1 GiB in about 1,600 items:** about 15 scheduled runs.
+- **About 1 GiB in 1,639 measured items:** 17 scheduled runs, about 16 minutes.
 - **5 GiB in about 8,000 similarly sized items:** about 1 hour 19 minutes.
 - **10 GiB in 16,384 measured items:** 163 scheduled runs, about 2 hours 42
   minutes.
@@ -332,6 +326,27 @@ database CPU and I/O, WAL/checkpoints, free disk, and batch duration.
   bounded design; use a restored copy to forecast another server.
 </Callout>
 
+A fresh PostgreSQL 13 check on 7 September 2026 copied about 1 GiB across 1,639
+items in **36.5 seconds of active work** at the default batch bounds. The 17
+runs project to about **16 minutes** at the normal cadence. Worker peak memory
+was 140 MiB, generated WAL was 1.08 GiB, additional database allocation was
+1.04 GiB, and all payload digests matched. These are separate measurements:
+generated WAL is not the peak amount retained on disk at once.
+
+An additional small test exercised authenticated uploads, legacy downloads,
+and new-original downloads through the production API routes while adoption
+ran. All 19 foreground rounds and the final byte checks passed. It used an
+in-process HTTP client, 20 legacy items totaling less than 1 MiB, and ten copy
+batches; it proves those request paths remain correct during adoption, not
+production latency under load. The resource benchmark's concurrent probe was
+only a metadata SQL query (p95 4.6 ms), not an HTTP request.
+
+The [recorded workload and results](https://github.com/eneo-ai/eneo/blob/develop/docs/deployment/benchmarks/file-icon-migration-pg13-20260907.json)
+include the pinned PostgreSQL image and source hashes. Both tests used a shared
+development machine. Neither measures the offline `db-init` phase, ingestion or
+model-provider load, replicas, backup retention, or a production-size restore.
+Use the following checklist to qualify those parts for the organization.
+
 The main throughput lever is cadence, not parallel PostgreSQL workers. Keep the
 defaults unless a restored-production canary shows that higher bounds preserve
 API latency, memory, I/O, WAL, and checkpoint behavior. Do not disable planner
@@ -363,15 +378,38 @@ or is paused. New uploads use the selected object-content target immediately;
 they do not write back to legacy columns.
 
 <Steps>
-### Read the worker status
+### Read migration status
+
+```bash
+docker compose exec worker python -m eneo.object_content.file_icon_migration status
+```
+
+Use the same Compose files and profile as the deployment. The reference service
+is named `worker`; split deployments may call it the maintenance worker. Run the
+command there so it reads the same database and capacity settings as that worker.
+The command returns a read-only snapshot and never starts migration work.
+
+| Status field | What to do |
+| --- | --- |
+| `state: preparing` | Let the worker finalize metadata. Required bytes remain unknown until this finishes. |
+| `state: waiting_for_capacity` | Reserve PostgreSQL and WAL headroom, then set `FILE_ICON_BACKFILL_INLINE_CAPACITY_ACK` in `env_backend.env` to at least `capacity_required_bytes` and recreate the worker with `docker compose up -d --force-recreate worker`. |
+| `state: waiting_for_object_store` | Select PostgreSQL inline for this migration, as described below. |
+| `state: active` | Monitor disk, WAL, errors, and API latency while batches finish. |
+| `state: halted` | Read `detail` and fix the cause. Clearing pause alone does not recover a halted campaign. |
+| `state: complete` | Perform the verification and backup checks below. |
+| `paused: true` | No new migration work will be claimed. Use `resume` when ready; the underlying `state` and `detail` remain visible. |
+
+Before a campaign starts, this command may sum ledger metadata to report
+capacity. Run it on demand rather than polling it frequently. It does not read
+payload bytes. After a campaign starts, `capacity_admitted_bytes` reports its
+accepted cumulative exposure; `capacity_required_bytes` is null.
+
+For recent worker activity:
 
 ```bash
 docker compose logs --since=30m worker \
   | grep "File/Icon legacy backfill"
 ```
-
-Use the same Compose files and profile as the deployment. The reference service
-is named `worker`; split deployments may call it the maintenance worker.
 
 `waiting_for_capacity` means the application is available while the worker waits
 for the exact acknowledgement. `waiting_for_object_store` means this release
@@ -417,8 +455,8 @@ SELECT target_kind,
 FROM file_icon_backfill_campaign;
 ```
 
-No campaign row while the worker waits for capacity or object storage is normal;
-those pre-campaign states are reported in the worker log.
+No campaign row while the worker prepares admission or waits for capacity or
+object storage is normal; the status command and worker log explain those states.
 
 - **`active`:** admission or adoption is progressing. Monitor disk, WAL, I/O,
   errors, and API latency.
@@ -429,8 +467,8 @@ those pre-campaign states are reported in the worker log.
 
 </Steps>
 
-For `waiting_for_object_store`, either wait for a compatible release or select
-**PostgreSQL inline** in **Admin > Storage**. Selecting inline also changes the
+For `waiting_for_object_store`, select **PostgreSQL inline** in **Admin > Storage**.
+Selecting inline also changes the
 target for eligible new uploads and may lead to the capacity decision above.
 Keep inline selected until the campaign is `complete`; changing the target
 earlier halts the campaign. Then reselect object storage and queue verified
@@ -447,17 +485,32 @@ runbook](https://github.com/eneo-ai/eneo/blob/develop/docs/deployment/OBJECT_CON
 
 ### Pause or respond to low disk
 
-Stop the worker first:
-
-Use the same Compose files and profile as the deployment:
+Pause new migration work using the same Compose files and profile as the deployment:
 
 ```bash
-docker compose stop worker
+docker compose exec worker python -m eneo.object_content.file_icon_migration pause
 ```
 
-An in-flight bounded item may finish. Committed items stay committed, leases
-expire safely, and old content remains readable. Stopping this worker also
-pauses other background jobs.
+A bounded batch already claimed may finish. The pause persists across worker
+restarts; committed items stay committed and old content remains readable. Other
+background jobs and ordinary storage moves keep their existing controls.
+
+To allow new migration claims again:
+
+```bash
+docker compose exec worker python -m eneo.object_content.file_icon_migration resume
+```
+
+This clears only pause. Capacity acknowledgement and recovery from a halt still
+apply. For a halted campaign, fix the reported cause, restore its original storage
+target if changed, and set `FILE_ICON_BACKFILL_RESUME_REVISION` strictly above
+`campaign_resume_revision` before recreating the worker. See the
+[recovery runbook](https://github.com/eneo-ai/eneo/blob/develop/docs/deployment/OBJECT_CONTENT.md#upgrade-and-rollback)
+for replacement-copy capacity requirements.
+
+If the worker itself must stop immediately, use `docker compose stop worker`;
+that also stops its other background jobs. The migration pause is intended to
+stop new batches, so allow headroom for a batch already in progress.
 
 If free disk continues to fall because users are creating new content, stop or
 block new writes as well. Add capacity or restore the current release's matching
@@ -550,19 +603,23 @@ runbook](https://github.com/eneo-ai/eneo/blob/develop/docs/deployment/OBJECT_CON
 
 ### Does the application stay available?
 
-After the coordinated schema and inventory phase, yes. Existing content falls
+The application is designed to serve requests after the coordinated schema and
+inventory phase. Existing content falls
 back to the frozen legacy bytes until its verified reference exists. Large
 deployments should still start the work at a quiet time because online does not
-mean free of I/O or WAL load.
+mean free of I/O or WAL load. The small concurrent API check above passed; test
+representative traffic on a restored production copy before promising the same
+latency for an installation.
 
 ### Can we pause and continue tomorrow?
 
-Yes. Stop the worker. Completed batches remain committed and the same release
-resumes from durable ledger and lease state. Other background jobs pause too.
+Yes. Use the migration `pause` command, then `resume` when ready. Completed
+batches remain committed, and the pause survives worker restarts. A batch already
+claimed may finish; other background jobs continue.
 
 ### What happens if disk runs low?
 
-Stop the worker, stop new writes if necessary, and add capacity or restore the
+Pause migration claims, stop the worker or new writes if necessary, and add capacity or restore the
 coordinated backup. Do not delete old or new payload rows manually. For future
 upgrades on tight disks, set the automatic threshold to zero and approve the
 stable estimate before copying.

--- a/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
+++ b/frontend/apps/docs-site/src/content/guides/object-content-storage.mdx
@@ -12,8 +12,10 @@ import { Callout, Steps, Tabs } from "nextra/components";
 - A policy change affects new writes only. Existing content never moves
   implicitly.
 - The one-time [File and Icon storage
-  upgrade](/guides/file-icon-storage-upgrade) runs online after schema expansion
-  and is required for PostgreSQL-only installations too.
+  upgrade](/guides/file-icon-storage-upgrade) consolidates legacy bytes and their
+  storage rules in the shared module. It applies to PostgreSQL-only installations
+  too. Follow its numbered preparation, maintenance-window upgrade, online
+  adoption, and verification steps before optional S3 moves.
 - You can change to another S3-compatible service later: copy the bucket with
   your own tooling, then switch destination in **Admin > Storage**. The previous
   destination stays available so you can switch back.


### PR DESCRIPTION
## TL;DR

Operators can inspect, pause and resume the one-time File/Icon migration without stopping other background jobs. The upgrade guide now explains why every legacy installation needs the shared content model, gives numbered preparation and upgrade steps, and keeps S3 optional. PostgreSQL 13 measurements and concurrent API checks are recorded with their limits.

## Changes

Add `python -m eneo.object_content.file_icon_migration status|pause|resume`, run inside the maintenance worker. One pause flag in the existing temporary admission table serializes with new claims across replicas and survives restarts. A claimed batch may finish; resume preserves the existing capacity and halt-recovery requirements.

Status reads a consistent, read-only snapshot of the existing migration facts and worker environment. It explains preparation and pre-campaign waits without starting a campaign. Capacity inspection may sum ledger metadata on demand; no dashboard, polling API, new approval owner or cached counters are added.

Update the deployment runbook and docs-site guides with the architecture purpose, ordered organizational upgrade steps, status/capacity/recovery commands, verification and later contraction. Add reproducible PostgreSQL 13 copy/resource evidence and authenticated API coverage during adoption.

## Where to inspect and see progress

After the schema upgrade, open a terminal on the deployment host and run these commands in the maintenance worker, using the same Compose files/profile as the deployment (`worker` is the reference service name):

```bash
docker compose exec worker python -m eneo.object_content.file_icon_migration status
docker compose exec worker python -m eneo.object_content.file_icon_migration pause
docker compose exec worker python -m eneo.object_content.file_icon_migration resume
```

`status` prints JSON with the migration state, pause flag, capacity requirement or admitted capacity, and the reason for a wait or halt. It uses that worker container's configuration. This inspection is an operator terminal command; Admin > Storage continues to manage storage targets and ordinary moves.

For numerical progress, run the [Check ledger progress SQL](https://github.com/eneo-ai/eneo/blob/4400a3049e673cb03266292251b67a0008de7abc/frontend/apps/docs-site/src/content/guides/file-icon-storage-upgrade.mdx#check-ledger-progress) in `psql` against the application database. It shows pending, ready, leased, failed, done and cancelled counts, finished percentage and estimated remaining bytes. During preparation, pending becomes ready; during copying, ready becomes done. Completion requires campaign state `complete` and no pending, ready, leased or failed items. Status alone does not provide a percentage or ETA.

The [upgrade guide](https://github.com/eneo-ai/eneo/blob/4400a3049e673cb03266292251b67a0008de7abc/frontend/apps/docs-site/src/content/guides/file-icon-storage-upgrade.mdx) also covers worker logs, capacity acknowledgement and recovery. Pause stops new claims across replicas; an already claimed batch may finish.

## Why

Stopping the shared worker also stops unrelated jobs. Logs alone make a migration waiting for capacity hard to distinguish from one that has not started. A temporary operator command fits this one-time task and can leave with the migration tables during the later contract release.

## Planning

- Task: Fixes #789, under epic #549.
- Native GitHub stack #791 contains #788 followed by this PR, with `develop` as its trunk. Both PRs inherit its required checks and will merge together through the merge queue.
- Full production-size upgrade/restore/load qualification, preflight tooling and guarded legacy removal remain separate work.

## Testing

- 66 affected integration tests pass, covering persisted pause, a real concurrent pause/claim boundary, read-only status, CLI output, cached capacity waits, halt/recovery preservation, and existing adoption/fallback/failure recovery.
- After adding pause during an active claimed batch, the controls and inline suite passes all 48 tests: the claimed batch finishes, the next run pauses, and resume completes the remaining item.
- All 4,653 backend unit tests pass; Ruff, Pyright (zero errors/warnings), Alembic graph and diff checks pass.
- The new schema revision follows `202609041000`, the current `develop` schema head, and round-trips on PostgreSQL 13, preserving admission generation and pause on a repeated upgrade. The graph and isolated round-trip pass after rebasing the stack.
- Authenticated production-route ASGI upload/old-download/new-original checks pass on PostgreSQL 13 and on the broader suite's existing PostgreSQL 16 fixture.
- A pinned PostgreSQL 13 benchmark copies about 1 GiB in 1,639 items in 36.49 seconds of active work, across 17 bounded runs. Peak worker RSS is 140 MiB; all digests match and legacy rows remain. At the normal cadence this projects to about 16 minutes. Raw workload, source hashes and results are committed.
- The final combined review of #788 and #790 by Fable 5.1 at high effort is green with no blockers. Its earlier active-batch coverage suggestion is included and verified.
- Exact Bun 1.3.14 docs build, search indexing and generated guide anchors pass.

Pause stops new claims; retain headroom for a batch already claimed. Run the command in the maintenance worker so its settings match. The API check uses a small in-process workload, and the resource benchmark's foreground probe is a metadata SQL query. Neither establishes production latency, offline upgrade duration, replica/backup headroom or restore qualification. Legacy columns remain until a separately gated contract release.
