### PR TITLE
fix(chat): render capability tool calls as built-in steps

### DIFF
--- a/backend/src/eneo/ai_models/completion_models/completion_model.py
+++ b/backend/src/eneo/ai_models/completion_models/completion_model.py
@@ -107,6 +107,11 @@ class ToolCallMetadata:
     # forms used by the UI; this field preserves the exact identifier needed
     # to replay the tool_use so it matches the currently-registered tools.
     mcp_tool_name: Optional[str] = None
+    # Capability the call serves ("web_search", "image_generation") when the
+    # server is a capability provider, whichever server backs it; None for
+    # general MCP servers and Eneo's own loopback servers. Clients render
+    # capability calls by purpose, not by the provider's name.
+    purpose: Optional[str] = None
     # The tool result's MCP `_meta` (capped by the client). Servers use it for
     # out-of-band facts about the call, e.g. OpenTelemetry GenAI usage
     # attributes (`gen_ai.usage.input_tokens`) from a model-backed tool.

--- a/backend/src/eneo/assistants/api/assistant_protocol.py
+++ b/backend/src/eneo/assistants/api/assistant_protocol.py
@@ -63,6 +63,7 @@ class _SupportsToolCallMetadata(Protocol):
     result: str | None
     mcp_tool_name: str | None
     meta: dict[str, Any] | None
+    purpose: str | None
 
 
 def _require_approval_id(chunk: Completion) -> str:
@@ -240,6 +241,7 @@ def to_sse_response(chunk: Completion, session_id: "UUID") -> ServerSentEvent:
                     approved=tc.approved,
                     result_status=tc.result_status,
                     mcp_tool_name=tc.mcp_tool_name,
+                    purpose=tc.purpose,
                     meta=tc.meta,
                 )
                 for tc in tool_calls
@@ -274,6 +276,7 @@ def to_sse_response(chunk: Completion, session_id: "UUID") -> ServerSentEvent:
                     tool_call_id=tc.tool_call_id,
                     approved=tc.approved,
                     result_status=tc.result_status,
+                    purpose=tc.purpose,
                 )
                 for tc in tool_calls
             ],
@@ -295,6 +298,7 @@ def to_sse_response(chunk: Completion, session_id: "UUID") -> ServerSentEvent:
                     tool_call_id=tc.tool_call_id,
                     approved=tc.approved,
                     result_status=tc.result_status,
+                    purpose=tc.purpose,
                 )
                 for tc in tool_calls
             ],

--- a/backend/src/eneo/assistants/assistant_service.py
+++ b/backend/src/eneo/assistants/assistant_service.py
@@ -2300,6 +2300,8 @@ class AssistantService:
                                             existing.result = tc.result
                                         if tc.meta is not None:
                                             existing.meta = tc.meta
+                                        if tc.purpose is not None:
+                                            existing.purpose = tc.purpose
                                     else:
                                         # Add new tool call
                                         tool_calls.append(
@@ -2316,6 +2318,7 @@ class AssistantService:
                                                 result_status=tc.result_status,
                                                 result=tc.result,
                                                 mcp_tool_name=tc.mcp_tool_name,
+                                                purpose=tc.purpose,
                                                 meta=tc.meta,
                                             )
                                         )
@@ -2359,6 +2362,7 @@ class AssistantService:
                                                 approved=None,
                                                 result_status=tc.result_status,
                                                 mcp_tool_name=tc.mcp_tool_name,
+                                                purpose=tc.purpose,
                                             )
                                         )
                             yield chunk
@@ -2395,6 +2399,7 @@ class AssistantService:
                                                 result_status=tc.result_status
                                                 or "timeout_denied",
                                                 mcp_tool_name=tc.mcp_tool_name,
+                                                purpose=tc.purpose,
                                             )
                                         )
                             yield chunk
@@ -2596,6 +2601,7 @@ class AssistantService:
                             result_status=tc.result_status,
                             result=tc.result,
                             mcp_tool_name=tc.mcp_tool_name,
+                            purpose=tc.purpose,
                             meta=tc.meta,
                         )
                         for tc in non_streaming_tool_metadata

