### PR TITLE
fix(chat): hold back only the unfinished citation tag while streaming

### DIFF
--- a/frontend/apps/web/src/lib/features/chat/ChatService.svelte.ts
+++ b/frontend/apps/web/src/lib/features/chat/ChatService.svelte.ts
@@ -1,4 +1,5 @@
 import { browser } from "$app/environment";
+import { splitPendingInref } from "./inrefBuffer";
 import { PAGINATION } from "$lib/core/constants";
 import { toastError } from "$lib/core/errors";
 import { createAsyncState } from "$lib/core/helpers/createAsyncState.svelte";
@@ -634,16 +635,10 @@ export class ChatService {
 
               if (!ensureCurrentSession(text)) return;
 
-              // Handle inref buffering (existing logic)
+              // Hold back text that may still become an <inref> citation tag.
               let textToAdd = text.answer;
               if (text.answer.includes("<") || inrefBuffer) {
-                inrefBuffer += text.answer;
-                if (isNotInref(inrefBuffer) || isCompleteInref(inrefBuffer)) {
-                  textToAdd = inrefBuffer;
-                  inrefBuffer = "";
-                } else {
-                  textToAdd = ""; // Wait for complete inref
-                }
+                [textToAdd, inrefBuffer] = splitPendingInref(inrefBuffer + text.answer);
               }
 
               // Buffer text for frame-aligned rendering (reduces jitter)
@@ -1138,19 +1133,3 @@ function emptyConversation(): Conversation {
     messages: []
   };
 }
-
-const couldBeInref = (buffer: string): boolean => {
-  // We assume that "<" can be anywhere in the buffer, but that there can only be one
-  const start = buffer.indexOf("<");
-  if (start === -1) return false;
-
-  const tag = "<inref";
-  const max = Math.min(tag.length, buffer.length - start);
-  return buffer.slice(start, start + max) === tag.slice(0, max);
-};
-const isNotInref = (buffer: string): boolean => !couldBeInref(buffer);
-const isCompleteInref = (buffer: string): boolean => {
-  if (!couldBeInref(buffer)) return false;
-  const start = buffer.indexOf("<");
-  return buffer.indexOf(">", start) !== -1;
-};

--- a/frontend/apps/web/src/lib/features/chat/ChatService.test.ts
+++ b/frontend/apps/web/src/lib/features/chat/ChatService.test.ts
@@ -423,3 +423,43 @@ describe("ChatService independent capabilities", () => {
     });
   });
 });
+
+describe("ChatService citation withholding", () => {
+  it("shows a finished citation at once and holds only the unfinished one", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test double for the stream callbacks
+    let activeCallbacks: any;
+    let finishStream: () => void = () => {};
+    const ask = vi.fn().mockImplementationOnce(
+      ({ callbacks }) =>
+        new Promise<void>((resolve) => {
+          activeCallbacks = callbacks;
+          callbacks.onFirstChunk({
+            id: "message-1",
+            session_id: "session-1",
+            answer: "",
+            references: []
+          });
+          finishStream = resolve;
+        })
+    );
+    const chat = chatService(vi.fn(), { ask });
+    const request = chat.askQuestion("Hello");
+    await vi.waitFor(() => expect(activeCallbacks).toBeDefined());
+    const answer = () => chat.currentConversation.messages.at(-1)?.answer;
+
+    // One provider chunk carries a complete citation and the start of the next.
+    activeCallbacks.onText({
+      session_id: "session-1",
+      answer: 'Se <inref id="aaaaaaaa"/> och <inref id="bbbb',
+      references: []
+    });
+    expect(answer()).toBe('Se <inref id="aaaaaaaa"/> och ');
+
+    activeCallbacks.onText({ session_id: "session-1", answer: 'bbbb"/> för mer.', references: [] });
+    expect(answer()).toBe('Se <inref id="aaaaaaaa"/> och <inref id="bbbbbbbb"/> för mer.');
+
+    finishStream();
+    await request;
+    expect(answer()).toBe('Se <inref id="aaaaaaaa"/> och <inref id="bbbbbbbb"/> för mer.');
+  });
+});

