### PR TITLE
fix(chat): localize the built-in image generation tool

### DIFF
--- a/backend/src/eneo/mcp_servers/infrastructure/proxy/mcp_proxy_session.py
+++ b/backend/src/eneo/mcp_servers/infrastructure/proxy/mcp_proxy_session.py
@@ -56,6 +56,21 @@ _CIRCUIT_BREAKER_STATE: dict[UUID, dict[str, float | int]] = {}
 _CIRCUIT_BREAKER_LOCK = asyncio.Lock()
 
 
+def _trace_server_name(server: MCPServer) -> str:
+    """Server name a tool call is reported under to clients.
+
+    A built-in provider is an admin-named row whose endpoint is one of Eneo's
+    loopback servers, mounted under its purpose (see
+    ``MCPServerService.builtin_provider_url``). Its tools are Eneo's own, so
+    they are reported under the loopback server's name like the knowledge and
+    files servers are; that lets the chat label them in the UI language
+    instead of showing the server-side English title under the row's name.
+    """
+    if is_builtin_provider(server.http_auth_type) and server.purpose:
+        return server.purpose
+    return server.name
+
+
 def _tool_call_timeout_for(server: MCPServer) -> int | None:
     """Per-server tool-call budget; ``None`` keeps the client default.
 
@@ -743,7 +758,7 @@ class MCPProxySession:
         if prefixed_tool_name not in self._tool_registry:
             return None
         server, original_tool_name, title = self._tool_registry[prefixed_tool_name]
-        return (server.name, original_tool_name, title)
+        return (_trace_server_name(server), original_tool_name, title)
 
     def _capture_owner_task(self) -> None:
         """Bind this proxy session to the current asyncio.Task on first connect.

--- a/backend/tests/unit/test_mcp_proxy_session_resilience.py
+++ b/backend/tests/unit/test_mcp_proxy_session_resilience.py
@@ -148,6 +148,42 @@ async def test_builtin_image_provider_gets_its_own_tool_call_budget(monkeypatch)
     )
 
 
+def test_builtin_provider_tool_calls_are_reported_under_the_loopback_server():
+    """A built-in provider's tools are Eneo's own: the trace names the
+    loopback server (its purpose), not the admin-named row, so clients can
+    localize them like the other internal servers. External servers keep
+    their own name."""
+    general = _make_server("general")
+    provider_id = uuid4()
+    image_provider = MCPServer(
+        id=provider_id,
+        tenant_id=general.tenant_id,
+        name="Image Studio",
+        http_url="http://localhost/internal-mcp/image_generation/mcp",
+        http_auth_type="internal",
+        purpose="image_generation",
+        image_model_id=uuid4(),
+        tools=[
+            MCPServerTool(
+                mcp_server_id=provider_id,
+                name="generate_image",
+                title="Generate image",
+                description="Generate an image from a text description.",
+                input_schema={"type": "object", "properties": {}},
+                is_enabled_by_default=True,
+            )
+        ],
+    )
+    proxy = MCPProxySession([general, image_provider])
+
+    assert proxy.get_tool_info("image_studio__generate_image") == (
+        "image_generation",
+        "generate_image",
+        "Generate image",
+    )
+    assert proxy.get_tool_info("general__tool") == ("general", "tool", None)
+
+
 class _InMemoryToolRepo:
     def __init__(self, tools: list[MCPServerTool]) -> None:
         self.tools = {tool.id: tool for tool in tools}

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -1079,6 +1079,8 @@
   "tool_read_file": "Reading attached file",
   "tool_read_file_done": "Read attached file",
   "tool_generate_image": "Generating image",
+  "tool_generate_image_title": "Generate image",
+  "tool_generate_image_description": "Generate an image from a text description.",
   "tool_generate_image_done": "Generated image",
   "internal_files_server": "Attachments",
   "internal_tool_steps_count": "{count} steps",

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -1078,6 +1078,8 @@
   "tool_describe_source_done": "Got an overview of the knowledge source",
   "tool_read_file": "Reading attached file",
   "tool_read_file_done": "Read attached file",
+  "tool_generate_image": "Generating image",
+  "tool_generate_image_done": "Generated image",
   "internal_files_server": "Attachments",
   "internal_tool_steps_count": "{count} steps",
   "mcp_internal_server_hint": "Built-in Eneo tool, always active",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -1076,6 +1076,8 @@
   "tool_read_file": "Läser bifogad fil",
   "tool_read_file_done": "Läste bifogad fil",
   "tool_generate_image": "Genererar bild",