--- a/backend/src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py
+++ b/backend/src/eneo/completion_models/infrastructure/adapters/tenant_model_adapter.py
@@ -1393,6 +1393,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                                 result_status=result_status,
                                 result=display_text,
                                 mcp_tool_name=call.name,
+                                purpose=mcp_proxy.get_tool_purpose(call.name),
                                 meta=result.get("meta") or None,
                             )
                         )
@@ -1598,6 +1599,9 @@ class TenantModelAdapter(CompletionModelAdapter):
                     return server_name, tool_name, None
                 return "", name, None
 
+            def _tool_purpose(name: str) -> str | None:
+                return mcp_proxy.get_tool_purpose(name) if mcp_proxy else None
+
             # Shared state for tool call accumulation and usage across stream draining
             class _StreamResult:
                 def __init__(self) -> None:
@@ -1748,6 +1752,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                                             tool_call_id=call_id,
                                             result_status="pending",
                                             mcp_tool_name=name,
+                                            purpose=_tool_purpose(name),
                                         )
                                     ],
                                 )
@@ -1926,6 +1931,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                                         title=title,
                                         tool_call_id=call.call_id,
                                         result_status="deferred",
+                                        purpose=_tool_purpose(call.name),
                                         result=json.dumps(
                                             {
                                                 "deferred": True,
@@ -1999,6 +2005,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                                 arguments=args,
                                 tool_call_id=tc["id"],
                                 mcp_tool_name=name,
+                                purpose=mcp_proxy.get_tool_purpose(name),
                             )
                         )
                     tool_args_by_call_id: dict[str, dict[str, Any] | None] = {}
@@ -2081,6 +2088,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                                         approved=False,
                                         result_status="timeout_denied",
                                         mcp_tool_name=tm.mcp_tool_name,
+                                        purpose=tm.purpose,
                                     )
                                     for tm in approval_metadata
                                 ],
@@ -2108,6 +2116,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                                         )
                                     ),
                                     mcp_tool_name=tm.mcp_tool_name,
+                                    purpose=tm.purpose,
                                 )
                                 for tm in tool_metadata
                             ],
@@ -2136,6 +2145,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                                     approved=tm.approved,
                                     result_status="approved",
                                     mcp_tool_name=tm.mcp_tool_name,
+                                    purpose=tm.purpose,
                                 )
                                 for tm in tool_metadata
                             ],
@@ -2240,6 +2250,9 @@ class TenantModelAdapter(CompletionModelAdapter):
                                     result_status=result_status,
                                     result=display_text,
                                     mcp_tool_name=tc["function"]["name"],
+                                    purpose=mcp_proxy.get_tool_purpose(
+                                        tc["function"]["name"]
+                                    ),
                                     meta=result_data.get("meta") or None,
                                 )
                             )
@@ -2296,6 +2309,9 @@ class TenantModelAdapter(CompletionModelAdapter):
                                 ),
                                 result=json.dumps(denial_payload),
                                 mcp_tool_name=tc["function"]["name"],
+                                purpose=mcp_proxy.get_tool_purpose(
+                                    tc["function"]["name"]
+                                ),
                             )
                         )
 
@@ -2392,6 +2408,7 @@ class TenantModelAdapter(CompletionModelAdapter):
                                     result_status="failed",
                                     result=refusal_payload,
                                     mcp_tool_name=name,