--- a/frontend/apps/web/src/lib/features/chat/inrefBuffer.test.ts
+++ b/frontend/apps/web/src/lib/features/chat/inrefBuffer.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { splitPendingInref } from "./inrefBuffer";
+
+const A = '<inref id="aaaaaaaa"/>';
+const B = '<inref id="bbbbbbbb"/>';
+
+describe("splitPendingInref", () => {
+  it("releases text without a possible tag", () => {
+    expect(splitPendingInref("plain text")).toEqual(["plain text", ""]);
+    expect(splitPendingInref("1 < 2 and 3 > 2")).toEqual(["1 < 2 and 3 > 2", ""]);
+  });
+
+  it("withholds an unfinished tag, however short", () => {
+    expect(splitPendingInref("Se <")).toEqual(["Se ", "<"]);
+    expect(splitPendingInref("Se <inr")).toEqual(["Se ", "<inr"]);
+    expect(splitPendingInref('Se <inref id="aaaa')).toEqual(["Se ", '<inref id="aaaa']);
+  });
+
+  it("releases a complete tag", () => {
+    expect(splitPendingInref(`Se ${A} mer`)).toEqual([`Se ${A} mer`, ""]);
+    expect(splitPendingInref('<inref id="x"></inref>')).toEqual(['<inref id="x"></inref>', ""]);
+  });
+
+  it("releases earlier complete citations but not a trailing unfinished one", () => {
+    expect(splitPendingInref(`${A} mer <inref id="bbbb`)).toEqual([`${A} mer `, '<inref id="bbbb']);
+    expect(splitPendingInref(`a < b ${A}<`)).toEqual([`a < b ${A}`, "<"]);
+  });
+
+  it("never shows a partial tag, whichever way the stream is split", () => {
+    const answer = `Se ${A} och ${B} för mer.`;
+    for (let cut = 1; cut < answer.length; cut++) {
+      for (let cut2 = cut + 1; cut2 <= answer.length; cut2++) {
+        const chunks = [answer.slice(0, cut), answer.slice(cut, cut2), answer.slice(cut2)];
+        let pending = "";
+        let shown = "";
+        for (const chunk of chunks) {
+          const [ready, rest] = splitPendingInref(pending + chunk);
+          pending = rest;
+          shown += ready;
+          // Every prefix shown so far must not end inside a citation tag.
+          expect(shown, `after chunks ${JSON.stringify(chunks)}`).not.toMatch(/<inref[^>]*$/);
+          expect(shown).not.toMatch(/<(i(n(r(e)?)?)?)?$/);
+        }
+        expect(shown + pending).toBe(answer);
+      }
+    }
+  });
+});

--- a/frontend/apps/web/src/lib/features/chat/inrefBuffer.ts
+++ b/frontend/apps/web/src/lib/features/chat/inrefBuffer.ts
@@ -1,0 +1,24 @@
+/*
+    Copyright (c) 2026 Sundsvalls Kommun
+*/
+
+const TAG = "<inref";
+
+/**
+ * Splits streamed answer text into what can be shown now and a trailing
+ * fragment that may still become an `<inref …/>` citation tag.
+ *
+ * Only the text from the last "<" onwards can be an unfinished tag, so
+ * everything before it is safe to render, including earlier complete
+ * citations. The previous check looked at the first "<" only, so a chunk
+ * holding a complete citation followed by the start of another released the
+ * unfinished tag as visible text.
+ */
+export function splitPendingInref(buffer: string): [ready: string, pending: string] {
+  const start = buffer.lastIndexOf("<");
+  if (start === -1) return [buffer, ""];
+  const tail = buffer.slice(start);
+  const couldBeTag = tail.length <= TAG.length ? TAG.startsWith(tail) : tail.startsWith(TAG);
+  if (!couldBeTag || tail.includes(">")) return [buffer, ""];
+  return [buffer.slice(0, start), tail];
+}


### PR DESCRIPTION
## Changes

While an answer streams, the chat holds back text that may still become an `<inref …/>` citation tag so the raw tag never flashes on screen. The check now looks at the last `<` in the pending text instead of the first: everything before it is shown, and only a trailing fragment that could still be a citation is withheld. The three ad-hoc helpers in `ChatService` are replaced by one `splitPendingInref` function in `inrefBuffer.ts`.

## Why

The old check assumed at most one `<` in the pending text. A provider chunk that carried a complete citation followed by the start of the next one (`<inref id="aaaaaaaa"/> och <inref id="bbbb`) passed the "complete" test on the first tag and released the whole chunk, so the unfinished second tag rendered literally as text until the rest arrived. The same happened after an ordinary `<` such as `1 < 2`. Whether users saw it depended on how the provider split its chunks; providers that send several tokens per chunk hit it more often. Found while reviewing streaming behaviour for #825; correctness only, no performance effect.

## Planning

- Task: Fixes #

## Testing

- `inrefBuffer.test.ts`: fixed cases, plus a replay that splits a two-citation answer at every pair of cut points and asserts the shown text never ends inside a tag and reassembles to the full answer.
- `ChatService.test.ts`: a chunk holding a finished and an unfinished citation shows the finished one at once and only the unfinished one later.
- Existing chat service and stream tests pass; eslint, prettier and `svelte-check` clean.

## Screenshots

None; the only visible change is that a half-received citation tag is no longer shown as text.