+  "tool_generate_image_title": "Generera bild",
+  "tool_generate_image_description": "Genererar en bild utifrån en textbeskrivning.",
   "tool_generate_image_done": "Genererade bild",
   "internal_files_server": "Bilagor",
   "internal_tool_steps_count": "{count} steg",

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -1075,6 +1075,8 @@
   "tool_describe_source_done": "Hämtade översikt av kunskapskällan",
   "tool_read_file": "Läser bifogad fil",
   "tool_read_file_done": "Läste bifogad fil",
+  "tool_generate_image": "Genererar bild",
+  "tool_generate_image_done": "Genererade bild",
   "internal_files_server": "Bilagor",
   "internal_tool_steps_count": "{count} steg",
   "mcp_internal_server_hint": "Inbyggt Eneo-verktyg, alltid aktivt",

--- a/frontend/apps/web/src/lib/features/chat/components/conversation/MessageAnswer.svelte
+++ b/frontend/apps/web/src/lib/features/chat/components/conversation/MessageAnswer.svelte
@@ -408,7 +408,7 @@
                   </span>
                 {/if}
               </div>
-              <span class="text-muted text-xs">{toolCall.server_name}</span>
+              <span class="text-muted text-xs">{serverDisplayName(toolCall.server_name)}</span>
             </div>
 
             <!-- Expand indicator -->

--- a/frontend/apps/web/src/lib/features/chat/internalToolLabels.ts
+++ b/frontend/apps/web/src/lib/features/chat/internalToolLabels.ts
@@ -8,6 +8,8 @@ import { m } from "$lib/paraglide/messages";
 
 type ToolArgs = Record<string, unknown> | undefined;
 
+type CatalogLabels = { title: () => string; description: () => string };
+
 /**
  * Localized display labels for Eneo's own built-in tools (the loopback
  * internal-MCP servers). External MCP servers provide their own titles and
@@ -24,6 +26,12 @@ const INTERNAL_SERVERS: Record<
       string,
       { running: (args?: ToolArgs) => string; done: (args?: ToolArgs) => string }
     >;
+    /**
+     * Admin-facing title and description per tool, for servers that admins
+     * see as catalog rows (built-in providers). Other internal servers are
+     * never listed in admin surfaces and carry none.
+     */
+    catalog?: Record<string, CatalogLabels>;
   }
 > = {
   knowledge: {
@@ -79,9 +87,31 @@ const INTERNAL_SERVERS: Record<
         running: () => m.tool_generate_image(),
         done: () => m.tool_generate_image_done()
       }
+    },
+    catalog: {
+      generate_image: {
+        title: () => m.tool_generate_image_title(),
+        description: () => m.tool_generate_image_description()
+      }
     }
   }
 };
+
+/**
+ * Localized admin-facing title and description of a tool on one of Eneo's
+ * built-in providers, or null for external servers and unknown tools. A
+ * built-in provider is an admin-named server row over the loopback server
+ * of its purpose; admin surfaces show synced protocol strings for external
+ * servers, while Eneo's own tools follow the UI language.
+ */
+export function builtinToolCatalogLabels(
+  server: { purpose?: string | null; http_auth_type?: string | null },
+  toolName: string
+): { title: string; description: string } | null {
+  if (server.http_auth_type !== "internal" || !server.purpose) return null;
+  const labels = INTERNAL_SERVERS[server.purpose]?.catalog?.[toolName];
+  return labels ? { title: labels.title(), description: labels.description() } : null;
+}
 
 /** Whether a server name refers to one of Eneo's built-in loopback servers. */
 export function isInternalServer(serverName: string): boolean {

--- a/frontend/apps/web/src/lib/features/chat/internalToolLabels.ts
+++ b/frontend/apps/web/src/lib/features/chat/internalToolLabels.ts
@@ -67,6 +67,19 @@ const INTERNAL_SERVERS: Record<
         done: () => m.tool_read_file_done()
       }
     }
+  },
+  // The built-in image generation provider is an admin-named server row over
+  // Eneo's loopback server; the backend reports its tool calls under the
+  // loopback server's name so the tool follows the UI language too. An
+  // external image provider keeps its own name and titles.
+  image_generation: {
+    label: () => m.image_generation(),
+    tools: {
+      generate_image: {
+        running: () => m.tool_generate_image(),
+        done: () => m.tool_generate_image_done()
+      }
+    }
   }
 };
 

--- a/frontend/apps/web/src/routes/(app)/admin/mcp-servers/MCPServersTable.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/mcp-servers/MCPServersTable.svelte
@@ -191,6 +191,7 @@
                   serverName={server.name}
                   tools={server.tools || []}
                   eneoClient={eneo}