+                                    purpose=_tool_purpose(name),
                                 )
                             )
                         yield Completion(

--- a/backend/src/eneo/mcp_servers/infrastructure/proxy/mcp_proxy_session.py
+++ b/backend/src/eneo/mcp_servers/infrastructure/proxy/mcp_proxy_session.py
@@ -27,6 +27,7 @@ from eneo.mcp_servers.domain.entities.mcp_server import (
     MCPServer,
     MCPServerTool,
     is_builtin_provider,
+    is_capability_purpose,
 )
 from eneo.mcp_servers.infrastructure.client.mcp_client import (
     MCPClient,
@@ -771,6 +772,19 @@ class MCPProxySession:
             return None
         server, original_tool_name, title = self._tool_registry[prefixed_tool_name]
         return (_trace_server_name(server), original_tool_name, title)
+
+    def get_tool_purpose(self, prefixed_tool_name: str) -> str | None:
+        """The capability a tool call serves, or None for general servers.
+
+        A capability provider (web search, image generation) is one function
+        from the user's point of view whichever server backs it, so clients
+        render its calls by purpose rather than by the provider's name.
+        """
+        entry = self._tool_registry.get(prefixed_tool_name)
+        if entry is None:
+            return None
+        server = entry[0]
+        return server.purpose if is_capability_purpose(server.purpose) else None
 
     def _capture_owner_task(self) -> None:
         """Bind this proxy session to the current asyncio.Task on first connect.

--- a/backend/src/eneo/questions/question.py
+++ b/backend/src/eneo/questions/question.py
@@ -95,6 +95,11 @@ class ToolCallInfo(BaseModel):
     # currently-registered tools. `tool_name` above is the unprefixed/display
     # form used by the UI.
     mcp_tool_name: Optional[str] = None
+    # Capability the call serves ("web_search", "image_generation") when the
+    # server is a capability provider, whichever server backs it; None for
+    # general MCP servers and Eneo's own loopback servers. Clients render
+    # capability calls by purpose, not by the provider's name.
+    purpose: Optional[str] = None
     # The tool result's MCP `_meta`, as sent by the server (size-capped by the
     # client). Model-backed tools report their own usage here under the
     # OpenTelemetry GenAI attribute names, e.g. `gen_ai.usage.input_tokens`,

--- a/backend/tests/unit/test_assistant_protocol.py
+++ b/backend/tests/unit/test_assistant_protocol.py
@@ -68,6 +68,32 @@ def test_tool_call_sse_preserves_null_tool_call_id():
     assert payload["tools"][0]["tool_call_id"] is None
 
 
+def test_tool_call_sse_carries_the_capability_purpose():
+    """A capability provider's call is rendered by purpose, so the purpose
+    must reach the client alongside the provider's name."""
+    event = to_sse_response(
+        Completion(
+            response_type=ResponseType.TOOL_CALL,
+            tool_calls_metadata=[
+                ToolCallMetadata(
+                    server_name="GDM Safe Search",
+                    tool_name="search",
+                    tool_call_id="call-1",
+                    purpose="web_search",
+                ),
+                ToolCallMetadata(server_name="general", tool_name="tool"),
+            ],
+        ),
+        uuid4(),
+    )
+
+    tools = json.loads(event.data)["tools"]
+
+    assert tools[0]["purpose"] == "web_search"
+    assert tools[0]["server_name"] == "GDM Safe Search"
+    assert tools[1]["purpose"] is None
+
+
 def test_token_usage_sse_separates_turn_cost_from_context_headroom():
     event = to_sse_response(
         Completion(

--- a/backend/tests/unit/test_mcp_proxy_session_resilience.py
+++ b/backend/tests/unit/test_mcp_proxy_session_resilience.py
@@ -184,6 +184,42 @@ def test_builtin_provider_tool_calls_are_reported_under_the_loopback_server():
     assert proxy.get_tool_info("general__tool") == ("general", "tool", None)
 
 
+def test_tool_purpose_names_the_capability_whichever_server_backs_it():
+    """A capability provider's calls carry the purpose so clients render
+    them as one function ("web search") rather than by the provider's name;
+    general servers carry none, and unknown tools resolve to none."""
+    general = _make_server("general")
+    provider_id = uuid4()
+    search_provider = MCPServer(
+        id=provider_id,
+        tenant_id=general.tenant_id,
+        name="GDM Safe Search",
+        http_url="https://search.example/mcp",
+        http_auth_type="bearer",
+        purpose="web_search",
+        tools=[
+            MCPServerTool(
+                mcp_server_id=provider_id,
+                name="search",
+                title="Search",
+                description="Search the web.",
+                input_schema={"type": "object", "properties": {}},
+                is_enabled_by_default=True,
+            )
+        ],
+    )
+    proxy = MCPProxySession([general, search_provider])
+
+    assert proxy.get_tool_purpose("gdm_safe_search__search") == "web_search"
+    assert proxy.get_tool_info("gdm_safe_search__search") == (
+        "GDM Safe Search",
+        "search",
+        "Search",
+    )
+    assert proxy.get_tool_purpose("general__tool") is None
+    assert proxy.get_tool_purpose("nope__tool") is None
+
+
 class _InMemoryToolRepo:
     def __init__(self, tools: list[MCPServerTool]) -> None:
         self.tools = {tool.id: tool for tool in tools}

--- a/backend/tests/unit/test_tenant_model_adapter_iterate_stream.py
+++ b/backend/tests/unit/test_tenant_model_adapter_iterate_stream.py
@@ -119,6 +119,10 @@ class _FakeMCPProxy:
     def get_tool_info(self, prefixed_tool_name: str):
         return ("Server", "tool", "Tool title")
 
+    def get_tool_purpose(self, prefixed_tool_name: str) -> str | None:
+        del prefixed_tool_name
+        return None
+
     async def call_tools_parallel(self, proxy_calls):
         self.calls.append(proxy_calls)
         return [

--- a/backend/tests/unit/test_tenant_model_adapter_skill_activation.py
+++ b/backend/tests/unit/test_tenant_model_adapter_skill_activation.py
@@ -58,6 +58,10 @@ class _FakeMCPProxy:
             return ("server", "lookup", "Lookup")
         return None
 
+    def get_tool_purpose(self, name: str) -> str | None:
+        del name
+        return None
+
     async def refresh_tools(self, *, touched_tool_names: list[str]) -> bool:
         del touched_tool_names
         return False

--- a/frontend/apps/web/messages/en.json
+++ b/frontend/apps/web/messages/en.json
@@ -4684,5 +4684,9 @@
   "functions_policy_description": "Your organization’s policy determines which functions are available and which start switched on in chat.",
   "functions_policy_none": "Your organization’s policy does not provide any functions.",
   "functions_default_on": "Starts on in chat",
-  "functions_default_off": "Starts off in chat"
+  "functions_default_off": "Starts off in chat",
+  "tool_web_search": "Searching the web",
+  "tool_web_search_query": "Searching the web for “{query}”",
+  "tool_web_search_done": "Searched the web",
+  "tool_web_search_query_done": "Searched the web for “{query}”"
 }

--- a/frontend/apps/web/messages/sv.json
+++ b/frontend/apps/web/messages/sv.json
@@ -4684,5 +4684,9 @@
   "functions_policy_description": "Organisationens policy styr vilka funktioner som är tillgängliga och vilka som är påslagna från början i chatten.",
   "functions_policy_none": "Organisationens policy tillhandahåller inga funktioner.",
   "functions_default_on": "På från början i chatten",
-  "functions_default_off": "Av från början i chatten"
+  "functions_default_off": "Av från början i chatten",
+  "tool_web_search": "Söker på webben",
+  "tool_web_search_query": "Söker på webben efter ”{query}”",
+  "tool_web_search_done": "Sökte på webben",
+  "tool_web_search_query_done": "Sökte på webben efter ”{query}”"
 }

--- a/frontend/apps/web/src/lib/features/chat/components/conversation/MessageAnswer.svelte
+++ b/frontend/apps/web/src/lib/features/chat/components/conversation/MessageAnswer.svelte
@@ -10,8 +10,9 @@
   import { getChatService } from "../../ChatService.svelte";
   import {
     internalReadFileId,
+    capabilityProviderDetail,
     internalToolDoneLabel,
-    isInternalServer,
+    isBuiltinToolCall,
     serverDisplayName,
     toolDisplayName
   } from "../../internalToolLabels";
@@ -49,6 +50,7 @@
           tool_call_id?: string;
           approved?: boolean;
           result_status?: string;
+          purpose?: string | null;
         }>
       | undefined
   );
@@ -125,18 +127,27 @@
               : toolsStillExecuting && isLastTraced
                 ? "running"
                 : "complete";
-      const toolName = toolDisplayName(tc.tool_name, tc.server_name, tc.title, tc.arguments);
+      const toolName = toolDisplayName(
+        tc.tool_name,
+        tc.server_name,
+        tc.title,
+        tc.arguments,
+        tc.purpose
+      );
       return {
-        // Eneo's own built-in tools get localized labels; otherwise prefer the
-        // server-provided title annotation, falling back to the raw tool name.
+        // Eneo's own tools and capability calls get localized labels; otherwise
+        // prefer the server-provided title, falling back to the raw tool name.
         toolName,
-        doneLabel: internalToolDoneLabel(tc.tool_name, tc.server_name, tc.arguments) ?? toolName,
-        serverName: serverDisplayName(tc.server_name),
-        detail: readFileDetail(tc),
+        doneLabel:
+          internalToolDoneLabel(tc.tool_name, tc.server_name, tc.arguments, tc.purpose) ?? toolName,
+        serverName: serverDisplayName(tc.server_name, tc.purpose),
+        detail: readFileDetail(tc) ?? capabilityProviderDetail(tc),
         args: tc.arguments,
         toolCallId: tc.tool_call_id,
         status,
-        internal: isInternalServer(tc.server_name)
+        // Capability calls render as built-in steps whichever provider served
+        // them; general external servers keep their cards.
+        internal: isBuiltinToolCall(tc)
       };
     })
   );
