### PR TITLE
feat(storage): inspect legacy upgrade requirements before downtime

### DIFF
--- a/backend/src/eneo/object_content/file_icon_migration.py
+++ b/backend/src/eneo/object_content/file_icon_migration.py
@@ -1,7 +1,7 @@
 """Operator controls for the temporary File/Icon migration.
 
 Run inside the maintenance worker environment:
-    python -m eneo.object_content.file_icon_migration status|pause|resume
+    python -m eneo.object_content.file_icon_migration preflight|status|pause|resume
 """
 
 import argparse
@@ -12,6 +12,35 @@ from contextlib import redirect_stdout
 from dataclasses import asdict
 
 import sqlalchemy as sa
+from pydantic import ValidationError
+
+
+async def _preflight(timeout_seconds: int) -> tuple[str, int]:
+    from eneo.main.config import get_settings
+    from eneo.object_content.file_icon_preflight import (
+        FileIconPreflightReport,
+        PreflightIssue,
+        run_file_icon_preflight,
+    )
+
+    try:
+        report = await run_file_icon_preflight(
+            get_settings().database_url, timeout_seconds=timeout_seconds
+        )
+    except (ValidationError, ValueError):
+        report = FileIconPreflightReport(
+            blockers=[
+                PreflightIssue(
+                    "invalid_configuration",
+                    "Preflight configuration is invalid. Check the worker's database and OBJECT_CONTENT settings; values are omitted to protect credentials.",
+                )
+            ]
+        )
+    return json.dumps(asdict(report), indent=2), {
+        "ready": 0,
+        "blocked": 2,
+        "incomplete": 3,
+    }[report.outcome]
 
 
 async def _run(command: str) -> str:
@@ -63,13 +92,26 @@ async def _run(command: str) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("command", choices=("status", "pause", "resume"))
+    parser.add_argument("command", choices=("preflight", "status", "pause", "resume"))
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=60,
+        help="Total preflight scan deadline in seconds (default: 60)",
+    )
     arguments = parser.parse_args()
+    if arguments.timeout_seconds < 1:
+        parser.error("--timeout-seconds must be positive")
     # App loggers bind their console stream on import. Keep diagnostics on
     # stderr and reserve stdout for one complete JSON result.
     with redirect_stdout(sys.stderr):
-        result = asyncio.run(_run(arguments.command))
+        if arguments.command == "preflight":
+            result, exit_code = asyncio.run(_preflight(arguments.timeout_seconds))
+        else:
+            result = asyncio.run(_run(arguments.command))
+            exit_code = 0
     print(result)
+    raise SystemExit(exit_code)
 
 
 if __name__ == "__main__":