+                  {server}
                 />
               </td>
             </tr>

--- a/frontend/apps/web/src/routes/(app)/admin/mcp-servers/MCPToolsPanel.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/mcp-servers/MCPToolsPanel.svelte
@@ -12,6 +12,7 @@
   import { invalidate } from "$app/navigation";
   import { untrack } from "svelte";
   import type { Eneo, components } from "@eneo/eneo-js";
+  import { builtinToolCatalogLabels } from "$lib/features/chat/internalToolLabels";
 
   type MCPTool = components["schemas"]["MCPServerToolPublic"];
 
@@ -20,9 +21,17 @@
     serverName: string;
     tools: MCPTool[];
     eneoClient: Eneo;
+    /** Purpose and auth type of the server; a built-in provider's tools get localized labels. */
+    server?: { purpose?: string | null; http_auth_type?: string | null };
   };
 
-  const { mcpServerId, serverName: _serverName, tools: initialTools, eneoClient }: Props = $props();
+  const {
+    mcpServerId,
+    serverName: _serverName,
+    tools: initialTools,
+    eneoClient,
+    server = {}
+  }: Props = $props();
 
   let tools: MCPTool[] = $state(untrack(() => initialTools));
   let syncing = $state(false);
@@ -71,7 +80,16 @@
 
   /** Admin-facing label: rename override, then the tool's own title, then the protocol name. */
   function toolLabel(tool: MCPTool): string {
-    return tool.display_name ?? tool.title ?? tool.name;
+    return (
+      tool.display_name ??
+      builtinToolCatalogLabels(server, tool.name)?.title ??
+      tool.title ??
+      tool.name
+    );
+  }
+
+  function toolDescription(tool: MCPTool): string | null {
+    return builtinToolCatalogLabels(server, tool.name)?.description ?? tool.description ?? null;
   }
 
   // Derived: tools needing review
@@ -448,6 +466,7 @@
                   </div>
                 </div>
               {:else}
+                {@const description = toolDescription(tool)}
                 <!-- Normal tool -->
                 <div
                   class="hover:bg-hover-dimmer flex items-center gap-3 px-3 py-2.5 transition-all {tool.is_enabled_by_default
@@ -534,10 +553,10 @@
                           </button>
                         </Tooltip>
                       </div>
