### PR TITLE
docs(capabilities): Functions guide (web search, image generation) and built-in tool servers

### DIFF
--- a/docs/CAPABILITIES.md
+++ b/docs/CAPABILITIES.md
@@ -100,11 +100,26 @@ An MCP `image` content block returned by any tool becomes a generated file shown
 | `MCP_TOOL_IMAGE_MAX_COUNT` | 4 | Images admitted per tool result; the rest are dropped with one notice. |
 | `MCP_TOOL_OUTPUT_MAX_CHARS` | 32768 | Text budget per tool result. Images do not count against it. |
 
-Only `image/png`, `image/jpeg`, `image/webp` and `image/gif` are accepted. The model sees a short placeholder instead of the bytes. Only the latest turn's generated images are replayed to the model on follow-ups; older ones are described by the placeholder in their tool result. Generated files are deleted with their conversation.
+Only `image/png`, `image/jpeg`, `image/webp` and `image/gif` are accepted. The model sees a short placeholder instead of the bytes. Only the latest turn's generated images are replayed to the model as vision input on follow-ups; older ones are described by the placeholder in their tool result plus a reference URL (below). Generated files are deleted with their conversation.
+
+### Reference images (variations and follow-up edits)
+
+A user can attach an image and ask for a variation or edit, and a follow-up turn can pass an image the assistant generated earlier back to the image tool. Both the built-in provider and external `purpose=image_generation` servers use the same mechanism: signed file reference URLs.
+
+- Attached images and generated images get signed reference URLs in the prompt, tagged `"kind": "image"` next to the document entries. Images are never URL-only; the entry is an extra handle beside the vision input. The system prompt directs image entries to image tools, never to `read_file`.
+- The built-in `generate_image` tool takes an optional `reference_images` list of those URLs. With references it calls the image edit API (`litellm.aimage_edit`) with the file bytes; the URL is verified locally like `read_file` does, never fetched. Count and size caps reuse `MCP_TOOL_IMAGE_MAX_COUNT` and `MCP_TOOL_IMAGE_MAX_BYTES`.
+- A model without edit support, or a provider that rejects the edit request, returns a tool error the model can recover from (generate from the description, or tell the user the image cannot be edited). Never a silent plain generation.
+- `ToolCallInfo.generated_file_ids` records which files a call produced. Replayed tool results get a fresh `Reference url for Image N` line per image; URLs are never persisted.
+- External image servers fetch the bytes through the signed download endpoint, so `FILE_REFERENCE_BASE_URL` must be reachable from the external server. A failed call carrying a reference URL tells the model the URL is valid, so it reports that the tool cannot reach the file rather than asking for a re-upload.
+- Image attachments are offered in the chat whenever image generation is available, even without a vision model.
+
+Known limitation: an image generated earlier in the same turn cannot be edited in that turn, because the file is persisted after the tool result reaches the model. Follow-ups work from the next turn on.
 
 ## 5. Extending the capability set
 
 Adding a capability requires updating the backend `CapabilityPurpose` type and `CAPABILITY_PURPOSES` list, adding the matching permission and frontend `capabilities.ts` descriptor with its messages, and migrating the association-table purpose constraints and existing role permissions. All admin, space, assistant and chat surfaces render from those lists.
+
+Whether a capability should be served by a built-in loopback server at all, and which attachment pattern it should use, is covered in the docs site page **Built-in Tool Servers** (`frontend/apps/docs-site/src/content/docs/builtin-tool-servers.mdx`). The rule in short: a loopback tool is a pure function of the request, the tenant database and at most one outbound provider call, finishing inside a tool-call timeout; anything with a runtime footprint (engine, process, storage, heavy dependency) is an external MCP server that receives the signed reference URL.
 
 
 ## 6. Deployment and client changes

