### PR TITLE
fix(chat): let a running built-in tool step expand to its parameters

### DIFF
--- a/frontend/apps/web/src/lib/features/chat/components/conversation/InternalToolStep.svelte
+++ b/frontend/apps/web/src/lib/features/chat/components/conversation/InternalToolStep.svelte
@@ -4,8 +4,9 @@
   A call to one of Eneo's built-in loopback tools, rendered with a thinking-
   like footprint instead of a tool card: a shimmer line while running
   ("Söker kunskap…"), collapsing to a muted past-tense line when done
-  ("Sökte i kunskap") that expands to parameters and result on click.
-  External MCP tools keep their ReasoningToolStep cards.
+  ("Sökte i kunskap"). Both states expand to the call's parameters on click;
+  the result joins the panel once the call completes. External MCP tools keep
+  their ReasoningToolStep cards.
 -->
 <script lang="ts">
   import { m } from "$lib/paraglide/messages";
@@ -46,62 +47,57 @@
   const canViewResult = $derived(
     !!toolCallId && !!onLoadResult && (status === "complete" || status === "failed")
   );
-  const canExpand = $derived(!isActive && (hasArgs || canViewResult));
+  // The parameters are known as soon as the model has written them, so a
+  // running call (a long image generation, say) already opens to its prompt.
+  const canExpand = $derived(hasArgs || canViewResult);
 </script>
 
-{#if isActive}
-  <div
-    class="flex w-fit min-w-0 max-w-full items-center gap-2 text-sm leading-tight"
-    role="status"
-    aria-label={runningLabel}
+<div role={isActive ? "status" : undefined} aria-label={isActive ? runningLabel : undefined}>
+  <button
+    type="button"
+    class="group flex w-fit max-w-full items-center gap-1.5 text-sm leading-tight transition-colors {isActive
+      ? ''
+      : 'text-muted hover:text-secondary'} {canExpand ? 'cursor-pointer' : 'cursor-default'}"
+    onclick={() => {
+      if (canExpand) open = !open;
+    }}
+    disabled={!canExpand}
+    aria-expanded={open}
   >