-                      {#if tool.description}
-                        <Tooltip text={tool.description} placement="bottom">
+                      {#if description}
+                        <Tooltip text={description} placement="bottom">
                           <p class="text-muted cursor-help truncate text-xs leading-snug">
-                            {tool.description}
+                            {description}
                           </p>
                         </Tooltip>
                       {/if}

--- a/frontend/apps/web/src/routes/(app)/admin/tools/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/tools/+page.svelte
@@ -279,7 +279,7 @@
                   {#if expanded}
                     <div id={"source-tools-" + source.mcp_server_id} class="mt-4 ml-9">
                       {#if source.http_auth_type === "internal"}
-                        <ProviderToolsSummary tools={source.tools ?? []} />
+                        <ProviderToolsSummary tools={source.tools ?? []} server={source} />
                       {:else}
                         <MCPToolsPanel
                           mcpServerId={source.mcp_server_id}

--- a/frontend/apps/web/src/routes/(app)/admin/tools/ProviderToolsSummary.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/tools/ProviderToolsSummary.svelte
@@ -2,8 +2,28 @@
   import { Wrench } from "lucide-svelte";
   import { m } from "$lib/paraglide/messages";
   import type { components } from "@eneo/eneo-js";
+  import { builtinToolCatalogLabels } from "$lib/features/chat/internalToolLabels";
 
-  let { tools }: { tools: components["schemas"]["MCPServerToolPublic"][] } = $props();
+  type Tool = components["schemas"]["MCPServerToolPublic"];
+
+  let {
+    tools,
+    server
+  }: {
+    tools: Tool[];
+    /** The provider the tools belong to; built-in providers get localized labels. */
+    server: { purpose?: string | null; http_auth_type?: string | null };
+  } = $props();
+
+  const title = (tool: Tool) =>
+    tool.display_name ??
+    builtinToolCatalogLabels(server, tool.name)?.title ??
+    tool.title ??
+    tool.name;
+  const description = (tool: Tool) =>
+    builtinToolCatalogLabels(server, tool.name)?.description ??
+    tool.description?.split(/\n\s*\n/)[0] ??
+    null;
 </script>
 
 <section class="border-dimmer bg-secondary/20 mt-4 rounded-lg border p-4" aria-label={m.tools()}>
@@ -16,11 +36,9 @@
       {#each tools as tool (tool.id)}
         <li class="flex flex-wrap items-start justify-between gap-2">
           <div class="min-w-0 flex-1">
-            <p class="text-default text-sm font-medium">
-              {tool.display_name ?? tool.title ?? tool.name}
-            </p>
-            {#if tool.description}
-              <p class="text-secondary mt-1 text-sm">{tool.description.split(/\n\s*\n/)[0]}</p>
+            <p class="text-default text-sm font-medium">{title(tool)}</p>
+            {#if description(tool)}
+              <p class="text-secondary mt-1 text-sm">{description(tool)}</p>
             {/if}
           </div>
           <span

--- a/frontend/apps/web/src/routes/(app)/admin/tools/tools-page.svelte.test.ts
+++ b/frontend/apps/web/src/routes/(app)/admin/tools/tools-page.svelte.test.ts
@@ -158,16 +158,20 @@ describe("Tools capability configuration", () => {
         ]
       })
     ]);
-    expect(page.getByText("Generate image", { exact: true }).elements()).toHaveLength(0);
+    // A built-in provider's tool is Eneo's own, so the listing shows its
+    // localized title and description rather than the synced English strings.
+    const title = m.tool_generate_image_title();
+    expect(page.getByText(title, { exact: true }).elements()).toHaveLength(0);
     const expand = page.getByRole("button", {
       name: `${m.governance_mcp_show_tools()}: Image Studio`
     });
     await expect.element(expand).toHaveAttribute("aria-expanded", "false");
     await expand.click();
-    await expect.element(page.getByText("Generate image", { exact: true })).toBeVisible();
+    await expect.element(page.getByText(title, { exact: true })).toBeVisible();
     await expect
-      .element(page.getByText("Generate an image from a text description.", { exact: true }))
+      .element(page.getByText(m.tool_generate_image_description(), { exact: true }))
       .toBeVisible();
+    expect(page.getByText("Generate image", { exact: true }).elements()).toHaveLength(0);
     expect(page.getByRole("button", { name: m.sync_tools(), exact: true }).elements()).toHaveLength(
       0
     );
@@ -176,7 +180,7 @@ describe("Tools capability configuration", () => {
     });
     await expect.element(collapse).toHaveAttribute("aria-expanded", "true");
     await collapse.click();
-    expect(page.getByText("Generate image", { exact: true }).elements()).toHaveLength(0);
+    expect(page.getByText(title, { exact: true }).elements()).toHaveLength(0);
   });
 
   it("configures a model and submits save-and-activate together", async () => {


### PR DESCRIPTION
## Problem

When an assistant uses the model-backed (built-in) image generation provider, the tool shows up as "Generate image" regardless of UI language, in the chat and in the admin listings. The built-in provider is an admin-named `mcp_servers` row over Eneo's loopback server, but its tool calls were reported under the row's name (e.g. "Image Studio"), so the chat's built-in label map (keyed on server name, covering `knowledge` and `files`) never matched and the synced English title was shown as-is. The loopback server itself is not a row in the MCP server list, so there is nothing to rename there, and renaming would be the wrong fix anyway.

## Change

- **Backend**: the proxy reports a built-in provider's tool calls under the loopback server's name (its purpose, matching `builtin_provider_url`), the same way the knowledge and files servers are reported. External providers keep their own name. Approval gating is unchanged: only knowledge and files are auto-approved.
- **Chat**: the built-in label map gets an `image_generation` entry. The tool renders as "Generating image…" while running and "Generated image" when done, under the server label "Image generation" (sv: "Genererar bild" / "Genererade bild" / "Bildgenerering"). The pending-approval card now shows the localized server label instead of the raw server name.
- **Admin**: the tools page summary and the MCP servers page tools panel resolve a localized title and description for a built-in provider's tools (sv: "Generera bild" / "Genererar en bild utifrån en textbeskrivning."). External servers keep their synced protocol strings, and an admin rename still wins.
- **Test**: unit test covering the reported server name for built-in vs external servers.

Side effect: in the chat the call is now recognized as a built-in tool and renders as a slim thinking-style line in the trace instead of an external tool card, matching knowledge searches. Approval cards are unaffected.

Persisted tool calls from before this change keep their old server name and still show the English title in history.

## Verification

- ruff, pyright, targeted proxy unit tests
- prettier, eslint, svelte-check