--- a/frontend/apps/docs-site/src/content/docs/_meta.ts
+++ b/frontend/apps/docs-site/src/content/docs/_meta.ts
@@ -7,6 +7,7 @@ const meta: MetaRecord = {
   "authentication-architecture": "Authentication Architecture",
   "module-authentication": "Module Authentication",
   "knowledge-retrieval-and-mcp": "Knowledge Retrieval and MCP",
+  "builtin-tool-servers": "Built-in Tool Servers",
   "object-content-architecture": "Object Content Architecture",
   "audit-logging": "Audit Logging",
   "api-key-management": "API Key Management",

--- a/frontend/apps/docs-site/src/content/docs/builtin-tool-servers.mdx
+++ b/frontend/apps/docs-site/src/content/docs/builtin-tool-servers.mdx
@@ -1,0 +1,177 @@
+# Built-in Tool Servers
+
+Eneo hosts a small set of Model Context Protocol (MCP) servers inside its own
+backend, reached over a loopback HTTP route during a completion. This page
+records what exists, the two ways such a server is attached to a completion,
+the contract every built-in tool honours, and the standpoint on **what belongs
+inside Eneo as a loopback tool and what belongs in an external MCP server**.
+
+import { Callout } from "nextra/components";
+
+<Callout type="info">
+  For how loopback routing, scoped tokens and the shared proxy work, see
+  [Knowledge Retrieval and MCP Interoperability](/docs/knowledge-retrieval-and-mcp).
+  For the administrator view of web search and image generation, see [Web
+  Search & Image Generation](/guides/capabilities).
+</Callout>
+
+## What exists today
+
+All loopback servers live in `backend/src/eneo/internal_mcp/`, one module per
+server plus shared scaffolding:
+
+| Module | Role |
+| --- | --- |
+| `foundation.py` | Hosting and auth. Each server is a stateless FastMCP app mounted at `/internal-mcp/<name>/mcp`; the ask path connects back over HTTP through `INTERNAL_MCP_BASE_URL`. Scope never travels in tool arguments: a 15-minute JWT minted per completion carries `assistant_id` and, for built-in providers, `mcp_server_id`. `internal_tool_context` opens a DB transaction, authenticates the token as the user, and hands the tool a user-bound DI container so every load passes normal permission checks. |
+| `registry.py` | The only hosting wiring. One tuple entry per server drives both the FastAPI mounts and the lifespan that runs each session manager. |
+| `constants.py` | Server names and the `INTERNAL_MCP_SERVER_NAMES` set that bypasses per-call user approval. |
+| `file_references.py` | The single resolver for signed attachment URLs. A URL is a capability handle: the token is verified locally and bytes come from the content store, never from an HTTP fetch. |
+| `builtin_tools.py` | Swaps a persisted tool snapshot for the running server's live catalog so the model always sees the deployed definitions. |
+| `availability.py` | The runtime gates for the ephemeral servers, in one place. |
+
+Three servers are registered:
+
+```text
+/internal-mcp/knowledge/mcp          four tools
+/internal-mcp/files/mcp              one tool  (read_file)
+/internal-mcp/image_generation/mcp   one tool  (generate_image)
+```
+
+Web search has no loopback server. It is external-only.
+
+## Two attachment patterns
+
+### Pattern A: ephemeral, per completion
+
+Used by **knowledge** and **files**. No database row, no admin surface, no
+permission.
+
+- The ask path checks `resolve_internal_mcp_availability`, calls
+  `build_<x>_mcp_server` with a fresh token, and passes the entity into
+  `Assistant.ask`, which prepends it so its tools lead the tool array and win
+  name collisions.
+- Tool calls are auto-approved by name.
+- The tool description gets a per-completion suffix (source labels, attachment
+  presence), but the docstring always leads.
+
+This is the right shape for read-only helpers whose scope is fully derivable
+from the request.
+
+### Pattern B: admin-registered built-in provider
+
+Used by **image generation**. An ordinary `mcp_servers` row with
+`http_auth_type = "internal"`, a capability purpose, and an `image_model_id`
+foreign key.
+
+- It goes through the full capability machinery in `capability_resolver.py`:
+  audiences and priority, role permission, space classification floor,
+  backing-model health, and per-user resolution at ask time.
+- The tool reads its configuration from the row named in the token, so the
+  caller cannot choose it.
+- Calls are **not** in the auto-approve set, so they honour the conversation's
+  tool-approval setting.
+- It has its own tool-call timeout in the proxy.
+
+This is the shape for anything an admin must choose a provider or model for,
+or that spends money.
+
+```mermaid
+flowchart TD
+  Q{Does an admin pick a model or provider,<br/>or does it need audience / permission /<br/>classification gating?}
+  Q -->|No| A[Pattern A<br/>ephemeral server, scope from the request]
+  Q -->|Yes| B[Pattern B<br/>admin-registered built-in provider row]
+  R{Runtime footprint?<br/>engine, process, storage,<br/>heavy dependency, work past one tool call}
+  A --> R
+  B --> R
+  R -->|None| OK[Loopback server in eneo/internal_mcp]
+  R -->|Any| EXT[External MCP server;<br/>hand it the signed reference URL]
+```
+
+## The shared contract
+
+These invariants hold for both patterns and should be treated as the contract
+for any new built-in tool:
+
+- Tools return MCP content types: `TextContent`, `EmbeddedResource`,
+  `ImageContent`, or a `CallToolResult` whose `_meta` uses OpenTelemetry GenAI
+  attribute names. The proxy turns `image` blocks into generated files for any
+  server, internal or external.
+- Output is self-capped through `default_page_cap` with an `offset` parameter,
+  because proxy truncation is destructive.
+- Model-facing error strings are constants, and *not found* is
+  indistinguishable from *out of scope*.
+- External provider calls run after the DB transaction closes.
+- Everything completes inside one tool call. No worker, no queue, no persistent
+  state beyond what the ask path already persists.
+
+## Standpoint: what should be a loopback tool
+
+<Callout type="warning">
+  **Rule.** A loopback tool is a pure function of the request, the tenant
+  database, and at most one outbound provider call, finishing within a
+  tool-call timeout, with no new process, storage, or heavyweight dependency.
+  Use Pattern A when scope comes from the request and nothing needs
+  configuring. Use Pattern B when an admin picks a backing model or provider,
+  or when the feature needs audience, permission, or classification gating.
+  Everything with a runtime footprint goes to an external MCP server.
+</Callout>
+
+Why the line sits there:
+
+- The loopback route exists so internal and external tools share one
+  execution boundary, not so Eneo becomes a host for arbitrary compute. The
+  backend process is the chat API; a tool that needs memory proportional to a
+  file or its own sandbox competes with every other request.
+- An external server gets the same integration surface a built-in tool would:
+  the signed file reference URL. Anything that can be expressed as "fetch this
+  reference, do work, return MCP content" loses nothing by living outside.
+- Built-in tools are deployed with Eneo, so their upgrade cadence, dependency
+  set and security review are Eneo's. Keeping them thin keeps that surface
+  small.
+
+### Worked example: tabular querying
+
+Tabular querying belongs **outside**. It needs an engine such as DuckDB, memory
+proportional to the file, and most likely execution sandboxing. The integration
+contract already exists: `read_file` tells the model to prefer "tabular or
+spreadsheet analysis tools" from other servers and to pass them the same signed
+URL. An external server receives the reference URL and fetches the bytes
+through the signed download endpoint, which is the standard attachment surface
+for all tools. See [How attachment references interoperate with external
+MCP](/docs/knowledge-retrieval-and-mcp#how-attachment-references-interoperate-with-external-mcp).
+
+### Worked example: image generation
+
+Image generation stays **inside** as Pattern B: one outbound call to a provider
+the admin already configured under model providers, credentials already
+managed, output already handled by the proxy's image path. The only new
+concept it needed was a purpose marker and a foreign key to the image model.
+Image edits with reference images fit the same rule: the bytes come from the
+content store through `file_references.py`, and the call is still one provider
+request.
+
+## Adding a new built-in server
+
+The hosting side is one entry in `registry.py`. The rest depends on the
+pattern:
+
+| Step | Pattern A | Pattern B |
+| --- | --- | --- |
+| Module in `internal_mcp/` with a FastMCP app and `@mcp.tool` functions | Yes | Yes |
+| Name in `constants.py` | Yes, and in `INTERNAL_MCP_SERVER_NAMES` if calls should be auto-approved | Yes; do not add to the auto-approve set |
+| Availability gate | Extend `availability.py` and `build_<x>_mcp_server` | Capability purpose in `CAPABILITY_PURPOSES`, role permission, frontend descriptor (see the *Extending the capability set* section of `docs/CAPABILITIES.md` in the repo) |
+| Token claims | `assistant_id` | `assistant_id` and `mcp_server_id` |
+| Tests | `tests/unit/internal_mcp/` | `tests/unit/internal_mcp/` |
+
+Things a new built-in server would hit that are not yet generic:
+
+- The table check constraint ties internal auth to a non-null `image_model_id`,
+  and the service validation is image-specific. A built-in provider without an
+  image model needs that relaxed into a general backing-model concept; the
+  `MCPServerBackingModel` projection is the generalisable half.
+- Auto-approval is a name set in `constants.py` rather than a per-server
+  attribute in the registry, and the per-server timeout in the proxy is keyed
+  on the image generation purpose.
+- Test placement is inconsistent: the newest server tests sit in
+  `tests/unit/internal_mcp/`, the knowledge and files tests sit at
+  `tests/unit/test_*_mcp_server.py`. New servers should use the former.

--- a/frontend/apps/docs-site/src/content/docs/knowledge-retrieval-and-mcp.mdx
+++ b/frontend/apps/docs-site/src/content/docs/knowledge-retrieval-and-mcp.mdx
@@ -260,7 +260,14 @@ Eneo registers built-in FastMCP applications under these backend routes:
 ```text
 /internal-mcp/knowledge/mcp
 /internal-mcp/files/mcp
+/internal-mcp/image_generation/mcp
 ```
+
+The knowledge and files servers are attached ephemerally per completion, as
+described below. The image generation server is instead attached through an
+admin-registered provider row; [Built-in Tool
+Servers](/docs/builtin-tool-servers) contrasts the two patterns and states
+which features should be built-in at all.
 
 During a completion, `INTERNAL_MCP_BASE_URL` is combined with one of those
 paths. The backend then connects through its ordinary Streamable HTTP MCP

--- a/frontend/apps/docs-site/src/content/guides/_meta.ts
+++ b/frontend/apps/docs-site/src/content/guides/_meta.ts
@@ -8,6 +8,7 @@ const meta: MetaRecord = {
   skills: "Skills",
   "ai-providers": "AI Provider Configuration",
   "mcp-servers": "MCP Servers",
+  capabilities: "Web Search & Image Generation",
   deployment: "Deploy Eneo",
   "file-icon-storage-upgrade": "Upgrade File & Icon Storage",
   "object-content-storage": "Choose Content Storage",

--- a/frontend/apps/docs-site/src/content/guides/capabilities.mdx
+++ b/frontend/apps/docs-site/src/content/guides/capabilities.mdx
@@ -1,0 +1,394 @@
+# Web Search & Image Generation
+
+Web search and image generation are **functions** (Swedish: *Funktioner*) that
+an assistant switches on, not servers it connects to. An administrator decides
+which search engine and which image generator the organisation uses; spaces,
+assistants and roles decide where and by whom the function may be used. This
+guide covers the administrator setup under **Admin → Tools → Functions**, how
+each function works at runtime, and what users see in the chat.
+
+import { Callout } from 'nextra/components'
+
+<Callout type="info">
+  Functions ride on the same Model Context Protocol (MCP) plumbing as ordinary
+  tool servers. For general tool servers, catalog approval and identity
+  forwarding, see [MCP Servers](/guides/mcp-servers). For the engineering view
+  of Eneo's built-in loopback servers, see [Built-in Tool
+  Servers](/docs/builtin-tool-servers).
+</Callout>
+
+## Overview
+
+| Function | What it does | Where the work runs |
+|----------|--------------|---------------------|
+| **Web search** | Lets the assistant search the web and cite live pages | An external MCP search server (for example Tavily or Exa behind an MCP endpoint) |
+| **Image generation** | Lets the assistant create images from a description, and edit or vary images | Either a catalog **image model** called by Eneo itself, or an external MCP image server |
+
+The key ideas:
+
+- **Saved intent is a purpose, not a server.** A space or assistant stores
+  `web_search` or `image_generation`. Which server serves that purpose is
+  resolved at ask time, so switching, disabling or deleting a provider never
+  breaks a saved configuration. A replacement restores availability.
+- **One default per function, any number of group sources.** The tenant has at
+  most one active default source per function. Additional sources can serve
+  selected user groups and take precedence for their members.
+- **Three gates, all required.** The space must make the function available,
+  the assistant must enable it, and the user's role must hold the matching
+  permission. If any gate is closed the tool is silently not offered to the
+  model for that turn.
+
+```mermaid
+flowchart LR
+  A[Admin activates a source<br/>Admin → Tools → Functions] --> R
+  S[Space makes the function available] --> R
+  T[Assistant enables the function] --> R
+  P[User's role grants web_search /<br/>image_generation] --> R
+  R{Resolve at ask time} -->|group source or default| M[Tool sent to the model]
+  R -->|any gate closed| N[Function silently unavailable this turn]
+  M --> C[Tool call → search results or image]
+```
+
+---
+
+## Administrator setup
+
+Open **Admin → Tools** (`/admin/tools`). Two tabs are shown:
+
+- **MCP servers** lists general tool servers. Select **Show function servers**
+  (*Visa funktionsservrar*) to also list external servers that serve a
+  function. The former `/admin/mcp-servers` URL redirects here.
+- **Functions** (*Funktioner*) lists one card per function with its current
+  sources, their configuration status and the activation action. Group
+  sources appear beneath the tenant default.
+
+### Adding a web search source
+
+Web search always runs on an external MCP server. Eneo governs which engine
+and which tools are exposed; search behaviour, ranking and rate limits belong
+to the engine.
+
+1. On the **Functions** tab, choose **Configure web search** (or add an MCP
+   server and set its **Function** to **Web search** instead of **General
+   tools**).
+2. Enter the server URL and authentication as for any MCP server. Enable
+   **Forward user identity** only if the search engine is trusted with the
+   signed-in user's name, email, role and organisation on every query.
+3. Save. The source is stored **inactive**. Review and approve the discovered
+   tools, then **activate** it.
+
+A search source with no enabled, approved tool cannot be activated.
+
+### Adding an image generation source
+
+Choose between **Image model** (*Bildmodell*) and **External MCP server**.
+
+**Image model (built-in).** Eneo calls a catalog image model itself; no
+external MCP server is needed.
+
+1. Add the image model under **Admin → Models → Image models**, or from the
+   function wizard via **Add image model**. Pick the model provider and enter
+   the model name the provider serves, for example `gpt-image-1` on OpenAI or
+   Azure OpenAI, `imagen-4.0-generate-001` on Gemini, or whatever name a vLLM
+   or other OpenAI-compatible endpoint exposes on its `/v1/images/generations`
+   route. Default size and quality, cost per image and the security
+   classification live on the model, like on any other catalog model.
+2. On the **Functions** tab, select the model under **Image generation** and
+   choose **Save and activate**. Saving and activation happen in one
+   transaction; a saved model that later becomes invalid stays visible with
+   its blocking reason.
+
+**External MCP server.** Same steps as for web search, with **Function** set
+to **Image generation**. Any MCP tool that returns an `image` content block
+produces a generated image in the chat.
+
+<Callout type="info">
+  To move from an external server to a built-in model (or the reverse), add the
+  replacement as a separate source and activate it. The activation action names
+  the default it will replace; the previous default is deactivated in the same
+  step.
+</Callout>
+
+### Audiences and priority
+
+| Audience | Behaviour |
+|----------|-----------|
+| **All users (default server)** | The tenant default. At most one active per function. |
+| **Selected user groups** | Serves members of the chosen groups. Any number may be active alongside the default. When a user matches several, the lowest **priority** number wins, then the name. |
+
+An active default cannot be narrowed to user groups in place. Deactivate it
+first, or activate another default. User groups are managed under
+**Access → User groups**.
+
+### Activation checks
+
+Activation is the only step that changes which source serves users. Before
+switching the default, Eneo rechecks:
+
+- the source belongs to this tenant;
+- for a built-in source, the image model is enabled, current, and its model
+  provider is active;
+- at least one tool is enabled and approved;
+- the connection validates (external sources).
+
+A failed check or transaction leaves the previous default active. Stored
+readiness describes configuration; it is **not** a claim of live health for an
+external server.
+
+---
+
+## Permissions, spaces and assistants
+
+### Role permissions
+
+Two role permissions gate use: **Web search** (`web_search`) and **Image
+generation** (`image_generation`), edited under **Admin → Roles**. Without the
+permission the tools are never attached for that user, even where an assistant
+offers the function. Configuring a function on a space or assistant is not
+gated by these permissions.
+
+### Spaces
+
+A space makes a function available to the assistants inside it. If the
+organisation uses security classifications, the function is only available
+when an active source meets the space's classification. For a built-in image
+source, the image model's classification is used; for an external source, the
+server's own. The space settings explain why a function cannot be enabled
+("No active search engine meets the space's security classification").
+
+### Assistants and governance policies
+
+Each assistant enables the functions it should use. Governance policies can
+enforce a function set and choose whether a function is on or off by default
+in new chats. Turning a function **off** always works; turning one **on**
+requires an eligible source and the space rules above. Temporary unavailability
+never blocks unrelated edits.
+
+Service API keys can use web search but not image generation: a generated
+image is stored as a file owned by a user, and a service key has no user.
+
+---
+
+## What users see in the chat
+
+- The tools popover in the chat input lists each enabled function with an
+  on/off toggle. Opting out is stored per purpose, so it survives a provider
+  switch on the admin side. Governance defaults seed the toggles for new
+  chats.
+- Unavailable functions show why: no active source, the space's classification
+  is not met, or the role lacks the permission.
+- Tool activity is shown inline. External search and image tools appear under
+  their own tool names; the built-in image tool shows "Generating image"
+  (*Genererar bild*) and, when it edits reference images, "Editing image"
+  (*Redigerar bild*).
+- Generated images appear in the answer. They are deleted with the
+  conversation.
+
+---
+
+## How web search works
+
+1. The assistant receives the search server's approved, enabled tools together
+   with any general tool servers. Search tools are ordinary MCP tools; the
+   model decides when to call them.
+2. Eneo proxies the call to the search server. If identity forwarding is on,
+   the `X-Eneo-*` headers described in [MCP Servers](/guides/mcp-servers#forwarding-user-identity)
+   are sent.
+3. The result text is returned to the model under the same output budget as
+   other tools (`MCP_TOOL_OUTPUT_MAX_CHARS`, default 32 768 characters). MCP
+   resource blocks the server returns alongside the text (for example the
+   pages behind a hit) are captured as references and shown with the answer
+   when the model cites them.
+4. Searches are replayed to the model on later turns like any other tool call,
+   so follow-up questions can build on earlier results.
+
+Eneo has no built-in search engine. Search quality, freshness, region and
+safe-search settings are the engine's; check its documentation.
+
+---
+
+## How image generation works
+
+### Built-in image model
+
+```mermaid
+sequenceDiagram
+  participant M as Completion model
+  participant P as MCP proxy
+  participant L as Loopback server<br/>/internal-mcp/image_generation
+  participant I as Image model provider
+  M->>P: generate_image(prompt, size?, quality?, reference_images?)
+  P->>L: Call with per-completion token naming the source row
+  L->>L: Load source row and image model; resolve credentials
+  alt reference_images given
+    L->>I: images.edit(prompt, image bytes)
+  else
+    L->>I: images.generate(prompt)
+  end
+  I-->>L: image (base64 or URL)
+  L-->>P: MCP image block + usage metadata
+  P-->>M: placeholder text; image persisted as a generated file
+```
+
+- The built-in source is an ordinary MCP server row whose endpoint is Eneo's
+  own loopback server and which references the image model by foreign key. It
+  carries no credentials of its own: on every request the ask path mints a
+  short-lived token naming the row, and the tool uses the credentials stored on
+  the model's provider.
+- Every provider is reached through the same OpenAI Images API shaped call via
+  LiteLLM, so a self-hosted GPU endpoint and a hosted API take the identical
+  path.
+- The tool accepts `size` (`1024x1024`, `1536x1024`, `1024x1536`) and
+  `quality` (`low`, `medium`, `high`). When the model omits them, the image
+  model's defaults apply; a default of **auto** sends nothing so the provider
+  decides. Parameters a provider rejects as unsupported are dropped and the
+  call retried, so a model that has no `quality` setting still works.
+- Image generation has its own tool-call timeout,
+  `IMAGE_GENERATION_TIMEOUT_SECONDS` (default 240), because image calls
+  routinely outlast a general tool call.
+- Token usage reported by the provider is attached to the tool result under
+  OpenTelemetry GenAI names (`gen_ai.usage.*`, `gen_ai.request.model`).
+- Disabling the image model makes the function unavailable until it is
+  re-enabled or the source is pointed at another model; deleting the model is
+  refused while a source runs on it.
+
+The backend must be able to reach its own loopback URL, `INTERNAL_MCP_BASE_URL`
+(the same requirement as the built-in knowledge and files servers).
+
+### Reference images: variations and follow-up edits
+
+Users can attach an image and ask for a variation or an edit, and a follow-up
+turn ("make it bluer", "same scene at night") can hand the image the assistant
+just generated back to the image tool. The mechanism is the same for the
+built-in model and for external image servers: **signed file reference URLs**.
+
+- Every attached image and every generated image gets a short-lived signed
+  reference URL in the prompt, tagged `"kind": "image"` next to the existing
+  document entries. The bytes are never in the prompt; images are still passed
+  as vision input where the completion model supports it, and the URL is an
+  extra handle for tools.
+- The system prompt tells the model that image entries go to image tools,
+  never to the built-in `read_file` tool.
+- The built-in `generate_image` tool takes an optional `reference_images`
+  list of those URLs. With references it calls the provider's image **edit**
+  API with the file bytes; the prompt then describes the change or variation.
+  The URL is verified locally (signature, file and tenant), and the bytes come
+  from Eneo's content store; nothing is fetched over HTTP.
+- On later turns, each tool call that produced images is replayed with a fresh
+  `Reference url for Image N` line per image. The URLs themselves are never
+  persisted.
+- Image attachments are offered in the chat whenever image generation is
+  available, even if the completion model has no vision support.
+
+Limits and failure behaviour:
+
+| Situation | Behaviour |
+|-----------|-----------|
+| Model has no edit support (for example a generation-only model) | The tool returns an error the model can recover from: it generates from the description instead, or tells the user the image cannot be edited with the organisation's model. Never a silent plain generation. |
+| Provider rejects the edit request (format, size) | Same recoverable error. |
+| More than `MCP_TOOL_IMAGE_MAX_COUNT` references, or a reference larger than `MCP_TOOL_IMAGE_MAX_BYTES` | Rejected with a message to the model. The caps are the same ones that bound images arriving from tool results. |
+| Reference is not an image, or the link has expired | Rejected; the model is told to ask for a fresh attachment only when the link is invalid. |
+
+<Callout type="warning">
+  **Known limitation.** An image generated earlier in the *same* turn cannot be
+  edited in that turn, because the file is persisted after the tool result
+  reaches the model. Follow-up edits work from the next turn on.
+</Callout>
+
+### External image servers
+
+An external image server receives the same `"kind": "image"` reference URLs
+and fetches the bytes through Eneo's signed download endpoint. That requires
+`FILE_REFERENCE_BASE_URL` to point at the Eneo backend's `/api/v1` on a host
+the external server can reach. On a developer machine
+`host.docker.internal` is typically not reachable from a remote server, and the
+call fails as expected. When a call carrying a reference URL fails, the model is
+told the URL is valid, so it reports that the tool cannot reach the file
+rather than asking the user to re-upload it.
+
+### Generated image limits
+
+Before an `image` content block is persisted, the proxy applies these guards
+regardless of which server produced it:
+
+| Setting | Default | Effect |
+|---------|---------|--------|
+| `MCP_TOOL_IMAGE_MAX_BYTES` | 10485760 | Decoded size cap per image; larger images are dropped with a notice to the model. |
+| `MCP_TOOL_IMAGE_MAX_COUNT` | 4 | Images admitted per tool result; the rest are dropped with one notice. |
+| `MCP_TOOL_OUTPUT_MAX_CHARS` | 32768 | Text budget per tool result. Images do not count against it. |
+
+Only `image/png`, `image/jpeg`, `image/webp` and `image/gif` are accepted. The
+model sees a short placeholder instead of the bytes. Only the latest turn's
+generated images are replayed to the model as vision input on follow-ups; older
+ones are described by the placeholder and, from this release, by their
+reference URL.
+
+---
+
+## Ask-time resolution
+
+For each function an assistant enables, the source is attached to a turn only
+when all of these hold:
+
+1. the user's role grants the permission;
+2. a source serves the user: a group source covering one of their groups, else
+   the tenant default;
+3. the source has at least one enabled, approved tool;
+4. for a built-in source, its image model is enabled, not deprecated or
+   deleted, and its model provider is active;
+5. the source's security classification (the image model's, for a built-in
+   source) meets the space's classification;
+6. the completion model supports tool calling.
+
+Otherwise the function is silently unavailable for that turn. The conversation
+request carries purpose-based opt-outs (`disabled_capabilities`); ordinary
+server opt-outs stay in `disabled_mcp_server_ids`.
+
+---
+
+## Configuration reference
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `INTERNAL_MCP_BASE_URL` | `http://localhost:8123` | URL the backend uses to reach its own loopback servers, including image generation. |
+| `FILE_REFERENCE_BASE_URL` | unset (falls back to `PUBLIC_ORIGIN`) | Base URL for signed file reference links handed to tools. Set it when external tool servers reach the backend on another host than the browser does. |
+| `IMAGE_GENERATION_TIMEOUT_SECONDS` | 240 | Tool-call budget for the built-in image source. |
+| `MCP_TOOL_IMAGE_MAX_BYTES` | 10485760 | Per-image size cap for tool results and reference inputs. |
+| `MCP_TOOL_IMAGE_MAX_COUNT` | 4 | Images per tool result, and reference images per edit call. |
+| `MCP_TOOL_OUTPUT_MAX_CHARS` | 32768 | Text budget per tool result. |
+
+---
+
+## Troubleshooting
+
+### The function toggle is missing in the chat
+
+- Check the user's role has the **Web search** or **Image generation**
+  permission.
+- Check the assistant enables the function and the space makes it available.
+- If the space is classified, check an active source meets that
+  classification.
+
+### "No active source" although one is configured
+
+- External sources are saved inactive. Approve the discovered tools, then
+  activate.
+- A built-in source needs an enabled, current image model on an active
+  provider. The Functions tab shows the blocking reason on the card.
+
+### Image generation times out
+
+- Raise `IMAGE_GENERATION_TIMEOUT_SECONDS`; high-quality or large sizes take
+  longer on most providers.
+- Check the backend can reach `INTERNAL_MCP_BASE_URL`.
+
+### Edits fall back to a new image, or the model says the image cannot be edited
+
+The configured image model has no edit endpoint, or the provider rejected the
+request. Use a model with edit support (for example `gpt-image-1`) for
+variations and follow-up edits.
+
+### An external image server cannot read attached images
+
+Set `FILE_REFERENCE_BASE_URL` to a URL the external server can reach. The
+signed link is the file; asking the user to re-upload changes nothing.

--- a/frontend/apps/docs-site/src/content/guides/index.mdx
+++ b/frontend/apps/docs-site/src/content/guides/index.mdx
@@ -13,6 +13,7 @@ matters.
 | Choose where durable bytes live   | [Choose Content Storage](/guides/object-content-storage)         |
 | Configure login and access        | [Authentication & OIDC](/guides/authentication)                  |
 | Connect an AI provider            | [AI Provider Configuration](/guides/ai-providers)                |
+| Enable web search or image generation | [Web Search & Image Generation](/guides/capabilities)        |
 | Add documents to a knowledge base | [Document Processing](/guides/document-processing)               |
 | Connect SharePoint or OneDrive    | [SharePoint Integration](/guides/sharepoint-integration)         |
 
@@ -61,6 +62,15 @@ Connect assistants to external tools while keeping discovery and execution under
 - Approve tool definitions before they reach the model
 - Forward user identity for user-specific catalogs
 - Preserve stateful MCP sessions across conversation turns
+
+### [Web Search & Image Generation](/guides/capabilities)
+
+Turn on the functions (*Funktioner*) assistants can use, and understand how they run:
+
+- Activate a search engine or an image source under Admin → Tools → Functions
+- Use a catalog image model directly, or an external MCP image server
+- Scope sources by user group, role permission and security classification
+- Edit and vary images with reference images, including follow-up edits
 
 ### [Deploy Eneo](/guides/deployment)
 

--- a/frontend/apps/docs-site/src/content/guides/mcp-servers.mdx
+++ b/frontend/apps/docs-site/src/content/guides/mcp-servers.mdx
@@ -9,7 +9,10 @@ import { Callout } from 'nextra/components'
   deeper architecture—including knowledge retrieval modes, Eneo's built-in
   loopback MCP servers, and how internal and external tools interoperate—see
   [Knowledge Retrieval and MCP
-  Interoperability](/docs/knowledge-retrieval-and-mcp).
+  Interoperability](/docs/knowledge-retrieval-and-mcp). Servers that act as
+  the organisation's search engine or image generator are managed as
+  functions instead; see [Web Search & Image
+  Generation](/guides/capabilities).
 </Callout>
 
 ## Overview
@@ -42,7 +45,9 @@ allowed to call. A tool must pass both checks.
 
 ## Adding an MCP Server
 
-MCP servers are managed in **Admin → MCP Servers**. Only admins can add, edit, or remove servers.
+MCP servers are managed on the **MCP servers** tab of **Admin → Tools** (`/admin/tools`; the former `/admin/mcp-servers` URL redirects there). Only admins can add, edit, or remove servers.
+
+The server form has a **Function** selection. Leave it at **General tools** for a server whose tools attach directly to assistants. Choose **Web search** or **Image generation** to register the server as a source for that function; it is then managed on the **Functions** tab and covered by [Web Search & Image Generation](/guides/capabilities).
 
 ### Steps
 


### PR DESCRIPTION
## Summary

Documents the **Functions** (*Funktioner*) surface and the two capabilities it manages, and records the standpoint on what should be a built-in loopback tool.

### New docs-site pages
- **Guides → Web Search & Image Generation** (`guides/capabilities.mdx`): Admin → Tools → Functions setup for both functions, audiences and priority, activation checks, role permissions, space and assistant gates, what users see in the chat, how web search runs on an external MCP engine, how the built-in image model path works (loopback server, LiteLLM, size/quality defaults, own timeout), generated-image limits, ask-time resolution, configuration reference, troubleshooting.
- **Docs → Built-in Tool Servers** (`docs/builtin-tool-servers.mdx`): what exists under `internal_mcp/`, the two attachment patterns (ephemeral per completion vs admin-registered built-in provider), the shared tool contract, the rule for what belongs inside Eneo vs in an external MCP server, worked examples (tabular querying outside, image generation inside), and the not-yet-generic spots a new built-in would hit.

### Covers #800
The guide and `docs/CAPABILITIES.md` describe reference images: `"kind": "image"` reference URLs, `generate_image(reference_images=...)` calling the edit API, recoverable errors for models without edit support, per-turn `Reference url for Image N` replay, `FILE_REFERENCE_BASE_URL` for external image servers, and the same-turn limitation.

### Cross-links
- Guides index: start-here row and section entry.
- MCP Servers guide: points to the Functions tab and the **Function** selection in the server form; notes the `/admin/tools` location.
- Knowledge Retrieval and MCP: lists the image generation loopback route and links the new developer page.

## Test plan
- [x] `bun run build` in `frontend/apps/docs-site` (34 pages, mermaid diagrams rendered, pagefind indexed)