@@ -376,7 +387,13 @@
             <div class="flex min-w-0 flex-1 flex-col gap-0.5">
               <div class="flex items-center gap-2">
                 <span class="text-default truncate text-sm font-medium"
-                  >{toolDisplayName(toolCall.tool_name, toolCall.server_name, toolCall.title)}</span
+                  >{toolDisplayName(
+                    toolCall.tool_name,
+                    toolCall.server_name,
+                    toolCall.title,
+                    undefined,
+                    toolCall.purpose
+                  )}</span
                 >
                 {#if pendingDetail}
                   <span class="text-muted min-w-0 truncate text-xs">{pendingDetail}</span>
@@ -395,7 +412,9 @@
                   </span>
                 {/if}
               </div>
-              <span class="text-muted text-xs">{serverDisplayName(toolCall.server_name)}</span>
+              <span class="text-muted text-xs"
+                >{serverDisplayName(toolCall.server_name, toolCall.purpose)}</span
+              >
             </div>
 
             <!-- Expand indicator -->

--- a/frontend/apps/web/src/lib/features/chat/internalToolLabels.test.ts
+++ b/frontend/apps/web/src/lib/features/chat/internalToolLabels.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  capabilityProviderDetail,
+  internalToolDoneLabel,
+  isBuiltinToolCall,
+  serverDisplayName,
+  toolDisplayName
+} from "./internalToolLabels";
+
+/**
+ * A tool call renders as a built-in step when it serves a capability (web
+ * search, image generation), whichever provider backs it, or when it runs on
+ * one of Eneo's own loopback servers. General external servers keep their
+ * cards. Rows persisted before `purpose` existed fall back to the name rule.
+ */
+describe("isBuiltinToolCall", () => {
+  it("treats a capability call from an external provider as built in", () => {
+    expect(isBuiltinToolCall({ server_name: "GDM Safe Search", purpose: "web_search" })).toBe(true);
+  });
+
+  it("keeps general external servers external", () => {
+    expect(isBuiltinToolCall({ server_name: "GDM Safe Search", purpose: null })).toBe(false);
+    expect(isBuiltinToolCall({ server_name: "Jira", purpose: "general" })).toBe(false);
+  });
+
+  it("keeps Eneo's own servers built in, with or without a purpose", () => {
+    expect(isBuiltinToolCall({ server_name: "knowledge" })).toBe(true);
+    expect(isBuiltinToolCall({ server_name: "image_generation" })).toBe(true);
+    expect(
+      isBuiltinToolCall({ server_name: "image_generation", purpose: "image_generation" })
+    ).toBe(true);
+  });
+});
+
+describe("labels", () => {
+  it("labels a web search by purpose and folds the query in", () => {
+    const args = { query: "lasagne recept" };
+    const running = toolDisplayName("search", "GDM Safe Search", "Search", args, "web_search");
+    const done = internalToolDoneLabel("search", "GDM Safe Search", args, "web_search");
+
+    expect(running).toContain("lasagne recept");
+    expect(running).not.toBe("Search");
+    expect(done).toContain("lasagne recept");
+    expect(done).not.toBe(running);
+  });
+
+  it("accepts q as the query argument", () => {
+    expect(toolDisplayName("search", "Provider", null, { q: "bygglov" }, "web_search")).toContain(
+      "bygglov"
+    );
+  });
+
+  it("labels an external image provider like the built-in one", () => {
+    const external = toolDisplayName(
+      "make_picture",
+      "Pixel Co",
+      "Make picture",
+      {},
+      "image_generation"
+    );
+    const builtin = toolDisplayName("generate_image", "image_generation", null, {});
+
+    expect(external).toBe(builtin);
+  });
+
+  it("falls back to the server title, then the raw name, for general tools", () => {
+    expect(toolDisplayName("lookup", "Jira", "Look up issue", {}, null)).toBe("Look up issue");
+    expect(toolDisplayName("lookup", "Jira", null, {}, null)).toBe("lookup");
+    expect(internalToolDoneLabel("lookup", "Jira", {}, null)).toBeNull();
+  });
+
+  it("names the server line by capability for providers and by name otherwise", () => {
+    expect(serverDisplayName("GDM Safe Search", "web_search")).not.toBe("GDM Safe Search");
+    expect(serverDisplayName("Jira", null)).toBe("Jira");
+    expect(serverDisplayName("knowledge")).not.toBe("knowledge");
+  });
+
+  it("shows the provider name as detail only for external capability calls", () => {
+    expect(
+      capabilityProviderDetail({ server_name: "GDM Safe Search", purpose: "web_search" })
+    ).toBe("GDM Safe Search");
+    expect(
+      capabilityProviderDetail({ server_name: "image_generation", purpose: "image_generation" })
+    ).toBeNull();
+    expect(capabilityProviderDetail({ server_name: "Jira", purpose: null })).toBeNull();
+  });
+});

