### PR TITLE
test(e2e): look for chat messages inside the conversation, not the whole page

### DIFF
--- a/frontend/apps/web/tests/assistant-authoring.spec.ts
+++ b/frontend/apps/web/tests/assistant-authoring.spec.ts
@@ -41,6 +41,8 @@ test("a created assistant can be edited and used in chat", async ({ page, reques
 
   await askChatQuestion(page, question);
 
-  await expect(page.getByText(question, { exact: true })).toBeVisible();
-  await expect(page.getByText(MOCK_REPLY)).toBeVisible({ timeout: 20_000 });
+  // Scope to the conversation: the reloaded history table also holds the question text.
+  const conversation = page.locator("#session-message-container");
+  await expect(conversation.getByText(question, { exact: true })).toBeVisible();
+  await expect(conversation.getByText(MOCK_REPLY)).toBeVisible({ timeout: 20_000 });
 });

--- a/frontend/apps/web/tests/chat.spec.ts
+++ b/frontend/apps/web/tests/chat.spec.ts
@@ -12,8 +12,13 @@ test("a streamed answer is saved and can be reopened from history", async ({ pag
   const question = uniqueName("e2e persistence ping");
   await askChatQuestion(page, question);
 
-  await expect(page.getByText(question, { exact: true })).toBeVisible();
-  await expect(page.getByText("E2E mock completion: pong")).toBeVisible({ timeout: 20_000 });
+  // Scope to the conversation: once the session exists the service reloads the
+  // history list, whose (hidden) table also contains the question text.
+  const conversation = page.locator("#session-message-container");
+  await expect(conversation.getByText(question, { exact: true })).toBeVisible();
+  await expect(conversation.getByText("E2E mock completion: pong")).toBeVisible({
+    timeout: 20_000
+  });
 
   await page.getByRole("tablist").getByRole("tab").nth(1).click();
 
@@ -21,7 +26,6 @@ test("a streamed answer is saved and can be reopened from history", async ({ pag
   await expect(savedConversation).toBeVisible({ timeout: 15_000 });
   await savedConversation.click();
 
-  const conversation = page.locator("#session-message-container");
   await expect(conversation.getByText(question, { exact: true })).toBeVisible();
   await expect(conversation.getByText("E2E mock completion: pong")).toBeVisible();
 

--- a/frontend/apps/web/tests/model-failure.spec.ts
+++ b/frontend/apps/web/tests/model-failure.spec.ts
@@ -14,6 +14,8 @@ test("chat recovers after the provider returns an error", async ({ page }) => {
   await askChatQuestion(page, recoveryQuestion);
 
   await expect(page.getByRole("alert")).toHaveCount(0);
-  await expect(page.getByText(recoveryQuestion, { exact: true })).toBeVisible();
-  await expect(page.getByText(MOCK_REPLY)).toBeVisible({ timeout: 20_000 });
+  // Scope to the conversation: the reloaded history table also holds the question text.
+  const conversation = page.locator("#session-message-container");
+  await expect(conversation.getByText(recoveryQuestion, { exact: true })).toBeVisible();
+  await expect(conversation.getByText(MOCK_REPLY)).toBeVisible({ timeout: 20_000 });
 });


### PR DESCRIPTION
## Changes

The three chat E2E specs (`chat`, `model-failure`, `assistant-authoring`) now look for the sent question and the mock reply inside `#session-message-container` instead of anywhere on the page.

## Why

The `Frontend E2E` job on develop failed after #822 merged (run 34530030898) with a strict-mode violation: `getByText(question)` matched both the message and a row in the history table. After a send, the chat service reloads the history list as soon as the stream finishes, and the history tab's table stays in the DOM while hidden. With the instant mock model the reload can land before the assertion's first successful poll, so the page-wide lookup is a race. The chat spec already scoped its later assertions the same way.

## Planning

- Task: Fixes #

## Testing

- Full Playwright suite run locally twice against the isolated test stack on this branch (develop + this change): 12 passed both times.

## Screenshots

None; test-only change.