--- a/backend/src/eneo/object_content/file_icon_preflight.py
+++ b/backend/src/eneo/object_content/file_icon_preflight.py
@@ -1,0 +1,481 @@
+"""Read-only planning facts for the temporary File/Icon upgrade."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+import sqlalchemy as sa
+from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from alembic.script import ScriptDirectory
+from alembic.script.revision import ResolutionError
+from alembic.util.exc import CommandError
+from eneo.object_content.configuration import ObjectContentCoreSettings
+
+_MIB = 1024 * 1024
+_FOUNDATION = "202607151200"
+_EXPAND = "202607231700"
+_POLICY = "202607251700"
+_CAPACITY = "202608281130"
+
+
+@dataclass(frozen=True, slots=True)
+class PreflightSizeBands:
+    """Counts of remaining items; all bounds refer to logical bytes."""
+
+    empty: int
+    up_to_1_mib: int
+    over_1_up_to_16_mib: int
+    over_16_up_to_200_mib: int
+    over_200_mib: int
+
+
+@dataclass(frozen=True, slots=True)
+class PreflightVariant:
+    owner_kind: str
+    variant: str
+    source_count: int
+    source_bytes: int
+    available_reference_count: int
+    available_reference_bytes: int
+    remaining_count: int
+    remaining_bytes: int
+    maximum_remaining_item_bytes: int
+    oversized_count: int
+    size_bands: PreflightSizeBands
+
+
+@dataclass(slots=True)
+class PreflightCapacity:
+    remaining_logical_bytes: int | None = None
+    campaign_admitted_logical_bytes: int | None = None
+    estimated_extra_database_bytes: int | None = None
+    generated_wal_bytes: int | None = None
+    retained_wal_bytes: int | None = None
+    host_free_bytes: int | None = None
+    detail: str = (
+        "Remaining logical payload is an estimate before admission. Existing legacy "
+        "bytes stay in PostgreSQL. Database allocation, generated WAL, retained WAL "
+        "and host free space require separate measurements; null means unknown. "
+        "This command neither approves capacity nor reserves disk. Recheck status "
+        "after admission for the worker's capacity decision."
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PreflightIssue:
+    code: str
+    detail: str
+
+
+@dataclass(slots=True)
+class FileIconPreflightReport:
+    format_version: int = 1
+    outcome: Literal["ready", "blocked", "incomplete"] = "incomplete"
+    schema_state: Literal["pre_expand", "expanded", "unsupported"] = "unsupported"
+    alembic_revision: str | None = None
+    server_encoding: str | None = None
+    inline_maximum_bytes: int | None = None
+    selected_new_write_target: str | None = None
+    campaign_state: str | None = None
+    variants: list[PreflightVariant] = field(default_factory=list[PreflightVariant])
+    capacity: PreflightCapacity = field(default_factory=PreflightCapacity)
+    blockers: list[PreflightIssue] = field(default_factory=list[PreflightIssue])
+
+
+async def _read_schema(
+    connection: AsyncConnection,
+    report: FileIconPreflightReport,
+    migration_directory: Path,
+) -> set[str] | None:
+    report.server_encoding = await connection.scalar(sa.text("SHOW server_encoding"))
+    if report.server_encoding != "UTF8":
+        report.blockers.append(
+            PreflightIssue(
+                "unsupported_encoding",
+                "The legacy inventory requires UTF8 server encoding.",
+            )
+        )
+
+    rows = await connection.execute(
+        sa.text(
+            """
+            SELECT c.relname, a.attname,
+                   CASE WHEN t.typname IN ('varchar', 'bpchar') THEN 'text'
+                        ELSE t.typname END AS type_name
+            FROM pg_catalog.pg_class c
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            JOIN pg_catalog.pg_attribute a ON a.attrelid = c.oid
+            JOIN pg_catalog.pg_type t ON t.oid = a.atttypid
+            WHERE n.nspname = current_schema() AND c.relkind IN ('r', 'p')
+              AND a.attnum > 0 AND NOT a.attisdropped
+              AND c.relname IN (
+                  'alembic_version', 'files', 'icons', 'object_contents',
+                  'file_content_references', 'icon_content_references',
+                  'file_icon_backfill_items', 'file_icon_backfill_campaign',
+                  'object_content_deployment_policy'
+              )
+            """
+        )
+    )
+    columns: dict[str, dict[str, str]] = {}
+    for table, column, type_name in rows:
+        columns.setdefault(table, {})[column] = type_name
+
+    if columns.get("alembic_version", {}).get("version_num") != "text":
+        report.blockers.append(
+            PreflightIssue(
+                "unsupported_schema",
+                "A readable Alembic revision is required; use the supported upgrade path.",
+            )
+        )
+        return None
+    revisions = (
+        await connection.scalars(
+            sa.text("SELECT version_num FROM alembic_version LIMIT 2")
+        )
+    ).all()
+    if len(revisions) != 1:
+        report.blockers.append(
+            PreflightIssue(
+                "unsupported_revision",
+                "Expected one installed Alembic revision. Resolve the migration state before upgrading.",
+            )
+        )
+        return None
+    report.alembic_revision = revisions[0]
+    try:
+        scripts = ScriptDirectory(str(migration_directory))
+        installed = scripts.get_revision(revisions[0])
+        if installed.revision != revisions[0]:
+            raise CommandError("An exact revision is required")
+        ancestors = {
+            revision.revision
+            for revision in scripts.iterate_revisions(revisions[0], "base")
+        }
+    except (CommandError, ResolutionError):
+        report.blockers.append(
+            PreflightIssue(
+                "unsupported_revision",
+                "The installed revision is not in this release's migration chain. Use its matching release and documented upgrade path.",
+            )
+        )
+        return None
+
+    required = {
+        "files": {
+            "id": "uuid",
+            "file_type": "text",
+            "parent_file_id": "uuid",
+            "text": "text",
+            "blob": "bytea",
+            "transcription": "text",
+        },
+        "icons": {"id": "uuid", "blob": "bytea"},
+    }
+    unexpected: set[str] = set()
+    if _FOUNDATION in ancestors:
+        required.update(
+            {
+                "object_contents": {"id": "uuid", "state": "text"},
+                "file_content_references": {
+                    "file_id": "uuid",
+                    "variant": "text",
+                    "ordinal": "int4",
+                    "content_id": "uuid",
+                },
+                "icon_content_references": {
+                    "icon_id": "uuid",
+                    "variant": "text",
+                    "content_id": "uuid",
+                },
+            }
+        )
+    else:
+        unexpected.update(
+            ("object_contents", "file_content_references", "icon_content_references")
+        )
+    if _EXPAND in ancestors:
+        required.update(
+            {
+                "file_icon_backfill_items": {
+                    "owner_kind": "text",
+                    "owner_id": "uuid",
+                    "variant": "text",
+                    "ordinal": "int4",
+                    "payload_size_estimate": "int8",
+                    "state": "text",
+                },
+                "file_icon_backfill_campaign": {"state": "text", "target_kind": "text"},
+            }
+        )
+        if _CAPACITY in ancestors:
+            required["file_icon_backfill_campaign"]["capacity_admitted_bytes"] = "int8"
+            required["file_icon_backfill_items"]["capacity_admitted"] = "bool"
+    else:
+        unexpected.update(("file_icon_backfill_items", "file_icon_backfill_campaign"))
+    if _POLICY in ancestors:
+        required["object_content_deployment_policy"] = {
+            "id": "int2",
+            "new_write_storage_target": "text",
+        }
+    else:
+        unexpected.add("object_content_deployment_policy")
+
+    mismatches = [
+        f"{table}.{name}"
+        for table, expected in required.items()
+        for name, kind in expected.items()
+        if columns.get(table, {}).get(name) != kind
+    ]
+    mismatches.extend(sorted(unexpected.intersection(columns)))
+    if _EXPAND in ancestors:
+        freezes = await connection.scalar(
+            sa.text(
+                """
+            SELECT count(*) FROM pg_catalog.pg_trigger t
+            JOIN pg_catalog.pg_class c ON c.oid = t.tgrelid
+            JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = current_schema() AND t.tgenabled IN ('O', 'A')
+              AND ((c.relname = 'files' AND t.tgname IN (
+                  'freeze_files_legacy_payload_insert', 'freeze_files_legacy_payload_update'))
+                OR (c.relname = 'icons' AND t.tgname IN (
+                  'freeze_icons_legacy_payload_insert', 'freeze_icons_legacy_payload_update')))
+            """
+            )
+        )
+        if freezes != 4:
+            mismatches.append("legacy write fence")
+    if mismatches:
+        report.blockers.append(
+            PreflightIssue(
+                "unsupported_schema",
+                "Schema does not match this revision: "
+                + ", ".join(mismatches)
+                + ". Stop before upgrade writes. An older destructive revision sharing the same ID requires its pre-upgrade backup; do not stamp past it.",
+            )
+        )
+        return None
+    report.schema_state = "expanded" if _EXPAND in ancestors else "pre_expand"
+    return ancestors
+
+
+def _source_query(has_references: bool) -> str:
+    # Keep these four source groups equivalent to frozen inventory 202607231745.
+    # Only AVAILABLE references are excluded: failed references still need recovery.
+    file_join = (
+        """
+        LEFT JOIN file_content_references r
+          ON r.file_id = source.owner_id AND r.variant = source.variant AND r.ordinal = 0
+        LEFT JOIN object_contents c ON c.id = r.content_id
+    """
+        if has_references
+        else ""
+    )
+    icon_join = (
+        """
+        LEFT JOIN icon_content_references r ON r.icon_id = icon.id AND r.variant = 'primary'
+        LEFT JOIN object_contents c ON c.id = r.content_id
+    """
+        if has_references
+        else ""
+    )
+    available = "coalesce(c.state = 'available', false)" if has_references else "false"
+    return f"""
+        SELECT 'file' AS owner_kind, source.variant, source.size_bytes,
+               {available} AS available
+        FROM (
+            SELECT id AS owner_id,
+                   CASE WHEN file_type = 'text' THEN 'extracted_text'
+                        WHEN file_type = 'audio' THEN 'original'
+                        WHEN parent_file_id IS NOT NULL THEN 'derived_page'
+                        ELSE 'legacy_image' END AS variant,
+                   CASE WHEN file_type = 'text' THEN octet_length(text)::bigint
+                        ELSE octet_length(blob)::bigint END AS size_bytes
+            FROM files
+            WHERE CASE WHEN file_type = 'text' THEN text IS NOT NULL
+                       ELSE blob IS NOT NULL END
+            UNION ALL
+            SELECT id, 'original', octet_length(blob)::bigint FROM files
+            WHERE file_type = 'text' AND blob IS NOT NULL
+            UNION ALL
+            SELECT id, 'transcription', octet_length(transcription)::bigint FROM files
+            WHERE transcription IS NOT NULL
+        ) source {file_join}
+        UNION ALL
+        SELECT 'icon', 'primary', octet_length(icon.blob)::bigint, {available}
+        FROM icons icon {icon_join} WHERE icon.blob IS NOT NULL
+    """
+
+
+async def _inspect(
+    connection: AsyncConnection,
+    report: FileIconPreflightReport,
+    migration_directory: Path,
+    inline_maximum_bytes: int,
+) -> None:
+    ancestors = await _read_schema(connection, report, migration_directory)
+    if ancestors is None or report.blockers:
+        report.outcome = "blocked"
+        return
+    report.selected_new_write_target = "postgres_inline"
+    if _POLICY in ancestors:
+        report.selected_new_write_target = await connection.scalar(
+            sa.text(
+                "SELECT new_write_storage_target FROM object_content_deployment_policy WHERE id = 1"
+            )
+        )
+    if report.selected_new_write_target not in ("postgres_inline", "object_store"):
+        report.blockers.append(
+            PreflightIssue(
+                "missing_storage_policy",
+                "Restore the deployment storage policy before upgrading.",
+            )
+        )
+    if _EXPAND in ancestors:
+        capacity_column = (
+            "capacity_admitted_bytes" if _CAPACITY in ancestors else "NULL"
+        )
+        campaign = (
+            await connection.execute(
+                sa.text(
+                    f"SELECT state, {capacity_column} AS admitted FROM file_icon_backfill_campaign"
+                )
+            )
+        ).one_or_none()
+        if campaign is not None:
+            report.campaign_state = campaign.state
+            report.capacity.campaign_admitted_logical_bytes = campaign.admitted
+
+    rows = await connection.execute(
+        sa.text(f"""
+        WITH source AS ({_source_query(_FOUNDATION in ancestors)})
+        SELECT owner_kind, variant, count(*) AS source_count,
+               sum(size_bytes) AS source_bytes,
+               count(*) FILTER (WHERE available) AS available_reference_count,
+               coalesce(sum(size_bytes) FILTER (WHERE available), 0) AS available_reference_bytes,
+               count(*) FILTER (WHERE NOT available) AS remaining_count,
+               coalesce(sum(size_bytes) FILTER (WHERE NOT available), 0) AS remaining_bytes,
+               coalesce(max(size_bytes) FILTER (WHERE NOT available), 0) AS maximum_remaining_item_bytes,
+               count(*) FILTER (WHERE NOT available AND size_bytes > :maximum) AS oversized_count,
+               count(*) FILTER (WHERE NOT available AND size_bytes = 0) AS empty,
+               count(*) FILTER (WHERE NOT available AND size_bytes > 0 AND size_bytes <= :mib) AS small,
+               count(*) FILTER (WHERE NOT available AND size_bytes > :mib AND size_bytes <= 16 * :mib) AS medium,
+               count(*) FILTER (WHERE NOT available AND size_bytes > 16 * :mib AND size_bytes <= 200 * :mib) AS large,
+               count(*) FILTER (WHERE NOT available AND size_bytes > 200 * :mib) AS extra_large
+        FROM source GROUP BY owner_kind, variant ORDER BY owner_kind, variant
+    """),
+        {"maximum": inline_maximum_bytes, "mib": _MIB},
+    )
+    for row in rows.mappings():
+        report.variants.append(
+            PreflightVariant(
+                owner_kind=row["owner_kind"],
+                variant=row["variant"],
+                source_count=row["source_count"],
+                source_bytes=int(row["source_bytes"]),
+                available_reference_count=row["available_reference_count"],
+                available_reference_bytes=int(row["available_reference_bytes"]),
+                remaining_count=row["remaining_count"],
+                remaining_bytes=int(row["remaining_bytes"]),
+                maximum_remaining_item_bytes=row["maximum_remaining_item_bytes"],
+                oversized_count=row["oversized_count"],
+                size_bands=PreflightSizeBands(
+                    row["empty"],
+                    row["small"],
+                    row["medium"],
+                    row["large"],
+                    row["extra_large"],
+                ),
+            )
+        )
+    report.capacity.remaining_logical_bytes = sum(
+        row.remaining_bytes for row in report.variants
+    )
+    if any(row.oversized_count for row in report.variants):
+        report.blockers.append(
+            PreflightIssue(
+                "oversized_legacy_items",
+                "Remaining legacy items exceed OBJECT_CONTENT_INLINE_MAXIMUM_BYTES. Resolve the per-item limit and measure database memory/capacity before starting adoption; batch limits do not override it.",
+            )
+        )
+    if (
+        any(row.remaining_count for row in report.variants)
+        and report.selected_new_write_target == "object_store"
+    ):
+        report.blockers.append(
+            PreflightIssue(
+                "unsupported_legacy_target",
+                "Select PostgreSQL inline for legacy adoption. Direct legacy-to-object-store adoption is unsupported; verified moves can follow completion.",
+            )
+        )
+    if report.campaign_state == "halted":
+        report.blockers.append(
+            PreflightIssue(
+                "halted_campaign",
+                "Inspect migration status and follow the halt-recovery procedure before resuming.",
+            )
+        )
+    report.outcome = "blocked" if report.blockers else "ready"
+
+
+async def run_file_icon_preflight(
+    database_url: str,
+    *,
+    core_settings: ObjectContentCoreSettings | None = None,
+    timeout_seconds: int = 60,
+    migration_directory: Path = Path("alembic"),
+) -> FileIconPreflightReport:
+    """Scan metadata in one bounded, read-only snapshot without fetching payloads.
+
+    Run from the release's backend directory, as in the maintenance worker image.
+    The total deadline also bounds connection setup and all statements together.
+    """
+    if timeout_seconds < 1:
+        raise ValueError("timeout_seconds must be positive")
+    settings = core_settings or ObjectContentCoreSettings()
+    report = FileIconPreflightReport(inline_maximum_bytes=settings.inline_maximum_bytes)
+    engine = create_async_engine(
+        make_url(database_url).set(drivername="postgresql+asyncpg"),
+        poolclass=NullPool,
+        connect_args={"timeout": min(timeout_seconds, 10)},
+        hide_parameters=True,
+    )
+    try:
+        async with (
+            asyncio.timeout(timeout_seconds),
+            engine.connect() as connection,
+            connection.begin(),
+        ):
+            await connection.execute(
+                sa.text("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY")
+            )
+            await connection.execute(
+                sa.text(
+                    "SELECT set_config('statement_timeout', :timeout, true), set_config('lock_timeout', '2000', true)"
+                ),
+                {"timeout": str(timeout_seconds * 1000)},
+            )
+            await _inspect(
+                connection, report, migration_directory, settings.inline_maximum_bytes
+            )
+    except Exception:
+        # Driver errors may contain SQL, hostnames and credentials. No partial
+        # scan is reported as complete, and no automatic retry extends its load.
+        report.outcome = "incomplete"
+        report.variants.clear()
+        report.capacity.remaining_logical_bytes = None
+        report.blockers.append(
+            PreflightIssue(
+                "inspection_incomplete",
+                "Preflight could not finish. Check database connectivity, read permissions and locks; rerun with --timeout-seconds increased if the scan needs a larger budget.",
+            )
+        )
+    finally:
+        await engine.dispose()
+    return report

--- a/backend/tests/integration/migrations/test_file_icon_preflight.py
+++ b/backend/tests/integration/migrations/test_file_icon_preflight.py
@@ -1,0 +1,350 @@
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict
+from hashlib import sha256
+from pathlib import Path
+from time import monotonic
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from psycopg2 import sql
+from testcontainers.postgres import PostgresContainer
+
+from alembic import command
+from eneo.object_content.configuration import ObjectContentCoreSettings
+from eneo.object_content.file_icon_preflight import run_file_icon_preflight
+from tests.integration.migrations import test_file_icon_staged_backfill_expand as expand
+
+cleanup_database = expand.cleanup_database
+encryption_service = expand.encryption_service
+override_settings_for_session = expand.override_settings_for_session
+seed_default_models = expand.seed_default_models
+_connect = expand._connect
+_seed_legacy_owners = expand._seed_legacy_owners
+
+pytestmark = [pytest.mark.integration, pytest.mark.migration_isolation]
+
+
+@pytest.fixture
+def migration_database(request):
+    with PostgresContainer(
+        image=expand._POSTGRES_13_IMAGE,
+        username="file_icon_expand",
+        password="file_icon_expand_password",
+        dbname="file_icon_expand",
+    ) as postgres:
+        database_url = postgres.get_connection_url()
+        config = expand._alembic_config(database_url)
+        command.upgrade(config, getattr(request, "param", expand._PREVIOUS_REVISION))
+        yield database_url, config
+
+
+def test_preflight_matches_frozen_inventory_without_changing_legacy_database(
+    migration_database,
+):
+    database_url, config = migration_database
+    ids = _seed_legacy_owners(database_url)
+    with _connect(database_url) as connection, connection.cursor() as cursor:
+        # Empty bytes are work; an absent payload and a deleted owner are not.
+        cursor.execute(
+            "UPDATE files SET text = '', transcription = NULL WHERE id = %s",
+            (ids["text"],),
+        )
+        cursor.execute(
+            "UPDATE files SET transcription = 'åäö' WHERE id = %s",
+            (ids["image"],),
+        )
+        cursor.execute("DELETE FROM files WHERE id = %s", (ids["audio"],))
+        cursor.execute("SELECT version_num FROM alembic_version")
+        (revision,) = cursor.fetchone()
+
+    result = asyncio.run(run_file_icon_preflight(database_url))
+    assert result.outcome == "ready"
+    assert result.schema_state == "pre_expand"
+    assert result.alembic_revision == revision == "202607240310"
+    assert result.server_encoding == "UTF8"
+    assert result.capacity.campaign_admitted_logical_bytes is None
+    assert result.capacity.host_free_bytes is None
+    assert result.capacity.estimated_extra_database_bytes is None
+    assert result.capacity.generated_wal_bytes is None
+    assert result.capacity.retained_wal_bytes is None
+
+    facts = {
+        (row.owner_kind, row.variant): (row.remaining_count, row.remaining_bytes)
+        for row in result.variants
+    }
+    assert facts == {
+        ("file", "extracted_text"): (1, 0),
+        ("file", "original"): (1, len(b"original pdf")),
+        ("file", "transcription"): (1, len("åäö".encode())),
+        ("file", "legacy_image"): (1, len(b"legacy image")),
+        ("file", "derived_page"): (1, len(b"derived page")),
+        ("icon", "primary"): (1, len(b"legacy icon")),
+    }
+    assert sum(row.size_bands.empty for row in result.variants) == 1
+    assert result.capacity.remaining_logical_bytes == sum(n for _, n in facts.values())
+
+    with _connect(database_url) as connection, connection.cursor() as cursor:
+        cursor.execute("SELECT version_num FROM alembic_version")
+        assert cursor.fetchone() == (revision,)
+        cursor.execute("SELECT to_regclass('file_icon_backfill_items')")
+        assert cursor.fetchone() == (None,)
+        cursor.execute("SELECT text, blob FROM files WHERE id = %s", (ids["text"],))
+        text, blob = cursor.fetchone()
+        assert text == "" and bytes(blob) == b"original pdf"
+
+    command.upgrade(config, "202607231745")
+    with _connect(database_url) as connection, connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT owner_kind, variant, count(*), sum(payload_size_estimate) "
+            "FROM file_icon_backfill_items GROUP BY owner_kind, variant"
+        )
+        assert {
+            (kind, variant): (n, int(size)) for kind, variant, n, size in cursor
+        } == facts
+    expanded = asyncio.run(run_file_icon_preflight(database_url))
+    assert expanded.outcome == "ready"
+    assert expanded.schema_state == "expanded"
+    assert [asdict(row) for row in expanded.variants] == [
+        asdict(row) for row in result.variants
+    ]
+
+    command.upgrade(config, "head")
+    with _connect(database_url) as connection, connection.cursor() as cursor:
+        for owner, variant, payload, state in (
+            (ids["text"], "original", b"original pdf", "available"),
+            (ids["derived"], "derived_page", b"derived page", "failed"),
+        ):
+            content_id = str(uuid4())
+            digest = sha256(payload).digest()
+            cursor.execute(
+                """
+                INSERT INTO object_contents (
+                    id, tenant_id, storage_kind, state, access_class, sha256,
+                    size_bytes, verified_media_type, idempotency_key,
+                    request_fingerprint, available_at, failure_code
+                ) VALUES (%s, %s, 'postgres_inline', %s, 'private_resource',
+                          %s, %s, 'application/octet-stream', %s, %s, now(), NULL)
+                """,
+                (
+                    content_id,
+                    ids["tenant"],
+                    "available",
+                    digest,
+                    len(payload),
+                    content_id,
+                    digest,
+                ),
+            )
+            cursor.execute(
+                "INSERT INTO inline_content_payloads (content_id, payload) VALUES (%s, %s)",
+                (content_id, payload),
+            )
+            cursor.execute(
+                "INSERT INTO file_content_references (file_id, content_id, variant, ordinal) VALUES (%s, %s, %s, 0)",
+                (owner, content_id, variant),
+            )
+            if state == "failed":
+                cursor.execute(
+                    "UPDATE object_contents SET state = 'failed', failure_code = 'backend_missing' WHERE id = %s",
+                    (content_id,),
+                )
+        cursor.execute(
+            "INSERT INTO file_icon_backfill_campaign (id, target_kind, state, capacity_admitted_bytes) VALUES (%s, 'postgres_inline', 'active', 1000)",
+            (str(uuid4()),),
+        )
+    partial = asyncio.run(
+        run_file_icon_preflight(
+            database_url,
+            core_settings=ObjectContentCoreSettings(
+                inline_maximum_bytes=11, inline_io_chunk_bytes=1
+            ),
+        )
+    )
+    assert partial.outcome == "blocked"
+    assert [issue.code for issue in partial.blockers] == ["oversized_legacy_items"]
+    partial_facts = {(row.owner_kind, row.variant): row for row in partial.variants}
+    original = partial_facts["file", "original"]
+    assert original.available_reference_count == 1
+    assert original.available_reference_bytes == len(b"original pdf")
+    assert original.remaining_count == original.oversized_count == 0
+    assert partial_facts["file", "derived_page"].oversized_count == 1
+    assert partial_facts["file", "derived_page"].available_reference_count == 0
+    assert partial_facts["icon", "primary"].oversized_count == 0  # Exact limit.
+    assert partial.capacity.campaign_admitted_logical_bytes == 1000
+    assert (
+        partial.capacity.remaining_logical_bytes
+        == result.capacity.remaining_logical_bytes - len(b"original pdf")
+    )
+    with _connect(database_url) as connection, connection.cursor() as cursor:
+        cursor.execute(
+            "UPDATE object_content_deployment_policy SET new_write_storage_target = 'object_store' WHERE id = 1"
+        )
+    remote = asyncio.run(run_file_icon_preflight(database_url))
+    assert "unsupported_legacy_target" in [issue.code for issue in remote.blockers]
+    with _connect(database_url) as connection, connection.cursor() as cursor:
+        cursor.execute(
+            "ALTER TABLE icons DISABLE TRIGGER freeze_icons_legacy_payload_update"
+        )
+    unfenced = asyncio.run(run_file_icon_preflight(database_url))
+    assert unfenced.schema_state == "unsupported"
+    assert "unsupported_schema" in [issue.code for issue in unfenced.blockers]
+
+
+@pytest.mark.parametrize("migration_database", ["202607071200"], indirect=True)
+def test_preflight_supports_legacy_release_before_reference_tables(migration_database):
+    database_url, _ = migration_database
+    _seed_legacy_owners(database_url)
+    result = asyncio.run(run_file_icon_preflight(database_url))
+    assert result.outcome == "ready"
+    assert result.schema_state == "pre_expand"
+    assert sum(row.remaining_count for row in result.variants) == 7
+    assert all(row.available_reference_count == 0 for row in result.variants)
+
+
+def test_preflight_refuses_non_utf8_before_source_scan(migration_database):
+    database_url, _ = migration_database
+    name = f"preflight_latin1_{uuid4().hex}"
+    connection = _connect(database_url)
+    try:
+        connection.autocommit = True
+        with connection.cursor() as cursor:
+            cursor.execute(
+                sql.SQL(
+                    "CREATE DATABASE {} ENCODING 'LATIN1' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0"
+                ).format(sql.Identifier(name))
+            )
+        latin1_url = (
+            sa.engine.make_url(database_url)
+            .set(database=name)
+            .render_as_string(hide_password=False)
+        )
+        result = asyncio.run(run_file_icon_preflight(latin1_url))
+        assert result.outcome == "blocked"
+        assert result.server_encoding == "LATIN1"
+        assert "unsupported_encoding" in [issue.code for issue in result.blockers]
+        assert result.variants == []
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize(
+    "change,undo,code",
+    [
+        (
+            "ALTER TABLE files RENAME COLUMN blob TO old_blob",
+            "ALTER TABLE files RENAME COLUMN old_blob TO blob",
+            "unsupported_schema",
+        ),
+        (
+            "UPDATE alembic_version SET version_num = 'unknown-preflight-revision'",
+            None,
+            "unsupported_revision",
+        ),
+    ],
+)
+def test_preflight_refuses_unknown_schema_or_revision(
+    migration_database, change, undo, code
+):
+    database_url, _ = migration_database
+    with _connect(database_url) as connection, connection.cursor() as cursor:
+        cursor.execute("SELECT version_num FROM alembic_version")
+        (revision,) = cursor.fetchone()
+        cursor.execute(change)
+    try:
+        result = asyncio.run(run_file_icon_preflight(database_url))
+        assert result.outcome == "blocked"
+        assert result.schema_state == "unsupported"
+        assert result.variants == []
+        assert result.capacity.remaining_logical_bytes is None
+        assert code in [issue.code for issue in result.blockers]
+    finally:
+        with _connect(database_url) as connection, connection.cursor() as cursor:
+            if undo:
+                cursor.execute(undo)
+            else:
+                cursor.execute(
+                    "UPDATE alembic_version SET version_num = %s", (revision,)
+                )
+
+
+def test_preflight_timeout_is_incomplete_and_leaves_no_waiter(migration_database):
+    database_url, _ = migration_database
+    with _connect(database_url) as blocker, blocker.cursor() as cursor:
+        cursor.execute("LOCK TABLE files IN ACCESS EXCLUSIVE MODE")
+        started = monotonic()
+        result = asyncio.run(run_file_icon_preflight(database_url, timeout_seconds=1))
+        assert monotonic() - started < 5
+        assert result.outcome == "incomplete"
+        assert result.variants == []
+        assert result.capacity.remaining_logical_bytes is None
+        cursor.execute(
+            "SELECT count(*) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid() AND wait_event_type = 'Lock'"
+        )
+        assert cursor.fetchone() == (0,)
+
+
+def test_preflight_cli_json_exit_codes_and_credentials(
+    migration_database, test_settings
+):
+    database_url, _ = migration_database
+    _seed_legacy_owners(database_url)
+    with _connect(database_url) as connection:
+        parameters = connection.get_dsn_parameters()
+    environment = os.environ.copy()
+    environment.update(
+        {
+            name.upper(): str(getattr(test_settings, name))
+            for name, model_field in type(test_settings).model_fields.items()
+            if model_field.is_required()
+        }
+    )
+    environment.update(
+        POSTGRES_HOST=parameters["host"],
+        POSTGRES_PORT=parameters["port"],
+        POSTGRES_USER=parameters["user"],
+        POSTGRES_PASSWORD="file_icon_expand_password",
+        POSTGRES_DB=parameters["dbname"],
+        LOGLEVEL="DEBUG",
+        TESTING="true",
+    )
+
+    def run():
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "eneo.object_content.file_icon_migration",
+                "preflight",
+                "--timeout-seconds",
+                "5",
+            ],
+            cwd=Path(__file__).resolve().parents[3],
+            env=environment,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+        assert "file_icon_expand_password" not in result.stdout + result.stderr
+        assert "original pdf" not in result.stdout + result.stderr
+        assert len(result.stdout) < 20_000
+        return result.returncode, json.loads(result.stdout)
+
+    exit_code, output = run()
+    assert exit_code == 0
+    assert output["format_version"] == 1
+    assert output["outcome"] == "ready"
+    environment["OBJECT_CONTENT_INLINE_MAXIMUM_BYTES"] = "1"
+    environment["OBJECT_CONTENT_INLINE_IO_CHUNK_BYTES"] = "1"
+    exit_code, output = run()
+    assert exit_code == 2
+    assert output["outcome"] == "blocked"
+    environment["POSTGRES_PASSWORD"] = "deliberately-wrong-preflight-password"
+    exit_code, output = run()
+    assert exit_code == 3
+    assert output["outcome"] == "incomplete"

--- a/docs/deployment/OBJECT_CONTENT.md
+++ b/docs/deployment/OBJECT_CONTENT.md
@@ -648,8 +648,9 @@ S3-compatible storage is optional and is not the reason the migration is require
 
 The organizational sequence is:
 
-1. Restore and test the intended release with representative data. Measure legacy
-   payload size, reserve PostgreSQL/WAL headroom, and keep PostgreSQL inline selected.
+1. Run read-only preflight with the intended release before downtime. Restore and
+   test representative data, reserve PostgreSQL/WAL headroom from the reported
+   legacy bytes, and keep PostgreSQL inline selected.
 2. Drain old jobs, stop all old backend/worker processes, take the coordinated
    recovery point, and run `db-init` with the API closed.
 3. Start the new release. Let bounded online adoption run, or acknowledge the
@@ -766,6 +767,56 @@ Waiting for capacity is non-fatal: the upgrade is complete, the application
 continues serving frozen legacy File/Icon content, and the worker emits a
 structured warning with the requirement and required acknowledgement on startup
 and every scheduled tick.
+
+### Preflight before downtime
+
+Use the intended new release's image with the existing database configuration.
+Keep old services running during this inspection and use the deployment's normal
+Compose files, profile and maintenance-worker service name:
+
+```bash
+docker compose pull worker
+docker compose run --rm --no-deps -T --entrypoint python worker \
+  -m eneo.object_content.file_icon_migration preflight --timeout-seconds 60 \
+  > file-icon-preflight.json
+```
+
+`run` uses the new image; an old running worker does not contain the command.
+`--entrypoint python` and `--no-deps` keep this invocation to the inspection
+without starting worker jobs or `db-init`. After upgrading, it can also run via
+`docker compose exec worker`.
+
+JSON format version 1 reports `outcome`, `schema_state`, `alembic_revision`,
+`server_encoding`, `inline_maximum_bytes`, storage target, per-variant facts,
+`capacity` and `blockers`. Exit 0 (`ready`) means the metadata checks passed;
+exit 2 (`blocked`) requires resolving a reported issue; exit 3 (`incomplete`)
+means the scan or configuration did not allow a complete result. Check both
+the exit status and JSON before proceeding. No payloads, SQL errors or credentials
+are printed.
+
+The four inventory source groups use logical `octet_length`, preserve empty
+payloads, omit absent payloads/deleted owners and exclude only references whose
+content is `available`. Counts, total bytes, maximum remaining item, oversized
+items and fixed remaining-item size bands are returned in bounded output.
+Remaining logical bytes estimate the future copy; an expanded campaign's
+`campaign_admitted_logical_bytes` is its existing cumulative exposure, including
+possible replacement copies. These are not interchangeable capacity approvals.
+
+Physical database allocation, generated WAL, retained WAL and host free bytes
+remain `null` (unknown). Use the guide's
+[disk planning procedure](https://docs.eneo.ai/guides/file-icon-storage-upgrade#disk-use-the-affected-bytes-not-total-database-size)
+for measurements. Preflight does not reserve capacity, hash/copy bytes, contact
+object storage, or write schema or ledger data. It uses one read-only repeatable
+snapshot, a two-second lock timeout and a total deadline. Increase
+`--timeout-seconds` deliberately for a larger metadata scan; no retry or ongoing
+polling is performed.
+
+Before the write fence, normal traffic can change the estimate. Recheck `status`
+after admission for the worker's actual capacity requirement. Resolve unsupported
+schema/revision/encoding, oversized items, an incompatible target or a halted
+campaign before proceeding. Matching revision IDs and schema cannot distinguish
+earlier unreleased migration implementations with the same shape; the existing
+backup-restore requirement for those revisions still applies.
 
 ### Inspect or pause the one-time File/Icon migration
 

--- a/frontend/apps/docs-site/src/content/guides/file-icon-storage-upgrade.mdx
+++ b/frontend/apps/docs-site/src/content/guides/file-icon-storage-upgrade.mdx
@@ -12,8 +12,9 @@ installations. S3-compatible storage is optional.**
 
 For an organization upgrading an existing installation:
 
-1. **Prepare and test.** Restore a recent backup in a test environment and follow
-   this guide with the intended release. Measure the affected legacy bytes,
+1. **Prepare and test.** Run [preflight before downtime](#run-preflight-before-downtime)
+   with the intended release image. Restore a recent backup in a test environment
+   and follow this guide. Use the reported legacy bytes to
    reserve additional PostgreSQL and WAL space, and test representative uploads
    and downloads during adoption. Keep **PostgreSQL inline** selected for the
    migration.
@@ -57,7 +58,8 @@ by that model.
 
 ```mermaid
 flowchart LR
-  expand["db-init\nschema · write fence · inventory"] --> online["Eneo starts\nlegacy files remain readable"]
+  preflight["Before downtime\nread-only preflight"] --> expand["db-init\nschema · write fence · inventory"]
+  expand --> online["Eneo starts\nlegacy files remain readable"]
   online --> adopt["Worker\nbounded copy · SHA-256 · reference"]
   adopt --> verify["Verification period\nfiles · backup · restore"]
   verify --> contract["Later contract release\nlock · recheck · remove legacy schema"]
@@ -80,6 +82,65 @@ a production-size test shows acceptable latency.
 </Callout>
 
 <Steps>
+### Run preflight before downtime
+
+Point the Compose `worker` service at the intended new release image and keep
+the current database settings. Use the same Compose files and profile as the
+deployment. Pull the image, then run only the preflight command while the old
+services are still available:
+
+```bash
+docker compose pull worker
+docker compose run --rm --no-deps -T --entrypoint python worker \
+  -m eneo.object_content.file_icon_migration preflight --timeout-seconds 60 \
+  > file-icon-preflight.json
+```
+
+The entrypoint override runs the inspection without starting a worker, running
+`db-init`, or starting its dependencies. An existing worker from the old release
+does not contain this command, so use `run` with the new image before the upgrade.
+After deployment, `exec worker` can run it in the current worker container.
+
+Preflight checks the installed revision, required schema shape and UTF8 encoding,
+then counts legacy File and Icon variants using their logical byte lengths.
+It reports the largest remaining item, items over
+`OBJECT_CONTENT_INLINE_MAXIMUM_BYTES`, and counts in fixed size bands: empty,
+up to 1 MiB, over 1–16 MiB, over 16–200 MiB, and over 200 MiB. Available content
+references are excluded from the remaining estimate; failed references are not.
+No payloads are fetched or hashed, and no capacity is approved or data changed.
+
+The command writes one JSON result to stdout with `format_version: 1`. Check its
+exit code as well as the report:
+
+| Exit code | `outcome` | Required action |
+| --- | --- | --- |
+| `0` | `ready` | Metadata checks passed. Plan disk/WAL headroom and test the upgrade before proceeding. |
+| `2` | `blocked` | Resolve the reported `blockers`: unsupported schema/encoding, oversized items, an incompatible storage target, or a halted campaign. |
+| `3` | `incomplete` | The inspection did not finish or configuration is invalid. Check connectivity, read permissions and locks; increase `--timeout-seconds` for an intentionally longer scan. |
+
+Resolve oversized items before adoption. Raising the inline ceiling also raises
+the possible database memory demand; test capacity and use matching backend and
+worker settings. Direct legacy-to-S3 adoption is unsupported. Keep PostgreSQL
+inline selected through completion, then use verified moves if needed.
+
+`capacity.remaining_logical_bytes` is the remaining copy estimate.
+`campaign_admitted_logical_bytes`, when present, is cumulative exposure already
+accepted by an existing campaign; it can include completed or replacement copies.
+Do not add it to the remaining estimate as a new requirement. Physical database
+growth, generated WAL, retained WAL and host free bytes are separate fields with
+`null` values because this scan cannot determine them. Use the
+[disk planning procedure](#disk-use-the-affected-bytes-not-total-database-size)
+to measure them and preserve operating headroom.
+
+Before the write fence, normal traffic can change these facts. The report is an
+estimate from one read-only snapshot, not a reservation or an upgrade guarantee.
+Recheck [migration status after admission](#read-migration-status) for the
+worker's actual capacity decision. This is an on-demand scan of source-row
+metadata, with a total deadline and a two-second lock timeout; it still consumes
+database I/O. Do not poll it frequently. Matching schema and revision IDs cannot
+prove which earlier unreleased migration code was applied; the restore warning
+above still applies.
+
 ### Test the complete path
 
 Restore a recent production backup in a test environment. Run the same release,


### PR DESCRIPTION
## TL;DR

Operators can inspect legacy File/Icon upgrade requirements before downtime. A new `preflight` command reports unsupported schemas, encoding and size blockers, remaining logical bytes, and incompatible storage targets while the old installation is still running. The existing upgrade guide now starts with this step.

## Changes

Extend `python -m eneo.object_content.file_icon_migration` with `preflight --timeout-seconds 60`. Run it from the intended new release image with the current database settings:

```bash
docker compose run --rm --no-deps -T --entrypoint python worker \
  -m eneo.object_content.file_icon_migration preflight --timeout-seconds 60
```

The command checks the known Alembic revision and required File/Icon schema, then reads byte-length metadata in one read-only snapshot with a total deadline and lock timeout. Versioned JSON includes per-variant counts and bytes, maximum remaining item, oversized counts, fixed size bands and available-reference exclusions. Exit codes distinguish passed metadata checks (0), blockers (2) and incomplete inspection (3).

For partial upgrades, remaining copy estimates and already admitted campaign exposure are separate. Physical database allocation, generated WAL, retained WAL and host free bytes remain explicitly unknown until measured. The worker retains ownership of its actual admission and capacity decision. The command does not fetch/hash/copy payloads, approve capacity or change database state.

The docs-site guide and deployment runbook explain how to use the new image before stopping old services, interpret the result, then proceed through backup, expand, capacity inspection, adoption and verification. S3 moves remain optional after adoption.

## Why

Post-upgrade status requires the expanded schema. Operators need actionable schema, item-size and volume checks before entering the maintenance window, including when content has already been partly adopted.

## Planning

- Task: Fixes #792, under epic #549.
- Builds on merged PRs #788 and #790; targets `develop` directly.
- Production-scale scan timing and complete upgrade/traffic/restore qualification remain separately tracked. This PR does not deploy or remove legacy storage.

## Testing

- Seven PostgreSQL 13 integration cases pass: pre-foundation and pre-expand schemas, exact inventory equivalence, empty/absent/UTF8/deleted sources, partial adoption, available versus failed references, size blockers, missing write fences, unsupported schema/revision/encoding, lock cancellation and real CLI JSON/exit codes with credentials withheld.
- All eight existing migration-control tests and all 4,868 backend unit tests pass.
- Ruff and strict Pyright pass with zero errors/warnings.
- Bun 1.3.14 docs build and search indexing pass; the rendered guide's 42 anchors, local links and operator commands are checked.
- Rebasing onto the merged stack left the validated file tree unchanged. [Required GitHub CI passed](https://github.com/eneo-ai/eneo/actions/runs/34114923609): 4,868 unit tests and 1,525 integration tests passed, with 113 skips and one expected failure. Merged into `develop` after [merge-queue CI passed](https://github.com/eneo-ai/eneo/actions/runs/34117066181). [PR review](https://github.com/eneo-ai/eneo/pull/793#issuecomment-5569746475) found no issues at the validated head.

Preflight remains an on-demand metadata scan whose facts can change before the write fence. A successful result does not reserve disk or replace the worker's post-admission capacity requirement. Matching revision IDs and schema cannot distinguish unreleased migration implementations that reused the same shape; the documented restore requirement still applies.