-    <ShimmerText text={`${runningLabel}…`} />
-    {#if detail}
-      <span class="text-muted min-w-0 truncate text-xs">{detail}</span>
-    {/if}
-  </div>
-{:else}
-  <div>
-    <button
-      type="button"
-      class="text-muted hover:text-secondary group flex w-fit max-w-full items-center gap-1.5 text-sm leading-tight transition-colors {canExpand
-        ? 'cursor-pointer'
-        : 'cursor-default'}"
-      onclick={() => {
-        if (canExpand) open = !open;
-      }}
-      disabled={!canExpand}
-      aria-expanded={open}
-    >
+    {#if isActive}
+      <ShimmerText text={`${runningLabel}…`} />
+    {:else}
       {#if isNegative}
         <X class="text-negative-default h-3.5 w-3.5 shrink-0" />
       {/if}
       <span class="truncate">{doneLabel}</span>
-      {#if detail}
-        <span class="min-w-0 truncate text-xs opacity-70">{detail}</span>
-      {/if}
-      {#if isNegative}
-        <span class="text-negative-default shrink-0 text-xs">
-          {status === "denied" ? m.tool_rejected_by_user() : m.chat_tool_status_failed()}
-        </span>
-      {/if}
-      {#if canExpand}
-        <ChevronRight
-          class="h-3.5 w-3.5 shrink-0 transition-transform {open
-            ? 'rotate-90 opacity-100'
-            : 'opacity-0 group-hover:opacity-100'}"
-        />
-      {/if}
-    </button>
+    {/if}
+    {#if detail}
+      <span class="text-muted min-w-0 truncate text-xs {isActive ? '' : 'opacity-70'}"
+        >{detail}</span
+      >
+    {/if}
+    {#if isNegative}
+      <span class="text-negative-default shrink-0 text-xs">
+        {status === "denied" ? m.tool_rejected_by_user() : m.chat_tool_status_failed()}
+      </span>
+    {/if}
+    {#if canExpand}
+      <ChevronRight
+        class="text-muted h-3.5 w-3.5 shrink-0 transition-transform {open
+          ? 'rotate-90 opacity-100'
+          : 'opacity-0 group-hover:opacity-100'}"
+      />
+    {/if}
+  </button>
 
-    <ToolCallDetailsPanel
-      {open}
-      toolName={serverName}
-      {args}
-      {toolCallId}
-      {onLoadResult}
-      {status}
-      containerClass="border-dimmer bg-secondary/40 mt-1 mb-1 rounded-lg border px-3 py-2.5"
-    />
-  </div>
-{/if}
+  <ToolCallDetailsPanel
+    {open}
+    toolName={serverName}
+    {args}
+    {toolCallId}
+    {onLoadResult}
+    {status}
+    containerClass="border-dimmer bg-secondary/40 mt-1 mb-1 rounded-lg border px-3 py-2.5"
+  />
+</div>

--- a/frontend/apps/web/src/lib/features/chat/components/conversation/MessageAnswer.svelte
+++ b/frontend/apps/web/src/lib/features/chat/components/conversation/MessageAnswer.svelte
@@ -275,38 +275,14 @@
         />
       </div>
     {:else}
-      {#snippet internalStepLines()}
-        {#each run.steps as step, i (step.toolCallId ?? i)}
-          <InternalToolStep
-            runningLabel={step.toolName}
-            doneLabel={step.doneLabel}
-            serverName={step.serverName}
-            detail={step.detail}
-            args={step.args}
-            toolCallId={step.toolCallId}
-            status={step.status}
-            onLoadResult={step.toolCallId
-              ? () => chat.getToolCallResult(step.toolCallId!)
-              : undefined}
-          />
-        {/each}
-      {/snippet}
+      <!-- The same keyed {#each} renders the run whether it is still working
+           (latest step only) or done (every step), so a step opened mid-run
+           keeps its panel open when the result lands. -->
+      {@const working = runWorking(run, runIndex)}
+      {@const folded = !working && run.steps.length > 1}
+      {@const visibleSteps = working ? run.steps.slice(-1) : run.steps}
       <div class="mb-4 flex flex-col gap-0.5">
-        {#if runWorking(run, runIndex)}
-          {@const currentStep = run.steps[run.steps.length - 1]}
-          <InternalToolStep
-            runningLabel={currentStep.toolName}
-            doneLabel={currentStep.doneLabel}
-            serverName={currentStep.serverName}
-            detail={currentStep.detail}
-            args={currentStep.args}
-            toolCallId={currentStep.toolCallId}
-            status={currentStep.status}
-            onLoadResult={currentStep.toolCallId
-              ? () => chat.getToolCallResult(currentStep.toolCallId!)
-              : undefined}
-          />
-        {:else if run.steps.length > 1}
+        {#if folded}
           <button
             type="button"
             class="text-muted hover:text-secondary flex w-fit max-w-full items-center gap-1.5 text-sm leading-tight transition-colors"
@@ -326,13 +302,24 @@
             {/if}
             <span class="truncate font-medium">{runSummary(run)}</span>
           </button>
-          {#if openInternalRuns.has(runIndex)}
-            <div class="flex flex-col gap-0.5 pl-7">
-              {@render internalStepLines()}
-            </div>
-          {/if}
-        {:else}
-          {@render internalStepLines()}
+        {/if}
+        {#if !folded || openInternalRuns.has(runIndex)}
+          <div class="flex flex-col gap-0.5 {folded ? 'pl-7' : ''}">
+            {#each visibleSteps as step, i (step.toolCallId ?? i)}
+              <InternalToolStep
+                runningLabel={step.toolName}
+                doneLabel={step.doneLabel}
+                serverName={step.serverName}
+                detail={step.detail}
+                args={step.args}
+                toolCallId={step.toolCallId}
+                status={step.status}
+                onLoadResult={step.toolCallId
+                  ? () => chat.getToolCallResult(step.toolCallId!)
+                  : undefined}
+              />
+            {/each}
+          </div>
         {/if}
       </div>
     {/if}


### PR DESCRIPTION
## Problem

The slim built-in tool line ("Genererar bild…") was a plain status element while the call ran, so the prompt of a long image generation could not be inspected until it finished. Only the finished line ("Genererade bild") expanded to the parameters.

## Change

- `InternalToolStep.svelte`: the running state is the same button as the finished one. It opens to the parameters as soon as the model has written them (the chevron appears on hover, as before), and the result section joins the panel when the call completes. The running wrapper keeps its `role="status"` announcement.
- `MessageAnswer.svelte`: a run's steps render through one keyed `{#each}` whether the run is still working (latest step only) or done (every step), so a step opened mid-run keeps its panel open when the result lands instead of being remounted closed. The folded multi-step summary is unchanged.

## Verification

- `svelte-check`: 0 errors, 0 warnings
- `eslint` and `prettier` clean on both files