--- a/frontend/apps/web/src/lib/features/chat/internalToolLabels.ts
+++ b/frontend/apps/web/src/lib/features/chat/internalToolLabels.ts
@@ -5,8 +5,12 @@
 */
 
 import { m } from "$lib/paraglide/messages";
+import { getCapability, type CapabilityPurpose } from "$lib/features/mcp/capabilities";
 
 type ToolArgs = Record<string, unknown> | undefined;
+
+/** The parts of a tool call the display rules need. */
+type ToolCallLike = { server_name: string; purpose?: string | null };
 
 type CatalogLabels = { title: () => string; description: () => string };
 
@@ -117,43 +121,105 @@ export function builtinToolCatalogLabels(
   return labels ? { title: labels.title(), description: labels.description() } : null;
 }
 
+/**
+ * Labels for capability calls, keyed by purpose rather than tool name: a
+ * capability (web search, image generation) is one function from the user's
+ * point of view whichever provider serves it, and external providers name
+ * their tools freely. The backend stamps `purpose` on a call served by a
+ * capability provider, external or built-in.
+ */
+const CAPABILITY_STEPS: Record<
+  CapabilityPurpose,
+  { running: (args?: ToolArgs) => string; done: (args?: ToolArgs) => string }
+> = {
+  web_search: {
+    running: (args) => {
+      const query = searchQuery(args);
+      return query ? m.tool_web_search_query({ query }) : m.tool_web_search();
+    },
+    done: (args) => {
+      const query = searchQuery(args);
+      return query ? m.tool_web_search_query_done({ query }) : m.tool_web_search_done();
+    }
+  },
+  image_generation: INTERNAL_SERVERS.image_generation.tools.generate_image
+};
+
+function capabilityPurpose(purpose: string | null | undefined): CapabilityPurpose | null {
+  return purpose && purpose in CAPABILITY_STEPS ? (purpose as CapabilityPurpose) : null;
+}
+
 /** Whether a server name refers to one of Eneo's built-in loopback servers. */
 export function isInternalServer(serverName: string): boolean {
   return serverName in INTERNAL_SERVERS;
 }
 
 /**
- * Past-tense label for a finished internal tool call ("Sökte i kunskap"), or
- * null for external servers and unknown internal tools.
+ * Whether a tool call renders as a built-in step (slim line, localized
+ * labels) rather than as an external tool card: capability calls whichever
+ * provider served them, and calls on Eneo's own loopback servers. Rows
+ * persisted before `purpose` existed fall back to the server name alone.
+ */
+export function isBuiltinToolCall(call: ToolCallLike): boolean {
+  return capabilityPurpose(call.purpose) !== null || isInternalServer(call.server_name);
+}
+
+/**
+ * Past-tense label for a finished built-in tool call ("Sökte i kunskap",
+ * "Sökte på webben"), or null for external tools and unknown internal tools.
  */
 export function internalToolDoneLabel(
   toolName: string,
   serverName: string,
-  args?: ToolArgs
+  args?: ToolArgs,
+  purpose?: string | null
 ): string | null {
-  return INTERNAL_SERVERS[serverName]?.tools[toolName]?.done(args) ?? null;
+  const internal = INTERNAL_SERVERS[serverName]?.tools[toolName]?.done(args);
+  if (internal) return internal;
+  const capability = capabilityPurpose(purpose);
+  return capability ? CAPABILITY_STEPS[capability].done(args) : null;
 }
 
 /**
- * Display name for a tool call: internal mapping > server title > raw name.
- * The internal mapping only applies to Eneo's own loopback servers.
+ * Display name for a tool call: internal mapping > capability label > server
+ * title > raw name. The internal mapping only applies to Eneo's own loopback
+ * servers; the capability label to any provider of that capability.
  */
 export function toolDisplayName(
   toolName: string,
   serverName: string,
   title?: string | null,
-  args?: ToolArgs
+  args?: ToolArgs,
+  purpose?: string | null
 ): string {
-  const internal = INTERNAL_SERVERS[serverName];
-  if (internal) {
-    return internal.tools[toolName]?.running(args) ?? title ?? toolName;
-  }
+  const internal = INTERNAL_SERVERS[serverName]?.tools[toolName]?.running(args);
+  if (internal) return internal;
+  const capability = capabilityPurpose(purpose);
+  if (capability) return CAPABILITY_STEPS[capability].running(args);
   return title ?? toolName;
 }
 
