### PR TITLE
fix(ui): highlight code blocks as their fenced language

### DIFF
--- a/frontend/apps/web/src/lib/features/chat/components/conversation/CodeBlockLanguage.svelte.test.ts
+++ b/frontend/apps/web/src/lib/features/chat/components/conversation/CodeBlockLanguage.svelte.test.ts
@@ -1,0 +1,33 @@
+import { render } from "vitest-browser-svelte";
+import { describe, expect, it } from "vitest";
+import { Markdown } from "@eneo/ui";
+
+const fence = (lang: string, code: string) => `Exempel:\n\n\`\`\`${lang}\n${code}\n\`\`\`\n`;
+
+describe("Markdown code blocks", () => {
+  it("highlights a fenced language as that language", () => {
+    const { container } = render(Markdown, {
+      source: fence("json", '{ "namn": "Anna", "aktiv": true }')
+    });
+    // JSON keys are attributes; detection used to read this block as JavaScript.
+    expect(container.querySelector("code.hljs .hljs-attr")?.textContent).toBe('"namn"');
+  });
+
+  it("falls back to detection for an unknown or missing language", () => {
+    const { container } = render(Markdown, {
+      source:
+        fence("brainfuck", "def hej():\n    return 1") + fence("", "const x = 1;\nconsole.log(x);")
+    });
+    const blocks = container.querySelectorAll("code.hljs");
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0].querySelector(".hljs-keyword")?.textContent).toBe("def");
+    expect(blocks[1].querySelector(".hljs-keyword")?.textContent).toBe("const");
+  });
+
+  it("tolerates a block that is still streaming", () => {
+    const { container } = render(Markdown, {
+      source: 'Kod:\n\n```python\nprint("hej'
+    });
+    expect(container.querySelector("code.hljs")?.textContent).toContain('print("hej');
+  });
+});

--- a/frontend/packages/ui/src/lib/CodeBlock/CodeBlock.svelte
+++ b/frontend/packages/ui/src/lib/CodeBlock/CodeBlock.svelte
@@ -4,21 +4,37 @@
   import python from "highlight.js/lib/languages/python";
   import c from "highlight.js/lib/languages/c";
   import xml from "highlight.js/lib/languages/xml";
+  import json from "highlight.js/lib/languages/json";
+  import bash from "highlight.js/lib/languages/bash";
+  import yaml from "highlight.js/lib/languages/yaml";
+  import sql from "highlight.js/lib/languages/sql";
   import { IconCopy } from "@eneo/icons/copy";
 
   hljs.registerLanguage("javascript", js);
   hljs.registerLanguage("python", python);
   hljs.registerLanguage("c", c);
   hljs.registerLanguage("xml", xml);
+  hljs.registerLanguage("json", json);
+  hljs.registerLanguage("bash", bash);
+  hljs.registerLanguage("yaml", yaml);
+  hljs.registerLanguage("sql", sql);
 
   export let source: string;
+  /** The fence info string (```python), when the markdown provided one. */
+  export let lang: string | undefined = undefined;
   let cls = "";
   export { cls as class };
 
   let showCopiedMessage = false;
-  // Maybe we can do smth here, marked will take the lang from the source
-  // export let lang: string | undefined = undefined
-  $: highlighted = hljs.highlightAuto(source, ["javascript", "python", "c"]).value;
+
+  // A fenced language we know is highlighted as that language; anything else
+  // falls back to detection among the common ones. Detection is also what
+  // mislabels JSON as JavaScript, so the fence wins whenever it is present.
+  $: fenced = lang?.trim().split(/\s+/)[0]?.toLowerCase();
+  $: language = fenced && hljs.getLanguage(fenced) ? fenced : undefined;
+  $: highlighted = language
+    ? hljs.highlight(source, { language, ignoreIllegals: true }).value
+    : hljs.highlightAuto(source, ["javascript", "python", "c"]).value;
 </script>
 
 <div class="code-wrapper group relative p-0" style="color-scheme: dark;">

--- a/frontend/packages/ui/src/lib/Markdown/renderers/Code.svelte
+++ b/frontend/packages/ui/src/lib/Markdown/renderers/Code.svelte
@@ -5,4 +5,4 @@
   export let token: Tokens.Code;
 </script>
 
-<CodeBlock source={token.text}></CodeBlock>
+<CodeBlock source={token.text} lang={token.lang}></CodeBlock>


### PR DESCRIPTION
## Changes

`CodeBlock` takes the fence language (`lang`) that marked already parses from ```lang fences, and `Code.svelte` passes it through. When the language is one highlight.js knows, the block is highlighted as that language (`ignoreIllegals` so a block that is still streaming never throws); otherwise the previous auto-detection among JavaScript, Python and C still applies. JSON, Bash, YAML and SQL are registered in addition (about 25 KB raw, 7 KB gzip); TypeScript is left to the JavaScript grammar.

## Why

Auto-detection over three grammars mislabels common answers: a JSON block is detected as JavaScript, so keys are highlighted as strings, and Bash/SQL/YAML get whichever of the three fits best. The fence language is authoritative and free. Timing on a 1.5 KB Python block re-highlighted across 30 streamed flushes: 27 ms with detection, 18 ms explicit, so this is a correctness change with a small speed gain, not a performance fix. Ranked as a worthwhile small follow-up in the Codex (gpt-6-astra, xhigh) review of the streaming work in #825.

## Planning

- Task: Fixes #

## Testing

- `CodeBlockLanguage.svelte.test.ts` (browser): a ```json fence yields `hljs-attr` keys (fails on develop, where the block is read as JavaScript); unknown and missing languages fall back to detection; a half-streamed block renders without throwing.
- ui package `svelte-check` 0 errors, eslint and prettier clean; web app `svelte-check` 0 errors.

## Screenshots

None; highlighting colours change only for blocks whose fence language differs from what detection guessed.