-/** Display name for the server line under a tool call. */
-export function serverDisplayName(serverName: string): string {
-  return INTERNAL_SERVERS[serverName]?.label() ?? serverName;
+/**
+ * Display name for the server line under a tool call: Eneo's own servers and
+ * capabilities by their localized name, external general servers by name.
+ */
+export function serverDisplayName(serverName: string, purpose?: string | null): string {
+  const internal = INTERNAL_SERVERS[serverName]?.label();
+  if (internal) return internal;
+  const capability = capabilityPurpose(purpose);
+  return capability ? (getCapability(capability)?.label() ?? serverName) : serverName;
+}
+
+/**
+ * The provider's own name for a capability call served by an external
+ * provider ("GDM Safe Search"), shown as the step's detail so the source
+ * stays visible; null for Eneo's own servers and general tools.
+ */
+export function capabilityProviderDetail(call: ToolCallLike): string | null {
+  if (capabilityPurpose(call.purpose) === null || isInternalServer(call.server_name)) {
+    return null;
+  }
+  return call.server_name;
 }
 
 /** Path of a signed file reference URL, mirroring the backend's parser. */
@@ -188,9 +254,9 @@ function hasReferenceImages(args?: ToolArgs): boolean {
 /** Longest query shown inline in a tool label before being cut with an ellipsis. */
 const MAX_INLINE_QUERY_LENGTH = 60;
 
-/** Query argument of a search_knowledge call, if present and non-empty. */
+/** Query argument of a search call (`query`, or `q` as some providers name it). */
 function searchQuery(args?: ToolArgs): string | null {
-  const query = args?.query;
+  const query = args?.query ?? args?.q;
   if (typeof query !== "string") return null;
   const trimmed = query.trim();
   if (trimmed.length === 0) return null;

--- a/frontend/packages/eneo-js/src/types/schema.d.ts
+++ b/frontend/packages/eneo-js/src/types/schema.d.ts
@@ -20122,6 +20122,8 @@ export interface components {
       result?: string | null;
       /** Mcp Tool Name */
       mcp_tool_name?: string | null;
+      /** Purpose */
+      purpose?: string | null;
       /** Meta */
       meta?: {
         [key: string]: unknown;
@@ -27769,6 +27771,8 @@ export interface operations {
                     result?: string | null;
                     /** Mcp Tool Name */
                     mcp_tool_name?: string | null;
+                    /** Purpose */
+                    purpose?: string | null;
                     /** Meta */
                     meta?: {
                       [key: string]: unknown;
@@ -27826,6 +27830,8 @@ export interface operations {
                     result?: string | null;
                     /** Mcp Tool Name */
                     mcp_tool_name?: string | null;
+                    /** Purpose */
+                    purpose?: string | null;
                     /** Meta */
                     meta?: {
                       [key: string]: unknown;
@@ -27883,6 +27889,8 @@ export interface operations {
                     result?: string | null;
                     /** Mcp Tool Name */
                     mcp_tool_name?: string | null;
+                    /** Purpose */
+                    purpose?: string | null;
                     /** Meta */
                     meta?: {
                       [key: string]: unknown;


### PR DESCRIPTION
## Summary

A web search served by an external provider rendered as the external MCP card ("Verktyg › search KLAR / GDM Safe Search"), while the built-in image provider rendered as the slim built-in step. The UI keyed purely on the reported server name, and only Eneo's loopback servers (`knowledge`, `files`, `image_generation`) matched; the built-in image provider only qualified because the backend reports it under its purpose string.

The distinction that matters to the user is **capability vs. general tool**, not loopback vs. external: web search and image generation are functions the admin switched on, and the provider behind them is an admin concern.

## Changes

**Backend**
- `MCPProxySession.get_tool_purpose(prefixed_name)`: the capability purpose of a registered tool, or `None` for general servers. `get_tool_info` and `_trace_server_name` are unchanged.
- The tenant model adapter stamps `purpose` on every `ToolCallMetadata` it builds (pending, executed, denied, deferred, refused, and the approval re-emissions).
- New optional `purpose` on `ToolCallMetadata` / `ToolCallInfo`, so it rides the SSE `tool_call` event and the persisted `tool_calls` JSONB. No migration; older rows simply lack it.

**Frontend**
- `internalToolLabels.ts`: purpose-keyed labels (`web_search`: "Söker på webben efter ”…”" / "Sökte på webben"; `image_generation` reuses the built-in labels), `isBuiltinToolCall`, and `capabilityProviderDetail` so the provider's name stays visible as the step's detail.
- `MessageAnswer.svelte` decides step vs. card with `isBuiltinToolCall` and passes `purpose` to the label helpers, including the pending-approval cards.
- Rows without `purpose` keep the name-based rule, so old conversations render as before.

## Tests

- Backend: proxy purpose lookup (capability provider, general server, unknown tool), SSE mapping carries `purpose`, adapter fakes extended; full unit suite green.
- Frontend: `internalToolLabels.test.ts` covers the step/card decision, purpose labels (including `q` as the query argument), the external-image-provider case, general-tool fallbacks and the provider detail.

## Manual check

On an assistant with web search enabled, ask something that triggers a search: the step reads "Söker på webben efter ”…”" while running and "Sökte på webben · GDM Safe Search" when done, expandable to parameters and result; no card. An assistant with a general MCP server attached still shows the card. Reloading an older conversation renders as before.
